### PR TITLE
fix(evaluator): Eager recalculation of dependent formulas (#163)

### DIFF
--- a/xl-evaluator/src/com/tjclp/xl/exports.scala
+++ b/xl-evaluator/src/com/tjclp/xl/exports.scala
@@ -40,6 +40,11 @@ object formulaExports:
   export formula.eval.WorkbookEvaluator
   export formula.eval.WorkbookEvaluator.*
 
+  // DependentRecalculation extension methods (GH-163)
+  // Note: Extension methods with default parameters must be imported directly,
+  // not via wildcard export (Scala 3 compiler bug)
+  export formula.eval.DependentRecalculation
+
   // Display strategy with formula evaluation
   // The evaluating given has higher priority than default due to LowPriority pattern
   export formula.display.EvaluatingFormulaDisplay

--- a/xl-evaluator/src/com/tjclp/xl/formula/eval/DependentRecalculation.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/eval/DependentRecalculation.scala
@@ -1,0 +1,167 @@
+package com.tjclp.xl.formula.eval
+
+import com.tjclp.xl.addressing.{ARef, SheetName}
+import com.tjclp.xl.cells.CellValue
+import com.tjclp.xl.formula.graph.DependencyGraph
+import com.tjclp.xl.formula.graph.DependencyGraph.QualifiedRef
+import com.tjclp.xl.sheets.Sheet
+import com.tjclp.xl.workbooks.Workbook
+import com.tjclp.xl.formula.Clock
+
+/**
+ * Extension methods for eager recalculation of dependent formulas.
+ *
+ * When a cell value changes, all formulas that depend on it (directly or transitively) must be
+ * re-evaluated to keep cached values current. This follows Excel's eager recalculation model.
+ *
+ * Usage:
+ * {{{
+ * import com.tjclp.xl.{*, given}
+ *
+ * // Single-sheet recalculation
+ * val updatedSheet = sheet.put(ref"A1", 100).recalculateDependents(Set(ref"A1"))
+ *
+ * // Cross-sheet recalculation (workbook-level)
+ * val updatedWb = wb.recalculateDependents(SheetName.unsafe("Sheet1"), Set(ref"A1"))
+ * }}}
+ */
+object DependentRecalculation:
+
+  extension (sheet: Sheet)
+    /**
+     * Recalculate all formulas depending on modifiedRefs.
+     *
+     * Evaluates in topological order and updates cached values in Formula cells.
+     *
+     * @param modifiedRefs
+     *   Set of cell references that have been modified
+     * @param workbook
+     *   Optional workbook context for cross-sheet formula references
+     * @param clock
+     *   Clock for date/time functions (defaults to system clock)
+     * @return
+     *   Sheet with updated formula caches
+     */
+    def recalculateDependents(
+      modifiedRefs: Set[ARef],
+      workbook: Option[Workbook] = None,
+      clock: Clock = Clock.system
+    ): Sheet =
+      if modifiedRefs.isEmpty then sheet
+      else
+        val graph = DependencyGraph.fromSheet(sheet)
+        val toRecalc = DependencyGraph.transitiveDependents(graph, modifiedRefs)
+        if toRecalc.isEmpty then sheet
+        else
+          // Get topological order and filter to only affected cells
+          DependencyGraph.topologicalSort(graph) match
+            case Right(evalOrder) =>
+              val orderedToRecalc = evalOrder.filter(toRecalc.contains)
+              recalculateInOrder(sheet, orderedToRecalc, workbook, clock)
+            case Left(_) =>
+              // Cycle detected - skip recalculation (formulas will show error on eval)
+              sheet
+
+  extension (wb: Workbook)
+    /**
+     * Cross-sheet recalculation - handles formulas on other sheets.
+     *
+     * When Sheet1!B1 changes, this recalculates Sheet2!A1 if it references Sheet1!B1. Uses system
+     * clock for date/time functions.
+     *
+     * @param sheetName
+     *   The sheet where cells were modified
+     * @param modifiedRefs
+     *   Set of cell references that have been modified on that sheet
+     * @return
+     *   Workbook with updated formula caches across all affected sheets
+     */
+    def recalculateDependents(
+      sheetName: SheetName,
+      modifiedRefs: Set[ARef]
+    ): Workbook =
+      recalculateDependentsWithClock(sheetName, modifiedRefs, Clock.system)
+
+    /**
+     * Cross-sheet recalculation with explicit clock.
+     *
+     * Use this variant when you need deterministic date/time function results.
+     */
+    def recalculateDependentsWithClock(
+      sheetName: SheetName,
+      modifiedRefs: Set[ARef],
+      clock: Clock
+    ): Workbook =
+      if modifiedRefs.isEmpty then wb
+      else
+        val qualifiedRefs = modifiedRefs.map(ref => QualifiedRef(sheetName, ref))
+        val graph = DependencyGraph.fromWorkbook(wb)
+        val dependentsMap = buildDependentsMap(graph)
+        val toRecalc = transitiveDependentsQualified(dependentsMap, qualifiedRefs)
+
+        if toRecalc.isEmpty then wb
+        else
+          // Group by sheet and recalculate each
+          toRecalc.groupBy(_.sheet).foldLeft(wb) { case (currentWb, (targetSheet, refs)) =>
+            currentWb(targetSheet).toOption
+              .map { sheet =>
+                val sheetGraph = DependencyGraph.fromSheet(sheet)
+                DependencyGraph.topologicalSort(sheetGraph) match
+                  case Right(evalOrder) =>
+                    val localRefs = refs.map(_.ref)
+                    val orderedToRecalc = evalOrder.filter(localRefs.contains)
+                    val updatedSheet =
+                      recalculateInOrder(sheet, orderedToRecalc, Some(currentWb), clock)
+                    currentWb.put(updatedSheet)
+                  case Left(_) => currentWb
+              }
+              .getOrElse(currentWb)
+          }
+
+  /** Recalculate formulas in the given order, updating cached values */
+  private def recalculateInOrder(
+    sheet: Sheet,
+    refs: List[ARef],
+    workbook: Option[Workbook],
+    clock: Clock
+  ): Sheet =
+    refs.foldLeft(sheet) { (s, ref) =>
+      s.cells
+        .get(ref)
+        .map { cell =>
+          cell.value match
+            case CellValue.Formula(expr, _) =>
+              // Evaluate the formula and update cache
+              val fullFormula = if expr.startsWith("=") then expr else s"=$expr"
+              SheetEvaluator.evaluateFormula(s)(fullFormula, clock, workbook) match
+                case Right(newValue) =>
+                  s.put(ref, CellValue.Formula(expr, Some(newValue)))
+                case Left(_) =>
+                  // Evaluation error - clear cache (will show error on next eval)
+                  s.put(ref, CellValue.Formula(expr, None))
+            case _ => s
+        }
+        .getOrElse(s)
+    }
+
+  /** Build reverse lookup from forward dependency graph */
+  private def buildDependentsMap(
+    graph: Map[QualifiedRef, Set[QualifiedRef]]
+  ): Map[QualifiedRef, Set[QualifiedRef]] =
+    graph.foldLeft(Map.empty[QualifiedRef, Set[QualifiedRef]]) { case (acc, (ref, deps)) =>
+      deps.foldLeft(acc) { (acc2, dep) =>
+        acc2.updated(dep, acc2.getOrElse(dep, Set.empty) + ref)
+      }
+    }
+
+  @scala.annotation.tailrec
+  private def transitiveDependentsQualified(
+    dependentsMap: Map[QualifiedRef, Set[QualifiedRef]],
+    refs: Set[QualifiedRef],
+    visited: Set[QualifiedRef] = Set.empty
+  ): Set[QualifiedRef] =
+    val toVisit = refs -- visited
+    if toVisit.isEmpty then visited -- refs
+    else
+      val directDeps = toVisit.flatMap(ref => dependentsMap.getOrElse(ref, Set.empty))
+      transitiveDependentsQualified(dependentsMap, directDeps, visited ++ toVisit)

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/DependentRecalculationSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/DependentRecalculationSpec.scala
@@ -1,0 +1,243 @@
+package com.tjclp.xl.formula
+
+import com.tjclp.xl.*
+import com.tjclp.xl.addressing.{ARef, SheetName}
+import com.tjclp.xl.cells.CellValue
+import com.tjclp.xl.formula.eval.DependentRecalculation.*
+import com.tjclp.xl.formula.graph.DependencyGraph
+import com.tjclp.xl.sheets.Sheet
+import com.tjclp.xl.workbooks.Workbook
+import munit.FunSuite
+
+/**
+ * Tests for DependentRecalculation (GH-163).
+ *
+ * Tests eager recalculation of dependent formulas when cells are modified.
+ */
+class DependentRecalculationSpec extends FunSuite:
+  val emptySheet = new Sheet(name = SheetName.unsafe("Test"))
+
+  def sheetWith(cells: (ARef, CellValue)*): Sheet =
+    cells.foldLeft(emptySheet) { case (s, (ref, value)) =>
+      s.put(ref, value)
+    }
+
+  // ===== Transitive Dependents Tests (6 tests) =====
+
+  test("transitiveDependents: empty set returns empty") {
+    val graph = DependencyGraph(Map.empty, Map.empty)
+    assertEquals(DependencyGraph.transitiveDependents(graph, Set.empty), Set.empty[ARef])
+  }
+
+  test("transitiveDependents: single node with no dependents") {
+    val sheet = sheetWith(ref"A1" -> CellValue.Number(BigDecimal(10)))
+    val graph = DependencyGraph.fromSheet(sheet)
+    assertEquals(DependencyGraph.transitiveDependents(graph, Set(ref"A1")), Set.empty[ARef])
+  }
+
+  test("transitiveDependents: direct dependent") {
+    // A1 <- B1 (B1 depends on A1)
+    val sheet = sheetWith(
+      ref"A1" -> CellValue.Number(BigDecimal(10)),
+      ref"B1" -> CellValue.Formula("=A1*2")
+    )
+    val graph = DependencyGraph.fromSheet(sheet)
+    val result = DependencyGraph.transitiveDependents(graph, Set(ref"A1"))
+    assertEquals(result, Set(ref"B1"))
+  }
+
+  test("transitiveDependents: chain of dependents") {
+    // A1 <- B1 <- C1 (C1 depends on B1, B1 depends on A1)
+    val sheet = sheetWith(
+      ref"A1" -> CellValue.Number(BigDecimal(10)),
+      ref"B1" -> CellValue.Formula("=A1*2"),
+      ref"C1" -> CellValue.Formula("=B1+5")
+    )
+    val graph = DependencyGraph.fromSheet(sheet)
+    val result = DependencyGraph.transitiveDependents(graph, Set(ref"A1"))
+    // When A1 changes, both B1 and C1 need recalculation
+    assertEquals(result, Set(ref"B1", ref"C1"))
+  }
+
+  test("transitiveDependents: diamond pattern") {
+    // A1 <- B1, A1 <- C1, B1 <- D1, C1 <- D1
+    // D1 depends on both B1 and C1, both depend on A1
+    val sheet = sheetWith(
+      ref"A1" -> CellValue.Number(BigDecimal(10)),
+      ref"B1" -> CellValue.Formula("=A1+5"),
+      ref"C1" -> CellValue.Formula("=A1*2"),
+      ref"D1" -> CellValue.Formula("=B1+C1")
+    )
+    val graph = DependencyGraph.fromSheet(sheet)
+    val result = DependencyGraph.transitiveDependents(graph, Set(ref"A1"))
+    // When A1 changes, B1, C1, and D1 all need recalculation
+    assertEquals(result, Set(ref"B1", ref"C1", ref"D1"))
+  }
+
+  test("transitiveDependents: multiple starting refs") {
+    val sheet = sheetWith(
+      ref"A1" -> CellValue.Number(BigDecimal(10)),
+      ref"A2" -> CellValue.Number(BigDecimal(20)),
+      ref"B1" -> CellValue.Formula("=A1*2"),
+      ref"B2" -> CellValue.Formula("=A2*3")
+    )
+    val graph = DependencyGraph.fromSheet(sheet)
+    val result = DependencyGraph.transitiveDependents(graph, Set(ref"A1", ref"A2"))
+    assertEquals(result, Set(ref"B1", ref"B2"))
+  }
+
+  // ===== Sheet recalculateDependents Tests (6 tests) =====
+
+  test("recalculateDependents: updates direct dependent cache") {
+    // A1=10, B1="=A1*2" (cached: 20)
+    val sheet = sheetWith(
+      ref"A1" -> CellValue.Number(BigDecimal(10)),
+      ref"B1" -> CellValue.Formula("A1*2", Some(CellValue.Number(BigDecimal(20))))
+    )
+
+    // Change A1 to 50 and recalculate
+    val updatedSheet = sheet.put(ref"A1", CellValue.Number(BigDecimal(50)))
+    val recalculated = updatedSheet.recalculateDependents(Set(ref"A1"))
+
+    // B1 should now have cached value of 100
+    val b1Cell = recalculated.cells.get(ref"B1")
+    assert(b1Cell.isDefined)
+    b1Cell.get.value match
+      case CellValue.Formula(_, Some(CellValue.Number(n))) =>
+        assertEquals(n, BigDecimal(100))
+      case other =>
+        fail(s"Expected Formula with cached Number(100), got $other")
+  }
+
+  test("recalculateDependents: updates transitive chain in correct order") {
+    // A1=10, B1="=A1*2", C1="=B1+5"
+    val sheet = sheetWith(
+      ref"A1" -> CellValue.Number(BigDecimal(10)),
+      ref"B1" -> CellValue.Formula("A1*2", Some(CellValue.Number(BigDecimal(20)))),
+      ref"C1" -> CellValue.Formula("B1+5", Some(CellValue.Number(BigDecimal(25))))
+    )
+
+    // Change A1 to 50 and recalculate
+    val updatedSheet = sheet.put(ref"A1", CellValue.Number(BigDecimal(50)))
+    val recalculated = updatedSheet.recalculateDependents(Set(ref"A1"))
+
+    // B1 should be 100 (50 * 2)
+    val b1Value = recalculated.cells.get(ref"B1").flatMap(_.value match
+      case CellValue.Formula(_, Some(CellValue.Number(n))) => Some(n)
+      case _ => None
+    )
+    assertEquals(b1Value, Some(BigDecimal(100)))
+
+    // C1 should be 105 (100 + 5)
+    val c1Value = recalculated.cells.get(ref"C1").flatMap(_.value match
+      case CellValue.Formula(_, Some(CellValue.Number(n))) => Some(n)
+      case _ => None
+    )
+    assertEquals(c1Value, Some(BigDecimal(105)))
+  }
+
+  test("recalculateDependents: preserves unrelated formula caches") {
+    // A1=10, B1="=A1*2", C1="=100" (unrelated)
+    val sheet = sheetWith(
+      ref"A1" -> CellValue.Number(BigDecimal(10)),
+      ref"B1" -> CellValue.Formula("A1*2", Some(CellValue.Number(BigDecimal(20)))),
+      ref"C1" -> CellValue.Formula("100", Some(CellValue.Number(BigDecimal(100))))
+    )
+
+    // Change A1 to 50 and recalculate
+    val updatedSheet = sheet.put(ref"A1", CellValue.Number(BigDecimal(50)))
+    val recalculated = updatedSheet.recalculateDependents(Set(ref"A1"))
+
+    // C1 should be untouched (still 100)
+    val c1Value = recalculated.cells.get(ref"C1").flatMap(_.value match
+      case CellValue.Formula(expr, cached) => Some((expr, cached))
+      case _ => None
+    )
+    assertEquals(c1Value.map(_._1), Some("100"))
+    assertEquals(
+      c1Value.flatMap(_._2),
+      Some(CellValue.Number(BigDecimal(100)))
+    )
+  }
+
+  test("recalculateDependents: handles evaluation errors gracefully") {
+    // A1="=1/0" will cause div by zero
+    val sheet = sheetWith(
+      ref"A1" -> CellValue.Number(BigDecimal(0)),
+      ref"B1" -> CellValue.Formula("1/A1", Some(CellValue.Number(BigDecimal(1))))
+    )
+
+    // Change A1 to 0 (will cause div by zero) and recalculate
+    val recalculated = sheet.recalculateDependents(Set(ref"A1"))
+
+    // B1 should have its cache cleared (None) due to error
+    val b1Value = recalculated.cells.get(ref"B1").map(_.value)
+    b1Value match
+      case Some(CellValue.Formula(_, None)) => () // Expected: cache cleared
+      case Some(CellValue.Formula(_, Some(CellValue.Error(_)))) => () // Also acceptable
+      case other => fail(s"Expected Formula with cleared cache or error, got $other")
+  }
+
+  test("recalculateDependents: handles empty modifiedRefs") {
+    val sheet = sheetWith(
+      ref"A1" -> CellValue.Number(BigDecimal(10)),
+      ref"B1" -> CellValue.Formula("A1*2", Some(CellValue.Number(BigDecimal(20))))
+    )
+
+    // Empty refs should return sheet unchanged
+    val result = sheet.recalculateDependents(Set.empty)
+    assertEquals(result.cells, sheet.cells)
+  }
+
+
+  // ===== Workbook Cross-Sheet Tests (3 tests) =====
+
+  test("workbook recalculateDependents: updates dependent on same sheet") {
+    val sheet = sheetWith(
+      ref"A1" -> CellValue.Number(BigDecimal(10)),
+      ref"B1" -> CellValue.Formula("A1*2", Some(CellValue.Number(BigDecimal(20))))
+    )
+    val wb = Workbook(sheet)
+
+    val updatedSheet = sheet.put(ref"A1", CellValue.Number(BigDecimal(50)))
+    val updatedWb = wb.put(updatedSheet).recalculateDependents(sheet.name, Set(ref"A1"))
+
+    val resultSheet = updatedWb(sheet.name).toOption.get
+    val b1Value = resultSheet.cells.get(ref"B1").flatMap(_.value match
+      case CellValue.Formula(_, Some(CellValue.Number(n))) => Some(n)
+      case _ => None
+    )
+    assertEquals(b1Value, Some(BigDecimal(100)))
+  }
+
+  test("workbook recalculateDependents: cross-sheet reference") {
+    val sheet1 = new Sheet(name = SheetName.unsafe("Sheet1"))
+      .put(ref"A1", CellValue.Number(BigDecimal(10)))
+
+    val sheet2 = new Sheet(name = SheetName.unsafe("Sheet2"))
+      .put(ref"A1", CellValue.Formula("Sheet1!A1*2", Some(CellValue.Number(BigDecimal(20)))))
+
+    val wb = Workbook(sheet1, sheet2)
+
+    // Change Sheet1!A1 to 50
+    val updatedSheet1 = sheet1.put(ref"A1", CellValue.Number(BigDecimal(50)))
+    val updatedWb = wb.put(updatedSheet1).recalculateDependents(sheet1.name, Set(ref"A1"))
+
+    // Sheet2!A1 should be recalculated to 100
+    val resultSheet2 = updatedWb(SheetName.unsafe("Sheet2")).toOption.get
+    val a1Value = resultSheet2.cells.get(ref"A1").flatMap(_.value match
+      case CellValue.Formula(_, Some(CellValue.Number(n))) => Some(n)
+      case _ => None
+    )
+    assertEquals(a1Value, Some(BigDecimal(100)))
+  }
+
+  test("workbook recalculateDependents: empty refs returns unchanged") {
+    val sheet = sheetWith(
+      ref"A1" -> CellValue.Number(BigDecimal(10))
+    )
+    val wb = Workbook(sheet)
+
+    val result = wb.recalculateDependents(sheet.name, Set.empty)
+    assertEquals(result.sheets.map(_.name), wb.sheets.map(_.name))
+  }


### PR DESCRIPTION
## Summary

- When a cell is modified via `put`, `putf`, or `fill`, all dependent formulas are now recalculated immediately in topological order
- Cached values stay current without requiring manual re-evaluation
- Follows Excel's eager recalculation model

## Changes

- Add `transitiveDependents()` to DependencyGraph for reverse dependency traversal
- Add `DependentRecalculation` extension methods for Sheet and Workbook
- Integrate recalculation into all WriteCommands write operations
- Add 14 test cases covering direct, transitive, and cross-sheet scenarios

## Test plan

- [x] All 719 existing tests pass
- [x] 14 new tests for DependentRecalculation
- [x] E2E verification: `xl put B1 100 && xl putf A1 "=B1*2"` → change B1 → A1 cache updates

Closes #163

🤖 Generated with [Claude Code](https://claude.ai/claude-code)