### PR TITLE
feat(evaluator): Add parser support for quoted sheet names (TJC-360)

### DIFF
--- a/xl-evaluator/src/com/tjclp/xl/formula/printer/FormulaPrinter.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/printer/FormulaPrinter.scala
@@ -193,7 +193,7 @@ object FormulaPrinter:
     location match
       case TExpr.RangeLocation.Local(range) => formatRange(range)
       case TExpr.RangeLocation.CrossSheet(sheet, range) =>
-        s"${sheet.value}!${formatRange(range)}"
+        s"${formatSheetName(sheet)}!${formatRange(range)}"
 
   /**
    * Format ARef to A1 notation with anchor support.


### PR DESCRIPTION
## Summary

- Add `parseQuotedSheetRef()` to handle `'Sheet-Name'!A1` syntax in formulas
- Fix `formatLocation()` in FormulaPrinter to properly quote sheet names with special characters
- Enable 4 previously ignored tests in CrossSheetFormulaSpec

## Supported Syntax

| Pattern | Example |
|---------|---------|
| Spaces | `'Q1 Report'!A1` |
| Hyphens | `'Debt-Schedule'!H29` |
| Special chars | `'Sales&Marketing'!A1` |
| Escaped quotes | `'O''Brien''s Data'!A1` |
| Digit prefix | `'2024Q1'!A1` |

## Test plan

- [x] All CrossSheetFormulaSpec tests pass (90+)
- [x] Full xl-evaluator test suite passes
- [x] Manual test with Shortcut-generated LBO model (`'Debt-Schedule'!H29` formulas now parse)

## Context

This was discovered when testing Shortcut's LBO model builder output - formulas with hyphenated sheet names like `'Debt-Schedule'!H29` failed to evaluate. The parser now handles all quoted sheet name variants per Excel spec.

🤖 Generated with [Claude Code](https://claude.ai/code)