### PR TITLE
chore: Eliminate WartRemover warnings across codebase

### DIFF
--- a/xl-cats-effect/src/com/tjclp/xl/io/StreamingXmlWriter.scala
+++ b/xl-cats-effect/src/com/tjclp/xl/io/StreamingXmlWriter.scala
@@ -21,6 +21,8 @@ import com.tjclp.xl.ooxml.{FormulaInjectionPolicy, XmlUtil}
  *   bounds.dimension // Option[CellRange] with tracked extent
  *   }}}
  */
+// Mutable accumulator for O(1) memory bounds tracking during streaming
+@SuppressWarnings(Array("org.wartremover.warts.Var"))
 final class BoundsAccumulator:
   private var minRow: Int = Int.MaxValue
   private var maxRow: Int = Int.MinValue
@@ -34,6 +36,8 @@ final class BoundsAccumulator:
    * @param row
    *   Row data with 1-based rowIndex and 0-based column keys in cells map
    */
+  // IterableOps: .min/.max safe because row.cells.nonEmpty checked first
+  @SuppressWarnings(Array("org.wartremover.warts.IterableOps"))
   def update(row: RowData): Unit =
     if row.cells.nonEmpty then
       hasData = true

--- a/xl-cats-effect/src/com/tjclp/xl/io/streaming/StylePatcher.scala
+++ b/xl-cats-effect/src/com/tjclp/xl/io/streaming/StylePatcher.scala
@@ -44,7 +44,7 @@ object StylePatcher:
    * @return
    *   XLResult containing (updated styles.xml content, Map[identifier -> new cellXf index])
    */
-  @SuppressWarnings(Array("org.wartremover.warts.Var"))
+  @SuppressWarnings(Array("org.wartremover.warts.Var", "org.wartremover.warts.While"))
   def addStyles[K](
     stylesXml: String,
     newStyles: Map[K, CellStyle]

--- a/xl-cli/src/com/tjclp/xl/cli/commands/StreamingWriteCommands.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/commands/StreamingWriteCommands.scala
@@ -807,6 +807,8 @@ object StreamingWriteCommands:
 
             if sheets.isEmpty then throw new Exception("Workbook has no sheets")
 
+            // IterableOps: .head safe because sheets.isEmpty checked above and size>1 throws
+            @SuppressWarnings(Array("org.wartremover.warts.IterableOps"))
             val targetSheet = sheetNameOpt match
               case None =>
                 if sheets.size > 1 then

--- a/xl-cli/test/src/com/tjclp/xl/cli/EvalCommandSpec.scala
+++ b/xl-cli/test/src/com/tjclp/xl/cli/EvalCommandSpec.scala
@@ -18,9 +18,11 @@ import com.tjclp.xl.macros.ref
  * example, if A1=100, B1=A1*2, C1=B1+50, then `eval "=C1" --with "A1=200"` should return 450 (not
  * 250).
  */
+// Test code uses .get/.head for brevity in assertions
 @SuppressWarnings(
   Array(
-    "org.wartremover.warts.OptionPartial"
+    "org.wartremover.warts.OptionPartial",
+    "org.wartremover.warts.IterableOps"
   )
 )
 class EvalCommandSpec extends CatsEffectSuite:

--- a/xl-cli/test/src/com/tjclp/xl/cli/StreamingWriteSpec.scala
+++ b/xl-cli/test/src/com/tjclp/xl/cli/StreamingWriteSpec.scala
@@ -32,8 +32,14 @@ import com.tjclp.xl.styles.font.Font
  *   - Hybrid streaming: Load workbook → mutate → stream output (O(1) output memory)
  *   - True streaming: CSV → XLSX with O(1) memory throughout (for --new-sheet)
  */
+// Test uses imperative zip manipulation for test fixtures
 @SuppressWarnings(
-  Array("org.wartremover.warts.OptionPartial", "org.wartremover.warts.IterableOps")
+  Array(
+    "org.wartremover.warts.OptionPartial",
+    "org.wartremover.warts.IterableOps",
+    "org.wartremover.warts.Var",
+    "org.wartremover.warts.While"
+  )
 )
 class StreamingWriteSpec extends FunSuite:
 

--- a/xl-evaluator/src/com/tjclp/xl/formula/ast/TExprAnalysis.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/ast/TExprAnalysis.scala
@@ -128,7 +128,9 @@ trait TExprAnalysis:
    * @return
    *   New expression with transformed ranges
    */
+  // GADT type erasure requires asInstanceOf; @nowarn for exhaustive pattern match false positives
   @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+  @annotation.nowarn("msg=Unreachable case")
   def transformRanges[A](expr: TExpr[A], f: (Option[SheetName], CellRange) => CellRange): TExpr[A] =
     (expr match
       case RangeRef(range) => RangeRef(f(None, range))

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/ArrayArithmeticSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/ArrayArithmeticSpec.scala
@@ -9,6 +9,8 @@ import com.tjclp.xl.formula.eval.SheetEvaluator.*
 import com.tjclp.xl.sheets.Sheet
 import com.tjclp.xl.syntax.*
 
+// Test code uses .get/.head for brevity in assertions
+@SuppressWarnings(Array("org.wartremover.warts.OptionPartial", "org.wartremover.warts.IterableOps"))
 class ArrayArithmeticSpec extends FunSuite:
 
   // ========== Broadcasting Unit Tests ==========

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/ArrayFunctionsSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/ArrayFunctionsSpec.scala
@@ -10,6 +10,8 @@ import com.tjclp.xl.patch.Patch
 import com.tjclp.xl.sheets.Sheet
 import com.tjclp.xl.syntax.*
 
+// Test code uses .get/.head for brevity in assertions
+@SuppressWarnings(Array("org.wartremover.warts.OptionPartial", "org.wartremover.warts.IterableOps"))
 class ArrayFunctionsSpec extends FunSuite:
 
   // ========== ArrayResult Tests ==========

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/RangeTransformSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/RangeTransformSpec.scala
@@ -4,6 +4,8 @@ import munit.FunSuite
 import com.tjclp.xl.*
 import com.tjclp.xl.formula.ast.TExpr
 
+// Test code uses .get for brevity in assertions (guarded by isDefined check)
+@SuppressWarnings(Array("org.wartremover.warts.OptionPartial"))
 class RangeTransformSpec extends FunSuite:
 
   test("collectRanges extracts ranges from SUMPRODUCT array expression") {

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/DirectSaxEmitterParitySpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/DirectSaxEmitterParitySpec.scala
@@ -11,6 +11,8 @@ import com.tjclp.xl.richtext.RichText.*
 import com.tjclp.xl.sheets.{ColumnProperties, RowProperties, Sheet}
 // DirectSaxEmitter is in the same package
 
+// Test code uses .get/.head for brevity in assertions
+@SuppressWarnings(Array("org.wartremover.warts.OptionPartial", "org.wartremover.warts.IterableOps"))
 class DirectSaxEmitterParitySpec extends FunSuite:
 
   test("direct SAX emission matches worksheet XML structure") {

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/XlsxWriterCorruptionRegressionSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/XlsxWriterCorruptionRegressionSpec.scala
@@ -32,7 +32,8 @@ import munit.FunSuite
  *   - e1f36fe: Row attribute preservation
  *   - 802e020: SST handling (9 fixes)
  */
-@SuppressWarnings(Array("org.wartremover.warts.OptionPartial"))
+// Test code uses .get/.head for brevity in assertions
+@SuppressWarnings(Array("org.wartremover.warts.OptionPartial", "org.wartremover.warts.IterableOps"))
 class XlsxWriterCorruptionRegressionSpec extends FunSuite:
 
   test("preserves mc:Ignorable namespace attribute on workbook root (PRIMARY corruption fix)") {

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/metadata/WorkbookMetadataReaderSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/metadata/WorkbookMetadataReaderSpec.scala
@@ -8,6 +8,8 @@ import com.tjclp.xl.{*, given}
 import com.tjclp.xl.addressing.{ARef, SheetName}
 import com.tjclp.xl.ooxml.XlsxWriter
 
+// Test code uses .get/.head for brevity in assertions
+@SuppressWarnings(Array("org.wartremover.warts.OptionPartial", "org.wartremover.warts.IterableOps"))
 class WorkbookMetadataReaderSpec extends FunSuite:
 
   // Helper to create a temp xlsx file with given sheets


### PR DESCRIPTION
## Summary

- Eliminate all WartRemover compile-time warnings across production and test code
- Replace imperative `return` statements with idiomatic Scala 3 `boundary`/`break` pattern
- Add appropriate suppressions for test code that legitimately uses `.get`/`.head` for assertion brevity

## Changes

**Production code:**
- `TExprAnalysis`: Add `@nowarn` for GADT unreachable case false positive
- `StreamingXmlWriter`: Add Var/IterableOps suppression for `BoundsAccumulator`
- `StylePatcher`: Add While to existing Var suppression
- `StreamingReadCommands`: Replace `.head` with pattern match, convert to boundary/break
- `StreamingWriteCommands`: Add IterableOps suppression with safety comment
- `StreamingCsvParser`: Use boundary/break for early returns, add suppressions

**Test code suppressions** (OptionPartial, IterableOps):
- ArrayArithmeticSpec, ArrayFunctionsSpec, RangeTransformSpec
- DirectSaxEmitterParitySpec, WorkbookMetadataReaderSpec
- EvalCommandSpec, StreamingWriteSpec, XlsxWriterCorruptionRegressionSpec

## Test plan

- [x] `./mill __.compile` - no warnings
- [x] `./mill __.test` - all tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)