### PR TITLE
feat(evaluator): Add AVERAGEIF and AVERAGEIFS conditional aggregation functions

### DIFF
--- a/.claude/skills/xl-cli/reference/FORMULAS.md
+++ b/.claude/skills/xl-cli/reference/FORMULAS.md
@@ -1,6 +1,6 @@
 # Supported Formula Functions
 
-The `eval` command supports 65 Excel functions.
+The `eval` command supports 67 Excel functions.
 
 ## Math Functions
 
@@ -100,8 +100,10 @@ The `eval` command supports 65 Excel functions.
 |----------|--------|---------|
 | SUMIF | `=SUMIF(range, criteria, [sum_range])` | `=SUMIF(A:A, ">100", B:B)` |
 | COUNTIF | `=COUNTIF(range, criteria)` | `=COUNTIF(A:A, "Yes")` |
+| AVERAGEIF | `=AVERAGEIF(range, criteria, [avg_range])` | `=AVERAGEIF(A:A, ">100", B:B)` |
 | SUMIFS | `=SUMIFS(sum_range, crit_range1, crit1, ...)` | `=SUMIFS(C:C, A:A, "Q1", B:B, ">0")` |
 | COUNTIFS | `=COUNTIFS(range1, crit1, range2, crit2, ...)` | `=COUNTIFS(A:A, "Active", B:B, ">100")` |
+| AVERAGEIFS | `=AVERAGEIFS(avg_range, crit_range1, crit1, ...)` | `=AVERAGEIFS(C:C, A:A, "Q1", B:B, ">0")` |
 | SUMPRODUCT | `=SUMPRODUCT(array1, [array2], ...)` | `=SUMPRODUCT(A1:A10, B1:B10)` |
 
 ## Error Handling Functions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ xl-core/         → Pure domain model (Cell, Sheet, Workbook, Patch, Style), ma
 xl-ooxml/        → Pure OOXML mapping (XlsxReader, XlsxWriter, SharedStrings, Styles)
 xl-cats-effect/  → IO interpreters and streaming (Excel[F], ExcelIO, SAX-based streaming)
 xl-benchmarks/   → JMH performance benchmarks
-xl-evaluator/    → Formula parser/evaluator (TExpr GADT, 65 functions, dependency graphs)
+xl-evaluator/    → Formula parser/evaluator (TExpr GADT, 67 functions, dependency graphs)
 xl-testkit/      → Test laws, generators, helpers [future]
 ```
 
@@ -225,7 +225,7 @@ sheet.evaluateFormula("=SUM(A1:A10)")      // XLResult[CellValue]
 sheet.evaluateWithDependencyCheck()         // Safe eval with cycle detection
 ```
 
-**65 Functions**: SUM, SUMIF, SUMIFS, SUMPRODUCT, COUNT, COUNTA, COUNTBLANK, COUNTIF, COUNTIFS, AVERAGE, MIN, MAX, IF, AND, OR, NOT, CONCATENATE, LEFT, RIGHT, MID, LEN, UPPER, LOWER, TRIM, SUBSTITUTE, TEXT, VALUE, TODAY, NOW, DATE, YEAR, MONTH, DAY, HOUR, MINUTE, SECOND, EOMONTH, ABS, ROUND, ROUNDUP, ROUNDDOWN, INT, MOD, POWER, SQRT, LOG, LN, EXP, FLOOR, CEILING, TRUNC, SIGN, NPV, IRR, VLOOKUP, XLOOKUP, PI, ROW, COLUMN, ROWS, COLUMNS, ADDRESS
+**67 Functions**: SUM, SUMIF, SUMIFS, SUMPRODUCT, COUNT, COUNTA, COUNTBLANK, COUNTIF, COUNTIFS, AVERAGE, AVERAGEIF, AVERAGEIFS, MIN, MAX, IF, AND, OR, NOT, CONCATENATE, LEFT, RIGHT, MID, LEN, UPPER, LOWER, TRIM, SUBSTITUTE, TEXT, VALUE, TODAY, NOW, DATE, YEAR, MONTH, DAY, HOUR, MINUTE, SECOND, EOMONTH, ABS, ROUND, ROUNDUP, ROUNDDOWN, INT, MOD, POWER, SQRT, LOG, LN, EXP, FLOOR, CEILING, TRUNC, SIGN, NPV, IRR, VLOOKUP, XLOOKUP, PI, ROW, COLUMN, ROWS, COLUMNS, ADDRESS
 
 ### Rich Text
 ```scala

--- a/xl-evaluator/src/com/tjclp/xl/formula/DependencyGraph.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/DependencyGraph.scala
@@ -218,6 +218,15 @@ object DependencyGraph:
         conditions.flatMap { case (range, criteria) =>
           range.localCells ++ extractDependencies(criteria)
         }.toSet
+      case TExpr.AverageIf(range, criteria, avgRangeOpt) =>
+        range.localCells ++
+          extractDependencies(criteria) ++
+          avgRangeOpt.map(_.localCells).getOrElse(Set.empty)
+      case TExpr.AverageIfs(avgRange, conditions) =>
+        avgRange.localCells ++
+          conditions.flatMap { case (range, criteria) =>
+            range.localCells ++ extractDependencies(criteria)
+          }.toSet
 
       // Array and advanced lookup functions
       case TExpr.SumProduct(arrays) =>
@@ -462,6 +471,15 @@ object DependencyGraph:
         conditions.flatMap { case (range, criteria) =>
           range.localCellsBounded(bounds) ++ extractDependenciesBounded(criteria, bounds)
         }.toSet
+      case TExpr.AverageIf(range, criteria, avgRangeOpt) =>
+        range.localCellsBounded(bounds) ++
+          extractDependenciesBounded(criteria, bounds) ++
+          avgRangeOpt.map(_.localCellsBounded(bounds)).getOrElse(Set.empty)
+      case TExpr.AverageIfs(avgRange, conditions) =>
+        avgRange.localCellsBounded(bounds) ++
+          conditions.flatMap { case (range, criteria) =>
+            range.localCellsBounded(bounds) ++ extractDependenciesBounded(criteria, bounds)
+          }.toSet
 
       // Array and advanced lookup functions
       case TExpr.SumProduct(arrays) =>
@@ -1199,6 +1217,18 @@ object DependencyGraph:
           locationToQualifiedRefs(range, currentSheet) ++
             extractQualifiedDependencies(criteria, currentSheet)
         }.toSet
+      case TExpr.AverageIf(range, criteria, avgRangeOpt) =>
+        locationToQualifiedRefs(range, currentSheet) ++
+          extractQualifiedDependencies(criteria, currentSheet) ++
+          avgRangeOpt
+            .map(locationToQualifiedRefs(_, currentSheet))
+            .getOrElse(Set.empty)
+      case TExpr.AverageIfs(avgRange, conditions) =>
+        locationToQualifiedRefs(avgRange, currentSheet) ++
+          conditions.flatMap { case (range, criteria) =>
+            locationToQualifiedRefs(range, currentSheet) ++
+              extractQualifiedDependencies(criteria, currentSheet)
+          }.toSet
       case TExpr.SumProduct(arrays) =>
         arrays.flatMap(locationToQualifiedRefs(_, currentSheet)).toSet
 

--- a/xl-evaluator/src/com/tjclp/xl/formula/FormulaPrinter.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/FormulaPrinter.scala
@@ -424,6 +424,23 @@ object FormulaPrinter:
           .mkString(", ")
         s"COUNTIFS($condStrs)"
 
+      case TExpr.AverageIf(range, criteria, avgRangeOpt) =>
+        val rangeStr = formatLocation(range)
+        val criteriaStr = printExpr(criteria, 0)
+        avgRangeOpt match
+          case Some(avgRange) =>
+            s"AVERAGEIF($rangeStr, $criteriaStr, ${formatLocation(avgRange)})"
+          case None =>
+            s"AVERAGEIF($rangeStr, $criteriaStr)"
+
+      case TExpr.AverageIfs(avgRange, conditions) =>
+        val condStrs = conditions
+          .map { case (r, criteria) =>
+            s"${formatLocation(r)}, ${printExpr(criteria, 0)}"
+          }
+          .mkString(", ")
+        s"AVERAGEIFS(${formatLocation(avgRange)}, $condStrs)"
+
       // Array and advanced lookup functions (now support cross-sheet via RangeLocation)
       case TExpr.SumProduct(arrays) =>
         s"SUMPRODUCT(${arrays.map(formatLocation).mkString(", ")})"
@@ -811,6 +828,19 @@ object FormulaPrinter:
           }
           .mkString(", ")
         s"CountIfs($condStrs)"
+      case TExpr.AverageIf(range, criteria, avgRangeOpt) =>
+        avgRangeOpt match
+          case Some(avgRange) =>
+            s"AverageIf(${formatLocation(range)}, ${printWithTypes(criteria)}, ${formatLocation(avgRange)})"
+          case None =>
+            s"AverageIf(${formatLocation(range)}, ${printWithTypes(criteria)})"
+      case TExpr.AverageIfs(avgRange, conditions) =>
+        val condStrs = conditions
+          .map { case (r, criteria) =>
+            s"(${formatLocation(r)}, ${printWithTypes(criteria)})"
+          }
+          .mkString(", ")
+        s"AverageIfs(${formatLocation(avgRange)}, $condStrs)"
       case TExpr.SumProduct(arrays) =>
         s"SumProduct(${arrays.map(formatLocation).mkString(", ")})"
       case TExpr.XLookup(

--- a/xl-evaluator/src/com/tjclp/xl/formula/FormulaShifter.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/FormulaShifter.scala
@@ -300,6 +300,19 @@ object FormulaShifter:
             (shiftLocation(r, colDelta, rowDelta), shiftWildcard(c, colDelta, rowDelta))
           }
         ).asInstanceOf[TExpr[A]]
+      case AverageIf(range, criteria, avgRange) =>
+        AverageIf(
+          shiftLocation(range, colDelta, rowDelta),
+          shiftWildcard(criteria, colDelta, rowDelta),
+          avgRange.map(shiftLocation(_, colDelta, rowDelta))
+        ).asInstanceOf[TExpr[A]]
+      case AverageIfs(avgRange, conditions) =>
+        AverageIfs(
+          shiftLocation(avgRange, colDelta, rowDelta),
+          conditions.map { case (r, c) =>
+            (shiftLocation(r, colDelta, rowDelta), shiftWildcard(c, colDelta, rowDelta))
+          }
+        ).asInstanceOf[TExpr[A]]
 
       // Array functions (now using RangeLocation)
       case SumProduct(arrays) =>

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/FormulaParserSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/FormulaParserSpec.scala
@@ -858,7 +858,7 @@ class FormulaParserSpec extends ScalaCheckSuite:
     }
   }
 
-  test("FunctionParser.allFunctions includes all 65 functions") {
+  test("FunctionParser.allFunctions includes all 67 functions") {
     val functions = FunctionParser.allFunctions
     assert(functions.contains("SUM"))
     assert(functions.contains("MIN"))
@@ -874,6 +874,8 @@ class FormulaParserSpec extends ScalaCheckSuite:
     assert(functions.contains("COUNTIF"))
     assert(functions.contains("SUMIFS"))
     assert(functions.contains("COUNTIFS"))
+    assert(functions.contains("AVERAGEIF"))
+    assert(functions.contains("AVERAGEIFS"))
     // Array and advanced lookup functions
     assert(functions.contains("SUMPRODUCT"))
     assert(functions.contains("XLOOKUP"))
@@ -922,7 +924,7 @@ class FormulaParserSpec extends ScalaCheckSuite:
     assert(functions.contains("ROWS"))
     assert(functions.contains("COLUMNS"))
     assert(functions.contains("ADDRESS"))
-    assertEquals(functions.length, 65)
+    assertEquals(functions.length, 67)
   }
 
   test("FunctionParser.lookup finds known functions") {


### PR DESCRIPTION
## Summary
- **AVERAGEIF**: Average cells matching criteria (`=AVERAGEIF(range, criteria, [avg_range])`)
- **AVERAGEIFS**: Multi-criteria averaging (`=AVERAGEIFS(avg_range, crit_range1, crit1, ...)`)

Brings function count from 65 → 67, completing Sprint 4 of the evaluator enhancement plan.

## Features
- Full wildcard support (*, ?) and numeric comparisons (>, >=, <, <=, <>)
- Case-insensitive text matching
- Non-numeric cells skipped (Excel behavior)
- Returns #DIV/0! when no matches or all matches are non-numeric
- Dimension validation (ranges must have same shape)
- Cross-sheet reference support via RangeLocation

## Implementation
| File | Changes |
|------|---------|
| `TExpr.scala` | `AverageIf`, `AverageIfs` cases + `averageIf`, `averageIfs` factory methods |
| `FunctionParser.scala` | Parser instances + registry registration |
| `Evaluator.scala` | Evaluation logic with sum/count accumulation + error handling |
| `FormulaPrinter.scala` | Both `printExpr` and `printWithTypes` cases |
| `FormulaShifter.scala` | Formula drag support |
| `DependencyGraph.scala` | All 3 dependency extraction methods |

## Test plan
- [x] Basic functionality (22 new tests)
- [x] Wildcard matching (*, ?)
- [x] Numeric comparisons (>, >=, <, <=, <>)
- [x] Multiple criteria (AND logic)
- [x] Round-trip parsing
- [x] Shape validation errors
- [x] Dependency graph extraction
- [x] Full test suite passes (719 tests)

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)