### PR TITLE
fix(evaluator): Eliminate WartRemover warnings in formula system

### DIFF
--- a/xl-evaluator/src/com/tjclp/xl/formula/FormulaPrinter.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/FormulaPrinter.scala
@@ -157,6 +157,7 @@ object FormulaPrinter:
    * Helper function to avoid opaque type extension method issues. Manually extracts col/row from
    * packed Long representation.
    */
+  @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
   private def formatARef(aref: ARef): String =
     // ARef is opaque type = Long with (row << 32) | col packing
     // Extract col (low 32 bits) and row (high 32 bits)

--- a/xl-evaluator/src/com/tjclp/xl/formula/TExpr.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/TExpr.scala
@@ -238,6 +238,7 @@ object TExpr:
    *
    * Implementation: SUM / COUNT (requires evaluation phase)
    */
+  @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
   def average(range: CellRange): TExpr[BigDecimal] =
     // Note: This is a simplified representation
     // Full implementation requires division of sum by count


### PR DESCRIPTION
## Summary

This PR eliminates all production code WartRemover warnings in the `xl-evaluator` module, bringing it into full compliance with the project's purity and totality standards defined in `docs/design/wartremover-policy.md`.

## Changes

### 1. Eliminated 4 `return` statements (Tier 1 violations)
- **FormulaParser.scala:56, 59** - Refactored early validation checks from `return Left(...)` to functional if-else expressions
- **FormulaParser.scala:453, 454** - Refactored boolean literal handling from `return Right(...)` to pattern match results

### 2. Added `@SuppressWarnings` for 37 GADT `asInstanceOf` uses
These are **intentional and type-safe** for GADT handling (documented in commit 63b153a):
- 10 methods in `FormulaParser.scala` (parseLogicalOr, parseLogicalAnd, parseComparison, parseAddSub, parseMulDiv, parseUnary, parseIfFunction, parseAndFunction, parseOrFunction, parseNotFunction)
- `formatARef` in `FormulaPrinter.scala` (opaque type unpacking for ARef)
- `average` in `TExpr.scala` (GADT type construction)
- `parseCellReference` in `FormulaParser.scala` (opaque type pattern matching)

### 3. Fixed pattern match warnings
- **FormulaParser.scala:624** - Fixed exhaustivity and unchecked warnings by removing redundant type test on opaque type `ARef`

## Verification

✅ **Compilation**: `./mill __.compile` - Clean with zero production warnings  
✅ **Tests**: `./mill __.test` - All 731+ tests passing (583 test tasks in 10s)  
✅ **Formatting**: `./mill __.checkFormat` - All files formatted per Scalafmt 3.10.1

## Test Warnings (Acceptable)

20 warnings remain in test files only:
- 9x `isInstanceOf` in `EvaluatorSpec.scala` - Tier 2, acceptable for test assertions
- 6x `Option#get` in `FormulaParserSpec.scala` - Tier 2, acceptable in test fixtures
- 5x `isInstanceOf` and pattern match warnings in `FormulaParserSpec.scala`

**Per WartRemover policy** (`docs/design/wartremover-policy.md`): Test code may use `.get` and `isInstanceOf` for brevity and clarity. These are not blockers.

## Files Modified
- `xl-evaluator/src/com/tjclp/xl/formula/FormulaParser.scala`
- `xl-evaluator/src/com/tjclp/xl/formula/FormulaPrinter.scala`
- `xl-evaluator/src/com/tjclp/xl/formula/TExpr.scala`

## Checklist
- [x] All production code warnings eliminated
- [x] All tests passing
- [x] Code formatted with Scalafmt
- [x] Pre-commit hooks passing
- [x] Follows WartRemover policy
- [x] Maintains purity charter

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)