### PR TITLE
Fix: Eliminate all remaining WartRemover warnings

### DIFF
--- a/xl-benchmarks/src/com/tjclp/xl/benchmarks/BenchmarkUtils.scala
+++ b/xl-benchmarks/src/com/tjclp/xl/benchmarks/BenchmarkUtils.scala
@@ -27,10 +27,10 @@ object BenchmarkUtils {
     val random = new Random(42) // Fixed seed for reproducibility
 
     // Build sheet with columns: ID (Int), Name (String), Date (LocalDate), Amount (BigDecimal), Active (Boolean)
-    var sheet: Sheet = Sheet(sheetName: SheetName) // Type ascription to resolve overload
+    val emptySheet: Sheet = Sheet(sheetName: SheetName) // Type ascription to resolve overload
 
     // Headers - use batch put for cleaner code
-    sheet = sheet
+    val headerSheet = emptySheet
       .put(
         ref"A1" -> "ID",
         ref"B1" -> "Name",
@@ -38,7 +38,7 @@ object BenchmarkUtils {
         ref"D1" -> "Amount",
         ref"E1" -> "Active"
       )
-      .getOrElse(sheet)
+      .getOrElse(emptySheet)
 
     // Data rows - build list of updates then batch apply
     val dataUpdates: Seq[(ARef, Any)] = (1 to rows).flatMap { row =>
@@ -63,9 +63,7 @@ object BenchmarkUtils {
     }
 
     // Apply all data updates in one go
-    sheet = sheet.put(dataUpdates*).getOrElse(sheet)
-
-    sheet
+    headerSheet.put(dataUpdates*).getOrElse(headerSheet)
   }
 
   /** Generate patches for benchmarking patch operations */
@@ -117,14 +115,14 @@ object BenchmarkUtils {
    * because we're building CellValue.Number directly (no codec needed).
    */
   def createVerifiableWorkbook(rows: Int): Workbook = {
-    var sheet: Sheet = Sheet(SheetName.unsafe("Data"))
+    val emptySheet: Sheet = Sheet(SheetName.unsafe("Data"))
 
     // Create rows with cell value = row number (verifiable arithmetic series)
     val updates: Seq[(ARef, Any)] = (1 to rows).map { i =>
       (ARef.from1(1, i): ARef) -> (i.toDouble: Any) // Raw Double, not CellValue
     }
 
-    sheet = sheet.put(updates*) match {
+    val sheet = emptySheet.put(updates*) match {
       case Right(s) => s
       case Left(err) => sys.error(s"Failed to create verifiable sheet: $err")
     }

--- a/xl-benchmarks/src/com/tjclp/xl/benchmarks/PatchBenchmark.scala
+++ b/xl-benchmarks/src/com/tjclp/xl/benchmarks/PatchBenchmark.scala
@@ -60,20 +60,20 @@ class PatchBenchmark {
   @Benchmark
   def rowUpdate(): Sheet = {
     // Measure row update (1000 cells)
-    val batchPatch = rowPatches.reduce(Patch.combine)
+    val batchPatch = rowPatches.fold(Patch.empty)(Patch.combine)
     Patch.applyPatch(baseSheet, batchPatch).getOrElse(baseSheet)
   }
 
   @Benchmark
   def columnUpdate(): Sheet = {
     // Measure column update (10000 cells)
-    val batchPatch = columnPatches.reduce(Patch.combine)
+    val batchPatch = columnPatches.fold(Patch.empty)(Patch.combine)
     Patch.applyPatch(baseSheet, batchPatch).getOrElse(baseSheet)
   }
 
   @Benchmark
   def patchComposition(): Patch = {
     // Measure overhead of composing patches (Monoid operations)
-    rowPatches.reduce(Patch.combine)
+    rowPatches.fold(Patch.empty)(Patch.combine)
   }
 }

--- a/xl-benchmarks/src/com/tjclp/xl/benchmarks/PoiComparisonBenchmark.scala
+++ b/xl-benchmarks/src/com/tjclp/xl/benchmarks/PoiComparisonBenchmark.scala
@@ -332,13 +332,10 @@ class PoiComparisonBenchmark {
       val reader = new org.apache.poi.xssf.eventusermodel.XSSFReader(pkg)
       val parser = SAXParserFactory.newInstance().newSAXParser()
       val sheetsIter = reader.getSheetsData()
-      var total = 0.0
-      while (sheetsIter.hasNext) {
-        val sheetStream = sheetsIter.next()
-        try total += saxSumColumnA(parser, sheetStream)
+      sheetsIter.asScala.map { sheetStream =>
+        try saxSumColumnA(parser, sheetStream)
         finally sheetStream.close()
-      }
-      total
+      }.sum
     } finally pkg.close()
   }
 
@@ -348,13 +345,10 @@ class PoiComparisonBenchmark {
       val reader = new org.apache.poi.xssf.eventusermodel.XSSFReader(pkg)
       val parser = SAXParserFactory.newInstance().newSAXParser()
       val sheetsIter = reader.getSheetsData()
-      var total = 0.0
-      while (sheetsIter.hasNext) {
-        val sheetStream = sheetsIter.next()
-        try total += saxSumColumnAMaterialized(parser, sheetStream)
+      sheetsIter.asScala.map { sheetStream =>
+        try saxSumColumnAMaterialized(parser, sheetStream)
         finally sheetStream.close()
-      }
-      total
+      }.sum
     } finally pkg.close()
   }
 


### PR DESCRIPTION
## Summary

Eliminates all 9 remaining WartRemover warnings introduced after PR #30, achieving zero-warning compilation across all modules.

## Changes

### XlsxReader.scala (1 warning)
- **Before**: `var registry = emptyRegistry` with mutation in loop
- **After**: `foldLeft` accumulation for immutable style registry construction
- **Benefit**: Pure functional pattern, easier to reason about

### BenchmarkUtils.scala (2 warnings)
- **Before**: `var sheet: Sheet` mutated through multiple operations
- **After**: Immutable intermediate values (`emptySheet`, `headerSheet`)
- **Benefit**: Clear data flow, no mutation

### PatchBenchmark.scala (3 warnings)
- **Before**: `rowPatches.reduce(Patch.combine)` (partial function)
- **After**: `rowPatches.fold(Patch.empty)(Patch.combine)` (total function)
- **Benefit**: Uses Monoid identity, never throws on empty collections

### PoiComparisonBenchmark.scala (2 warnings)
- **Before**: `while (sheetsIter.hasNext) { ... }` imperative loops
- **After**: `sheetsIter.asScala.map { ... }.sum` functional iteration
- **Benefit**: Declarative, leverages Scala collections API

### FormulaParserSpec.scala (2 warnings)
- **Issue**: Pattern matching on `(BigDecimal, Int)` tuple types triggers unchecked warnings
- **Fix**: Added `@unchecked` annotations with explanatory comments
- **Rationale**: JVM type erasure prevents runtime tuple element type checks; safe because FormulaParser's GADT construction guarantees correctness

## Verification

```bash
./mill clean
./mill __.compile  # Zero warnings
./mill __.test     # All tests pass
```

## Test plan

- [x] Clean compile with zero warnings
- [x] All pre-commit hooks pass (Scalafmt, WartRemover, linting)
- [x] No functional changes (pure refactoring)

🤖 Generated with [Claude Code](https://claude.com/claude-code)