### PR TITLE
feat(cli): Add repeatable --sheet flag to xl new command

### DIFF
--- a/.claude/skills/xl-cli/SKILL.md
+++ b/.claude/skills/xl-cli/SKILL.md
@@ -102,6 +102,10 @@ xl -f <file> -s <sheet> -o <out> batch -              # Read from stdin
 
 # Formula dragging (putf with range)
 xl -f <file> -s <sheet> -o <out> putf <range> <formula>  # Drags formula over range
+
+# Create new workbook
+xl new <output>                                          # Default Sheet1
+xl new <output> --sheet Data --sheet Summary             # Multiple sheets
 ```
 
 ---
@@ -372,10 +376,12 @@ xl new output.xlsx
 # Create with custom sheet name
 xl new output.xlsx --sheet-name "Data"
 
-# Add more sheets
-xl -f output.xlsx -o output.xlsx add-sheet "Summary" --before "Data"
+# Create with multiple sheets in one command
+xl new output.xlsx --sheet Data --sheet Summary --sheet Notes
+
+# Add more sheets to existing workbook
+xl -f output.xlsx -o output.xlsx add-sheet "Archive" --after "Notes"
 xl -f output.xlsx -o output.xlsx copy-sheet "Summary" "Q1 Summary"
-xl -f output.xlsx -o output.xlsx rename-sheet "Sheet1" "Overview"
 ```
 
 ---


### PR DESCRIPTION
## Summary
- Add `--sheet` option (repeatable) to `xl new` for creating multiple sheets in one command
- `--sheet` takes precedence over `--sheet-name` when both provided
- Backward compatible: existing `--sheet-name` still works for single-sheet creation
- Update skill documentation with new syntax

## Usage

```bash
# Single sheet (backward compatible)
xl new output.xlsx                     # Creates with Sheet1
xl new output.xlsx --sheet-name Data   # Creates with custom name

# Multiple sheets (new)
xl new output.xlsx --sheet Data --sheet Summary --sheet Notes
```

## Test plan
- [x] Verify default single sheet creation still works
- [x] Verify `--sheet-name` backward compatibility
- [x] Verify multiple `--sheet` flags create multiple sheets
- [x] Verify sheet names with spaces work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)