### PR TITLE
fix(evaluator): Formula cell type + zero-arg ROW()/COLUMN()

### DIFF
--- a/xl-evaluator/src/com/tjclp/xl/formula/ast/TExprReferenceOps.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/ast/TExprReferenceOps.scala
@@ -9,20 +9,36 @@ import TExpr.*
 @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
 trait TExprReferenceOps:
   /**
-   * Create ROW expression.
+   * Create ROW expression with a cell reference argument.
    *
    * Example: TExpr.row(TExpr.PolyRef(ref"A5", Anchor.Relative))
    */
   def row(ref: TExpr[?]): TExpr[BigDecimal] =
-    Call(FunctionSpecs.row, ref.asInstanceOf[TExpr[Any]])
+    Call(FunctionSpecs.row, Some(ref.asInstanceOf[TExpr[Any]]))
 
   /**
-   * Create COLUMN expression.
+   * Create ROW expression with no arguments (returns row of current cell).
+   *
+   * Example: TExpr.row() in cell B5 returns 5
+   */
+  def row(): TExpr[BigDecimal] =
+    Call(FunctionSpecs.row, None)
+
+  /**
+   * Create COLUMN expression with a cell reference argument.
    *
    * Example: TExpr.column(TExpr.PolyRef(ref"C1", Anchor.Relative))
    */
   def column(ref: TExpr[?]): TExpr[BigDecimal] =
-    Call(FunctionSpecs.column, ref.asInstanceOf[TExpr[Any]])
+    Call(FunctionSpecs.column, Some(ref.asInstanceOf[TExpr[Any]]))
+
+  /**
+   * Create COLUMN expression with no arguments (returns column of current cell).
+   *
+   * Example: TExpr.column() in cell C5 returns 3
+   */
+  def column(): TExpr[BigDecimal] =
+    Call(FunctionSpecs.column, None)
 
   /**
    * Create ROWS expression.

--- a/xl-evaluator/src/com/tjclp/xl/formula/eval/SheetEvaluator.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/eval/SheetEvaluator.scala
@@ -67,7 +67,8 @@ object SheetEvaluator:
     def evaluateFormula(
       formula: String,
       clock: Clock = Clock.system,
-      workbook: Option[Workbook] = None
+      workbook: Option[Workbook] = None,
+      currentCell: Option[ARef] = None
     ): XLResult[CellValue] =
       for
         // Parse formula string to TExpr AST
@@ -83,7 +84,7 @@ object SheetEvaluator:
 
         // Evaluate TExpr against sheet
         result <- Evaluator.instance
-          .eval(expr, sheet, clock, workbook)
+          .eval(expr, sheet, clock, workbook, currentCell)
           .left
           .map(evalError => evalErrorToXLError(evalError, Some(formula)))
 
@@ -124,7 +125,8 @@ object SheetEvaluator:
       val cell = sheet(ref)
       cell.value match
         case CellValue.Formula(expr, _) =>
-          evaluateFormula(expr, clock, workbook)
+          // Pass the current cell ref for ROW()/COLUMN() without arguments
+          evaluateFormula(expr, clock, workbook, Some(ref))
         case other =>
           scala.util.Right(other)
 

--- a/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpec.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpec.scala
@@ -6,6 +6,7 @@ import com.tjclp.xl.formula.parser.ParseError
 import com.tjclp.xl.formula.{Clock, Arity}
 
 import com.tjclp.xl.CellRange
+import com.tjclp.xl.addressing.ARef
 import com.tjclp.xl.cells.CellValue
 import com.tjclp.xl.sheets.Sheet
 import com.tjclp.xl.workbooks.Workbook
@@ -28,7 +29,9 @@ final case class EvalContext(
   sheet: Sheet,
   clock: Clock,
   workbook: Option[Workbook],
-  evalExpr: [A] => TExpr[A] => Either[EvalError, A]
+  evalExpr: [A] => TExpr[A] => Either[EvalError, A],
+  /** Current cell being evaluated. Used by ROW() and COLUMN() with no arguments. */
+  currentCell: Option[ARef] = None
 )
 
 sealed trait ArgValue

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/DirectSaxEmitter.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/DirectSaxEmitter.scala
@@ -307,11 +307,17 @@ object DirectSaxEmitter:
         ("n", CellValue.Number(BigDecimal(serial)))
 
       case CellValue.Formula(_, cachedValue) =>
+        // Cell type is determined by cached value type.
+        // When no cached value exists, omit type attribute (empty string)
+        // to let Excel infer the type. Using "str" for formulas without
+        // cached values causes Excel to show a corruption warning.
         val cType = cachedValue match
           case Some(CellValue.Number(_)) => "n"
           case Some(CellValue.Bool(_)) => "b"
           case Some(CellValue.Error(_)) => "e"
-          case _ => "str"
+          case Some(CellValue.Text(_)) => "str"
+          case Some(CellValue.DateTime(_)) => "n"
+          case _ => "" // No type attr - Excel infers
         (cType, value)
 
       case CellValue.Error(_) => ("e", value)

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/OoxmlWorksheet.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/OoxmlWorksheet.scala
@@ -318,12 +318,17 @@ object OoxmlWorksheet extends com.tjclp.xl.ooxml.XmlReadable[OoxmlWorksheet]:
             val serial = com.tjclp.xl.cells.CellValue.dateTimeToExcelSerial(dt)
             ("n", com.tjclp.xl.cells.CellValue.Number(BigDecimal(serial)))
           case com.tjclp.xl.cells.CellValue.Formula(_, cachedValue) =>
-            // Use cached value's type if available, otherwise "str"
+            // Cell type determined by cached value. When no cached value,
+            // omit type attribute (empty string) to let Excel infer.
+            // Using "str" for formulas without cached values causes
+            // Excel to show a corruption warning.
             val cellType = cachedValue match
               case Some(com.tjclp.xl.cells.CellValue.Number(_)) => "n"
               case Some(com.tjclp.xl.cells.CellValue.Bool(_)) => "b"
               case Some(com.tjclp.xl.cells.CellValue.Error(_)) => "e"
-              case _ => "str"
+              case Some(com.tjclp.xl.cells.CellValue.Text(_)) => "str"
+              case Some(com.tjclp.xl.cells.CellValue.DateTime(_)) => "n"
+              case _ => "" // No type attr
             (cellType, cell.value)
           case com.tjclp.xl.cells.CellValue.Error(_) => ("e", cell.value)
           case com.tjclp.xl.cells.CellValue.Empty => ("", cell.value)


### PR DESCRIPTION
## Summary

This PR addresses three issues discovered during SpreadsheetBench task 52292 dogfooding:

- **Fix Excel corruption warning**: Formulas without cached values were written with `t="str"` causing Excel to show a recovery dialog. Now omits type attribute so Excel infers correctly.
- **Add zero-argument ROW()/COLUMN()**: Excel allows `=ROW()` and `=COLUMN()` without arguments to return the row/column of the containing cell. Now supported.
- **Fix currentCell propagation**: Updated all recursive eval() calls to pass currentCell, enabling compound formulas like `=ROW()+COLUMN()`.

## Test plan

- [x] Added 14 new tests covering zero-arg forms, parser round-trip, and integration via `evaluateCell`
- [x] Added regression test for formula cell type in `DirectSaxEmitterParitySpec`
- [x] All 719 existing tests pass
- [x] Manual verification with `xl` CLI confirms `=ROW()` and `=COLUMN()` work correctly

## Files changed

| Module | Files | Changes |
|--------|-------|---------|
| xl-ooxml | DirectSaxEmitter.scala, OoxmlWorksheet.scala | Fix formula cell type |
| xl-evaluator | FunctionSpec.scala, Evaluator.scala, SheetEvaluator.scala | Add currentCell to EvalContext |
| xl-evaluator | FunctionSpecsReference.scala, TExprReferenceOps.scala | Zero-arg ROW/COLUMN |
| tests | ReferenceFunctionsSpec.scala, DirectSaxEmitterParitySpec.scala | New tests |

🤖 Generated with [Claude Code](https://claude.ai/claude-code)