### PR TITLE
fix: Resolve all WartRemover warnings (73 → 0)

### DIFF
--- a/xl-benchmarks/src/com/tjclp/xl/benchmarks/SaxWriterBenchmark.scala
+++ b/xl-benchmarks/src/com/tjclp/xl/benchmarks/SaxWriterBenchmark.scala
@@ -34,7 +34,13 @@ import scala.xml.Elem
 @Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
 @Fork(value = 1)
-@SuppressWarnings(Array("org.wartremover.warts.Var", "org.wartremover.warts.Null"))
+@SuppressWarnings(
+  Array(
+    "org.wartremover.warts.Var",
+    "org.wartremover.warts.Null",
+    "org.wartremover.warts.OptionPartial"
+  )
+)
 class SaxWriterBenchmark {
 
   @Param(Array("1000", "10000", "100000"))

--- a/xl-cats-effect/test/src/com/tjclp/xl/io/ExcelIOSpec.scala
+++ b/xl-cats-effect/test/src/com/tjclp/xl/io/ExcelIOSpec.scala
@@ -58,7 +58,7 @@ class ExcelIOSpec extends CatsEffectSuite:
     }
   }
 
-  tempDir.test("writeFast: creates valid XLSX file using SAX backend") { dir =>
+  tempDir.test("writeWith SaxStax: creates valid XLSX file using SAX backend") { dir =>
     val initial = Workbook("OutputFast")
     val sheet = initial.sheets(0)
       .put(ref"A1", CellValue.Text("Fast"))
@@ -68,7 +68,7 @@ class ExcelIOSpec extends CatsEffectSuite:
     val path = dir.resolve("output-fast.xlsx")
     val excel = ExcelIO.instance[IO]
 
-    excel.writeFast(wb, path).flatMap { _ =>
+    excel.writeWith(wb, path, WriterConfig.saxStax).flatMap { _ =>
       IO(Files.exists(path)).map { exists =>
         assert(exists, "File should exist")
       }

--- a/xl-cli/src/com/tjclp/xl/cli/commands/WriteCommands.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/commands/WriteCommands.scala
@@ -90,11 +90,11 @@ object WriteCommands:
           // Mode 2: Fill pattern
           putFillPattern(wb, targetSheet, range, singleValue, outputPath, config)
 
-        case (Right(range), multipleValues) =>
-          // Mode 3: Batch values (validate count matches)
+        case (Right(range), multipleValues @ (_ :: _ :: _)) =>
+          // Mode 3: Batch values (validate count matches) - 2+ values
           putBatchValues(wb, targetSheet, range, multipleValues, outputPath, config)
 
-        case (Left(ref), multipleValues) =>
+        case (Left(ref), multipleValues @ (_ :: _)) =>
           IO.raiseError(
             new Exception(
               s"Cannot put ${multipleValues.length} values to single cell ${ref.toA1}. " +
@@ -191,11 +191,11 @@ object WriteCommands:
           // Mode 2: Formula dragging (existing behavior with $ anchors)
           putfFormulaDragging(wb, targetSheet, range, singleFormula, outputPath, config)
 
-        case (Right(range), multipleFormulas) =>
-          // Mode 3: Batch formulas (no dragging, apply as-is)
+        case (Right(range), multipleFormulas @ (_ :: _ :: _)) =>
+          // Mode 3: Batch formulas (no dragging, apply as-is) - 2+ formulas
           putfBatchFormulas(wb, targetSheet, range, multipleFormulas, outputPath, config)
 
-        case (Left(ref), multipleFormulas) =>
+        case (Left(ref), multipleFormulas @ (_ :: _)) =>
           IO.raiseError(
             new Exception(
               s"Cannot put ${multipleFormulas.length} formulas to single cell ${ref.toA1}. " +

--- a/xl-cli/test/src/com/tjclp/xl/cli/BatchPutSpec.scala
+++ b/xl-cli/test/src/com/tjclp/xl/cli/BatchPutSpec.scala
@@ -15,7 +15,9 @@ import com.tjclp.xl.ooxml.writer.WriterConfig
 /**
  * Integration tests for batch put and fill pattern functionality.
  */
-@SuppressWarnings(Array("org.wartremover.warts.OptionPartial"))
+@SuppressWarnings(
+  Array("org.wartremover.warts.OptionPartial", "org.wartremover.warts.IterableOps")
+)
 class BatchPutSpec extends FunSuite:
 
   given unsafe.IORuntime = unsafe.IORuntime.global

--- a/xl-cli/test/src/com/tjclp/xl/cli/ClearCommandSpec.scala
+++ b/xl-cli/test/src/com/tjclp/xl/cli/ClearCommandSpec.scala
@@ -18,7 +18,9 @@ import com.tjclp.xl.styles.color.Color
 /**
  * Integration tests for clear command functionality.
  */
-@SuppressWarnings(Array("org.wartremover.warts.OptionPartial"))
+@SuppressWarnings(
+  Array("org.wartremover.warts.OptionPartial", "org.wartremover.warts.IterableOps")
+)
 class ClearCommandSpec extends FunSuite:
 
   given unsafe.IORuntime = unsafe.IORuntime.global
@@ -192,7 +194,11 @@ class ClearCommandSpec extends FunSuite:
     val wb = Workbook(sheet)
 
     // Verify formula is present
-    assert(sheet.cells.get(ref).exists(_.value.isInstanceOf[CellValue.Formula]))
+    assert(sheet.cells.get(ref).exists { cell =>
+      cell.value match
+        case _: CellValue.Formula => true
+        case _                    => false
+    })
 
     val result = CellCommands
       .clear(wb, Some(sheet), "A1", all = false, styles = false, comments = false, outputPath, config)

--- a/xl-cli/test/src/com/tjclp/xl/cli/FillCommandSpec.scala
+++ b/xl-cli/test/src/com/tjclp/xl/cli/FillCommandSpec.scala
@@ -17,7 +17,9 @@ import com.tjclp.xl.ooxml.writer.WriterConfig
  *
  * Note: ARef.from0(col, row) - column comes first!
  */
-@SuppressWarnings(Array("org.wartremover.warts.OptionPartial"))
+@SuppressWarnings(
+  Array("org.wartremover.warts.OptionPartial", "org.wartremover.warts.IterableOps")
+)
 class FillCommandSpec extends FunSuite:
 
   given unsafe.IORuntime = unsafe.IORuntime.global

--- a/xl-cli/test/src/com/tjclp/xl/cli/SortCommandSpec.scala
+++ b/xl-cli/test/src/com/tjclp/xl/cli/SortCommandSpec.scala
@@ -17,7 +17,9 @@ import com.tjclp.xl.ooxml.writer.WriterConfig
  *
  * Note: ARef.from0(col, row) - column comes first!
  */
-@SuppressWarnings(Array("org.wartremover.warts.OptionPartial"))
+@SuppressWarnings(
+  Array("org.wartremover.warts.OptionPartial", "org.wartremover.warts.IterableOps")
+)
 class SortCommandSpec extends FunSuite:
 
   given unsafe.IORuntime = unsafe.IORuntime.global

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/DependentRecalculationSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/DependentRecalculationSpec.scala
@@ -14,6 +14,9 @@ import munit.FunSuite
  *
  * Tests eager recalculation of dependent formulas when cells are modified.
  */
+@SuppressWarnings(
+  Array("org.wartremover.warts.OptionPartial", "org.wartremover.warts.IterableOps")
+)
 class DependentRecalculationSpec extends FunSuite:
   val emptySheet = new Sheet(name = SheetName.unsafe("Test"))
 

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/DirectSaxEmitter.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/DirectSaxEmitter.scala
@@ -106,7 +106,16 @@ object DirectSaxEmitter:
 
   /**
    * Emit column definitions from sheet.
+   *
+   * Performance: Uses imperative two-pointer merge algorithm for O(1) memory overhead. The
+   * .head/.tail calls are safe because we guard with nonEmpty check above.
    */
+  @SuppressWarnings(
+    Array(
+      "org.wartremover.warts.IterableOps",
+      "org.wartremover.warts.Var"
+    )
+  )
   private def emitCols(writer: SaxWriter, sheet: Sheet): Unit =
     val colProps = sheet.columnProperties
     if colProps.nonEmpty then
@@ -144,7 +153,10 @@ object DirectSaxEmitter:
 
   /**
    * Emit sheetData directly from domain cells, grouped by row.
+   *
+   * Performance: Uses imperative two-pointer merge algorithm for O(1) memory overhead.
    */
+  @SuppressWarnings(Array("org.wartremover.warts.Var", "org.wartremover.warts.While"))
   private def emitSheetData(
     writer: SaxWriter,
     sheet: Sheet,
@@ -201,7 +213,10 @@ object DirectSaxEmitter:
 
   /**
    * Emit a single row element.
+   *
+   * Performance: Uses imperative loop for O(1) memory overhead.
    */
+  @SuppressWarnings(Array("org.wartremover.warts.Var", "org.wartremover.warts.While"))
   private def emitRow(
     writer: SaxWriter,
     rowIdx: Int,


### PR DESCRIPTION
## Summary

- Eliminates all 73 WartRemover warnings from `./mill __.compile`
- Uses idiomatic Scala 3 patterns where possible (boundary/break, pattern matching)
- Preserves imperative style with suppressions only in performance-critical hot paths

## Changes

### Production Code
| File | Change |
|------|--------|
| `DirectSaxEmitter.scala` | Method-level suppressions for `var`/`while`/`IterableOps` (perf-justified SAX streaming) |
| `Evaluator.scala` | Refactored early `return` to Scala 3 `boundary`/`break` |
| `WriteCommands.scala` | Fixed unreachable `Nil` pattern using `@` binding syntax |

### Test Code
| File | Change |
|------|--------|
| `BatchPutSpec.scala` | Added `IterableOps` to existing suppression |
| `FillCommandSpec.scala` | Added `IterableOps` to existing suppression |
| `SortCommandSpec.scala` | Added `IterableOps` to existing suppression |
| `ClearCommandSpec.scala` | Added `IterableOps` + refactored `isInstanceOf` to pattern match |
| `StaxNamespaceRegressionSpec.scala` | Refactored to functional `Iterator.continually.takeWhile` style |
| `DependentRecalculationSpec.scala` | Added class-level suppression |
| `ExcelIOSpec.scala` | Replaced deprecated `writeFast` with `writeWith(..., WriterConfig.saxStax)` |

### Benchmark Code
| File | Change |
|------|--------|
| `SaxWriterBenchmark.scala` | Consolidated `OptionPartial` into existing suppression |

## Test plan

- [x] `./mill __.compile` — 0 warnings
- [x] `./mill __.checkFormat` — passes
- [x] `./mill __.test` — all 719 tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)