### PR TITLE
chore(release): Bump version to 0.9.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.9.7] - 2026-04-15
+
+### Added
+
+- **`formula` alias for `putf` batch ops + `--dry-run` flag** (#224)
+  - Batch JSON `putf` operations now accept `"formula"` as an alias for `"value"`, matching natural user intent
+  - New `--dry-run` flag validates batch JSON without reading or writing files
+
+### Fixed
+
+- **Resolve worksheet paths via workbook relationships** (#226, GH-225)
+  - Streaming reader now resolves worksheet paths from `xl/workbook.xml.rels` instead of assuming `xl/worksheets/sheet{N}.xml` naming convention
+  - Fixes failures on workbooks with non-standard worksheet paths (e.g., files produced by third-party tools)
+
+---
+
 ## [0.9.6] - 2026-02-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ```scala 3 raw
 //> using scala 3.7.4
-//> using dep com.tjclp::xl:0.9.6
+//> using dep com.tjclp::xl:0.9.7
 
 import com.tjclp.xl.{*, given}
 
@@ -55,13 +55,13 @@ import com.tjclp.xl.{*, given}
 
 ```scala 3 ignore
 // build.mill — single dependency for everything
-def ivyDeps = Agg(ivy"com.tjclp::xl:0.9.6")
+def ivyDeps = Agg(ivy"com.tjclp::xl:0.9.7")
 
 // Or individual modules for minimal footprint:
-// ivy"com.tjclp::xl-core:0.9.6"        — Pure domain model only
-// ivy"com.tjclp::xl-ooxml:0.9.6"       — Add OOXML read/write
-// ivy"com.tjclp::xl-cats-effect:0.9.6" — Add IO streaming
-// ivy"com.tjclp::xl-evaluator:0.9.6"   — Add formula evaluation
+// ivy"com.tjclp::xl-core:0.9.7"        — Pure domain model only
+// ivy"com.tjclp::xl-ooxml:0.9.7"       — Add OOXML read/write
+// ivy"com.tjclp::xl-cats-effect:0.9.7" — Add IO streaming
+// ivy"com.tjclp::xl-evaluator:0.9.7"   — Add formula evaluation
 ```
 
 ### Basic Usage

--- a/build.mill
+++ b/build.mill
@@ -67,7 +67,7 @@ trait XLModule extends XLModuleBase with PublishModule {
 
   /** Version derived from PUBLISH_VERSION env var (set by CI), or SNAPSHOT for local dev */
   override def publishVersion: T[String] =
-    sys.env.getOrElse("PUBLISH_VERSION", "0.9.6")
+    sys.env.getOrElse("PUBLISH_VERSION", "0.9.7")
 
   override def pomSettings: T[PomSettings] = PomSettings(
     description = artifactDescription,

--- a/docs/QUICK-START.md
+++ b/docs/QUICK-START.md
@@ -12,19 +12,19 @@ import mill._, scalalib._
 
 object myproject extends ScalaModule {
   def scalaVersion = "3.7.4"
-  def ivyDeps = Agg(ivy"com.tjclp::xl:0.9.6")
+  def ivyDeps = Agg(ivy"com.tjclp::xl:0.9.7")
 }
 ```
 
 ### With sbt (build.sbt)
 ```scala
 scalaVersion := "3.7.4"
-libraryDependencies += "com.tjclp" %% "xl" % "0.9.6"
+libraryDependencies += "com.tjclp" %% "xl" % "0.9.7"
 ```
 
 ### With Scala CLI
 ```scala
-//> using dep com.tjclp::xl:0.9.6
+//> using dep com.tjclp::xl:0.9.7
 ```
 
 ### Individual Modules (Optional)

--- a/examples/README.md
+++ b/examples/README.md
@@ -141,4 +141,4 @@ chmod +x examples/my_example.sc
 ./examples/my_example.sc
 ```
 
-The `project.scala` file centralizes dependencies (`com.tjclp::xl:0.9.6`) for all examples.
+The `project.scala` file centralizes dependencies (`com.tjclp::xl:0.9.7`) for all examples.

--- a/examples/project.scala
+++ b/examples/project.scala
@@ -2,4 +2,4 @@
 //> using repository ivy2Local
 
 // XL aggregate - includes all modules (core, ooxml, cats-effect, evaluator)
-//> using dep com.tjclp::xl:0.9.6
+//> using dep com.tjclp::xl:0.9.7

--- a/xl-core/src/com/tjclp/xl/workbooks/WorkbookMetadata.scala
+++ b/xl-core/src/com/tjclp/xl/workbooks/WorkbookMetadata.scala
@@ -16,7 +16,7 @@ final case class WorkbookMetadata(
   modified: Option[java.time.LocalDateTime] = None,
   lastModifiedBy: Option[String] = None,
   application: Option[String] = Some("XL - Pure Scala 3.7 Excel Library"),
-  appVersion: Option[String] = Some("0.9.6"),
+  appVersion: Option[String] = Some("0.9.7"),
   theme: ThemePalette = ThemePalette.office,
   definedNames: Vector[DefinedName] = Vector.empty,
   sheetStates: Map[SheetName, Option[String]] = Map.empty


### PR DESCRIPTION
## Summary

- Bump all version references from 0.9.6 → 0.9.7 across build, docs, and metadata
- Add CHANGELOG entry for 0.9.7 with 2 changes since 0.9.6:
  - **feat**: `"formula"` alias for `putf` batch ops + `--dry-run` flag (#224)
  - **fix**: Resolve worksheet paths via workbook relationships (#226, GH-225)

## Files changed

- `build.mill` — publish version fallback
- `xl-core/.../WorkbookMetadata.scala` — appVersion
- `README.md` — hero example + ivyDeps
- `docs/QUICK-START.md` — Mill, sbt, Scala CLI examples
- `examples/project.scala` — aggregate dependency
- `examples/README.md` — dependency reference
- `CHANGELOG.md` — new 0.9.7 section

## Test plan

- [x] `./mill __.compile` passes (705/705)
- [x] `./mill __.test` passes (837 tasks)
- [x] No stale 0.9.6 or SNAPSHOT references remain
- [ ] After merge: create annotated tag `v0.9.7` and push to trigger release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)