### PR TITLE
refactor(streaming): Rename writeStreamTrue to writeStream

### DIFF
--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -91,7 +91,7 @@ This document provides a comprehensive overview of what XL can and cannot do tod
 - In‑memory:
   - `Sheet.mergedRanges: Set[CellRange]` tracks merged regions.
   - `OoxmlWorksheet.toXml` emits `<mergeCells>` / `<mergeCell>` for those ranges.
-- Streaming write (`writeStreamTrue`, `writeStreamsSeqTrue`):
+- Streaming write (`writeStream`, `writeStreamsSeq`):
   - Only writes `sheetData` with plain rows and cells; no merged cell metadata is currently generated.
 
 **Impact**:
@@ -218,7 +218,7 @@ Color.Theme(ThemeSlot.Accent1, tint = 0.5)
 **Phase**: P6 (Future)
 
 **Current State**:
-- `writeStreamTrue` uses `type="inlineStr"` for all text cells
+- `writeStream` uses `type="inlineStr"` for all text cells
 - Each cell carries full string (no deduplication)
 - File size: ~2x larger for files with repeated strings
 
@@ -415,8 +415,8 @@ XlsxWriter.writeWith(workbook, path, WriterConfig.secure)
 // All text cells starting with =, +, -, @ are automatically escaped
 
 // Streaming writes also support formula injection escaping (TJC-339)
-excel.writeStreamTrue(path, "Sheet1", config = WriterConfig.secure)(rows)
-excel.writeStreamsSeqTrue(path, sheets, config = WriterConfig.secure)
+excel.writeStream(path, "Sheet1", config = WriterConfig.secure)(rows)
+excel.writeStreamsSeq(path, sheets, config = WriterConfig.secure)
 ```
 
 **Escaping Rules**:
@@ -477,7 +477,7 @@ excel.readStream(path).through(Codec[Person].decode)
 
 // Write: Stream[F, Person] → XLSX
 people.through(Codec[Person].encode)
-  .through(excel.writeStreamTrue(path, "People"))
+  .through(excel.writeStream(path, "People"))
 ```
 
 **Effort**: 7-10 days
@@ -547,7 +547,7 @@ val headerStyle = style"font-weight: bold; background: #CCCCCC; border: all thin
 
 **Current API**:
 ```scala
-excel.writeStreamsSeqTrue(
+excel.writeStreamsSeq(
   path,
   Seq("Sheet1" -> rows1, "Sheet2" -> rows2)  // Sequential consumption
 )
@@ -797,7 +797,7 @@ SAX parsing is inherently synchronous - the `parser.parse()` call blocks until t
 ### Q: How should I choose between streaming and in-memory?
 
 - **Need full styles/metadata or random access**: use in-memory read/write (`ExcelIO`).
-- **Need constant memory and sequential processing**: use streaming (`readStream`, `writeStreamTrue`); styles are minimal and strings are inline.
+- **Need constant memory and sequential processing**: use streaming (`readStream`, `writeStream`); styles are minimal and strings are inline.
 
 ---
 

--- a/docs/QUICK-START.md
+++ b/docs/QUICK-START.md
@@ -186,7 +186,7 @@ Stream.range(1, 1_000_001)
     0 -> CellValue.Text(s"Row $i"),
     1 -> CellValue.Number(BigDecimal(i))
   )))
-  .through(Excel.forIO.writeStreamTrue(path, "Data"))
+  .through(Excel.forIO.writeStream(path, "Data"))
   .compile.drain
   .unsafeRunSync()
 ```
@@ -409,7 +409,7 @@ import cats.effect.unsafe.implicits.global
 
 Stream.range(1, 1_000_001)
   .map(i => RowData(i, Map(0 -> CellValue.Text(s"Row $i"))))
-  .through(Excel.forIO.writeStreamTrue(path, "Data"))
+  .through(Excel.forIO.writeStream(path, "Data"))
   .compile.drain
   .unsafeRunSync()
 ```

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -59,7 +59,7 @@
 - ✅ Excel[F[_]] algebra trait
 - ✅ ExcelIO[IO] interpreter
 - ✅ `readStream` / `readSheetStream` / `readStreamByIndex` – constant‑memory streaming read (fs2.io.readInputStream + fs2‑data‑xml)
-- ✅ `writeStreamTrue` / `writeStreamsSeqTrue` – constant‑memory streaming write (fs2‑data‑xml)
+- ✅ `writeStream` / `writeStreamsSeq` – constant‑memory streaming write (fs2‑data‑xml)
 - ✅ **`writeFast`** – SAX/StAX streaming write (opt-in via `ExcelIO.writeFast()` or `WriterConfig(backend = XmlBackend.SaxStax)`)
 - ✅ Benchmark: 100k rows in ~1.8s read (~10MB constant memory) / ~1.1s write (~10MB constant memory)
 
@@ -174,7 +174,7 @@
 ### Streaming I/O Limitations (CRITICAL)
 
 **Write Path** (✅ Working):
-- ✅ True constant-memory streaming with `writeStreamTrue`
+- ✅ True constant-memory streaming with `writeStream`
 - ✅ O(1) memory regardless of file size
 - ⚠️  No SST support (inline strings only - larger files)
 - ⚠️  Minimal styles (default only - no rich formatting)

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -61,7 +61,7 @@ flowchart LR
   ExcelAPI -->|write(wb, path)| XW
 
   ExcelAPI -->|readStream / readSheetStream| SR
-  ExcelAPI -->|writeStreamTrue / writeStreamsSeqTrue| SW
+  ExcelAPI -->|writeStream / writeStreamsSeq| SW
 ```
 
 - **In‑memory path** (default):
@@ -71,7 +71,7 @@ flowchart LR
 
 - **Streaming path**:
   - `ExcelIO.readStream` / `readSheetStream` open the ZIP and stream a worksheet’s XML through fs2‑data‑xml, yielding a `Stream[F, RowData]` with constant memory use (SST is still materialized once if present).
-  - `ExcelIO.writeStreamTrue` / `writeStreamsSeqTrue` write static parts once, then stream worksheet XML events directly to a `ZipOutputStream` from a `Stream[F, RowData]` without ever materializing all rows.
+  - `ExcelIO.writeStream` / `writeStreamsSeq` write static parts once, then stream worksheet XML events directly to a `ZipOutputStream` from a `Stream[F, RowData]` without ever materializing all rows.
 
 See also:
 - `docs/design/io-modes.md` – deeper comparison of in-memory vs streaming modes.

--- a/docs/design/io-modes.md
+++ b/docs/design/io-modes.md
@@ -73,7 +73,7 @@ Characteristics:
 
 ### Streaming Path
 
-Write (`writeStreamTrue` / `writeStreamsSeqTrue`):
+Write (`writeStream` / `writeStreamsSeq`):
 - Static parts (`[Content_Types].xml`, workbook relationships, minimal `styles.xml`) are written once up front.
 - For each streamed `RowData`, `StreamingXmlWriter` emits XML events directly to a `ZipOutputStream` without building intermediate XML trees.
 - Output is compact XML with `Compression.Deflated` by default; by design it uses inline strings (no SST) and a minimal style set.
@@ -283,7 +283,7 @@ test("streaming write uses constant memory"):
 
   Stream.range(1, 1_000_001)
     .map(i => RowData(i, Map(0 -> CellValue.Number(i))))
-    .through(Excel.forIO.writeStreamTrue(path, "Data"))
+    .through(Excel.forIO.writeStream(path, "Data"))
     .compile.drain
     .unsafeRunSync()
 

--- a/docs/reference/migration-from-poi.md
+++ b/docs/reference/migration-from-poi.md
@@ -201,7 +201,7 @@ Stream.range(1, 1_000_001)
     0 -> CellValue.Text(s"Row $i"),
     1 -> CellValue.Number(BigDecimal(i * 100))
   )))
-  .through(Excel.forIO.writeStreamTrue(path, "Data"))
+  .through(Excel.forIO.writeStream(path, "Data"))
   .compile.drain
   .unsafeRunSync()
 

--- a/docs/reference/performance-guide.md
+++ b/docs/reference/performance-guide.md
@@ -79,7 +79,7 @@ Stream.range(1, 1_000_001)
     0 -> CellValue.Text(s"Row $i"),
     1 -> CellValue.Number(BigDecimal(i))
   )))
-  .through(excel.writeStreamTrue(path, "Data"))
+  .through(excel.writeStream(path, "Data"))
   .compile.drain
   .unsafeRunSync()
 
@@ -237,7 +237,7 @@ sheet.put(cells)  // Then write
 ```scala
 database.stream()  // fs2.Stream[IO, Row]
   .map(row => RowData(/* convert */))
-  .through(excel.writeStreamTrue(path, "Data"))
+  .through(excel.writeStream(path, "Data"))
   .compile.drain
   .unsafeRunSync()
 ```
@@ -430,7 +430,7 @@ import fs2.Stream
 
 Stream.range(1, 1_000_001)
   .map(i => RowData(i, Map(0 -> CellValue.Text(s"Row $i"))))
-  .through(Excel.forIO.writeStreamTrue(path, "Data"))
+  .through(Excel.forIO.writeStream(path, "Data"))
   .compile.drain
   .unsafeRunSync()
 ```

--- a/docs/reference/testing-guide.md
+++ b/docs/reference/testing-guide.md
@@ -101,7 +101,7 @@ xl-cats-effect/test/src/com/tjclp/xl/io/
 ### xl-cats-effect: 18 tests ✅
 
 #### Streaming I/O (18 tests)
-- **writeStreamTrue / writeStreamsSeqTrue**: Event-based ZIP write via fs2-data-xml
+- **writeStream / writeStreamsSeq**: Event-based ZIP write via fs2-data-xml
 - **readStream / readSheetStream / readStreamByIndex**: Event-based worksheet reads with fs2-data-xml + fs2.io.readInputStream
 - **Constant memory**: O(1) memory usage verified (100k rows @ ~50MB)
 - **Large files**: 100k+ row tests pass

--- a/examples/streaming_pressure_test.sc
+++ b/examples/streaming_pressure_test.sc
@@ -31,7 +31,7 @@ object StreamingPressureTest:
     val rowCount = 100_000
     val outputPath = testDir.resolve("streaming_100k.xlsx")
 
-    println(s"\n[Test 1] Writing $rowCount rows with writeStreamTrue...")
+    println(s"\n[Test 1] Writing $rowCount rows with writeStream...")
     val writeStart = System.currentTimeMillis()
 
     val rows: Stream[IO, RowData] = Stream
@@ -49,7 +49,7 @@ object StreamingPressureTest:
       }
 
     rows
-      .through(excel.writeStreamTrue(outputPath, "Data"))
+      .through(excel.writeStream(outputPath, "Data"))
       .compile
       .drain
       .unsafeRunSync()
@@ -98,7 +98,7 @@ object StreamingPressureTest:
           }
         )
       }
-      .through(excel.writeStreamTrue(transformPath, "Transformed"))
+      .through(excel.writeStream(transformPath, "Transformed"))
       .compile
       .drain
       .unsafeRunSync()


### PR DESCRIPTION
## Summary

**BREAKING CHANGE**: Streaming write API renamed for clarity

- `writeStreamTrue` → `writeStream` (true O(1) streaming)
- `writeStreamsSeqTrue` → `writeStreamsSeq`
- Old `writeStream` → `writeStreamMaterialized` (deprecated)

The previous `writeStream` was misleading - it materialized all rows before writing, defeating the purpose of streaming. The new naming makes the O(1) streaming method the default and deprecates the materializing version.

## Changes

- Excel.scala trait definitions updated
- ExcelIO.scala implementations updated  
- All docs and examples updated
- README streaming example now shows correct API
- Test suite updated (719 tests passing)

## Test plan

- [x] All 719 tests pass
- [x] `examples/readme_test.sc` validates README examples
- [x] `examples/streaming_pressure_test.sc` verifies O(1) memory with 100k rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)