### PR TITLE
feat(cli): Copy, freeze/unfreeze, in-place edit, CSV auto-split (#124, #130, #135, #186)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,7 +230,7 @@ xl -f huge.xlsx --max-size 0 sheets      # Disable limits
 xl -f huge.xlsx --max-size 500 cell A1   # 500MB limit
 ```
 
-**Streaming limitations**: HTML/SVG/PDF need styles (use --max-size instead). Cell details, formula eval, and writes require full workbook load.
+**Streaming limitations**: HTML/SVG/PDF need styles (use --max-size instead). Cell details, formula eval, writes, and `put --csv` auto-split require full workbook load.
 
 See `docs/design/smart-streaming.md` for future enhancements.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -270,7 +270,7 @@ echo '[{"op":"add-sheet","name":"Summary","after":"Sheet1"}]' | xl ...
 echo '[{"op":"rename-sheet","from":"Old","to":"New"}]' | xl ...
 ```
 
-**All 17 batch operations**: `put`, `putf`, `style`, `merge`, `unmerge`, `colwidth`, `rowheight`, `comment`, `remove-comment`, `clear`, `col-hide`, `col-show`, `row-hide`, `row-show`, `autofit`, `add-sheet`, `rename-sheet`
+**All 20 batch operations**: `put`, `putf`, `style`, `merge`, `unmerge`, `colwidth`, `rowheight`, `comment`, `remove-comment`, `clear`, `col-hide`, `col-show`, `row-hide`, `row-show`, `autofit`, `add-sheet`, `rename-sheet`, `freeze`, `unfreeze`, `copy`
 
 **Common mistake**: Using unqualified range without `--sheet`:
 ```bash

--- a/build.mill
+++ b/build.mill
@@ -13,6 +13,9 @@ val organization = "com.tjclp"
 
 /** Shared build configuration constants */
 object BuildConfig {
+  /** Project version: CI sets PUBLISH_VERSION; local builds use this fallback */
+  val version: String = sys.env.getOrElse("PUBLISH_VERSION", "0.9.7")
+
   /** JVM options to silence Scala 3 LazyVals sun.misc.Unsafe deprecation warnings (JDK 21+) */
   val lazyValsJvmArgs: Seq[String] = Seq(
     "--add-opens=java.base/sun.misc=ALL-UNNAMED",
@@ -65,9 +68,8 @@ trait XLModuleBase extends ScalaModule with ScalafmtModule {
 /** Trait for publishable library modules - publishes to Maven Central via Sonatype */
 trait XLModule extends XLModuleBase with PublishModule {
 
-  /** Version derived from PUBLISH_VERSION env var (set by CI), or SNAPSHOT for local dev */
-  override def publishVersion: T[String] =
-    sys.env.getOrElse("PUBLISH_VERSION", "0.9.7")
+  /** Version derived from PUBLISH_VERSION env var (set by CI), or fallback from BuildConfig */
+  override def publishVersion: T[String] = BuildConfig.version
 
   override def pomSettings: T[PomSettings] = PomSettings(
     description = artifactDescription,

--- a/plugin/skills/xl-cli/SKILL.md
+++ b/plugin/skills/xl-cli/SKILL.md
@@ -246,11 +246,11 @@ xl ... put A1:A10 "TBD"
 # Batch values (row-major order)
 xl ... put A1:D1 "Q1" "Q2" "Q3" "Q4"
 
-# CSV auto-split (comma-separated values distributed across range)
-xl ... put A1:D1 "Q1,Q2,Q3,Q4"
+# CSV split (opt-in: requires --csv flag)
+xl ... put A1:D1 "Q1,Q2,Q3,Q4" --csv
 ```
 
-**CSV auto-split**: When a single value contains commas and the count matches the range size, values are automatically distributed. Smart type detection applies to each split value.
+**`--csv`**: Opt-in flag that splits a single comma-separated value across the target range. Required because comma-containing values are common in real data (`"Smith, John"`); without `--csv`, the value is written as literal text. The split count must match the range size exactly, otherwise the command errors. Smart type detection applies to each split value.
 
 **Negative numbers**: Use `--value` flag (bare `-` is interpreted as flag):
 ```bash
@@ -566,7 +566,7 @@ Run `xl view --help` for complete options.
 
 | Command | Key Options |
 |---------|-------------|
-| `put <ref> <values>` | `--value` for negatives, `--stream` for O(1) memory, CSV auto-split |
+| `put <ref> <values>` | `--value` for negatives, `--stream` for O(1) memory, `--csv` to split comma-separated value |
 | `putf <ref> <formulas>` | Supports dragging (no dragging with `--stream`) |
 | `style <range>` | `--bold`, `--bg`, `--fg`, `--format`, `--border`, `--stream` for O(1) memory |
 | `copy <source> <target>` | `--values-only` (no formula adjustment) |

--- a/plugin/skills/xl-cli/SKILL.md
+++ b/plugin/skills/xl-cli/SKILL.md
@@ -511,7 +511,7 @@ xl -f huge.xlsx --max-size 500 cell A1    # Custom 500MB limit
 
 **Streaming supports**: search, stats, bounds, view (markdown/csv/json), put, putf, style
 
-**Requires in-memory**: cell (dependencies), eval (formulas), HTML/SVG/PDF (styles), formula dragging
+**Requires in-memory**: cell (dependencies), eval (formulas), HTML/SVG/PDF (styles), formula dragging, `put --csv` (CSV auto-split)
 
 ---
 

--- a/plugin/skills/xl-cli/SKILL.md
+++ b/plugin/skills/xl-cli/SKILL.md
@@ -89,11 +89,15 @@ xl -f <file> -s <sheet> view <range> --eval       # Computed values
 
 **Note**: `--eval` may show formula text instead of computed values for cells with deep multi-hop cross-sheet formula dependencies. The xlsx file will compute correctly when opened in Excel.
 
-### Write Operations (require `-o`)
+### Write Operations (require `-o` or `-i`)
 ```bash
 xl -f <file> -s <sheet> -o <out> put <ref> <value>
+xl -f <file> -s <sheet> -i put <ref> <value>         # In-place edit (no -o needed)
 xl -f <file> -s <sheet> -o <out> putf <ref> <formula>
 xl -f <file> -s <sheet> -o <out> style <range> --bold --bg yellow
+xl -f <file> -s <sheet> -o <out> copy <source> <target>  # Range copy with formula shift
+xl -f <file> -s <sheet> -o <out> freeze <ref>         # Freeze panes
+xl -f <file> -s <sheet> -o <out> unfreeze             # Remove freeze panes
 xl -f <file> -o <out> import <csv-file> --new-sheet "Data"
 ```
 
@@ -241,7 +245,12 @@ xl ... put A1:A10 "TBD"
 
 # Batch values (row-major order)
 xl ... put A1:D1 "Q1" "Q2" "Q3" "Q4"
+
+# CSV auto-split (comma-separated values distributed across range)
+xl ... put A1:D1 "Q1,Q2,Q3,Q4"
 ```
+
+**CSV auto-split**: When a single value contains commas and the count matches the range size, values are automatically distributed. Smart type detection applies to each split value.
 
 **Negative numbers**: Use `--value` flag (bare `-` is interpreted as flag):
 ```bash
@@ -422,7 +431,15 @@ echo '[{"op":"putf","ref":"A1","formula":"=SUM(B1:B10)"},{"op":"style","range":"
 echo '[{"op":"put","ref":"A1","value":"test"}]' | xl -f in.xlsx -o out.xlsx batch --dry-run -
 ```
 
-**All batch operations**: `put`, `putf`, `style`, `merge`, `unmerge`, `colwidth`, `rowheight`, `comment`, `remove-comment`, `clear`, `col-hide`, `col-show`, `row-hide`, `row-show`, `autofit`, `add-sheet`, `rename-sheet`
+**All batch operations** (20): `put`, `putf`, `style`, `merge`, `unmerge`, `colwidth`, `rowheight`, `comment`, `remove-comment`, `clear`, `col-hide`, `col-show`, `row-hide`, `row-show`, `autofit`, `add-sheet`, `rename-sheet`, `freeze`, `unfreeze`, `copy`
+
+**Freeze/unfreeze/copy in batch:**
+```json
+{"op": "freeze", "ref": "B2"}
+{"op": "unfreeze"}
+{"op": "copy", "source": "A1:D10", "target": "F1"}
+{"op": "copy", "source": "A1:D10", "target": "F1", "valuesOnly": true}
+```
 
 ### CSV to Styled Table
 
@@ -507,6 +524,7 @@ xl -f huge.xlsx --max-size 500 cell A1    # Custom 500MB limit
 | `--file <path>` | `-f` | Input file (required) |
 | `--sheet <name>` | `-s` | Sheet name |
 | `--output <path>` | `-o` | Output file (for writes) |
+| `--in-place` | `-i` | Edit file in-place (mutually exclusive with `-o`) |
 | `--backend <type>` | | Write backend: scalaxml (default) or saxstax (36-39% faster). Reads always use StAX. |
 | `--max-size <MB>` | | Override 100MB security limit (0 = unlimited) |
 | `--stream` | | O(1) memory mode for reads + writes (search/stats/bounds/view/put/putf/style) |
@@ -548,10 +566,13 @@ Run `xl view --help` for complete options.
 
 | Command | Key Options |
 |---------|-------------|
-| `put <ref> <values>` | `--value` for negatives, `--stream` for O(1) memory |
+| `put <ref> <values>` | `--value` for negatives, `--stream` for O(1) memory, CSV auto-split |
 | `putf <ref> <formulas>` | Supports dragging (no dragging with `--stream`) |
 | `style <range>` | `--bold`, `--bg`, `--fg`, `--format`, `--border`, `--stream` for O(1) memory |
-| `batch <json-file>` | 17 operations (see below) |
+| `copy <source> <target>` | `--values-only` (no formula adjustment) |
+| `freeze <ref>` | Freeze panes (rows above + columns left of ref) |
+| `unfreeze` | Remove freeze panes |
+| `batch <json-file>` | 20 operations (see below) |
 | `import <csv> [ref]` | `--new-sheet`, `--delimiter`, `--no-type-inference` |
 
 Run `xl <command> --help` for complete options.
@@ -574,6 +595,9 @@ Run `xl <command> --help` for complete options.
 |---------|---------|
 | `merge <range>` | |
 | `unmerge <range>` | |
+| `copy <source> <target>` | `--values-only` |
+| `freeze <ref>` | Rows above + columns left of ref are locked |
+| `unfreeze` | |
 | `comment <ref> <text>` | `--author` |
 | `remove-comment <ref>` | |
 | `clear <range>` | `--all`, `--styles`, `--comments` |

--- a/xl-cli/package.mill
+++ b/xl-cli/package.mill
@@ -23,11 +23,10 @@ object `package` extends build.XLInternalModule with NativeImageModule {
   override def mainClass = Some("com.tjclp.xl.cli.Main")
 
   // Generate version.properties resource at build time
-  // Reads PUBLISH_VERSION env var (set by CI), or defaults to "dev" for local builds
+  // Uses shared BuildConfig.version (CI sets PUBLISH_VERSION, local uses build.mill fallback)
   def generatedVersionResource: T[PathRef] = Task {
-    val version = Task.env.getOrElse("PUBLISH_VERSION", "dev")
     val dest = Task.dest / "version.properties"
-    os.write(dest, s"version=$version\n")
+    os.write(dest, s"version=${build.BuildConfig.version}\n")
     PathRef(Task.dest)
   }
 

--- a/xl-cli/src/com/tjclp/xl/cli/Command.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/Command.scala
@@ -103,6 +103,11 @@ enum CliCommand:
   case Fill(source: String, target: String, direction: FillDirection)
   case AutoFit(columns: Option[String]) // None = all used columns, Some("A:F") = specific range
   case Sort(range: String, sortKeys: List[SortKey], hasHeader: Boolean)
+  // View operations (require -o)
+  case Freeze(ref: String) // Freeze panes at ref (rows above + columns left)
+  case Unfreeze // Remove freeze panes
+  // Range operations
+  case Copy(source: String, target: String, valuesOnly: Boolean)
 
 /** Fill direction for the fill command */
 enum FillDirection derives CanEqual:

--- a/xl-cli/src/com/tjclp/xl/cli/Command.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/Command.scala
@@ -53,7 +53,7 @@ enum CliCommand:
   case Eval(formula: String, overrides: List[String])
   case EvalArray(formula: String, targetRef: Option[String], overrides: List[String])
   // Mutate (require -o)
-  case Put(ref: String, values: List[String])
+  case Put(ref: String, values: List[String], csvSplit: Boolean = false)
   case PutFormula(ref: String, formulas: List[String])
   case Style(
     range: String,
@@ -103,10 +103,10 @@ enum CliCommand:
   case Fill(source: String, target: String, direction: FillDirection)
   case AutoFit(columns: Option[String]) // None = all used columns, Some("A:F") = specific range
   case Sort(range: String, sortKeys: List[SortKey], hasHeader: Boolean)
-  // View operations (require -o)
+  // Freeze pane operations (require -o)
   case Freeze(ref: String) // Freeze panes at ref (rows above + columns left)
   case Unfreeze // Remove freeze panes
-  // Range operations
+  // Range operations (require -o)
   case Copy(source: String, target: String, valuesOnly: Boolean)
 
 /** Fill direction for the fill command */

--- a/xl-cli/src/com/tjclp/xl/cli/Main.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/Main.scala
@@ -71,8 +71,8 @@ object Main
     val sheetsOpts =
       (fileOpt, outputOpt.orNone, inPlaceOpt, backendOpt, maxSizeOpt, streamOpt, sheetsCmd).mapN {
         (file, outOpt, inPlace, backend, maxSize, stream, cmd) =>
-          resolveOutput(outOpt, inPlace, file).flatMap { effectiveOutput =>
-            run(file, None, effectiveOutput, backend, maxSize, stream, cmd)
+          runWithOutput(outOpt, inPlace, file) { out =>
+            run(file, None, out, backend, maxSize, stream, cmd)
           }
       }
 
@@ -110,8 +110,8 @@ object Main
         streamOpt,
         sheetWriteSubcmds
       ).mapN { (file, sheet, outOpt, inPlace, backend, maxSize, stream, cmd) =>
-        resolveOutput(outOpt, inPlace, file).flatMap { effectiveOutput =>
-          run(file, sheet, effectiveOutput, backend, maxSize, stream, cmd)
+        runWithOutput(outOpt, inPlace, file) { out =>
+          run(file, sheet, out, backend, maxSize, stream, cmd)
         }
       }
 
@@ -602,10 +602,18 @@ EXAMPLES:
   // Variadic values for put (supports single value, fill pattern, or batch values)
   private val valuesArg = Opts.arguments[String]("value")
 
+  private val csvOpt: Opts[Boolean] =
+    Opts
+      .flag(
+        "csv",
+        "Split a single comma-separated value across the target range (count must match)"
+      )
+      .orFalse
+
   val putCmd: Opts[CliCommand] = Opts.subcommand("put", putHelp) {
     // Support both positional args and --value flag (for negative numbers)
     val valuesOrOpt = valueOpt.map(v => List(v)) orElse valuesArg.map(_.toList)
-    (refArg, valuesOrOpt).mapN(CliCommand.Put.apply)
+    (refArg, valuesOrOpt, csvOpt).mapN(CliCommand.Put.apply)
   }
 
   // Variadic formulas for putf (supports single formula, dragging, or batch formulas)
@@ -1309,12 +1317,19 @@ Use --dry-run to validate JSON without writing."""
             replace
           )
 
-    case CliCommand.Put(refStr, values) =>
-      outputOpt match
-        case None =>
-          IO.raiseError(new Exception("--output is required for put command"))
-        case Some(outputPath) =>
-          StreamingWriteCommands.put(filePath, outputPath, sheetNameOpt, refStr, values)
+    case CliCommand.Put(refStr, values, csvSplit) =>
+      if csvSplit then
+        IO.raiseError(
+          new Exception(
+            "--csv auto-split is not supported with --stream. Omit --stream to use --csv."
+          )
+        )
+      else
+        outputOpt match
+          case None =>
+            IO.raiseError(new Exception("--output is required for put command"))
+          case Some(outputPath) =>
+            StreamingWriteCommands.put(filePath, outputPath, sheetNameOpt, refStr, values)
 
     case CliCommand.PutFormula(refStr, formulas) =>
       outputOpt match
@@ -1421,9 +1436,9 @@ Use --dry-run to validate JSON without writing."""
       ReadCommands.evalArray(wb, sheetOpt, formulaStr, targetRef, overrides)
 
     // Write commands (require output)
-    case CliCommand.Put(refStr, values) =>
+    case CliCommand.Put(refStr, values, csvSplit) =>
       requireOutput(outputOpt, backendOpt, stream)(
-        WriteCommands.put(wb, sheetOpt, refStr, values, _, _, _)
+        WriteCommands.put(wb, sheetOpt, refStr, values, _, _, _, csvSplit)
       )
 
     case CliCommand.PutFormula(refStr, formulas) =>
@@ -1611,20 +1626,50 @@ Use --dry-run to validate JSON without writing."""
       f(path, config, stream)
     )
 
-  /** Resolve effective output from --output and --in-place flags. */
-  private[cli] def resolveOutput(
+  /**
+   * Dispatch `run` with effective output path from --output / --in-place flags.
+   *
+   * Cases:
+   *   - `-o` only: writes directly to the output path
+   *   - `-i` only: writes to a sibling temp file then atomically moves onto input. If the command
+   *     exits with a non-success code OR throws, the temp is deleted and the original is untouched
+   *   - Neither: passes `None` through (for read-only subcommands that don't need output)
+   *   - Both: errors with "mutually exclusive"
+   */
+  private[cli] def runWithOutput(
     outOpt: Option[Path],
     inPlace: Boolean,
     file: Path
-  ): IO[Option[Path]] =
+  )(execute: Option[Path] => IO[ExitCode]): IO[ExitCode] =
     (outOpt, inPlace) match
       case (Some(_), true) =>
-        IO.raiseError(
-          new IllegalArgumentException("--in-place (-i) and --output (-o) are mutually exclusive")
-        )
-      case (Some(out), false) => IO.pure(Some(out))
-      case (None, true) => IO.pure(Some(file))
-      case (None, false) => IO.pure(None)
+        IO.println(
+          Format.errorSimple("--in-place (-i) and --output (-o) are mutually exclusive")
+        ).as(ExitCode.Error)
+      case (Some(out), false) => execute(Some(out))
+      case (None, false) => execute(None)
+      case (None, true) =>
+        val tmpDir = Option(file.getParent).getOrElse(java.nio.file.Paths.get("."))
+        val tmpResource = cats.effect.Resource.make(
+          IO.blocking(java.nio.file.Files.createTempFile(tmpDir, ".xl-inplace-", ".xlsx"))
+        )(tmp => IO.blocking(java.nio.file.Files.deleteIfExists(tmp)).void)
+
+        tmpResource.use { tmp =>
+          execute(Some(tmp)).flatMap {
+            case ExitCode.Success =>
+              // Atomic move: same directory guarantees same filesystem on POSIX/NTFS
+              IO.blocking(
+                java.nio.file.Files.move(
+                  tmp,
+                  file,
+                  java.nio.file.StandardCopyOption.REPLACE_EXISTING
+                )
+              ).as(ExitCode.Success)
+            case other =>
+              // Non-success exit: leave original file alone; Resource cleans up temp
+              IO.pure(other)
+          }
+        }
 
   /** Require output path or raise user-friendly error, providing path to action */
   private def requireOutputAction(outputOpt: Option[Path], commandName: String)(

--- a/xl-cli/src/com/tjclp/xl/cli/Main.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/Main.scala
@@ -69,9 +69,11 @@ object Main
     // Sheets command: --file required, --output optional (required for hide/show, not for list)
     // This needs its own opts chain because list doesn't need output but hide/show do
     val sheetsOpts =
-      (fileOpt, outputOpt.orNone, backendOpt, maxSizeOpt, streamOpt, sheetsCmd).mapN {
-        (file, output, backend, maxSize, stream, cmd) =>
-          run(file, None, output, backend, maxSize, stream, cmd)
+      (fileOpt, outputOpt.orNone, inPlaceOpt, backendOpt, maxSizeOpt, streamOpt, sheetsCmd).mapN {
+        (file, outOpt, inPlace, backend, maxSize, stream, cmd) =>
+          resolveOutput(outOpt, inPlace, file).flatMap { effectiveOutput =>
+            run(file, None, effectiveOutput, backend, maxSize, stream, cmd)
+          }
       }
 
     // Headless commands: --file is optional (for constant formulas like =1+1, =PI())
@@ -95,12 +97,22 @@ object Main
     // Sheet-level write: --file, --sheet, and --output (required)
     // --stream enables O(1) output memory with style preservation (hybrid streaming)
     val sheetWriteSubcmds =
-      putCmd orElse putfCmd orElse styleCmd orElse rowCmd orElse colCmd orElse autoFitCmd orElse batchCmd orElse importCmd orElse addSheetCmd orElse removeSheetCmd orElse renameSheetCmd orElse moveSheetCmd orElse copySheetCmd orElse mergeCmd orElse unmergeCmd orElse commentCmd orElse removeCommentCmd orElse clearCmd orElse fillCmd orElse sortCmd
+      putCmd orElse putfCmd orElse styleCmd orElse rowCmd orElse colCmd orElse autoFitCmd orElse batchCmd orElse importCmd orElse addSheetCmd orElse removeSheetCmd orElse renameSheetCmd orElse moveSheetCmd orElse copySheetCmd orElse mergeCmd orElse unmergeCmd orElse commentCmd orElse removeCommentCmd orElse clearCmd orElse fillCmd orElse sortCmd orElse freezeCmd orElse unfreezeCmd orElse copyCmd
 
     val sheetWriteOpts =
-      (fileOpt, sheetOpt, outputOpt, backendOpt, maxSizeOpt, streamOpt, sheetWriteSubcmds).mapN {
-        (file, sheet, out, backend, maxSize, stream, cmd) =>
-          run(file, sheet, Some(out), backend, maxSize, stream, cmd)
+      (
+        fileOpt,
+        sheetOpt,
+        outputOpt.orNone,
+        inPlaceOpt,
+        backendOpt,
+        maxSizeOpt,
+        streamOpt,
+        sheetWriteSubcmds
+      ).mapN { (file, sheet, outOpt, inPlace, backend, maxSize, stream, cmd) =>
+        resolveOutput(outOpt, inPlace, file).flatMap { effectiveOutput =>
+          run(file, sheet, effectiveOutput, backend, maxSize, stream, cmd)
+        }
       }
 
     // Standalone: no --file required (creates new files)
@@ -169,6 +181,9 @@ object Main
         "Use O(1) memory streaming for large files (100k+ rows). Supports: search, stats, bounds, view (markdown/csv/json). 7-8x faster than in-memory."
       )
       .orFalse
+
+  private val inPlaceOpt: Opts[Boolean] =
+    Opts.flag("in-place", "Edit file in-place (same as -o matching -f)", "i").orFalse
 
   // ==========================================================================
   // Command definitions
@@ -871,6 +886,32 @@ Use --dry-run to validate JSON without writing."""
       }
     }
 
+  // --- Freeze/Unfreeze commands ---
+
+  private val freezeCmd: Opts[CliCommand] =
+    Opts.subcommand(
+      "freeze",
+      "Freeze panes at cell reference (rows above and columns left are locked)"
+    ) {
+      refArg.map(CliCommand.Freeze.apply)
+    }
+
+  private val unfreezeCmd: Opts[CliCommand] =
+    Opts.subcommand("unfreeze", "Remove freeze panes") {
+      Opts(CliCommand.Unfreeze)
+    }
+
+  // --- Copy command ---
+
+  private val copyCmd: Opts[CliCommand] =
+    Opts.subcommand("copy", "Copy range to another location (with formula adjustment)") {
+      val copySrcArg = Opts.argument[String]("source")
+      val copyTgtArg = Opts.argument[String]("target")
+      val valuesOnlyOpt =
+        Opts.flag("values-only", "Copy values only (no formula adjustment)").orFalse
+      (copySrcArg, copyTgtArg, valuesOnlyOpt).mapN(CliCommand.Copy.apply)
+    }
+
   // ==========================================================================
   // Command execution
   // ==========================================================================
@@ -1541,6 +1582,21 @@ Use --dry-run to validate JSON without writing."""
         WriteCommands.sort(wb, sheetOpt, rangeStr, sortKeys, hasHeader, _, _, _)
       )
 
+    case CliCommand.Freeze(refStr) =>
+      requireOutput(outputOpt, backendOpt, stream)(
+        WriteCommands.freeze(wb, sheetOpt, refStr, _, _, _)
+      )
+
+    case CliCommand.Unfreeze =>
+      requireOutput(outputOpt, backendOpt, stream)(
+        WriteCommands.unfreeze(wb, sheetOpt, _, _, _)
+      )
+
+    case CliCommand.Copy(source, target, valuesOnly) =>
+      requireOutput(outputOpt, backendOpt, stream)(
+        WriteCommands.copyRange(wb, sheetOpt, source, target, valuesOnly, _, _, _)
+      )
+
   // ==========================================================================
   // Helpers
   // ==========================================================================
@@ -1554,6 +1610,21 @@ Use --dry-run to validate JSON without writing."""
     outputOpt.fold(IO.raiseError[String](new Exception("Internal: output required")))(path =>
       f(path, config, stream)
     )
+
+  /** Resolve effective output from --output and --in-place flags. */
+  private[cli] def resolveOutput(
+    outOpt: Option[Path],
+    inPlace: Boolean,
+    file: Path
+  ): IO[Option[Path]] =
+    (outOpt, inPlace) match
+      case (Some(_), true) =>
+        IO.raiseError(
+          new IllegalArgumentException("--in-place (-i) and --output (-o) are mutually exclusive")
+        )
+      case (Some(out), false) => IO.pure(Some(out))
+      case (None, true) => IO.pure(Some(file))
+      case (None, false) => IO.pure(None)
 
   /** Require output path or raise user-friendly error, providing path to action */
   private def requireOutputAction(outputOpt: Option[Path], commandName: String)(

--- a/xl-cli/src/com/tjclp/xl/cli/commands/WriteCommands.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/commands/WriteCommands.scala
@@ -7,7 +7,7 @@ import cats.implicits.*
 import com.tjclp.xl.{*, given}
 import com.tjclp.xl.addressing.{ARef, CellRange, Column, Row}
 import com.tjclp.xl.cells.CellValue
-import com.tjclp.xl.cli.helpers.{BatchParser, SheetResolver, StyleBuilder, ValueParser}
+import com.tjclp.xl.cli.helpers.{BatchParser, CopyOps, SheetResolver, StyleBuilder, ValueParser}
 import com.tjclp.xl.cli.output.Format
 import com.tjclp.xl.formula.{
   FormulaParser,
@@ -90,9 +90,16 @@ object WriteCommands:
    *
    * Supports three modes:
    *   1. Single cell: put A1 100
-   *   2. Fill pattern: put A1:A10 100 (all cells get same value)
+   *   2. Fill pattern: put A1:A10 100 (all cells get same value — literal, even if it contains
+   *      commas)
    *   3. Batch values: put A1:A3 1 2 3 (values map 1:1, row-major)
    *
+   * When `csvSplit` is true and Mode 2 input contains commas, the value is split on commas and
+   * distributed across the range (requires exact count match). This is opt-in to avoid regressing
+   * legitimate fills like `put A1:B1 "Smith, John"`.
+   *
+   * @param csvSplit
+   *   Enable CSV auto-split in Mode 2 (fill pattern with comma-containing value)
    * @param stream
    *   If true, uses streaming writer for O(1) output memory
    */
@@ -103,7 +110,8 @@ object WriteCommands:
     values: List[String],
     outputPath: Path,
     config: WriterConfig,
-    stream: Boolean = false
+    stream: Boolean = false,
+    csvSplit: Boolean = false
   ): IO[String] =
     for
       resolved <- SheetResolver.resolveRef(wb, sheetOpt, refStr, "put")
@@ -112,12 +120,21 @@ object WriteCommands:
       // Determine mode based on ref type and value count
       result <- (refOrRange, values) match
         case (Left(ref), List(singleValue)) =>
-          // Mode 1: Single cell
-          putSingleCell(wb, targetSheet, ref, singleValue, outputPath, config, stream)
+          // Mode 1: Single cell (--csv is meaningless here)
+          if csvSplit then
+            IO.raiseError(
+              new Exception(
+                s"--csv requires a range target; ${ref.toA1} is a single cell."
+              )
+            )
+          else putSingleCell(wb, targetSheet, ref, singleValue, outputPath, config, stream)
 
         case (Right(range), List(singleValue)) =>
-          // Mode 2: Fill pattern
-          putFillPattern(wb, targetSheet, range, singleValue, outputPath, config, stream)
+          // Mode 2: Fill pattern (opt-in CSV split with --csv)
+          if csvSplit then
+            putCsvSplit(wb, targetSheet, range, singleValue, outputPath, config, stream)
+          else
+            putFillPatternLiteral(wb, targetSheet, range, singleValue, outputPath, config, stream)
 
         case (Right(range), multipleValues @ (_ :: _ :: _)) =>
           // Mode 3: Batch values (validate count matches) - 2+ values
@@ -152,8 +169,8 @@ object WriteCommands:
       s"${Format.putSuccess(ref, value)}\n${saveSuffix(outputPath, stream)}"
     }
 
-  /** Mode 2: Fill all cells in range with same value (with CSV auto-split detection) */
-  private def putFillPattern(
+  /** Mode 2 with --csv: split a comma-separated value across the range. Requires exact count. */
+  private def putCsvSplit(
     wb: Workbook,
     sheet: Sheet,
     range: CellRange,
@@ -162,22 +179,16 @@ object WriteCommands:
     config: WriterConfig,
     stream: Boolean
   ): IO[String] =
-    // CSV auto-split: if value contains commas, try splitting and distributing
-    if valueStr.contains(',') then
-      val parts = valueStr.split(",", -1).map(_.trim).toList
-      val cellCount = range.cellCount.toInt
-      if parts.length == cellCount then
-        // Split count matches range size — distribute as batch values
-        putBatchValues(wb, sheet, range, parts, outputPath, config, stream)
-      else
-        // Mismatch — treat as literal text, but print a hint to stderr
-        IO(
-          System.err.println(
-            s"Hint: CSV value has ${parts.length} element(s) but range ${range.toA1} has $cellCount cell(s). " +
-              "Treating as literal text. Adjust the range or value count to enable auto-split."
-          )
-        ) *> putFillPatternLiteral(wb, sheet, range, valueStr, outputPath, config, stream)
-    else putFillPatternLiteral(wb, sheet, range, valueStr, outputPath, config, stream)
+    val parts = valueStr.split(",", -1).map(_.trim).toList
+    val cellCount = range.cellCount.toInt
+    if parts.length != cellCount then
+      IO.raiseError(
+        new Exception(
+          s"--csv: value split into ${parts.length} element(s) but range ${range.toA1} has $cellCount cell(s). " +
+            "Adjust the range size or value count to match."
+        )
+      )
+    else putBatchValues(wb, sheet, range, parts, outputPath, config, stream)
 
   /** Fill all cells in range with the same literal value (no CSV splitting) */
   private def putFillPatternLiteral(
@@ -1053,12 +1064,16 @@ object WriteCommands:
    *
    * Source can be a single cell (treated as 1x1 range) or a range. If the target is a single cell,
    * it auto-expands to match the source dimensions. Formulas are shifted relative to the
-   * displacement unless `valuesOnly` is true.
+   * displacement unless `valuesOnly` is true. The target may live on a different sheet than the
+   * source (via qualified refs like `Sheet2!A1`).
+   *
+   * Overlapping copies within the same sheet are safe: source cells are snapshotted before any
+   * mutation, so `copy A1:A3 A2` produces the expected result regardless of iteration order.
    *
    * @param valuesOnly
-   *   If true, copies only computed/cached values (no formula shifting)
+   *   If true, formula cells are materialized to their cached/computed value.
    * @param stream
-   *   If true, uses streaming writer for O(1) output memory
+   *   If true, uses streaming writer for O(1) output memory.
    */
   def copyRange(
     wb: Workbook,
@@ -1071,19 +1086,18 @@ object WriteCommands:
     stream: Boolean = false
   ): IO[String] =
     for
+      // Resolve source sheet + ref/range
       sourceResolved <- SheetResolver.resolveRef(wb, sheetOpt, sourceStr, "copy")
       (sourceSheet, sourceRefOrRange) = sourceResolved
-
-      // Convert source to range (single cell = 1x1 range)
       sourceRange = sourceRefOrRange match
         case Left(ref) => CellRange(ref, ref)
         case Right(range) => range
 
-      // Parse target ref (may be single cell or range)
+      // Resolve target sheet + ref/range — target sheet may differ from source (qualified refs)
       targetResolved <- SheetResolver.resolveRef(wb, sheetOpt, targetStr, "copy")
-      (_, targetRefOrRange) = targetResolved
+      (targetSheet, targetRefOrRange) = targetResolved
 
-      // Determine target range: if single cell, auto-expand to match source dimensions
+      // Auto-expand single-cell target to match source dimensions
       targetRange = targetRefOrRange match
         case Right(range) => range
         case Left(ref) =>
@@ -1095,7 +1109,7 @@ object WriteCommands:
           )
           CellRange(ref, endRef)
 
-      // Validate dimensions match
+      // Validate dimensions
       srcRowCount = Row.index0(sourceRange.rowEnd) - Row.index0(sourceRange.rowStart) + 1
       srcColCount = Column.index0(sourceRange.colEnd) - Column.index0(sourceRange.colStart) + 1
       tgtRowCount = Row.index0(targetRange.rowEnd) - Row.index0(targetRange.rowStart) + 1
@@ -1110,72 +1124,18 @@ object WriteCommands:
           )
         else IO.unit
 
-      // Compute displacement
-      colDelta = Column.index0(targetRange.colStart) - Column.index0(sourceRange.colStart)
-      rowDelta = Row.index0(targetRange.rowStart) - Row.index0(sourceRange.rowStart)
+      // Delegate to shared helper (handles overlap, cross-sheet, style preservation)
+      updatedWb =
+        CopyOps.copyRange(wb, sourceSheet, sourceRange, targetSheet, targetRange, valuesOnly)
+      finalWb = updatedWb.recalculateDependents(targetSheet.name, targetRange.cells.toSet)
+      _ <- writeWorkbook(finalWb, outputPath, config, stream)
 
-      // Copy each cell
-      updatedSheet = applyCopyRange(
-        sourceSheet,
-        wb,
-        sourceRange,
-        targetRange,
-        colDelta,
-        rowDelta,
-        valuesOnly
-      )
-      modifiedRefs = targetRange.cells.toSet
-      updatedWb = wb.put(updatedSheet).recalculateDependents(sourceSheet.name, modifiedRefs)
-      _ <- writeWorkbook(updatedWb, outputPath, config, stream)
+      crossSheetLabel =
+        if sourceSheet.name != targetSheet.name then
+          s" (${sourceSheet.name.value} → ${targetSheet.name.value})"
+        else ""
       modeLabel = if valuesOnly then " (values only)" else " (with formula adjustment)"
-    yield s"Copied ${sourceRange.toA1} to ${targetRange.toA1}$modeLabel\n${saveSuffix(outputPath, stream)}"
-
-  /** Apply copy operation: iterate source cells and copy to target positions */
-  private def applyCopyRange(
-    sheet: Sheet,
-    wb: Workbook,
-    source: CellRange,
-    target: CellRange,
-    colDelta: Int,
-    rowDelta: Int,
-    valuesOnly: Boolean
-  ): Sheet =
-    val srcStartRow = Row.index0(source.rowStart)
-    val srcStartCol = Column.index0(source.colStart)
-    val srcEndRow = Row.index0(source.rowEnd)
-    val srcEndCol = Column.index0(source.colEnd)
-
-    (srcStartRow to srcEndRow).foldLeft(sheet) { (s, rowIdx) =>
-      (srcStartCol to srcEndCol).foldLeft(s) { (s2, colIdx) =>
-        val sourceRef = ARef.from0(colIdx, rowIdx)
-        val targetRef = ARef.from0(colIdx + colDelta, rowIdx + rowDelta)
-        if valuesOnly then copyCellValuesOnly(s2, wb, sourceRef, targetRef)
-        else copyCell(s2, wb, sourceRef, targetRef, colDelta, rowDelta)
-      }
-    }
-
-  /** Copy a single cell, keeping only the computed/cached value (no formula shifting) */
-  private def copyCellValuesOnly(
-    sheet: Sheet,
-    wb: Workbook,
-    sourceRef: ARef,
-    targetRef: ARef
-  ): Sheet =
-    sheet.cells.get(sourceRef) match
-      case None => sheet
-      case Some(sourceCell) =>
-        sourceCell.value match
-          case CellValue.Formula(_, Some(cached)) =>
-            // Replace formula with its cached value
-            sheet.put(targetRef, cached)
-          case CellValue.Formula(expr, None) =>
-            // No cached value; try evaluating
-            val fullFormula = s"=$expr"
-            val evaluated =
-              SheetEvaluator.evaluateFormula(sheet)(fullFormula, workbook = Some(wb)).toOption
-            sheet.put(targetRef, evaluated.getOrElse(CellValue.Empty))
-          case value =>
-            sheet.put(targetRef, value)
+    yield s"Copied ${sourceRange.toA1} to ${targetRange.toA1}$crossSheetLabel$modeLabel\n${saveSuffix(outputPath, stream)}"
 
   /** Validate that all sort columns are within the range */
   private def validateSortColumns(range: CellRange, keys: List[SortKey]): IO[Unit] =

--- a/xl-cli/src/com/tjclp/xl/cli/commands/WriteCommands.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/commands/WriteCommands.scala
@@ -5,7 +5,7 @@ import java.nio.file.Path
 import cats.effect.IO
 import cats.implicits.*
 import com.tjclp.xl.{*, given}
-import com.tjclp.xl.addressing.{CellRange, Column, Row}
+import com.tjclp.xl.addressing.{ARef, CellRange, Column, Row}
 import com.tjclp.xl.cells.CellValue
 import com.tjclp.xl.cli.helpers.{BatchParser, SheetResolver, StyleBuilder, ValueParser}
 import com.tjclp.xl.cli.output.Format
@@ -152,8 +152,35 @@ object WriteCommands:
       s"${Format.putSuccess(ref, value)}\n${saveSuffix(outputPath, stream)}"
     }
 
-  /** Mode 2: Fill all cells in range with same value */
+  /** Mode 2: Fill all cells in range with same value (with CSV auto-split detection) */
   private def putFillPattern(
+    wb: Workbook,
+    sheet: Sheet,
+    range: CellRange,
+    valueStr: String,
+    outputPath: Path,
+    config: WriterConfig,
+    stream: Boolean
+  ): IO[String] =
+    // CSV auto-split: if value contains commas, try splitting and distributing
+    if valueStr.contains(',') then
+      val parts = valueStr.split(",", -1).map(_.trim).toList
+      val cellCount = range.cellCount.toInt
+      if parts.length == cellCount then
+        // Split count matches range size — distribute as batch values
+        putBatchValues(wb, sheet, range, parts, outputPath, config, stream)
+      else
+        // Mismatch — treat as literal text, but print a hint to stderr
+        IO(
+          System.err.println(
+            s"Hint: CSV value has ${parts.length} element(s) but range ${range.toA1} has $cellCount cell(s). " +
+              "Treating as literal text. Adjust the range or value count to enable auto-split."
+          )
+        ) *> putFillPatternLiteral(wb, sheet, range, valueStr, outputPath, config, stream)
+    else putFillPatternLiteral(wb, sheet, range, valueStr, outputPath, config, stream)
+
+  /** Fill all cells in range with the same literal value (no CSV splitting) */
+  private def putFillPatternLiteral(
     wb: Workbook,
     sheet: Sheet,
     range: CellRange,
@@ -974,6 +1001,181 @@ object WriteCommands:
         .mkString(", ")
       headerNote = if hasHeader then " (header row preserved)" else ""
     yield s"Sorted ${range.toA1} by $keyDesc$headerNote\n${saveSuffix(outputPath, stream)}"
+
+  /**
+   * Freeze panes at the given cell reference.
+   *
+   * Rows above and columns to the left of the reference are locked in place when scrolling.
+   *
+   * @param stream
+   *   If true, uses streaming writer for O(1) output memory
+   */
+  def freeze(
+    wb: Workbook,
+    sheetOpt: Option[Sheet],
+    refStr: String,
+    outputPath: Path,
+    config: WriterConfig,
+    stream: Boolean = false
+  ): IO[String] =
+    for
+      sheet <- SheetResolver.requireSheet(wb, sheetOpt, "freeze")
+      ref <- IO.fromEither(
+        ARef.parse(refStr).left.map(e => new Exception(s"Invalid cell reference: $e"))
+      )
+      updatedSheet = sheet.freezeAt(ref)
+      updatedWb = wb.put(updatedSheet)
+      _ <- writeWorkbook(updatedWb, outputPath, config, stream)
+    yield s"Froze panes at ${ref.toA1} on sheet '${sheet.name.value}'\n${saveSuffix(outputPath, stream)}"
+
+  /**
+   * Remove freeze panes from the sheet.
+   *
+   * @param stream
+   *   If true, uses streaming writer for O(1) output memory
+   */
+  def unfreeze(
+    wb: Workbook,
+    sheetOpt: Option[Sheet],
+    outputPath: Path,
+    config: WriterConfig,
+    stream: Boolean = false
+  ): IO[String] =
+    for
+      sheet <- SheetResolver.requireSheet(wb, sheetOpt, "unfreeze")
+      updatedSheet = sheet.unfreeze
+      updatedWb = wb.put(updatedSheet)
+      _ <- writeWorkbook(updatedWb, outputPath, config, stream)
+    yield s"Removed freeze panes from sheet '${sheet.name.value}'\n${saveSuffix(outputPath, stream)}"
+
+  /**
+   * Copy a range of cells to another location with optional formula adjustment.
+   *
+   * Source can be a single cell (treated as 1x1 range) or a range. If the target is a single cell,
+   * it auto-expands to match the source dimensions. Formulas are shifted relative to the
+   * displacement unless `valuesOnly` is true.
+   *
+   * @param valuesOnly
+   *   If true, copies only computed/cached values (no formula shifting)
+   * @param stream
+   *   If true, uses streaming writer for O(1) output memory
+   */
+  def copyRange(
+    wb: Workbook,
+    sheetOpt: Option[Sheet],
+    sourceStr: String,
+    targetStr: String,
+    valuesOnly: Boolean,
+    outputPath: Path,
+    config: WriterConfig,
+    stream: Boolean = false
+  ): IO[String] =
+    for
+      sourceResolved <- SheetResolver.resolveRef(wb, sheetOpt, sourceStr, "copy")
+      (sourceSheet, sourceRefOrRange) = sourceResolved
+
+      // Convert source to range (single cell = 1x1 range)
+      sourceRange = sourceRefOrRange match
+        case Left(ref) => CellRange(ref, ref)
+        case Right(range) => range
+
+      // Parse target ref (may be single cell or range)
+      targetResolved <- SheetResolver.resolveRef(wb, sheetOpt, targetStr, "copy")
+      (_, targetRefOrRange) = targetResolved
+
+      // Determine target range: if single cell, auto-expand to match source dimensions
+      targetRange = targetRefOrRange match
+        case Right(range) => range
+        case Left(ref) =>
+          val srcRows = Row.index0(sourceRange.rowEnd) - Row.index0(sourceRange.rowStart)
+          val srcCols = Column.index0(sourceRange.colEnd) - Column.index0(sourceRange.colStart)
+          val endRef = ARef.from0(
+            Column.index0(ref.col) + srcCols,
+            Row.index0(ref.row) + srcRows
+          )
+          CellRange(ref, endRef)
+
+      // Validate dimensions match
+      srcRowCount = Row.index0(sourceRange.rowEnd) - Row.index0(sourceRange.rowStart) + 1
+      srcColCount = Column.index0(sourceRange.colEnd) - Column.index0(sourceRange.colStart) + 1
+      tgtRowCount = Row.index0(targetRange.rowEnd) - Row.index0(targetRange.rowStart) + 1
+      tgtColCount = Column.index0(targetRange.colEnd) - Column.index0(targetRange.colStart) + 1
+      _ <-
+        if srcRowCount != tgtRowCount || srcColCount != tgtColCount then
+          IO.raiseError(
+            new Exception(
+              s"Source (${srcRowCount}x${srcColCount}) and target (${tgtRowCount}x${tgtColCount}) dimensions mismatch. " +
+                "Use a single target cell to auto-expand, or specify matching range."
+            )
+          )
+        else IO.unit
+
+      // Compute displacement
+      colDelta = Column.index0(targetRange.colStart) - Column.index0(sourceRange.colStart)
+      rowDelta = Row.index0(targetRange.rowStart) - Row.index0(sourceRange.rowStart)
+
+      // Copy each cell
+      updatedSheet = applyCopyRange(
+        sourceSheet,
+        wb,
+        sourceRange,
+        targetRange,
+        colDelta,
+        rowDelta,
+        valuesOnly
+      )
+      modifiedRefs = targetRange.cells.toSet
+      updatedWb = wb.put(updatedSheet).recalculateDependents(sourceSheet.name, modifiedRefs)
+      _ <- writeWorkbook(updatedWb, outputPath, config, stream)
+      modeLabel = if valuesOnly then " (values only)" else " (with formula adjustment)"
+    yield s"Copied ${sourceRange.toA1} to ${targetRange.toA1}$modeLabel\n${saveSuffix(outputPath, stream)}"
+
+  /** Apply copy operation: iterate source cells and copy to target positions */
+  private def applyCopyRange(
+    sheet: Sheet,
+    wb: Workbook,
+    source: CellRange,
+    target: CellRange,
+    colDelta: Int,
+    rowDelta: Int,
+    valuesOnly: Boolean
+  ): Sheet =
+    val srcStartRow = Row.index0(source.rowStart)
+    val srcStartCol = Column.index0(source.colStart)
+    val srcEndRow = Row.index0(source.rowEnd)
+    val srcEndCol = Column.index0(source.colEnd)
+
+    (srcStartRow to srcEndRow).foldLeft(sheet) { (s, rowIdx) =>
+      (srcStartCol to srcEndCol).foldLeft(s) { (s2, colIdx) =>
+        val sourceRef = ARef.from0(colIdx, rowIdx)
+        val targetRef = ARef.from0(colIdx + colDelta, rowIdx + rowDelta)
+        if valuesOnly then copyCellValuesOnly(s2, wb, sourceRef, targetRef)
+        else copyCell(s2, wb, sourceRef, targetRef, colDelta, rowDelta)
+      }
+    }
+
+  /** Copy a single cell, keeping only the computed/cached value (no formula shifting) */
+  private def copyCellValuesOnly(
+    sheet: Sheet,
+    wb: Workbook,
+    sourceRef: ARef,
+    targetRef: ARef
+  ): Sheet =
+    sheet.cells.get(sourceRef) match
+      case None => sheet
+      case Some(sourceCell) =>
+        sourceCell.value match
+          case CellValue.Formula(_, Some(cached)) =>
+            // Replace formula with its cached value
+            sheet.put(targetRef, cached)
+          case CellValue.Formula(expr, None) =>
+            // No cached value; try evaluating
+            val fullFormula = s"=$expr"
+            val evaluated =
+              SheetEvaluator.evaluateFormula(sheet)(fullFormula, workbook = Some(wb)).toOption
+            sheet.put(targetRef, evaluated.getOrElse(CellValue.Empty))
+          case value =>
+            sheet.put(targetRef, value)
 
   /** Validate that all sort columns are within the range */
   private def validateSortColumns(range: CellRange, keys: List[SortKey]): IO[Unit] =

--- a/xl-cli/src/com/tjclp/xl/cli/commands/WriteCommands.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/commands/WriteCommands.scala
@@ -1030,10 +1030,16 @@ object WriteCommands:
     stream: Boolean = false
   ): IO[String] =
     for
-      sheet <- SheetResolver.requireSheet(wb, sheetOpt, "freeze")
-      ref <- IO.fromEither(
-        ARef.parse(refStr).left.map(e => new Exception(s"Invalid cell reference: $e"))
-      )
+      resolved <- SheetResolver.resolveRef(wb, sheetOpt, refStr, "freeze")
+      (sheet, refOrRange) = resolved
+      ref <- refOrRange match
+        case Left(r) => IO.pure(r)
+        case Right(range) =>
+          IO.raiseError(
+            new Exception(
+              s"freeze expects a single cell reference, got range: ${range.toA1}"
+            )
+          )
       updatedSheet = sheet.freezeAt(ref)
       updatedWb = wb.put(updatedSheet)
       _ <- writeWorkbook(updatedWb, outputPath, config, stream)
@@ -1109,25 +1115,14 @@ object WriteCommands:
           )
           CellRange(ref, endRef)
 
-      // Validate dimensions
-      srcRowCount = Row.index0(sourceRange.rowEnd) - Row.index0(sourceRange.rowStart) + 1
-      srcColCount = Column.index0(sourceRange.colEnd) - Column.index0(sourceRange.colStart) + 1
-      tgtRowCount = Row.index0(targetRange.rowEnd) - Row.index0(targetRange.rowStart) + 1
-      tgtColCount = Column.index0(targetRange.colEnd) - Column.index0(targetRange.colStart) + 1
-      _ <-
-        if srcRowCount != tgtRowCount || srcColCount != tgtColCount then
-          IO.raiseError(
-            new Exception(
-              s"Source (${srcRowCount}x${srcColCount}) and target (${tgtRowCount}x${tgtColCount}) dimensions mismatch. " +
-                "Use a single target cell to auto-expand, or specify matching range."
-            )
-          )
-        else IO.unit
+      // Validate dimensions (shared helper keeps CLI + batch error text aligned)
+      _ <- IO.fromEither(
+        CopyOps.validateDimensions(sourceRange, targetRange).left.map(new Exception(_))
+      )
 
-      // Delegate to shared helper (handles overlap, cross-sheet, style preservation)
-      updatedWb =
+      // Delegate to shared helper (handles overlap, cross-sheet, style preservation, recalc)
+      finalWb =
         CopyOps.copyRange(wb, sourceSheet, sourceRange, targetSheet, targetRange, valuesOnly)
-      finalWb = updatedWb.recalculateDependents(targetSheet.name, targetRange.cells.toSet)
       _ <- writeWorkbook(finalWb, outputPath, config, stream)
 
       crossSheetLabel =

--- a/xl-cli/src/com/tjclp/xl/cli/helpers/BatchParser.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/helpers/BatchParser.scala
@@ -1418,7 +1418,14 @@ object BatchParser:
       result <- IO.fromEither(wb.rename(oldName, newName).left.map(e => new Exception(e.message)))
     yield result
 
-  /** Apply a copy range operation. */
+  /**
+   * Apply a copy range operation, respecting qualified sheet refs on each side.
+   *
+   * Source and target may each be qualified (e.g. `Sheet2!A1`). If unqualified, the default sheet
+   * is used. An error is raised if the default is missing and either side lacks qualification.
+   * Delegates actual cell copying to [[CopyOps.copyRange]] which handles overlapping copies,
+   * formula shifting, and style preservation.
+   */
   private def applyCopyRange(
     wb: Workbook,
     defaultSheetName: Option[SheetName],
@@ -1426,59 +1433,65 @@ object BatchParser:
     targetStr: String,
     valuesOnly: Boolean
   ): IO[Workbook] =
-    val sheetName = defaultSheetName.getOrElse(
-      throw new Exception("copy requires --sheet")
-    )
-    IO.fromEither(wb(sheetName).left.map(e => new Exception(e.message))).flatMap { sheet =>
-      // Parse source as range
-      val sourceRange = RefType.parse(sourceStr) match
-        case Right(RefType.Cell(ref)) => CellRange(ref, ref)
-        case Right(RefType.Range(r)) => r
-        case Right(RefType.QualifiedCell(_, ref)) => CellRange(ref, ref)
-        case Right(RefType.QualifiedRange(_, r)) => r
-        case Left(err) => throw new Exception(s"Invalid source ref '$sourceStr': $err")
 
-      // Parse target as ref or range
-      val targetStart = RefType.parse(targetStr) match
-        case Right(RefType.Cell(ref)) => ref
-        case Right(RefType.Range(r)) => r.start
-        case Right(RefType.QualifiedCell(_, ref)) => ref
-        case Right(RefType.QualifiedRange(_, r)) => r.start
-        case Left(err) => throw new Exception(s"Invalid target ref '$targetStr': $err")
-
-      val colDelta = targetStart.col.index0 - sourceRange.start.col.index0
-      val rowDelta = targetStart.row.index0 - sourceRange.start.row.index0
-
-      // Copy each cell from source to target
-      val updatedSheet = sourceRange.cells.foldLeft(sheet) { (s, srcRef) =>
-        val tgtRef = ARef(
-          Column.from0(srcRef.col.index0 + colDelta),
-          Row.from0(srcRef.row.index0 + rowDelta)
-        )
-        val srcCell = s(srcRef)
-        if srcCell.value == CellValue.Empty then s
-        else if valuesOnly then s.put(tgtRef, srcCell.value)
-        else
-          // Copy with formula shifting
-          val newValue = srcCell.value match
-            case CellValue.Formula(expr, _) =>
-              val fullFormula = s"=$expr"
-              FormulaParser.parse(fullFormula) match
-                case Right(parsed) =>
-                  val shifted = FormulaShifter.shift(parsed, colDelta, rowDelta)
-                  CellValue.Formula(FormulaPrinter.print(shifted, includeEquals = false))
-                case Left(_) => CellValue.Formula(expr) // Unparseable: copy as-is
-            case other => other
-          val updated = s.put(tgtRef, newValue)
-          // Preserve style
-          srcCell.styleId.flatMap(s.styleRegistry.get) match
-            case Some(style) =>
-              import com.tjclp.xl.sheets.styleSyntax.withCellStyle
-              updated.withCellStyle(tgtRef, style)
-            case None => updated
+    def parseSide(label: String, s: String): IO[(Option[SheetName], Either[ARef, CellRange])] =
+      IO.fromEither(
+        RefType.parse(s).left.map(e => new Exception(s"Invalid $label ref '$s': $e"))
+      ).map {
+        case RefType.Cell(ref) => (None, Left(ref))
+        case RefType.Range(r) => (None, Right(r))
+        case RefType.QualifiedCell(sheet, ref) => (Some(sheet), Left(ref))
+        case RefType.QualifiedRange(sheet, r) => (Some(sheet), Right(r))
       }
-      IO.pure(wb.put(updatedSheet))
-    }
+
+    def resolveSheetName(label: String, qualified: Option[SheetName]): IO[SheetName] =
+      qualified.orElse(defaultSheetName) match
+        case Some(name) => IO.pure(name)
+        case None =>
+          IO.raiseError(
+            new Exception(s"copy $label requires --sheet or a qualified ref")
+          )
+
+    for
+      (srcQualified, srcEither) <- parseSide("source", sourceStr)
+      (tgtQualified, tgtEither) <- parseSide("target", targetStr)
+      sourceSheetName <- resolveSheetName("source", srcQualified)
+      targetSheetName <- resolveSheetName("target", tgtQualified)
+      sourceSheet <- IO.fromEither(wb(sourceSheetName).left.map(e => new Exception(e.message)))
+      targetSheet <- IO.fromEither(wb(targetSheetName).left.map(e => new Exception(e.message)))
+
+      sourceRange = srcEither match
+        case Left(ref) => CellRange(ref, ref)
+        case Right(r) => r
+
+      // Auto-expand single-cell target to match source dimensions
+      targetRange = tgtEither match
+        case Right(r) => r
+        case Left(ref) =>
+          val srcCols =
+            Column.index0(sourceRange.colEnd) - Column.index0(sourceRange.colStart)
+          val srcRows =
+            Row.index0(sourceRange.rowEnd) - Row.index0(sourceRange.rowStart)
+          val endRef = ARef.from0(
+            Column.index0(ref.col) + srcCols,
+            Row.index0(ref.row) + srcRows
+          )
+          CellRange(ref, endRef)
+
+      srcRowCount = Row.index0(sourceRange.rowEnd) - Row.index0(sourceRange.rowStart) + 1
+      srcColCount = Column.index0(sourceRange.colEnd) - Column.index0(sourceRange.colStart) + 1
+      tgtRowCount = Row.index0(targetRange.rowEnd) - Row.index0(targetRange.rowStart) + 1
+      tgtColCount = Column.index0(targetRange.colEnd) - Column.index0(targetRange.colStart) + 1
+      _ <-
+        if srcRowCount != tgtRowCount || srcColCount != tgtColCount then
+          IO.raiseError(
+            new Exception(
+              s"Source (${srcRowCount}x${srcColCount}) and target " +
+                s"(${tgtRowCount}x${tgtColCount}) dimensions mismatch"
+            )
+          )
+        else IO.unit
+    yield CopyOps.copyRange(wb, sourceSheet, sourceRange, targetSheet, targetRange, valuesOnly)
 
   // ========== Utilities ==========
 

--- a/xl-cli/src/com/tjclp/xl/cli/helpers/BatchParser.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/helpers/BatchParser.scala
@@ -91,6 +91,9 @@ object BatchParser:
     case AutoFit(columns: Option[String])
     case AddSheet(name: String, after: Option[String])
     case RenameSheet(from: String, to: String)
+    case Freeze(ref: String)
+    case Unfreeze
+    case CopyRange(source: String, target: String, valuesOnly: Boolean)
 
   /**
    * Result of batch parsing with optional warnings.
@@ -136,6 +139,10 @@ object BatchParser:
         case BatchOp.AutoFit(cols) => s"  AUTOFIT ${cols.getOrElse("all")}"
         case BatchOp.AddSheet(name, _) => s"  ADD-SHEET $name"
         case BatchOp.RenameSheet(from, to) => s"  RENAME-SHEET $from -> $to"
+        case BatchOp.Freeze(ref) => s"  FREEZE $ref"
+        case BatchOp.Unfreeze => "  UNFREEZE"
+        case BatchOp.CopyRange(src, tgt, vo) =>
+          s"  COPY $src -> $tgt${if vo then " (values-only)" else ""}"
       }
       .mkString("\n")
 
@@ -345,12 +352,25 @@ object BatchParser:
             val to = requireString(objMap, "to", idx)
             BatchOp.RenameSheet(from, to)
 
+          case "freeze" =>
+            val ref = requireString(objMap, "ref", idx)
+            BatchOp.Freeze(ref)
+
+          case "unfreeze" =>
+            BatchOp.Unfreeze
+
+          case "copy" =>
+            val source = requireString(objMap, "source", idx)
+            val target = requireString(objMap, "target", idx)
+            val valuesOnly = objMap.get("valuesOnly").flatMap(_.boolOpt).getOrElse(false)
+            BatchOp.CopyRange(source, target, valuesOnly)
+
           case other =>
             throw new Exception(
               s"Object ${idx + 1}: Unknown operation '$other'. " +
                 "Valid: put, putf, style, merge, unmerge, colwidth, rowheight, " +
                 "comment, remove-comment, clear, col-hide, col-show, row-hide, row-show, " +
-                "autofit, add-sheet, rename-sheet"
+                "autofit, add-sheet, rename-sheet, freeze, unfreeze, copy"
             )
       }
 
@@ -819,6 +839,35 @@ object BatchParser:
 
           case BatchOp.RenameSheet(from, to) =>
             applyRenameSheet(currentWb, from, to)
+
+          case BatchOp.Freeze(refStr) =>
+            IO.fromEither(ARef.parse(refStr).left.map(e => new Exception(e))).flatMap { ref =>
+              defaultSheetName match
+                case Some(sheetName) =>
+                  IO.fromEither(
+                    currentWb(sheetName)
+                      .map(s => currentWb.put(s.freezeAt(ref)))
+                      .left
+                      .map(e => new Exception(e.message))
+                  )
+                case None =>
+                  IO.raiseError(new Exception("freeze requires --sheet"))
+            }
+
+          case BatchOp.Unfreeze =>
+            defaultSheetName match
+              case Some(sheetName) =>
+                IO.fromEither(
+                  currentWb(sheetName)
+                    .map(s => currentWb.put(s.unfreeze))
+                    .left
+                    .map(e => new Exception(e.message))
+                )
+              case None =>
+                IO.raiseError(new Exception("unfreeze requires --sheet"))
+
+          case BatchOp.CopyRange(sourceStr, targetStr, valuesOnly) =>
+            applyCopyRange(currentWb, defaultSheetName, sourceStr, targetStr, valuesOnly)
       }
     }
 
@@ -1368,6 +1417,68 @@ object BatchParser:
       newName <- IO.fromEither(SheetName(to).left.map(e => new Exception(e)))
       result <- IO.fromEither(wb.rename(oldName, newName).left.map(e => new Exception(e.message)))
     yield result
+
+  /** Apply a copy range operation. */
+  private def applyCopyRange(
+    wb: Workbook,
+    defaultSheetName: Option[SheetName],
+    sourceStr: String,
+    targetStr: String,
+    valuesOnly: Boolean
+  ): IO[Workbook] =
+    val sheetName = defaultSheetName.getOrElse(
+      throw new Exception("copy requires --sheet")
+    )
+    IO.fromEither(wb(sheetName).left.map(e => new Exception(e.message))).flatMap { sheet =>
+      // Parse source as range
+      val sourceRange = RefType.parse(sourceStr) match
+        case Right(RefType.Cell(ref)) => CellRange(ref, ref)
+        case Right(RefType.Range(r)) => r
+        case Right(RefType.QualifiedCell(_, ref)) => CellRange(ref, ref)
+        case Right(RefType.QualifiedRange(_, r)) => r
+        case Left(err) => throw new Exception(s"Invalid source ref '$sourceStr': $err")
+
+      // Parse target as ref or range
+      val targetStart = RefType.parse(targetStr) match
+        case Right(RefType.Cell(ref)) => ref
+        case Right(RefType.Range(r)) => r.start
+        case Right(RefType.QualifiedCell(_, ref)) => ref
+        case Right(RefType.QualifiedRange(_, r)) => r.start
+        case Left(err) => throw new Exception(s"Invalid target ref '$targetStr': $err")
+
+      val colDelta = targetStart.col.index0 - sourceRange.start.col.index0
+      val rowDelta = targetStart.row.index0 - sourceRange.start.row.index0
+
+      // Copy each cell from source to target
+      val updatedSheet = sourceRange.cells.foldLeft(sheet) { (s, srcRef) =>
+        val tgtRef = ARef(
+          Column.from0(srcRef.col.index0 + colDelta),
+          Row.from0(srcRef.row.index0 + rowDelta)
+        )
+        val srcCell = s(srcRef)
+        if srcCell.value == CellValue.Empty then s
+        else if valuesOnly then s.put(tgtRef, srcCell.value)
+        else
+          // Copy with formula shifting
+          val newValue = srcCell.value match
+            case CellValue.Formula(expr, _) =>
+              val fullFormula = s"=$expr"
+              FormulaParser.parse(fullFormula) match
+                case Right(parsed) =>
+                  val shifted = FormulaShifter.shift(parsed, colDelta, rowDelta)
+                  CellValue.Formula(FormulaPrinter.print(shifted, includeEquals = false))
+                case Left(_) => CellValue.Formula(expr) // Unparseable: copy as-is
+            case other => other
+          val updated = s.put(tgtRef, newValue)
+          // Preserve style
+          srcCell.styleId.flatMap(s.styleRegistry.get) match
+            case Some(style) =>
+              import com.tjclp.xl.sheets.styleSyntax.withCellStyle
+              updated.withCellStyle(tgtRef, style)
+            case None => updated
+      }
+      IO.pure(wb.put(updatedSheet))
+    }
 
   // ========== Utilities ==========
 

--- a/xl-cli/src/com/tjclp/xl/cli/helpers/BatchParser.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/helpers/BatchParser.scala
@@ -841,17 +841,39 @@ object BatchParser:
             applyRenameSheet(currentWb, from, to)
 
           case BatchOp.Freeze(refStr) =>
-            IO.fromEither(ARef.parse(refStr).left.map(e => new Exception(e))).flatMap { ref =>
-              defaultSheetName match
-                case Some(sheetName) =>
-                  IO.fromEither(
-                    currentWb(sheetName)
-                      .map(s => currentWb.put(s.freezeAt(ref)))
-                      .left
-                      .map(e => new Exception(e.message))
-                  )
-                case None =>
-                  IO.raiseError(new Exception("freeze requires --sheet"))
+            // Accept either bare ref ("B2") or qualified ref ("Sheet2!B2").
+            IO.fromEither(
+              RefType
+                .parse(refStr)
+                .left
+                .map(e => new Exception(s"Invalid freeze ref '$refStr': $e"))
+            ).flatMap {
+              case RefType.Cell(ref) =>
+                defaultSheetName match
+                  case Some(sheetName) =>
+                    IO.fromEither(
+                      currentWb(sheetName)
+                        .map(s => currentWb.put(s.freezeAt(ref)))
+                        .left
+                        .map(e => new Exception(e.message))
+                    )
+                  case None =>
+                    IO.raiseError(
+                      new Exception(
+                        "freeze requires --sheet or a qualified ref (e.g., 'Sheet1!B2')"
+                      )
+                    )
+              case RefType.QualifiedCell(sheetName, ref) =>
+                IO.fromEither(
+                  currentWb(sheetName)
+                    .map(s => currentWb.put(s.freezeAt(ref)))
+                    .left
+                    .map(e => new Exception(e.message))
+                )
+              case RefType.Range(_) | RefType.QualifiedRange(_, _) =>
+                IO.raiseError(
+                  new Exception(s"freeze expects a single cell reference, got range: $refStr")
+                )
             }
 
           case BatchOp.Unfreeze =>
@@ -864,7 +886,9 @@ object BatchParser:
                     .map(e => new Exception(e.message))
                 )
               case None =>
-                IO.raiseError(new Exception("unfreeze requires --sheet"))
+                IO.raiseError(
+                  new Exception("unfreeze requires --sheet (specify which sheet to unfreeze)")
+                )
 
           case BatchOp.CopyRange(sourceStr, targetStr, valuesOnly) =>
             applyCopyRange(currentWb, defaultSheetName, sourceStr, targetStr, valuesOnly)
@@ -1478,19 +1502,9 @@ object BatchParser:
           )
           CellRange(ref, endRef)
 
-      srcRowCount = Row.index0(sourceRange.rowEnd) - Row.index0(sourceRange.rowStart) + 1
-      srcColCount = Column.index0(sourceRange.colEnd) - Column.index0(sourceRange.colStart) + 1
-      tgtRowCount = Row.index0(targetRange.rowEnd) - Row.index0(targetRange.rowStart) + 1
-      tgtColCount = Column.index0(targetRange.colEnd) - Column.index0(targetRange.colStart) + 1
-      _ <-
-        if srcRowCount != tgtRowCount || srcColCount != tgtColCount then
-          IO.raiseError(
-            new Exception(
-              s"Source (${srcRowCount}x${srcColCount}) and target " +
-                s"(${tgtRowCount}x${tgtColCount}) dimensions mismatch"
-            )
-          )
-        else IO.unit
+      _ <- IO.fromEither(
+        CopyOps.validateDimensions(sourceRange, targetRange).left.map(new Exception(_))
+      )
     yield CopyOps.copyRange(wb, sourceSheet, sourceRange, targetSheet, targetRange, valuesOnly)
 
   // ========== Utilities ==========

--- a/xl-cli/src/com/tjclp/xl/cli/helpers/CopyOps.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/helpers/CopyOps.scala
@@ -18,9 +18,14 @@ import com.tjclp.xl.sheets.styleSyntax.withCellStyle
  *   - Formula adjustment: relative references shifted by the source-to-target displacement.
  *   - `valuesOnly` mode: formulas materialized to their cached value, or evaluated against the
  *     source sheet if no cache is present.
+ *   - Formula cache population against the final target-sheet state, so copied formulas see the
+ *     destination context and any copied dependencies in the target range.
  *   - Style preservation in all modes (source cell styles applied to target cells).
  */
 object CopyOps:
+
+  /** Formula cell written in phase 1; cache is populated after the target sheet is complete. */
+  private final case class PendingFormulaCache(ref: ARef, expr: String)
 
   /**
    * Copy `sourceRange` cells from `sourceSheet` into `targetSheet` at `targetRange`.
@@ -53,44 +58,57 @@ object CopyOps:
     val sameSheet = sourceSheet.name == targetSheet.name
     val workingSheet = if sameSheet then sourceSheet else targetSheet
 
-    val updated = sourceRange.cells.foldLeft(workingSheet) { (s, srcRef) =>
-      val tgtRef = ARef.from0(
-        Column.index0(srcRef.col) + colDelta,
-        Row.index0(srcRef.row) + rowDelta
-      )
-      snapshot.get(srcRef) match
-        case None => s // Empty source cell: skip, leave target unchanged.
-        case Some(srcCell) =>
-          val withValue =
-            writeCopiedValue(s, sourceSheet, wb, srcCell, tgtRef, colDelta, rowDelta, valuesOnly)
-          // Preserve style from source (looked up in source's registry, registered into target's).
-          srcCell.styleId.flatMap(sourceSheet.styleRegistry.get) match
-            case Some(style) => withValue.withCellStyle(tgtRef, style)
-            case None => withValue
-    }
+    val (phase1Sheet, pendingFormulaCaches) =
+      sourceRange.cells.foldLeft((workingSheet, Vector.empty[PendingFormulaCache])) {
+        case ((s, pending), srcRef) =>
+          val tgtRef = ARef.from0(
+            Column.index0(srcRef.col) + colDelta,
+            Row.index0(srcRef.row) + rowDelta
+          )
+          snapshot.get(srcRef) match
+            case None => (s, pending) // Empty source cell: skip, leave target unchanged.
+            case Some(srcCell) =>
+              val (copiedValue, pendingFormula) =
+                copiedCellValue(sourceSheet, wb, srcCell, colDelta, rowDelta, valuesOnly)
+              val withValue = s.put(tgtRef, copiedValue)
+              // Preserve style from source (looked up in source's registry, registered into target's).
+              val withStyle = srcCell.styleId.flatMap(sourceSheet.styleRegistry.get) match
+                case Some(style) => withValue.withCellStyle(tgtRef, style)
+                case None => withValue
+              val updatedPending = pendingFormula match
+                case Some(expr) => pending :+ PendingFormulaCache(tgtRef, expr)
+                case None => pending
+              (withStyle, updatedPending)
+      }
+
+    val updated =
+      if pendingFormulaCaches.isEmpty then phase1Sheet
+      else populateFormulaCaches(phase1Sheet, wb, pendingFormulaCaches)
 
     wb.put(updated)
 
-  /** Write the cell value at `tgtRef`, adjusting formulas unless `valuesOnly` is set. */
-  private def writeCopiedValue(
-    target: Sheet,
+  /** Compute the copied value, shifting formulas unless `valuesOnly` is set. */
+  private def copiedCellValue(
     sourceSheet: Sheet,
     wb: Workbook,
     srcCell: Cell,
-    tgtRef: ARef,
     colDelta: Int,
     rowDelta: Int,
     valuesOnly: Boolean
-  ): Sheet =
+  ): (CellValue, Option[String]) =
     srcCell.value match
       case CellValue.Formula(expr, cachedOpt) if valuesOnly =>
         // Materialize: prefer cached value, fall back to evaluating against source sheet.
         val materialized = cachedOpt.getOrElse {
           SheetEvaluator
-            .evaluateFormula(sourceSheet)(s"=$expr", workbook = Some(wb))
+            .evaluateFormula(sourceSheet)(
+              s"=$expr",
+              workbook = Some(wb),
+              currentCell = Some(srcCell.ref)
+            )
             .getOrElse(CellValue.Empty)
         }
-        target.put(tgtRef, materialized)
+        (materialized, None)
 
       case CellValue.Formula(expr, _) =>
         // Shift formula references by the displacement.
@@ -98,16 +116,25 @@ object CopyOps:
           case Right(parsed) =>
             val shifted = FormulaShifter.shift(parsed, colDelta, rowDelta)
             val shiftedExpr = FormulaPrinter.print(shifted, includeEquals = false)
-            val cached = SheetEvaluator
-              .evaluateFormula(sourceSheet)(s"=$shiftedExpr", workbook = Some(wb))
-              .toOption
-            target.put(tgtRef, CellValue.Formula(shiftedExpr, cached))
+            (CellValue.Formula(shiftedExpr, None), Some(shiftedExpr))
           case Left(_) =>
-            // Unparseable formula: preserve as-is, try to cache.
-            val cached = SheetEvaluator
-              .evaluateFormula(sourceSheet)(s"=$expr", workbook = Some(wb))
-              .toOption
-            target.put(tgtRef, CellValue.Formula(expr, cached))
+            // Unparseable formula: preserve as-is and try to cache in phase 2.
+            (CellValue.Formula(expr, None), Some(expr))
 
       case other =>
-        target.put(tgtRef, other)
+        (other, None)
+
+  /** Populate caches for copied formulas after the final target-sheet state has been assembled. */
+  private def populateFormulaCaches(
+    sheet: Sheet,
+    wb: Workbook,
+    pendingFormulaCaches: Vector[PendingFormulaCache]
+  ): Sheet =
+    pendingFormulaCaches.foldLeft(sheet) { case (s, PendingFormulaCache(ref, expr)) =>
+      val workbookWithCurrentSheet = wb.put(s)
+      val cached =
+        SheetEvaluator
+          .evaluateCell(s)(ref, workbook = Some(workbookWithCurrentSheet))
+          .toOption
+      s.put(ref, CellValue.Formula(expr, cached))
+    }

--- a/xl-cli/src/com/tjclp/xl/cli/helpers/CopyOps.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/helpers/CopyOps.scala
@@ -8,6 +8,8 @@ import com.tjclp.xl.formula.eval.DependentRecalculation.*
 import com.tjclp.xl.sheets.Sheet
 import com.tjclp.xl.sheets.styleSyntax.withCellStyle
 
+import scala.annotation.tailrec
+
 /**
  * Shared copy logic used by both the `copy` CLI command and the `copy` batch operation.
  *
@@ -152,19 +154,34 @@ object CopyOps:
   /**
    * Populate caches for copied formulas against the final target-sheet state.
    *
-   * Each formula's cache is independent: we don't need to see sibling caches to evaluate one
-   * formula, so the workbook-with-sheet is constructed once outside the fold rather than per cell.
+   * Some evaluator paths (notably lookup/match functions over ranges) only consult formula caches
+   * rather than recursively evaluating uncached sibling formulas. We therefore iterate until the
+   * copied formula caches reach a fixed point, rebuilding workbook context from the current sheet
+   * state on each step so same-sheet-qualified refs like `Sheet1!A1:B2` also see freshly-populated
+   * sibling caches.
+   *
+   * The pass count is bounded by the number of copied formulas. In the worst acyclic case, each
+   * pass resolves one more layer of dependencies. Cyclic or otherwise unevaluable formulas remain
+   * uncached (`None`), matching the prior best-effort behavior.
    */
   private def populateFormulaCaches(
     sheet: Sheet,
     wb: Workbook,
     pendingFormulaCaches: Vector[PendingFormulaCache]
   ): Sheet =
-    val wbForEval = wb.put(sheet)
-    pendingFormulaCaches.foldLeft(sheet) { case (s, PendingFormulaCache(ref, expr)) =>
-      val cached =
-        SheetEvaluator
-          .evaluateCell(s)(ref, workbook = Some(wbForEval))
-          .toOption
-      s.put(ref, CellValue.Formula(expr, cached))
-    }
+    @tailrec
+    def loop(currentSheet: Sheet, passesRemaining: Int): Sheet =
+      val nextSheet = pendingFormulaCaches.foldLeft(currentSheet) {
+        case (s, PendingFormulaCache(ref, expr)) =>
+          val currentWorkbook = wb.put(s)
+          val cached =
+            SheetEvaluator
+              .evaluateCell(s)(ref, workbook = Some(currentWorkbook))
+              .toOption
+          s.put(ref, CellValue.Formula(expr, cached))
+      }
+
+      if nextSheet == currentSheet || passesRemaining <= 1 then nextSheet
+      else loop(nextSheet, passesRemaining - 1)
+
+    loop(sheet, pendingFormulaCaches.length.max(1))

--- a/xl-cli/src/com/tjclp/xl/cli/helpers/CopyOps.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/helpers/CopyOps.scala
@@ -1,0 +1,113 @@
+package com.tjclp.xl.cli.helpers
+
+import com.tjclp.xl.{*, given}
+import com.tjclp.xl.addressing.{ARef, CellRange, Column, Row}
+import com.tjclp.xl.cells.{Cell, CellValue}
+import com.tjclp.xl.formula.{FormulaParser, FormulaPrinter, FormulaShifter, SheetEvaluator}
+import com.tjclp.xl.sheets.Sheet
+import com.tjclp.xl.sheets.styleSyntax.withCellStyle
+
+/**
+ * Shared copy logic used by both the `copy` CLI command and the `copy` batch operation.
+ *
+ * Handles:
+ *   - Overlapping copies (source and target ranges overlap in the same sheet). Source cells are
+ *     snapshotted into an immutable map before mutation so each target read sees the pre-copy state
+ *     regardless of iteration order.
+ *   - Cross-sheet copies (source and target in different sheets).
+ *   - Formula adjustment: relative references shifted by the source-to-target displacement.
+ *   - `valuesOnly` mode: formulas materialized to their cached value, or evaluated against the
+ *     source sheet if no cache is present.
+ *   - Style preservation in all modes (source cell styles applied to target cells).
+ */
+object CopyOps:
+
+  /**
+   * Copy `sourceRange` cells from `sourceSheet` into `targetSheet` at `targetRange`.
+   *
+   * Requires `sourceRange.cells.size == targetRange.cells.size`; the caller must validate
+   * dimensions first.
+   *
+   * When `sourceSheet.name == targetSheet.name` (same sheet), a single updated sheet is written
+   * back. When they differ, only `targetSheet` is updated; the source sheet is untouched.
+   *
+   * Empty source cells (absent from `sourceSheet.cells`) are skipped — the target cell is left
+   * unchanged rather than cleared.
+   */
+  def copyRange(
+    wb: Workbook,
+    sourceSheet: Sheet,
+    sourceRange: CellRange,
+    targetSheet: Sheet,
+    targetRange: CellRange,
+    valuesOnly: Boolean
+  ): Workbook =
+    // Snapshot source cells BEFORE any mutation so overlapping same-sheet copies are correct.
+    val snapshot: Map[ARef, Cell] =
+      sourceRange.cells.flatMap(ref => sourceSheet.cells.get(ref).map(ref -> _)).toMap
+
+    val colDelta = Column.index0(targetRange.start.col) - Column.index0(sourceRange.start.col)
+    val rowDelta = Row.index0(targetRange.start.row) - Row.index0(sourceRange.start.row)
+
+    // Same-sheet vs cross-sheet: work on one sheet when both refer to the same one by name.
+    val sameSheet = sourceSheet.name == targetSheet.name
+    val workingSheet = if sameSheet then sourceSheet else targetSheet
+
+    val updated = sourceRange.cells.foldLeft(workingSheet) { (s, srcRef) =>
+      val tgtRef = ARef.from0(
+        Column.index0(srcRef.col) + colDelta,
+        Row.index0(srcRef.row) + rowDelta
+      )
+      snapshot.get(srcRef) match
+        case None => s // Empty source cell: skip, leave target unchanged.
+        case Some(srcCell) =>
+          val withValue =
+            writeCopiedValue(s, sourceSheet, wb, srcCell, tgtRef, colDelta, rowDelta, valuesOnly)
+          // Preserve style from source (looked up in source's registry, registered into target's).
+          srcCell.styleId.flatMap(sourceSheet.styleRegistry.get) match
+            case Some(style) => withValue.withCellStyle(tgtRef, style)
+            case None => withValue
+    }
+
+    wb.put(updated)
+
+  /** Write the cell value at `tgtRef`, adjusting formulas unless `valuesOnly` is set. */
+  private def writeCopiedValue(
+    target: Sheet,
+    sourceSheet: Sheet,
+    wb: Workbook,
+    srcCell: Cell,
+    tgtRef: ARef,
+    colDelta: Int,
+    rowDelta: Int,
+    valuesOnly: Boolean
+  ): Sheet =
+    srcCell.value match
+      case CellValue.Formula(expr, cachedOpt) if valuesOnly =>
+        // Materialize: prefer cached value, fall back to evaluating against source sheet.
+        val materialized = cachedOpt.getOrElse {
+          SheetEvaluator
+            .evaluateFormula(sourceSheet)(s"=$expr", workbook = Some(wb))
+            .getOrElse(CellValue.Empty)
+        }
+        target.put(tgtRef, materialized)
+
+      case CellValue.Formula(expr, _) =>
+        // Shift formula references by the displacement.
+        FormulaParser.parse(s"=$expr") match
+          case Right(parsed) =>
+            val shifted = FormulaShifter.shift(parsed, colDelta, rowDelta)
+            val shiftedExpr = FormulaPrinter.print(shifted, includeEquals = false)
+            val cached = SheetEvaluator
+              .evaluateFormula(sourceSheet)(s"=$shiftedExpr", workbook = Some(wb))
+              .toOption
+            target.put(tgtRef, CellValue.Formula(shiftedExpr, cached))
+          case Left(_) =>
+            // Unparseable formula: preserve as-is, try to cache.
+            val cached = SheetEvaluator
+              .evaluateFormula(sourceSheet)(s"=$expr", workbook = Some(wb))
+              .toOption
+            target.put(tgtRef, CellValue.Formula(expr, cached))
+
+      case other =>
+        target.put(tgtRef, other)

--- a/xl-cli/src/com/tjclp/xl/cli/helpers/CopyOps.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/helpers/CopyOps.scala
@@ -4,6 +4,7 @@ import com.tjclp.xl.{*, given}
 import com.tjclp.xl.addressing.{ARef, CellRange, Column, Row}
 import com.tjclp.xl.cells.{Cell, CellValue}
 import com.tjclp.xl.formula.{FormulaParser, FormulaPrinter, FormulaShifter, SheetEvaluator}
+import com.tjclp.xl.formula.eval.DependentRecalculation.*
 import com.tjclp.xl.sheets.Sheet
 import com.tjclp.xl.sheets.styleSyntax.withCellStyle
 
@@ -20,6 +21,7 @@ import com.tjclp.xl.sheets.styleSyntax.withCellStyle
  *     source sheet if no cache is present.
  *   - Formula cache population against the final target-sheet state, so copied formulas see the
  *     destination context and any copied dependencies in the target range.
+ *   - Transitive dependent recalculation on the target sheet after the copy completes.
  *   - Style preservation in all modes (source cell styles applied to target cells).
  */
 object CopyOps:
@@ -28,16 +30,37 @@ object CopyOps:
   private final case class PendingFormulaCache(ref: ARef, expr: String)
 
   /**
+   * Validate that `source` and `target` have identical dimensions.
+   *
+   * Returns `Left` with a user-facing message when they differ, `Right(())` when they match.
+   * Extracted so both CLI and batch paths produce the same error text.
+   */
+  def validateDimensions(source: CellRange, target: CellRange): Either[String, Unit] =
+    val srcRowCount = Row.index0(source.rowEnd) - Row.index0(source.rowStart) + 1
+    val srcColCount = Column.index0(source.colEnd) - Column.index0(source.colStart) + 1
+    val tgtRowCount = Row.index0(target.rowEnd) - Row.index0(target.rowStart) + 1
+    val tgtColCount = Column.index0(target.colEnd) - Column.index0(target.colStart) + 1
+    if srcRowCount == tgtRowCount && srcColCount == tgtColCount then Right(())
+    else
+      Left(
+        s"Source (${srcRowCount}x${srcColCount}) and target (${tgtRowCount}x${tgtColCount}) dimensions mismatch. " +
+          "Use a single target cell to auto-expand, or specify matching range."
+      )
+
+  /**
    * Copy `sourceRange` cells from `sourceSheet` into `targetSheet` at `targetRange`.
    *
    * Requires `sourceRange.cells.size == targetRange.cells.size`; the caller must validate
-   * dimensions first.
+   * dimensions first (see [[validateDimensions]]).
    *
    * When `sourceSheet.name == targetSheet.name` (same sheet), a single updated sheet is written
    * back. When they differ, only `targetSheet` is updated; the source sheet is untouched.
    *
    * Empty source cells (absent from `sourceSheet.cells`) are skipped — the target cell is left
    * unchanged rather than cleared.
+   *
+   * After phase-2 cache population, transitive dependents on the target sheet are recalculated so
+   * that pre-existing formulas pointing into the target range see the new values.
    */
   def copyRange(
     wb: Workbook,
@@ -81,11 +104,13 @@ object CopyOps:
               (withStyle, updatedPending)
       }
 
-    val updated =
+    val cachedSheet =
       if pendingFormulaCaches.isEmpty then phase1Sheet
       else populateFormulaCaches(phase1Sheet, wb, pendingFormulaCaches)
 
-    wb.put(updated)
+    // Recalculate transitive dependents (pre-existing formulas that reference the target range).
+    val wbWithCopied = wb.put(cachedSheet)
+    wbWithCopied.recalculateDependents(cachedSheet.name, targetRange.cells.toSet)
 
   /** Compute the copied value, shifting formulas unless `valuesOnly` is set. */
   private def copiedCellValue(
@@ -124,17 +149,22 @@ object CopyOps:
       case other =>
         (other, None)
 
-  /** Populate caches for copied formulas after the final target-sheet state has been assembled. */
+  /**
+   * Populate caches for copied formulas against the final target-sheet state.
+   *
+   * Each formula's cache is independent: we don't need to see sibling caches to evaluate one
+   * formula, so the workbook-with-sheet is constructed once outside the fold rather than per cell.
+   */
   private def populateFormulaCaches(
     sheet: Sheet,
     wb: Workbook,
     pendingFormulaCaches: Vector[PendingFormulaCache]
   ): Sheet =
+    val wbForEval = wb.put(sheet)
     pendingFormulaCaches.foldLeft(sheet) { case (s, PendingFormulaCache(ref, expr)) =>
-      val workbookWithCurrentSheet = wb.put(s)
       val cached =
         SheetEvaluator
-          .evaluateCell(s)(ref, workbook = Some(workbookWithCurrentSheet))
+          .evaluateCell(s)(ref, workbook = Some(wbForEval))
           .toOption
       s.put(ref, CellValue.Formula(expr, cached))
     }

--- a/xl-cli/test/src/com/tjclp/xl/cli/BatchCopyFreezeSpec.scala
+++ b/xl-cli/test/src/com/tjclp/xl/cli/BatchCopyFreezeSpec.scala
@@ -184,6 +184,103 @@ class BatchCopyFreezeSpec extends FunSuite:
       case other => fail(s"Expected D1 = Formula(B1, Some(Number(999))), got: $other")
   }
 
+  test("batch copy: copied formula with sheet-qualified self-range caches correctly") {
+    // Reviewer's repro: A1=1, B1=VLOOKUP(1, Test!A1:C1, 3, FALSE) with NO cache, C1=42.
+    // Copy A1:C1 to D1:F1. The shifted formula at E1 references Test!D1:F1 which
+    // includes E1 itself — the cache eval must not get confused by the self-reference
+    // and must resolve to 42 (the value at F1).
+    val sheet = Sheet("Test")
+      .put(ARef.from0(0, 0), CellValue.Number(1)) // A1
+      .put(
+        ARef.from0(1, 0),
+        CellValue.Formula("VLOOKUP(1,Test!A1:C1,3,FALSE)", None)
+      ) // B1 — no prior cache
+      .put(ARef.from0(2, 0), CellValue.Number(42)) // C1
+    val wb = Workbook(sheet)
+
+    val json = """[{"op":"copy","source":"A1:C1","target":"D1:F1"}]"""
+    val result = runBatch(wb, Some(sheet), json)
+    val s = result.sheets.head
+
+    cellValueAt(s, 4, 0) match
+      case Some(CellValue.Formula(expr, Some(CellValue.Number(n)))) =>
+        assert(expr.contains("D1:F1"), s"Expected shifted range D1:F1, got: $expr")
+        assertEquals(n, BigDecimal(42), "Cache must be 42 (copied formula sees copied siblings)")
+      case other =>
+        fail(s"Expected Formula(VLOOKUP(...,Test!D1:F1,...), Some(Number(42))), got: $other")
+  }
+
+  test("batch copy: copied formula with sheet-qualified self-range sees copied formula sibling cache") {
+    // Stronger cache regression: the lookup key itself is a copied formula sibling.
+    // D1 comes from A1 (=1) and E1 comes from B1 (=VLOOKUP(1, Test!A1:C1, 3, FALSE)).
+    // E1's cache should only resolve if the copy path makes D1's copied formula cache visible.
+    val sheet = Sheet("Test")
+      .put(ARef.from0(0, 0), CellValue.Formula("1", None)) // A1
+      .put(
+        ARef.from0(1, 0),
+        CellValue.Formula("VLOOKUP(1,Test!A1:C1,3,FALSE)", None)
+      ) // B1
+      .put(ARef.from0(2, 0), CellValue.Number(42)) // C1
+    val wb = Workbook(sheet)
+
+    val json = """[{"op":"copy","source":"A1:C1","target":"D1:F1"}]"""
+    val result = runBatch(wb, Some(sheet), json)
+    val s = result.sheets.head
+
+    cellValueAt(s, 3, 0) match
+      case Some(CellValue.Formula(expr, Some(CellValue.Number(n)))) =>
+        assertEquals(expr, "1")
+        assertEquals(n, BigDecimal(1), "D1 should cache before E1 evaluates its lookup")
+      case other =>
+        fail(s"Expected D1 = Formula(1, Some(Number(1))), got: $other")
+
+    cellValueAt(s, 4, 0) match
+      case Some(CellValue.Formula(expr, Some(CellValue.Number(n)))) =>
+        assert(expr.contains("D1:F1"), s"Expected shifted range D1:F1, got: $expr")
+        assertEquals(
+          n,
+          BigDecimal(42),
+          "E1 should cache once D1's copied formula cache is available"
+        )
+      case other =>
+        fail(s"Expected E1 = Formula(VLOOKUP(...,Test!D1:F1,...), Some(Number(42))), got: $other")
+  }
+
+  test("batch copy: cache population converges across multiple copied-formula passes") {
+    // D1 depends on E1 via a sheet-qualified range. Row-major iteration sees D1 before E1,
+    // so a single pass is not enough: E1 must cache first, then D1 on a later pass.
+    val sheet = Sheet("Test")
+      .put(
+        ARef.from0(0, 0),
+        CellValue.Formula("VLOOKUP(1,Test!B1:C1,2,FALSE)", None)
+      ) // A1
+      .put(ARef.from0(1, 0), CellValue.Formula("1", None)) // B1
+      .put(ARef.from0(2, 0), CellValue.Number(42)) // C1
+    val wb = Workbook(sheet)
+
+    val json = """[{"op":"copy","source":"A1:C1","target":"D1:F1"}]"""
+    val result = runBatch(wb, Some(sheet), json)
+    val s = result.sheets.head
+
+    cellValueAt(s, 3, 0) match
+      case Some(CellValue.Formula(expr, Some(CellValue.Number(n)))) =>
+        assert(expr.contains("E1:F1"), s"Expected shifted range E1:F1, got: $expr")
+        assertEquals(
+          n,
+          BigDecimal(42),
+          "D1 should cache after a later pass once E1's copied formula cache exists"
+        )
+      case other =>
+        fail(s"Expected D1 = Formula(VLOOKUP(...,Test!E1:F1,...), Some(Number(42))), got: $other")
+
+    cellValueAt(s, 4, 0) match
+      case Some(CellValue.Formula(expr, Some(CellValue.Number(n)))) =>
+        assertEquals(expr, "1")
+        assertEquals(n, BigDecimal(1))
+      case other =>
+        fail(s"Expected E1 = Formula(1, Some(Number(1))), got: $other")
+  }
+
   test("batch copy: formula cache sees copied dependencies in the final target range") {
     val sheet = Sheet("Test")
       .put(ARef.from0(0, 0), CellValue.Formula("B1", Some(CellValue.Number(2)))) // A1

--- a/xl-cli/test/src/com/tjclp/xl/cli/BatchCopyFreezeSpec.scala
+++ b/xl-cli/test/src/com/tjclp/xl/cli/BatchCopyFreezeSpec.scala
@@ -166,6 +166,24 @@ class BatchCopyFreezeSpec extends FunSuite:
     assertEquals(cellValueAt(s, 0, 3), Some(CellValue.Number(3)), "A4 = source A3")
   }
 
+  test("batch copy: pre-existing dependents on target range are recalculated") {
+    // D1 depends on B1; copying A1 → B1 should cause D1's cache to refresh to the new value.
+    val sheet = Sheet("Test")
+      .put(ARef.from0(0, 0), CellValue.Number(999)) // A1 = 999
+      .put(ARef.from0(1, 0), CellValue.Number(1)) // B1 = 1 (pre-existing)
+      .put(ARef.from0(3, 0), CellValue.Formula("B1", Some(CellValue.Number(1)))) // D1 = B1, cached 1
+    val wb = Workbook(sheet)
+
+    val json = """[{"op":"copy","source":"A1","target":"B1"}]"""
+    val result = runBatch(wb, Some(sheet), json)
+    val s = result.sheets.head
+
+    cellValueAt(s, 3, 0) match
+      case Some(CellValue.Formula(_, Some(CellValue.Number(n)))) =>
+        assertEquals(n, BigDecimal(999), "D1's cache must be recalculated after B1 is overwritten")
+      case other => fail(s"Expected D1 = Formula(B1, Some(Number(999))), got: $other")
+  }
+
   test("batch copy: formula cache sees copied dependencies in the final target range") {
     val sheet = Sheet("Test")
       .put(ARef.from0(0, 0), CellValue.Formula("B1", Some(CellValue.Number(2)))) // A1
@@ -219,6 +237,25 @@ class BatchCopyFreezeSpec extends FunSuite:
       .unsafeRunSync()
 
     assert(err.isLeft, "Expected error when freeze has no sheet to target")
+    val msg = err.swap.getOrElse(throw new Exception("expected left")).getMessage
+    assert(
+      msg.contains("qualified ref"),
+      s"Error should mention qualified ref as an alternative: $msg"
+    )
+  }
+
+  test("batch freeze: qualified ref targets named sheet without default") {
+    val s1 = Sheet("Sheet1")
+    val s2 = Sheet("Sheet2")
+    val wb = Workbook(Vector(s1, s2))
+
+    val json = """[{"op":"freeze","ref":"Sheet2!C3"}]"""
+    val result = runBatch(wb, None, json)
+
+    val sheet1 = result.sheets.find(_.name.value == "Sheet1").get
+    val sheet2 = result.sheets.find(_.name.value == "Sheet2").get
+    assertEquals(sheet1.freezePane, None)
+    assertEquals(sheet2.freezePane, Some(FreezePane.At(ARef.from0(2, 2))))
   }
 
   test("batch copy: invalid ref produces user-facing error (not bypass JVM exception)") {

--- a/xl-cli/test/src/com/tjclp/xl/cli/BatchCopyFreezeSpec.scala
+++ b/xl-cli/test/src/com/tjclp/xl/cli/BatchCopyFreezeSpec.scala
@@ -1,0 +1,205 @@
+package com.tjclp.xl.cli
+
+import munit.FunSuite
+
+import cats.effect.unsafe
+import com.tjclp.xl.{Sheet, Workbook}
+import com.tjclp.xl.addressing.ARef
+import com.tjclp.xl.cells.CellValue
+import com.tjclp.xl.cli.helpers.BatchParser
+import com.tjclp.xl.sheets.FreezePane
+
+/**
+ * Batch JSON tests for `copy`, `freeze`, and `unfreeze` operations.
+ *
+ * Exercises the end-to-end BatchParser flow: JSON → BatchOp → applyBatchOperations → Workbook.
+ * Covers the correctness issues flagged in review:
+ *   - Qualified source/target sheet refs in copy
+ *   - valuesOnly copy materializes formulas (doesn't just write `CellValue.Formula` again)
+ *   - Overlapping copies within a sheet use snapshotted sources
+ */
+@SuppressWarnings(
+  Array("org.wartremover.warts.OptionPartial", "org.wartremover.warts.IterableOps")
+)
+class BatchCopyFreezeSpec extends FunSuite:
+
+  given unsafe.IORuntime = unsafe.IORuntime.global
+
+  private def cellValueAt(sheet: Sheet, col: Int, row: Int): Option[CellValue] =
+    sheet.cells.get(ARef.from0(col, row)).map(_.value)
+
+  private def runBatch(
+    wb: Workbook,
+    defaultSheet: Option[Sheet],
+    json: String
+  ): Workbook =
+    val parseResult = BatchParser.parseBatchJson(json) match
+      case Right(r) => r
+      case Left(e) => throw e
+    BatchParser.applyBatchOperations(wb, defaultSheet, parseResult.ops).unsafeRunSync()
+
+  // =========================================================================
+  // batch copy — qualified source/target sheet refs
+  // =========================================================================
+
+  test("batch copy: cross-sheet with qualified refs writes to destination sheet") {
+    val s1 = Sheet("Source").put(ARef.from0(0, 0), CellValue.Text("hello"))
+    val s2 = Sheet("Dest")
+    val wb = Workbook(Vector(s1, s2))
+
+    val json = """[{"op":"copy","source":"Source!A1","target":"Dest!B1"}]"""
+    // No default sheet provided — must use qualified refs
+    val result = runBatch(wb, None, json)
+
+    val dest = result.sheets.find(_.name.value == "Dest").get
+    val source = result.sheets.find(_.name.value == "Source").get
+    assertEquals(cellValueAt(dest, 1, 0), Some(CellValue.Text("hello")))
+    assertEquals(cellValueAt(source, 1, 0), None, "Source sheet must not be written to")
+  }
+
+  test("batch copy: unqualified refs fall back to default sheet") {
+    val s1 = Sheet("Main")
+      .put(ARef.from0(0, 0), CellValue.Number(10))
+    val wb = Workbook(s1)
+
+    val json = """[{"op":"copy","source":"A1","target":"B1"}]"""
+    val result = runBatch(wb, Some(s1), json)
+
+    val s = result.sheets.head
+    assertEquals(cellValueAt(s, 1, 0), Some(CellValue.Number(10)))
+  }
+
+  test("batch copy: unqualified side requires default sheet (error otherwise)") {
+    val s1 = Sheet("A").put(ARef.from0(0, 0), CellValue.Number(1))
+    val s2 = Sheet("B")
+    val wb = Workbook(Vector(s1, s2))
+
+    val json = """[{"op":"copy","source":"A!A1","target":"B1"}]"""
+    val err = BatchParser
+      .applyBatchOperations(wb, None, BatchParser.parseBatchJson(json).toOption.get.ops)
+      .attempt
+      .unsafeRunSync()
+
+    assert(err.isLeft)
+    val msg = err.swap.getOrElse(throw new Exception("expected left")).getMessage
+    assert(msg.contains("target"), s"Expected target-side error: $msg")
+  }
+
+  // =========================================================================
+  // batch copy --values-only materializes formulas (P2 bug)
+  // =========================================================================
+
+  test("batch copy valuesOnly: formula with cached value becomes the cached value") {
+    val formulaCell = CellValue.Formula("A1+A2", Some(CellValue.Number(42)))
+    val sheet = Sheet("Test")
+      .put(ARef.from0(0, 0), CellValue.Number(20))
+      .put(ARef.from0(0, 1), CellValue.Number(22))
+      .put(ARef.from0(0, 2), formulaCell)
+    val wb = Workbook(sheet)
+
+    val json = """[{"op":"copy","source":"A3","target":"B3","valuesOnly":true}]"""
+    val result = runBatch(wb, Some(sheet), json)
+
+    val s = result.sheets.head
+    cellValueAt(s, 1, 2) match
+      case Some(CellValue.Number(n)) =>
+        assertEquals(n, BigDecimal(42), "batch valuesOnly must materialize, not copy formula")
+      case other => fail(s"Expected Number(42), got: $other")
+  }
+
+  test("batch copy (no valuesOnly): formula shifts relative refs") {
+    val sheet = Sheet("Test")
+      .put(ARef.from0(0, 0), CellValue.Number(5))
+      .put(ARef.from0(0, 1), CellValue.Formula("A1*2", Some(CellValue.Number(10))))
+    val wb = Workbook(sheet)
+
+    val json = """[{"op":"copy","source":"A2","target":"B5"}]"""
+    val result = runBatch(wb, Some(sheet), json)
+
+    val s = result.sheets.head
+    cellValueAt(s, 1, 4) match
+      case Some(CellValue.Formula(expr, _)) =>
+        // Shifted from A1*2 by (+1 col, +3 rows) → B4*2
+        assert(expr.contains("B4"), s"Expected B4 in shifted formula: $expr")
+      case other => fail(s"Expected Formula, got: $other")
+  }
+
+  // =========================================================================
+  // batch copy — overlapping (P1 correctness)
+  // =========================================================================
+
+  test("batch copy: overlapping A1:A3 -> A2 preserves source snapshot") {
+    val sheet = Sheet("Test")
+      .put(ARef.from0(0, 0), CellValue.Number(1))
+      .put(ARef.from0(0, 1), CellValue.Number(2))
+      .put(ARef.from0(0, 2), CellValue.Number(3))
+    val wb = Workbook(sheet)
+
+    val json = """[{"op":"copy","source":"A1:A3","target":"A2"}]"""
+    val result = runBatch(wb, Some(sheet), json)
+
+    val s = result.sheets.head
+    assertEquals(cellValueAt(s, 0, 0), Some(CellValue.Number(1)), "A1 unchanged")
+    assertEquals(cellValueAt(s, 0, 1), Some(CellValue.Number(1)), "A2 = source A1")
+    assertEquals(cellValueAt(s, 0, 2), Some(CellValue.Number(2)), "A3 = source A2")
+    assertEquals(cellValueAt(s, 0, 3), Some(CellValue.Number(3)), "A4 = source A3")
+  }
+
+  // =========================================================================
+  // batch freeze / unfreeze
+  // =========================================================================
+
+  test("batch freeze: sets At override on default sheet") {
+    val sheet = Sheet("Main")
+    val wb = Workbook(sheet)
+
+    val json = """[{"op":"freeze","ref":"C3"}]"""
+    val result = runBatch(wb, Some(sheet), json)
+
+    val s = result.sheets.head
+    assertEquals(s.freezePane, Some(FreezePane.At(ARef.from0(2, 2))))
+  }
+
+  test("batch unfreeze: sets Remove override on default sheet") {
+    val sheet = Sheet("Main").freezeAt(ARef.from0(1, 1))
+    val wb = Workbook(sheet)
+
+    val json = """[{"op":"unfreeze"}]"""
+    val result = runBatch(wb, Some(sheet), json)
+
+    val s = result.sheets.head
+    assertEquals(s.freezePane, Some(FreezePane.Remove))
+  }
+
+  test("batch freeze: errors without --sheet if no default") {
+    val wb = Workbook(Sheet("A"), Sheet("B"))
+    val json = """[{"op":"freeze","ref":"B2"}]"""
+    val err = BatchParser
+      .applyBatchOperations(wb, None, BatchParser.parseBatchJson(json).toOption.get.ops)
+      .attempt
+      .unsafeRunSync()
+
+    assert(err.isLeft, "Expected error when freeze has no sheet to target")
+  }
+
+  test("batch copy: invalid ref produces user-facing error (not bypass JVM exception)") {
+    val sheet = Sheet("Test")
+    val wb = Workbook(sheet)
+
+    val json = """[{"op":"copy","source":"not-a-ref","target":"A1"}]"""
+    val err = BatchParser
+      .applyBatchOperations(
+        wb,
+        Some(sheet),
+        BatchParser.parseBatchJson(json).toOption.get.ops
+      )
+      .attempt
+      .unsafeRunSync()
+
+    assert(err.isLeft, "Expected IO error, not JVM exception bypass")
+    val msg = err.swap.getOrElse(throw new Exception("expected left")).getMessage
+    assert(
+      msg.contains("Invalid source ref") || msg.contains("not-a-ref"),
+      s"Expected source-side parse error: $msg"
+    )
+  }

--- a/xl-cli/test/src/com/tjclp/xl/cli/BatchCopyFreezeSpec.scala
+++ b/xl-cli/test/src/com/tjclp/xl/cli/BatchCopyFreezeSpec.scala
@@ -57,6 +57,27 @@ class BatchCopyFreezeSpec extends FunSuite:
     assertEquals(cellValueAt(source, 1, 0), None, "Source sheet must not be written to")
   }
 
+  test("batch copy: shifted formula cache uses destination-sheet context") {
+    val source = Sheet("Source")
+      .put(ARef.from0(0, 0), CellValue.Number(10)) // A1
+      .put(ARef.from0(1, 0), CellValue.Formula("A1", Some(CellValue.Number(10)))) // B1
+      .put(ARef.from0(2, 0), CellValue.Number(5)) // C1
+    val dest = Sheet("Dest")
+      .put(ARef.from0(2, 0), CellValue.Number(99)) // C1
+    val wb = Workbook(Vector(source, dest))
+
+    val json = """[{"op":"copy","source":"Source!B1","target":"Dest!D1"}]"""
+    val result = runBatch(wb, None, json)
+    val updatedDest = result.sheets.find(_.name.value == "Dest").get
+
+    cellValueAt(updatedDest, 3, 0) match
+      case Some(CellValue.Formula(expr, Some(CellValue.Number(n)))) =>
+        assert(expr.contains("C1"), s"Expected shifted formula to reference C1, got: $expr")
+        assertEquals(n, BigDecimal(99), "Cache must be evaluated against Dest, not Source")
+      case other =>
+        fail(s"Expected Formula(C1, Some(Number(99))), got: $other")
+  }
+
   test("batch copy: unqualified refs fall back to default sheet") {
     val s1 = Sheet("Main")
       .put(ARef.from0(0, 0), CellValue.Number(10))
@@ -143,6 +164,24 @@ class BatchCopyFreezeSpec extends FunSuite:
     assertEquals(cellValueAt(s, 0, 1), Some(CellValue.Number(1)), "A2 = source A1")
     assertEquals(cellValueAt(s, 0, 2), Some(CellValue.Number(2)), "A3 = source A2")
     assertEquals(cellValueAt(s, 0, 3), Some(CellValue.Number(3)), "A4 = source A3")
+  }
+
+  test("batch copy: formula cache sees copied dependencies in the final target range") {
+    val sheet = Sheet("Test")
+      .put(ARef.from0(0, 0), CellValue.Formula("B1", Some(CellValue.Number(2)))) // A1
+      .put(ARef.from0(1, 0), CellValue.Number(2)) // B1
+    val wb = Workbook(sheet)
+
+    val json = """[{"op":"copy","source":"A1:B1","target":"B1"}]"""
+    val result = runBatch(wb, Some(sheet), json)
+    val s = result.sheets.head
+
+    cellValueAt(s, 1, 0) match
+      case Some(CellValue.Formula(expr, Some(CellValue.Number(n)))) =>
+        assert(expr.contains("C1"), s"Expected shifted formula to reference C1, got: $expr")
+        assertEquals(n, BigDecimal(2), "Cache must see copied B1 -> C1 value in final target state")
+      case other =>
+        fail(s"Expected Formula(C1, Some(Number(2))), got: $other")
   }
 
   // =========================================================================

--- a/xl-cli/test/src/com/tjclp/xl/cli/CopyCommandSpec.scala
+++ b/xl-cli/test/src/com/tjclp/xl/cli/CopyCommandSpec.scala
@@ -1,0 +1,300 @@
+package com.tjclp.xl.cli
+
+import munit.FunSuite
+
+import java.nio.file.{Files, Path}
+
+import cats.effect.{IO, unsafe}
+import com.tjclp.xl.{Sheet, Workbook}
+import com.tjclp.xl.addressing.ARef
+import com.tjclp.xl.cells.CellValue
+import com.tjclp.xl.cli.commands.WriteCommands
+import com.tjclp.xl.io.ExcelIO
+import com.tjclp.xl.ooxml.writer.WriterConfig
+import com.tjclp.xl.styles.CellStyle
+import com.tjclp.xl.styles.dsl.{bold, italic}
+import com.tjclp.xl.sheets.styleSyntax.withCellStyle
+
+/**
+ * Integration tests for the `copy` command.
+ *
+ * Covers the correctness issues flagged in review:
+ *   - Overlapping copies within a sheet (source cells must be snapshotted)
+ *   - Cross-sheet copies (qualified target must actually write to target sheet)
+ *   - Values-only mode materializes formulas instead of keeping them
+ *   - Styles are preserved in both modes
+ *   - Formulas shift relative references by the correct delta
+ */
+@SuppressWarnings(
+  Array("org.wartremover.warts.OptionPartial", "org.wartremover.warts.IterableOps")
+)
+class CopyCommandSpec extends FunSuite:
+
+  given unsafe.IORuntime = unsafe.IORuntime.global
+
+  val outputPath: Path = Files.createTempFile("copy-test-", ".xlsx")
+  val config: WriterConfig = WriterConfig.default
+
+  override def afterEach(context: AfterEach): Unit =
+    if Files.exists(outputPath) then Files.delete(outputPath)
+
+  private def cellValueAt(sheet: Sheet, col: Int, row: Int): Option[CellValue] =
+    sheet.cells.get(ARef.from0(col, row)).map(_.value)
+
+  // =========================================================================
+  // Overlapping copies within a sheet (P1 correctness)
+  // =========================================================================
+
+  test("copy: overlapping A1:A3 -> A2 preserves source snapshot (1,2,3 -> 1,1,2,3)") {
+    // A1=1, A2=2, A3=3. Copy A1:A3 down by 1. Result should be A1=1, A2=1, A3=2, A4=3
+    // (i.e., the original sequence, not 1,1,1,1 from reading already-copied values)
+    val sheet = Sheet("Test")
+      .put(ARef.from0(0, 0), CellValue.Number(1))
+      .put(ARef.from0(0, 1), CellValue.Number(2))
+      .put(ARef.from0(0, 2), CellValue.Number(3))
+    val wb = Workbook(sheet)
+
+    WriteCommands
+      .copyRange(
+        wb,
+        Some(sheet),
+        "A1:A3",
+        "A2",
+        valuesOnly = false,
+        outputPath,
+        config
+      )
+      .unsafeRunSync()
+
+    val imported = ExcelIO.instance[IO].read(outputPath).unsafeRunSync()
+    val s = imported.sheets.head
+    assertEquals(cellValueAt(s, 0, 0), Some(CellValue.Number(1)), "A1 unchanged")
+    assertEquals(cellValueAt(s, 0, 1), Some(CellValue.Number(1)), "A2 = source A1")
+    assertEquals(cellValueAt(s, 0, 2), Some(CellValue.Number(2)), "A3 = source A2")
+    assertEquals(cellValueAt(s, 0, 3), Some(CellValue.Number(3)), "A4 = source A3")
+  }
+
+  test("copy: overlapping B1:D1 -> A1 shifts left without corruption") {
+    // B1=10, C1=20, D1=30. Copy B1:D1 left by 1. Result: A1=10, B1=20, C1=30
+    val sheet = Sheet("Test")
+      .put(ARef.from0(1, 0), CellValue.Number(10))
+      .put(ARef.from0(2, 0), CellValue.Number(20))
+      .put(ARef.from0(3, 0), CellValue.Number(30))
+    val wb = Workbook(sheet)
+
+    WriteCommands
+      .copyRange(wb, Some(sheet), "B1:D1", "A1", valuesOnly = false, outputPath, config)
+      .unsafeRunSync()
+
+    val imported = ExcelIO.instance[IO].read(outputPath).unsafeRunSync()
+    val s = imported.sheets.head
+    assertEquals(cellValueAt(s, 0, 0), Some(CellValue.Number(10)), "A1 = source B1")
+    assertEquals(cellValueAt(s, 1, 0), Some(CellValue.Number(20)), "B1 = source C1")
+    assertEquals(cellValueAt(s, 2, 0), Some(CellValue.Number(30)), "C1 = source D1")
+  }
+
+  // =========================================================================
+  // Cross-sheet copy (qualified target — P2 bug)
+  // =========================================================================
+
+  test("copy: cross-sheet with qualified target writes to target sheet, not source") {
+    val s1 = Sheet("Source").put(ARef.from0(0, 0), CellValue.Text("hello"))
+    val s2 = Sheet("Dest")
+    val wb = Workbook(Vector(s1, s2))
+
+    WriteCommands
+      .copyRange(
+        wb,
+        Some(s1),
+        "A1",
+        "Dest!B1",
+        valuesOnly = false,
+        outputPath,
+        config
+      )
+      .unsafeRunSync()
+
+    val imported = ExcelIO.instance[IO].read(outputPath).unsafeRunSync()
+    val source = imported.sheets.find(_.name.value == "Source").get
+    val dest = imported.sheets.find(_.name.value == "Dest").get
+
+    // Destination should have the value at B1
+    assertEquals(cellValueAt(dest, 1, 0), Some(CellValue.Text("hello")))
+    // Source should be unchanged — particularly, B1 on the source sheet must be empty
+    assertEquals(cellValueAt(source, 1, 0), None, "Source B1 must not be written")
+    // And the original source A1 is still intact
+    assertEquals(cellValueAt(source, 0, 0), Some(CellValue.Text("hello")))
+  }
+
+  test("copy: fully-qualified source and destination sheets") {
+    val s1 = Sheet("Income").put(ARef.from0(0, 0), CellValue.Number(1000))
+    val s2 = Sheet("Summary")
+    val wb = Workbook(Vector(s1, s2))
+
+    // Both sides qualified, no --sheet fallback provided
+    WriteCommands
+      .copyRange(
+        wb,
+        None,
+        "Income!A1",
+        "Summary!C3",
+        valuesOnly = false,
+        outputPath,
+        config
+      )
+      .unsafeRunSync()
+
+    val imported = ExcelIO.instance[IO].read(outputPath).unsafeRunSync()
+    val summary = imported.sheets.find(_.name.value == "Summary").get
+    assertEquals(cellValueAt(summary, 2, 2), Some(CellValue.Number(1000)))
+  }
+
+  // =========================================================================
+  // Values-only mode (P2 bug: batch version kept formulas)
+  // =========================================================================
+
+  test("copy --values-only: formula with cached value materializes to cached") {
+    val formulaCell = CellValue.Formula("A1+A2", Some(CellValue.Number(30)))
+    val sheet = Sheet("Test")
+      .put(ARef.from0(0, 0), CellValue.Number(10))
+      .put(ARef.from0(0, 1), CellValue.Number(20))
+      .put(ARef.from0(0, 2), formulaCell)
+    val wb = Workbook(sheet)
+
+    WriteCommands
+      .copyRange(wb, Some(sheet), "A3", "B3", valuesOnly = true, outputPath, config)
+      .unsafeRunSync()
+
+    val imported = ExcelIO.instance[IO].read(outputPath).unsafeRunSync()
+    val s = imported.sheets.head
+    // B3 should hold 30 (the cached value), NOT "=A1+A2" (formula)
+    cellValueAt(s, 1, 2) match
+      case Some(CellValue.Number(n)) =>
+        assertEquals(n, BigDecimal(30), "values-only should materialize formula to cached value")
+      case other => fail(s"Expected Number(30), got: $other")
+  }
+
+  test("copy --values-only: formula with no cache evaluates against source") {
+    val sheet = Sheet("Test")
+      .put(ARef.from0(0, 0), CellValue.Number(5))
+      .put(ARef.from0(0, 1), CellValue.Number(7))
+      // Formula with no cached value
+      .put(ARef.from0(0, 2), CellValue.Formula("A1+A2", None))
+    val wb = Workbook(sheet)
+
+    WriteCommands
+      .copyRange(wb, Some(sheet), "A3", "B3", valuesOnly = true, outputPath, config)
+      .unsafeRunSync()
+
+    val imported = ExcelIO.instance[IO].read(outputPath).unsafeRunSync()
+    val s = imported.sheets.head
+    cellValueAt(s, 1, 2) match
+      case Some(CellValue.Number(n)) =>
+        assertEquals(n, BigDecimal(12), "Expected evaluated result 5+7=12")
+      case other => fail(s"Expected Number(12), got: $other")
+  }
+
+  // =========================================================================
+  // Formula shifting (non-values-only mode)
+  // =========================================================================
+
+  test("copy: formulas shift relative references by the delta") {
+    val sheet = Sheet("Test")
+      .put(ARef.from0(0, 0), CellValue.Number(10)) // A1
+      .put(ARef.from0(1, 0), CellValue.Number(20)) // B1
+      .put(ARef.from0(0, 1), CellValue.Formula("A1+B1", Some(CellValue.Number(30)))) // A2
+    val wb = Workbook(sheet)
+
+    // Copy A2 down to A5: formula should shift A1+B1 → A4+B4
+    WriteCommands
+      .copyRange(wb, Some(sheet), "A2", "A5", valuesOnly = false, outputPath, config)
+      .unsafeRunSync()
+
+    val imported = ExcelIO.instance[IO].read(outputPath).unsafeRunSync()
+    val s = imported.sheets.head
+    cellValueAt(s, 0, 4) match
+      case Some(CellValue.Formula(expr, _)) =>
+        // Expr should reference A4 and B4 (shifted by +3 rows)
+        assert(expr.contains("A4"), s"Expected A4 in shifted formula: $expr")
+        assert(expr.contains("B4"), s"Expected B4 in shifted formula: $expr")
+      case other => fail(s"Expected Formula, got: $other")
+  }
+
+  // =========================================================================
+  // Style preservation (both modes)
+  // =========================================================================
+
+  test("copy: preserves source cell style on target") {
+    val boldStyle = CellStyle.default.bold
+    val sheet = Sheet("Test")
+      .put(ARef.from0(0, 0), CellValue.Text("Bold"))
+      .withCellStyle(ARef.from0(0, 0), boldStyle)
+    val wb = Workbook(sheet)
+
+    WriteCommands
+      .copyRange(wb, Some(sheet), "A1", "C1", valuesOnly = false, outputPath, config)
+      .unsafeRunSync()
+
+    val imported = ExcelIO.instance[IO].read(outputPath).unsafeRunSync()
+    val s = imported.sheets.head
+    val c1Cell = s.cells.get(ARef.from0(2, 0))
+    val c1Style = c1Cell.flatMap(_.styleId).flatMap(s.styleRegistry.get)
+    assert(c1Style.exists(_.font.bold), s"Expected bold style on C1, got: $c1Style")
+  }
+
+  test("copy --values-only: preserves source cell style on target") {
+    val italicStyle = CellStyle.default.italic
+    val sheet = Sheet("Test")
+      .put(ARef.from0(0, 0), CellValue.Text("Italic"))
+      .withCellStyle(ARef.from0(0, 0), italicStyle)
+    val wb = Workbook(sheet)
+
+    WriteCommands
+      .copyRange(wb, Some(sheet), "A1", "C1", valuesOnly = true, outputPath, config)
+      .unsafeRunSync()
+
+    val imported = ExcelIO.instance[IO].read(outputPath).unsafeRunSync()
+    val s = imported.sheets.head
+    val c1Cell = s.cells.get(ARef.from0(2, 0))
+    val c1Style = c1Cell.flatMap(_.styleId).flatMap(s.styleRegistry.get)
+    assert(c1Style.exists(_.font.italic), s"Expected italic style on C1, got: $c1Style")
+  }
+
+  // =========================================================================
+  // Dimension handling
+  // =========================================================================
+
+  test("copy: single-cell target auto-expands to source dimensions") {
+    val sheet = Sheet("Test")
+      .put(ARef.from0(0, 0), CellValue.Text("a"))
+      .put(ARef.from0(1, 0), CellValue.Text("b"))
+      .put(ARef.from0(0, 1), CellValue.Text("c"))
+      .put(ARef.from0(1, 1), CellValue.Text("d"))
+    val wb = Workbook(sheet)
+
+    // Copy 2x2 source A1:B2 to a single-cell target D1 (expands to D1:E2)
+    WriteCommands
+      .copyRange(wb, Some(sheet), "A1:B2", "D1", valuesOnly = false, outputPath, config)
+      .unsafeRunSync()
+
+    val imported = ExcelIO.instance[IO].read(outputPath).unsafeRunSync()
+    val s = imported.sheets.head
+    assertEquals(cellValueAt(s, 3, 0), Some(CellValue.Text("a")))
+    assertEquals(cellValueAt(s, 4, 0), Some(CellValue.Text("b")))
+    assertEquals(cellValueAt(s, 3, 1), Some(CellValue.Text("c")))
+    assertEquals(cellValueAt(s, 4, 1), Some(CellValue.Text("d")))
+  }
+
+  test("copy: dimension mismatch errors") {
+    val sheet = Sheet("Test").put(ARef.from0(0, 0), CellValue.Number(1))
+    val wb = Workbook(sheet)
+
+    val err = WriteCommands
+      .copyRange(wb, Some(sheet), "A1:A3", "B1:B2", valuesOnly = false, outputPath, config)
+      .attempt
+      .unsafeRunSync()
+
+    assert(err.isLeft, "Expected dimension mismatch error")
+    val msg = err.swap.getOrElse(throw new Exception("expected left")).getMessage
+    assert(msg.contains("mismatch"), s"Expected 'mismatch' in message: $msg")
+  }

--- a/xl-cli/test/src/com/tjclp/xl/cli/CopyCommandSpec.scala
+++ b/xl-cli/test/src/com/tjclp/xl/cli/CopyCommandSpec.scala
@@ -205,6 +205,43 @@ class CopyCommandSpec extends FunSuite:
       case other => fail(s"Expected Formula, got: $other")
   }
 
+  outputFixture.test("copy: copied sheet-qualified lookup sees copied formula sibling caches") {
+    outputPath =>
+      val sheet = Sheet("Test")
+        .put(ARef.from0(0, 0), CellValue.Formula("1", None)) // A1
+        .put(
+          ARef.from0(1, 0),
+          CellValue.Formula("VLOOKUP(1,Test!A1:C1,3,FALSE)", None)
+        ) // B1
+        .put(ARef.from0(2, 0), CellValue.Number(42)) // C1
+      val wb = Workbook(sheet)
+
+      WriteCommands
+        .copyRange(wb, Some(sheet), "A1:C1", "D1:F1", valuesOnly = false, outputPath, config)
+        .unsafeRunSync()
+
+      val imported = ExcelIO.instance[IO].read(outputPath).unsafeRunSync()
+      val s = imported.sheets.head
+
+      cellValueAt(s, 3, 0) match
+        case Some(CellValue.Formula(expr, Some(CellValue.Number(n)))) =>
+          assertEquals(expr, "1")
+          assertEquals(n, BigDecimal(1))
+        case other =>
+          fail(s"Expected D1 = Formula(1, Some(Number(1))), got: $other")
+
+      cellValueAt(s, 4, 0) match
+        case Some(CellValue.Formula(expr, Some(CellValue.Number(n)))) =>
+          assert(expr.contains("D1:F1"), s"Expected shifted range D1:F1, got: $expr")
+          assertEquals(
+            n,
+            BigDecimal(42),
+            "E1 should cache after seeing the copied D1 formula cache"
+          )
+        case other =>
+          fail(s"Expected E1 = Formula(VLOOKUP(...,Test!D1:F1,...), Some(Number(42))), got: $other")
+  }
+
   // =========================================================================
   // Style preservation (both modes)
   // =========================================================================

--- a/xl-cli/test/src/com/tjclp/xl/cli/CopyCommandSpec.scala
+++ b/xl-cli/test/src/com/tjclp/xl/cli/CopyCommandSpec.scala
@@ -24,6 +24,8 @@ import com.tjclp.xl.sheets.styleSyntax.withCellStyle
  *   - Values-only mode materializes formulas instead of keeping them
  *   - Styles are preserved in both modes
  *   - Formulas shift relative references by the correct delta
+ *
+ * Each test gets a fresh temp output file via `outputFixture` — no cross-test coupling.
  */
 @SuppressWarnings(
   Array("org.wartremover.warts.OptionPartial", "org.wartremover.warts.IterableOps")
@@ -32,11 +34,13 @@ class CopyCommandSpec extends FunSuite:
 
   given unsafe.IORuntime = unsafe.IORuntime.global
 
-  val outputPath: Path = Files.createTempFile("copy-test-", ".xlsx")
   val config: WriterConfig = WriterConfig.default
 
-  override def afterEach(context: AfterEach): Unit =
-    if Files.exists(outputPath) then Files.delete(outputPath)
+  /** Per-test temp output path; MUnit handles setup/teardown around each test body. */
+  val outputFixture: FunFixture[Path] = FunFixture[Path](
+    setup = _ => Files.createTempFile("copy-test-", ".xlsx"),
+    teardown = path => if Files.exists(path) then Files.delete(path)
+  )
 
   private def cellValueAt(sheet: Sheet, col: Int, row: Int): Option[CellValue] =
     sheet.cells.get(ARef.from0(col, row)).map(_.value)
@@ -45,103 +49,82 @@ class CopyCommandSpec extends FunSuite:
   // Overlapping copies within a sheet (P1 correctness)
   // =========================================================================
 
-  test("copy: overlapping A1:A3 -> A2 preserves source snapshot (1,2,3 -> 1,1,2,3)") {
-    // A1=1, A2=2, A3=3. Copy A1:A3 down by 1. Result should be A1=1, A2=1, A3=2, A4=3
-    // (i.e., the original sequence, not 1,1,1,1 from reading already-copied values)
-    val sheet = Sheet("Test")
-      .put(ARef.from0(0, 0), CellValue.Number(1))
-      .put(ARef.from0(0, 1), CellValue.Number(2))
-      .put(ARef.from0(0, 2), CellValue.Number(3))
-    val wb = Workbook(sheet)
+  outputFixture.test("copy: overlapping A1:A3 -> A2 preserves source snapshot (1,2,3 -> 1,1,2,3)") {
+    outputPath =>
+      // A1=1, A2=2, A3=3. Copy A1:A3 down by 1. Result should be A1=1, A2=1, A3=2, A4=3
+      // (i.e., the original sequence, not 1,1,1,1 from reading already-copied values)
+      val sheet = Sheet("Test")
+        .put(ARef.from0(0, 0), CellValue.Number(1))
+        .put(ARef.from0(0, 1), CellValue.Number(2))
+        .put(ARef.from0(0, 2), CellValue.Number(3))
+      val wb = Workbook(sheet)
 
-    WriteCommands
-      .copyRange(
-        wb,
-        Some(sheet),
-        "A1:A3",
-        "A2",
-        valuesOnly = false,
-        outputPath,
-        config
-      )
-      .unsafeRunSync()
+      WriteCommands
+        .copyRange(wb, Some(sheet), "A1:A3", "A2", valuesOnly = false, outputPath, config)
+        .unsafeRunSync()
 
-    val imported = ExcelIO.instance[IO].read(outputPath).unsafeRunSync()
-    val s = imported.sheets.head
-    assertEquals(cellValueAt(s, 0, 0), Some(CellValue.Number(1)), "A1 unchanged")
-    assertEquals(cellValueAt(s, 0, 1), Some(CellValue.Number(1)), "A2 = source A1")
-    assertEquals(cellValueAt(s, 0, 2), Some(CellValue.Number(2)), "A3 = source A2")
-    assertEquals(cellValueAt(s, 0, 3), Some(CellValue.Number(3)), "A4 = source A3")
+      val imported = ExcelIO.instance[IO].read(outputPath).unsafeRunSync()
+      val s = imported.sheets.head
+      assertEquals(cellValueAt(s, 0, 0), Some(CellValue.Number(1)), "A1 unchanged")
+      assertEquals(cellValueAt(s, 0, 1), Some(CellValue.Number(1)), "A2 = source A1")
+      assertEquals(cellValueAt(s, 0, 2), Some(CellValue.Number(2)), "A3 = source A2")
+      assertEquals(cellValueAt(s, 0, 3), Some(CellValue.Number(3)), "A4 = source A3")
   }
 
-  test("copy: overlapping B1:D1 -> A1 shifts left without corruption") {
-    // B1=10, C1=20, D1=30. Copy B1:D1 left by 1. Result: A1=10, B1=20, C1=30
-    val sheet = Sheet("Test")
-      .put(ARef.from0(1, 0), CellValue.Number(10))
-      .put(ARef.from0(2, 0), CellValue.Number(20))
-      .put(ARef.from0(3, 0), CellValue.Number(30))
-    val wb = Workbook(sheet)
+  outputFixture.test("copy: overlapping B1:D1 -> A1 shifts left without corruption") {
+    outputPath =>
+      // B1=10, C1=20, D1=30. Copy B1:D1 left by 1. Result: A1=10, B1=20, C1=30
+      val sheet = Sheet("Test")
+        .put(ARef.from0(1, 0), CellValue.Number(10))
+        .put(ARef.from0(2, 0), CellValue.Number(20))
+        .put(ARef.from0(3, 0), CellValue.Number(30))
+      val wb = Workbook(sheet)
 
-    WriteCommands
-      .copyRange(wb, Some(sheet), "B1:D1", "A1", valuesOnly = false, outputPath, config)
-      .unsafeRunSync()
+      WriteCommands
+        .copyRange(wb, Some(sheet), "B1:D1", "A1", valuesOnly = false, outputPath, config)
+        .unsafeRunSync()
 
-    val imported = ExcelIO.instance[IO].read(outputPath).unsafeRunSync()
-    val s = imported.sheets.head
-    assertEquals(cellValueAt(s, 0, 0), Some(CellValue.Number(10)), "A1 = source B1")
-    assertEquals(cellValueAt(s, 1, 0), Some(CellValue.Number(20)), "B1 = source C1")
-    assertEquals(cellValueAt(s, 2, 0), Some(CellValue.Number(30)), "C1 = source D1")
+      val imported = ExcelIO.instance[IO].read(outputPath).unsafeRunSync()
+      val s = imported.sheets.head
+      assertEquals(cellValueAt(s, 0, 0), Some(CellValue.Number(10)), "A1 = source B1")
+      assertEquals(cellValueAt(s, 1, 0), Some(CellValue.Number(20)), "B1 = source C1")
+      assertEquals(cellValueAt(s, 2, 0), Some(CellValue.Number(30)), "C1 = source D1")
   }
 
   // =========================================================================
   // Cross-sheet copy (qualified target — P2 bug)
   // =========================================================================
 
-  test("copy: cross-sheet with qualified target writes to target sheet, not source") {
-    val s1 = Sheet("Source").put(ARef.from0(0, 0), CellValue.Text("hello"))
-    val s2 = Sheet("Dest")
-    val wb = Workbook(Vector(s1, s2))
+  outputFixture.test("copy: cross-sheet with qualified target writes to target sheet, not source") {
+    outputPath =>
+      val s1 = Sheet("Source").put(ARef.from0(0, 0), CellValue.Text("hello"))
+      val s2 = Sheet("Dest")
+      val wb = Workbook(Vector(s1, s2))
 
-    WriteCommands
-      .copyRange(
-        wb,
-        Some(s1),
-        "A1",
-        "Dest!B1",
-        valuesOnly = false,
-        outputPath,
-        config
-      )
-      .unsafeRunSync()
+      WriteCommands
+        .copyRange(wb, Some(s1), "A1", "Dest!B1", valuesOnly = false, outputPath, config)
+        .unsafeRunSync()
 
-    val imported = ExcelIO.instance[IO].read(outputPath).unsafeRunSync()
-    val source = imported.sheets.find(_.name.value == "Source").get
-    val dest = imported.sheets.find(_.name.value == "Dest").get
+      val imported = ExcelIO.instance[IO].read(outputPath).unsafeRunSync()
+      val source = imported.sheets.find(_.name.value == "Source").get
+      val dest = imported.sheets.find(_.name.value == "Dest").get
 
-    // Destination should have the value at B1
-    assertEquals(cellValueAt(dest, 1, 0), Some(CellValue.Text("hello")))
-    // Source should be unchanged — particularly, B1 on the source sheet must be empty
-    assertEquals(cellValueAt(source, 1, 0), None, "Source B1 must not be written")
-    // And the original source A1 is still intact
-    assertEquals(cellValueAt(source, 0, 0), Some(CellValue.Text("hello")))
+      // Destination should have the value at B1
+      assertEquals(cellValueAt(dest, 1, 0), Some(CellValue.Text("hello")))
+      // Source should be unchanged — particularly, B1 on the source sheet must be empty
+      assertEquals(cellValueAt(source, 1, 0), None, "Source B1 must not be written")
+      // And the original source A1 is still intact
+      assertEquals(cellValueAt(source, 0, 0), Some(CellValue.Text("hello")))
   }
 
-  test("copy: fully-qualified source and destination sheets") {
+  outputFixture.test("copy: fully-qualified source and destination sheets") { outputPath =>
     val s1 = Sheet("Income").put(ARef.from0(0, 0), CellValue.Number(1000))
     val s2 = Sheet("Summary")
     val wb = Workbook(Vector(s1, s2))
 
     // Both sides qualified, no --sheet fallback provided
     WriteCommands
-      .copyRange(
-        wb,
-        None,
-        "Income!A1",
-        "Summary!C3",
-        valuesOnly = false,
-        outputPath,
-        config
-      )
+      .copyRange(wb, None, "Income!A1", "Summary!C3", valuesOnly = false, outputPath, config)
       .unsafeRunSync()
 
     val imported = ExcelIO.instance[IO].read(outputPath).unsafeRunSync()
@@ -153,52 +136,54 @@ class CopyCommandSpec extends FunSuite:
   // Values-only mode (P2 bug: batch version kept formulas)
   // =========================================================================
 
-  test("copy --values-only: formula with cached value materializes to cached") {
-    val formulaCell = CellValue.Formula("A1+A2", Some(CellValue.Number(30)))
-    val sheet = Sheet("Test")
-      .put(ARef.from0(0, 0), CellValue.Number(10))
-      .put(ARef.from0(0, 1), CellValue.Number(20))
-      .put(ARef.from0(0, 2), formulaCell)
-    val wb = Workbook(sheet)
+  outputFixture.test("copy --values-only: formula with cached value materializes to cached") {
+    outputPath =>
+      val formulaCell = CellValue.Formula("A1+A2", Some(CellValue.Number(30)))
+      val sheet = Sheet("Test")
+        .put(ARef.from0(0, 0), CellValue.Number(10))
+        .put(ARef.from0(0, 1), CellValue.Number(20))
+        .put(ARef.from0(0, 2), formulaCell)
+      val wb = Workbook(sheet)
 
-    WriteCommands
-      .copyRange(wb, Some(sheet), "A3", "B3", valuesOnly = true, outputPath, config)
-      .unsafeRunSync()
+      WriteCommands
+        .copyRange(wb, Some(sheet), "A3", "B3", valuesOnly = true, outputPath, config)
+        .unsafeRunSync()
 
-    val imported = ExcelIO.instance[IO].read(outputPath).unsafeRunSync()
-    val s = imported.sheets.head
-    // B3 should hold 30 (the cached value), NOT "=A1+A2" (formula)
-    cellValueAt(s, 1, 2) match
-      case Some(CellValue.Number(n)) =>
-        assertEquals(n, BigDecimal(30), "values-only should materialize formula to cached value")
-      case other => fail(s"Expected Number(30), got: $other")
+      val imported = ExcelIO.instance[IO].read(outputPath).unsafeRunSync()
+      val s = imported.sheets.head
+      // B3 should hold 30 (the cached value), NOT "=A1+A2" (formula)
+      cellValueAt(s, 1, 2) match
+        case Some(CellValue.Number(n)) =>
+          assertEquals(n, BigDecimal(30), "values-only should materialize formula to cached value")
+        case other => fail(s"Expected Number(30), got: $other")
   }
 
-  test("copy --values-only: formula with no cache evaluates against source") {
-    val sheet = Sheet("Test")
-      .put(ARef.from0(0, 0), CellValue.Number(5))
-      .put(ARef.from0(0, 1), CellValue.Number(7))
-      // Formula with no cached value
-      .put(ARef.from0(0, 2), CellValue.Formula("A1+A2", None))
-    val wb = Workbook(sheet)
+  outputFixture.test("copy --values-only: formula with no cache evaluates against source") {
+    outputPath =>
+      val sheet = Sheet("Test")
+        .put(ARef.from0(0, 0), CellValue.Number(5))
+        .put(ARef.from0(0, 1), CellValue.Number(7))
+        // Formula with no cached value
+        .put(ARef.from0(0, 2), CellValue.Formula("A1+A2", None))
+      val wb = Workbook(sheet)
 
-    WriteCommands
-      .copyRange(wb, Some(sheet), "A3", "B3", valuesOnly = true, outputPath, config)
-      .unsafeRunSync()
+      WriteCommands
+        .copyRange(wb, Some(sheet), "A3", "B3", valuesOnly = true, outputPath, config)
+        .unsafeRunSync()
 
-    val imported = ExcelIO.instance[IO].read(outputPath).unsafeRunSync()
-    val s = imported.sheets.head
-    cellValueAt(s, 1, 2) match
-      case Some(CellValue.Number(n)) =>
-        assertEquals(n, BigDecimal(12), "Expected evaluated result 5+7=12")
-      case other => fail(s"Expected Number(12), got: $other")
+      val imported = ExcelIO.instance[IO].read(outputPath).unsafeRunSync()
+      val s = imported.sheets.head
+      cellValueAt(s, 1, 2) match
+        case Some(CellValue.Number(n)) =>
+          assertEquals(n, BigDecimal(12), "Expected evaluated result 5+7=12")
+        case other => fail(s"Expected Number(12), got: $other")
   }
 
   // =========================================================================
   // Formula shifting (non-values-only mode)
   // =========================================================================
 
-  test("copy: formulas shift relative references by the delta") {
+  outputFixture.test("copy: formulas shift relative references by the delta") { outputPath =>
     val sheet = Sheet("Test")
       .put(ARef.from0(0, 0), CellValue.Number(10)) // A1
       .put(ARef.from0(1, 0), CellValue.Number(20)) // B1
@@ -224,7 +209,7 @@ class CopyCommandSpec extends FunSuite:
   // Style preservation (both modes)
   // =========================================================================
 
-  test("copy: preserves source cell style on target") {
+  outputFixture.test("copy: preserves source cell style on target") { outputPath =>
     val boldStyle = CellStyle.default.bold
     val sheet = Sheet("Test")
       .put(ARef.from0(0, 0), CellValue.Text("Bold"))
@@ -242,7 +227,7 @@ class CopyCommandSpec extends FunSuite:
     assert(c1Style.exists(_.font.bold), s"Expected bold style on C1, got: $c1Style")
   }
 
-  test("copy --values-only: preserves source cell style on target") {
+  outputFixture.test("copy --values-only: preserves source cell style on target") { outputPath =>
     val italicStyle = CellStyle.default.italic
     val sheet = Sheet("Test")
       .put(ARef.from0(0, 0), CellValue.Text("Italic"))
@@ -264,7 +249,7 @@ class CopyCommandSpec extends FunSuite:
   // Dimension handling
   // =========================================================================
 
-  test("copy: single-cell target auto-expands to source dimensions") {
+  outputFixture.test("copy: single-cell target auto-expands to source dimensions") { outputPath =>
     val sheet = Sheet("Test")
       .put(ARef.from0(0, 0), CellValue.Text("a"))
       .put(ARef.from0(1, 0), CellValue.Text("b"))
@@ -285,7 +270,7 @@ class CopyCommandSpec extends FunSuite:
     assertEquals(cellValueAt(s, 4, 1), Some(CellValue.Text("d")))
   }
 
-  test("copy: dimension mismatch errors") {
+  outputFixture.test("copy: dimension mismatch errors") { outputPath =>
     val sheet = Sheet("Test").put(ARef.from0(0, 0), CellValue.Number(1))
     val wb = Workbook(sheet)
 

--- a/xl-cli/test/src/com/tjclp/xl/cli/CsvAutoSplitSpec.scala
+++ b/xl-cli/test/src/com/tjclp/xl/cli/CsvAutoSplitSpec.scala
@@ -5,7 +5,7 @@ import munit.FunSuite
 import java.nio.file.{Files, Path}
 
 import cats.effect.{IO, unsafe}
-import com.tjclp.xl.{Workbook, Sheet}
+import com.tjclp.xl.{Sheet, Workbook}
 import com.tjclp.xl.addressing.ARef
 import com.tjclp.xl.cells.CellValue
 import com.tjclp.xl.cli.commands.WriteCommands
@@ -13,10 +13,10 @@ import com.tjclp.xl.io.ExcelIO
 import com.tjclp.xl.ooxml.writer.WriterConfig
 
 /**
- * Tests for CSV auto-split in the put command.
+ * Tests for the opt-in `--csv` flag on the put command.
  *
- * When put receives a single comma-separated value targeting a range, it should auto-split and
- * distribute the values across cells if the element count matches the range size.
+ * The flag enables splitting a single comma-separated value across a target range. Without the
+ * flag, comma-containing values are written as literal text (the safe default).
  */
 @SuppressWarnings(
   Array("org.wartremover.warts.OptionPartial", "org.wartremover.warts.IterableOps")
@@ -31,41 +31,53 @@ class CsvAutoSplitSpec extends FunSuite:
   override def afterEach(context: AfterEach): Unit =
     if Files.exists(outputPath) then Files.delete(outputPath)
 
-  test("put: CSV auto-split distributes comma-separated values across range") {
+  test("put --csv: splits comma-separated values across range with matching count") {
     val wb = Workbook(Sheet("Test"))
-    val result =
-      WriteCommands
-        .put(wb, Some(wb.sheets.head), "A1:C1", List("1,2,3"), outputPath, config)
-        .unsafeRunSync()
+    val result = WriteCommands
+      .put(
+        wb,
+        Some(wb.sheets.head),
+        "A1:C1",
+        List("1,2,3"),
+        outputPath,
+        config,
+        stream = false,
+        csvSplit = true
+      )
+      .unsafeRunSync()
 
-    // Should behave like batch values mode (not fill pattern)
-    assert(result.contains("Put 3 values"))
-    assert(result.contains("row-major"))
+    assert(result.contains("Put 3 values"), s"Unexpected message: $result")
 
     val imported = ExcelIO.instance[IO].read(outputPath).unsafeRunSync()
     val sheet = imported.sheets.head
     assertEquals(
       sheet.cells.get(ARef.from0(0, 0)).map(_.value),
       Some(CellValue.Number(BigDecimal("1")))
-    ) // A1
+    )
     assertEquals(
       sheet.cells.get(ARef.from0(1, 0)).map(_.value),
       Some(CellValue.Number(BigDecimal("2")))
-    ) // B1
+    )
     assertEquals(
       sheet.cells.get(ARef.from0(2, 0)).map(_.value),
       Some(CellValue.Number(BigDecimal("3")))
-    ) // C1
+    )
   }
 
-  test("put: CSV auto-split trims whitespace around values") {
+  test("put --csv: trims whitespace around split values") {
     val wb = Workbook(Sheet("Test"))
-    val result =
-      WriteCommands
-        .put(wb, Some(wb.sheets.head), "A1:C1", List("Q1 , Q2 , Q3"), outputPath, config)
-        .unsafeRunSync()
-
-    assert(result.contains("Put 3 values"))
+    WriteCommands
+      .put(
+        wb,
+        Some(wb.sheets.head),
+        "A1:C1",
+        List("Q1 , Q2 , Q3"),
+        outputPath,
+        config,
+        stream = false,
+        csvSplit = true
+      )
+      .unsafeRunSync()
 
     val imported = ExcelIO.instance[IO].read(outputPath).unsafeRunSync()
     val sheet = imported.sheets.head
@@ -74,24 +86,91 @@ class CsvAutoSplitSpec extends FunSuite:
       Some(CellValue.Text("Q1"))
     )
     assertEquals(
-      sheet.cells.get(ARef.from0(1, 0)).map(_.value),
-      Some(CellValue.Text("Q2"))
-    )
-    assertEquals(
       sheet.cells.get(ARef.from0(2, 0)).map(_.value),
       Some(CellValue.Text("Q3"))
     )
   }
 
-  test("put: single cell with commas stays as literal text") {
+  test("put --csv: errors when split count does not match range size") {
     val wb = Workbook(Sheet("Test"))
-    val result =
-      WriteCommands
-        .put(wb, Some(wb.sheets.head), "A1", List("hello,world"), outputPath, config)
-        .unsafeRunSync()
+    val err = WriteCommands
+      .put(
+        wb,
+        Some(wb.sheets.head),
+        "A1:D1",
+        List("a,b,c"),
+        outputPath,
+        config,
+        stream = false,
+        csvSplit = true
+      )
+      .attempt
+      .unsafeRunSync()
 
-    // Single cell mode: never split
-    assert(result.contains("Put: A1"))
+    assert(err.isLeft, s"Expected error but got: $err")
+    val msg = err.swap.getOrElse(throw new Exception("expected left")).getMessage
+    assert(msg.contains("--csv"), s"Expected error to mention --csv: $msg")
+  }
+
+  test("put --csv: rejects single-cell target") {
+    val wb = Workbook(Sheet("Test"))
+    val err = WriteCommands
+      .put(
+        wb,
+        Some(wb.sheets.head),
+        "A1",
+        List("hello,world"),
+        outputPath,
+        config,
+        stream = false,
+        csvSplit = true
+      )
+      .attempt
+      .unsafeRunSync()
+
+    assert(err.isLeft, "Expected error for --csv with single-cell target")
+    val msg = err.swap.getOrElse(throw new Exception("expected left")).getMessage
+    assert(msg.contains("single cell"))
+  }
+
+  test("put (no --csv): comma-containing value stays as literal fill across range") {
+    val wb = Workbook(Sheet("Test"))
+    WriteCommands
+      .put(
+        wb,
+        Some(wb.sheets.head),
+        "A1:B1",
+        List("Smith, John"),
+        outputPath,
+        config
+      )
+      .unsafeRunSync()
+
+    val imported = ExcelIO.instance[IO].read(outputPath).unsafeRunSync()
+    val sheet = imported.sheets.head
+    // Default behavior: fill both cells with the literal comma-containing string
+    assertEquals(
+      sheet.cells.get(ARef.from0(0, 0)).map(_.value),
+      Some(CellValue.Text("Smith, John"))
+    )
+    assertEquals(
+      sheet.cells.get(ARef.from0(1, 0)).map(_.value),
+      Some(CellValue.Text("Smith, John"))
+    )
+  }
+
+  test("put (no --csv): single cell with commas is literal text") {
+    val wb = Workbook(Sheet("Test"))
+    WriteCommands
+      .put(
+        wb,
+        Some(wb.sheets.head),
+        "A1",
+        List("hello,world"),
+        outputPath,
+        config
+      )
+      .unsafeRunSync()
 
     val imported = ExcelIO.instance[IO].read(outputPath).unsafeRunSync()
     val sheet = imported.sheets.head
@@ -101,48 +180,33 @@ class CsvAutoSplitSpec extends FunSuite:
     )
   }
 
-  test("put: CSV auto-split count mismatch falls back to literal fill") {
+  test("put --csv: applies smart type detection to each split value") {
     val wb = Workbook(Sheet("Test"))
-    val result =
-      WriteCommands
-        .put(wb, Some(wb.sheets.head), "A1:D1", List("a,b,c"), outputPath, config)
-        .unsafeRunSync()
-
-    // 3 CSV parts vs 4 cells: falls back to fill pattern (literal text)
-    assert(result.contains("Filled 4 cells"))
-
-    val imported = ExcelIO.instance[IO].read(outputPath).unsafeRunSync()
-    val sheet = imported.sheets.head
-    // All cells should have the literal text "a,b,c"
-    (0 to 3).foreach { col =>
-      assertEquals(
-        sheet.cells.get(ARef.from0(col, 0)).map(_.value),
-        Some(CellValue.Text("a,b,c"))
+    WriteCommands
+      .put(
+        wb,
+        Some(wb.sheets.head),
+        "A1:C1",
+        List("true,42,hello"),
+        outputPath,
+        config,
+        stream = false,
+        csvSplit = true
       )
-    }
-  }
-
-  test("put: CSV auto-split applies smart type detection") {
-    val wb = Workbook(Sheet("Test"))
-    val result =
-      WriteCommands
-        .put(wb, Some(wb.sheets.head), "A1:C1", List("true,42,hello"), outputPath, config)
-        .unsafeRunSync()
-
-    assert(result.contains("Put 3 values"))
+      .unsafeRunSync()
 
     val imported = ExcelIO.instance[IO].read(outputPath).unsafeRunSync()
     val sheet = imported.sheets.head
     assertEquals(
       sheet.cells.get(ARef.from0(0, 0)).map(_.value),
       Some(CellValue.Bool(true))
-    ) // A1
+    )
     assertEquals(
       sheet.cells.get(ARef.from0(1, 0)).map(_.value),
       Some(CellValue.Number(BigDecimal("42")))
-    ) // B1
+    )
     assertEquals(
       sheet.cells.get(ARef.from0(2, 0)).map(_.value),
       Some(CellValue.Text("hello"))
-    ) // C1
+    )
   }

--- a/xl-cli/test/src/com/tjclp/xl/cli/CsvAutoSplitSpec.scala
+++ b/xl-cli/test/src/com/tjclp/xl/cli/CsvAutoSplitSpec.scala
@@ -1,0 +1,148 @@
+package com.tjclp.xl.cli
+
+import munit.FunSuite
+
+import java.nio.file.{Files, Path}
+
+import cats.effect.{IO, unsafe}
+import com.tjclp.xl.{Workbook, Sheet}
+import com.tjclp.xl.addressing.ARef
+import com.tjclp.xl.cells.CellValue
+import com.tjclp.xl.cli.commands.WriteCommands
+import com.tjclp.xl.io.ExcelIO
+import com.tjclp.xl.ooxml.writer.WriterConfig
+
+/**
+ * Tests for CSV auto-split in the put command.
+ *
+ * When put receives a single comma-separated value targeting a range, it should auto-split and
+ * distribute the values across cells if the element count matches the range size.
+ */
+@SuppressWarnings(
+  Array("org.wartremover.warts.OptionPartial", "org.wartremover.warts.IterableOps")
+)
+class CsvAutoSplitSpec extends FunSuite:
+
+  given unsafe.IORuntime = unsafe.IORuntime.global
+
+  val outputPath: Path = Files.createTempFile("csv-split-test", ".xlsx")
+  val config: WriterConfig = WriterConfig.default
+
+  override def afterEach(context: AfterEach): Unit =
+    if Files.exists(outputPath) then Files.delete(outputPath)
+
+  test("put: CSV auto-split distributes comma-separated values across range") {
+    val wb = Workbook(Sheet("Test"))
+    val result =
+      WriteCommands
+        .put(wb, Some(wb.sheets.head), "A1:C1", List("1,2,3"), outputPath, config)
+        .unsafeRunSync()
+
+    // Should behave like batch values mode (not fill pattern)
+    assert(result.contains("Put 3 values"))
+    assert(result.contains("row-major"))
+
+    val imported = ExcelIO.instance[IO].read(outputPath).unsafeRunSync()
+    val sheet = imported.sheets.head
+    assertEquals(
+      sheet.cells.get(ARef.from0(0, 0)).map(_.value),
+      Some(CellValue.Number(BigDecimal("1")))
+    ) // A1
+    assertEquals(
+      sheet.cells.get(ARef.from0(1, 0)).map(_.value),
+      Some(CellValue.Number(BigDecimal("2")))
+    ) // B1
+    assertEquals(
+      sheet.cells.get(ARef.from0(2, 0)).map(_.value),
+      Some(CellValue.Number(BigDecimal("3")))
+    ) // C1
+  }
+
+  test("put: CSV auto-split trims whitespace around values") {
+    val wb = Workbook(Sheet("Test"))
+    val result =
+      WriteCommands
+        .put(wb, Some(wb.sheets.head), "A1:C1", List("Q1 , Q2 , Q3"), outputPath, config)
+        .unsafeRunSync()
+
+    assert(result.contains("Put 3 values"))
+
+    val imported = ExcelIO.instance[IO].read(outputPath).unsafeRunSync()
+    val sheet = imported.sheets.head
+    assertEquals(
+      sheet.cells.get(ARef.from0(0, 0)).map(_.value),
+      Some(CellValue.Text("Q1"))
+    )
+    assertEquals(
+      sheet.cells.get(ARef.from0(1, 0)).map(_.value),
+      Some(CellValue.Text("Q2"))
+    )
+    assertEquals(
+      sheet.cells.get(ARef.from0(2, 0)).map(_.value),
+      Some(CellValue.Text("Q3"))
+    )
+  }
+
+  test("put: single cell with commas stays as literal text") {
+    val wb = Workbook(Sheet("Test"))
+    val result =
+      WriteCommands
+        .put(wb, Some(wb.sheets.head), "A1", List("hello,world"), outputPath, config)
+        .unsafeRunSync()
+
+    // Single cell mode: never split
+    assert(result.contains("Put: A1"))
+
+    val imported = ExcelIO.instance[IO].read(outputPath).unsafeRunSync()
+    val sheet = imported.sheets.head
+    assertEquals(
+      sheet.cells.get(ARef.from0(0, 0)).map(_.value),
+      Some(CellValue.Text("hello,world"))
+    )
+  }
+
+  test("put: CSV auto-split count mismatch falls back to literal fill") {
+    val wb = Workbook(Sheet("Test"))
+    val result =
+      WriteCommands
+        .put(wb, Some(wb.sheets.head), "A1:D1", List("a,b,c"), outputPath, config)
+        .unsafeRunSync()
+
+    // 3 CSV parts vs 4 cells: falls back to fill pattern (literal text)
+    assert(result.contains("Filled 4 cells"))
+
+    val imported = ExcelIO.instance[IO].read(outputPath).unsafeRunSync()
+    val sheet = imported.sheets.head
+    // All cells should have the literal text "a,b,c"
+    (0 to 3).foreach { col =>
+      assertEquals(
+        sheet.cells.get(ARef.from0(col, 0)).map(_.value),
+        Some(CellValue.Text("a,b,c"))
+      )
+    }
+  }
+
+  test("put: CSV auto-split applies smart type detection") {
+    val wb = Workbook(Sheet("Test"))
+    val result =
+      WriteCommands
+        .put(wb, Some(wb.sheets.head), "A1:C1", List("true,42,hello"), outputPath, config)
+        .unsafeRunSync()
+
+    assert(result.contains("Put 3 values"))
+
+    val imported = ExcelIO.instance[IO].read(outputPath).unsafeRunSync()
+    val sheet = imported.sheets.head
+    assertEquals(
+      sheet.cells.get(ARef.from0(0, 0)).map(_.value),
+      Some(CellValue.Bool(true))
+    ) // A1
+    assertEquals(
+      sheet.cells.get(ARef.from0(1, 0)).map(_.value),
+      Some(CellValue.Number(BigDecimal("42")))
+    ) // B1
+    assertEquals(
+      sheet.cells.get(ARef.from0(2, 0)).map(_.value),
+      Some(CellValue.Text("hello"))
+    ) // C1
+  }

--- a/xl-cli/test/src/com/tjclp/xl/cli/FreezePaneSpec.scala
+++ b/xl-cli/test/src/com/tjclp/xl/cli/FreezePaneSpec.scala
@@ -36,24 +36,35 @@ class FreezePaneSpec extends FunSuite:
 
   /** Extract the `<pane>` element from `<sheetViews>` of the first sheet, if present. */
   private def readPaneXml(path: Path): Option[scala.xml.Elem] =
+    readAllPaneXmls(path).headOption.flatMap(_._2)
+
+  /**
+   * Return a map from worksheet entry name (e.g. "xl/worksheets/sheet1.xml") to its `<pane>`
+   * element, if present. Lets tests check per-sheet pane state.
+   */
+  private def readAllPaneXmls(path: Path): Vector[(String, Option[scala.xml.Elem])] =
     val bytes = Files.readAllBytes(path)
     val zip = new java.util.zip.ZipInputStream(new java.io.ByteArrayInputStream(bytes))
     try
+      val result = Vector.newBuilder[(String, Option[scala.xml.Elem])]
       LazyList
         .continually(Option(zip.getNextEntry))
         .takeWhile(_.isDefined)
         .flatten
-        .find(_.getName.startsWith("xl/worksheets/sheet"))
-        .flatMap { _ =>
-          val buf = new java.io.ByteArrayOutputStream()
-          val data = new Array[Byte](4096)
-          LazyList
-            .continually(zip.read(data))
-            .takeWhile(_ != -1)
-            .foreach(n => buf.write(data, 0, n))
-          val xml = scala.xml.XML.loadString(buf.toString("UTF-8"))
-          (xml \\ "pane").headOption.collect { case e: scala.xml.Elem => e }
+        .foreach { entry =>
+          val name = entry.getName
+          if name.startsWith("xl/worksheets/sheet") && name.endsWith(".xml") then
+            val buf = new java.io.ByteArrayOutputStream()
+            val data = new Array[Byte](4096)
+            LazyList
+              .continually(zip.read(data))
+              .takeWhile(_ != -1)
+              .foreach(n => buf.write(data, 0, n))
+            val xml = scala.xml.XML.loadString(buf.toString("UTF-8"))
+            val pane = (xml \\ "pane").headOption.collect { case e: scala.xml.Elem => e }
+            result += ((name, pane))
         }
+      result.result().sortBy(_._1)
     finally zip.close()
 
   // =========================================================================
@@ -145,4 +156,41 @@ class FreezePaneSpec extends FunSuite:
       Some(FreezePane.Remove),
       "unfreeze sets Remove, distinct from None (preserve)"
     )
+  }
+
+  // =========================================================================
+  // Qualified-ref support (freeze with `Sheet2!B2` syntax)
+  // =========================================================================
+
+  test("freeze Sheet2!B2: qualified ref targets the named sheet without -s") {
+    val s1 = Sheet("Sheet1")
+    val s2 = Sheet("Sheet2")
+    val wb = Workbook(Vector(s1, s2))
+
+    // No default sheet passed; qualified ref selects Sheet2.
+    WriteCommands
+      .freeze(wb, None, "Sheet2!B2", outputPath, config)
+      .unsafeRunSync()
+
+    // Verify per-worksheet XML: only sheet2.xml should carry a <pane> element.
+    val panes = readAllPaneXmls(outputPath)
+    assertEquals(panes.length, 2, "Should have two worksheets")
+    assertEquals(panes(0)._2, None, "sheet1.xml must not have a pane")
+    val sheet2Pane = panes(1)._2
+    assert(sheet2Pane.isDefined, "sheet2.xml should carry the pane element")
+    assertEquals(sheet2Pane.get.attribute("topLeftCell").map(_.text), Some("B2"))
+  }
+
+  test("freeze: range argument errors with clear message") {
+    val sheet = Sheet("Test")
+    val wb = Workbook(sheet)
+
+    val err = WriteCommands
+      .freeze(wb, Some(sheet), "A1:B2", outputPath, config)
+      .attempt
+      .unsafeRunSync()
+
+    assert(err.isLeft, "Expected range-arg rejection")
+    val msg = err.swap.getOrElse(throw new Exception("expected left")).getMessage
+    assert(msg.contains("single cell"), s"Expected 'single cell' in message: $msg")
   }

--- a/xl-cli/test/src/com/tjclp/xl/cli/FreezePaneSpec.scala
+++ b/xl-cli/test/src/com/tjclp/xl/cli/FreezePaneSpec.scala
@@ -1,0 +1,148 @@
+package com.tjclp.xl.cli
+
+import munit.FunSuite
+
+import java.nio.file.{Files, Path}
+
+import cats.effect.{IO, unsafe}
+import com.tjclp.xl.{Sheet, Workbook}
+import com.tjclp.xl.addressing.ARef
+import com.tjclp.xl.cells.CellValue
+import com.tjclp.xl.cli.commands.WriteCommands
+import com.tjclp.xl.io.ExcelIO
+import com.tjclp.xl.ooxml.writer.WriterConfig
+import com.tjclp.xl.sheets.FreezePane
+
+/**
+ * Integration tests for `freeze` / `unfreeze` CLI commands.
+ *
+ * The domain model stores a `FreezePane` override on the sheet. The OOXML write layer turns that
+ * override into a `<pane>` element inside `<sheetViews>`. These tests exercise the full read/write
+ * round-trip by writing an xlsx and parsing the resulting `<sheetViews>` XML to verify the pane
+ * attributes.
+ */
+@SuppressWarnings(
+  Array("org.wartremover.warts.OptionPartial", "org.wartremover.warts.IterableOps")
+)
+class FreezePaneSpec extends FunSuite:
+
+  given unsafe.IORuntime = unsafe.IORuntime.global
+
+  val outputPath: Path = Files.createTempFile("freeze-test-", ".xlsx")
+  val config: WriterConfig = WriterConfig.default
+
+  override def afterEach(context: AfterEach): Unit =
+    if Files.exists(outputPath) then Files.delete(outputPath)
+
+  /** Extract the `<pane>` element from `<sheetViews>` of the first sheet, if present. */
+  private def readPaneXml(path: Path): Option[scala.xml.Elem] =
+    val bytes = Files.readAllBytes(path)
+    val zip = new java.util.zip.ZipInputStream(new java.io.ByteArrayInputStream(bytes))
+    try
+      LazyList
+        .continually(Option(zip.getNextEntry))
+        .takeWhile(_.isDefined)
+        .flatten
+        .find(_.getName.startsWith("xl/worksheets/sheet"))
+        .flatMap { _ =>
+          val buf = new java.io.ByteArrayOutputStream()
+          val data = new Array[Byte](4096)
+          LazyList
+            .continually(zip.read(data))
+            .takeWhile(_ != -1)
+            .foreach(n => buf.write(data, 0, n))
+          val xml = scala.xml.XML.loadString(buf.toString("UTF-8"))
+          (xml \\ "pane").headOption.collect { case e: scala.xml.Elem => e }
+        }
+    finally zip.close()
+
+  // =========================================================================
+  // freeze
+  // =========================================================================
+
+  test("freeze B2: creates pane with xSplit=1, ySplit=1, bottomRight active") {
+    val sheet = Sheet("Test").put(ARef.from0(0, 0), CellValue.Text("header"))
+    val wb = Workbook(sheet)
+
+    WriteCommands
+      .freeze(wb, Some(sheet), "B2", outputPath, config)
+      .unsafeRunSync()
+
+    val pane = readPaneXml(outputPath)
+    assert(pane.isDefined, "Expected <pane> element in sheetViews")
+    assertEquals(pane.get.attribute("xSplit").map(_.text), Some("1"))
+    assertEquals(pane.get.attribute("ySplit").map(_.text), Some("1"))
+    assertEquals(pane.get.attribute("topLeftCell").map(_.text), Some("B2"))
+    assertEquals(pane.get.attribute("activePane").map(_.text), Some("bottomRight"))
+    assertEquals(pane.get.attribute("state").map(_.text), Some("frozen"))
+  }
+
+  test("freeze A3: rows-only freeze produces ySplit without xSplit") {
+    val sheet = Sheet("Test").put(ARef.from0(0, 0), CellValue.Text("hi"))
+    val wb = Workbook(sheet)
+
+    WriteCommands
+      .freeze(wb, Some(sheet), "A3", outputPath, config)
+      .unsafeRunSync()
+
+    val pane = readPaneXml(outputPath)
+    assert(pane.isDefined, "Expected <pane> element")
+    // A3 means freeze rows 1-2, no column freeze
+    assertEquals(pane.get.attribute("xSplit"), None, "No xSplit for column-less freeze")
+    assertEquals(pane.get.attribute("ySplit").map(_.text), Some("2"))
+    assertEquals(pane.get.attribute("topLeftCell").map(_.text), Some("A3"))
+  }
+
+  test("freeze C1: columns-only freeze produces xSplit without ySplit") {
+    val sheet = Sheet("Test").put(ARef.from0(0, 0), CellValue.Text("hi"))
+    val wb = Workbook(sheet)
+
+    WriteCommands
+      .freeze(wb, Some(sheet), "C1", outputPath, config)
+      .unsafeRunSync()
+
+    val pane = readPaneXml(outputPath)
+    assert(pane.isDefined, "Expected <pane> element")
+    assertEquals(pane.get.attribute("xSplit").map(_.text), Some("2"))
+    assertEquals(pane.get.attribute("ySplit"), None, "No ySplit for row-less freeze")
+    assertEquals(pane.get.attribute("topLeftCell").map(_.text), Some("C1"))
+  }
+
+  // =========================================================================
+  // unfreeze
+  // =========================================================================
+
+  test("unfreeze: removes pane from sheet that had one") {
+    // Step 1: freeze B2
+    val sheet = Sheet("Test").put(ARef.from0(0, 0), CellValue.Text("hi"))
+    WriteCommands
+      .freeze(wb = Workbook(sheet), sheetOpt = Some(sheet), refStr = "B2", outputPath, config)
+      .unsafeRunSync()
+    assert(readPaneXml(outputPath).isDefined, "Setup: pane should exist before unfreeze")
+
+    // Step 2: unfreeze
+    val frozenWb = ExcelIO.instance[IO].read(outputPath).unsafeRunSync()
+    WriteCommands
+      .unfreeze(frozenWb, Some(frozenWb.sheets.head), outputPath, config)
+      .unsafeRunSync()
+
+    assert(readPaneXml(outputPath).isEmpty, "Pane should be removed after unfreeze")
+  }
+
+  // =========================================================================
+  // Domain model
+  // =========================================================================
+
+  test("FreezePane: Sheet.freezeAt sets At override") {
+    val sheet = Sheet("Test").freezeAt(ARef.from0(1, 1))
+    assertEquals(sheet.freezePane, Some(FreezePane.At(ARef.from0(1, 1))))
+  }
+
+  test("FreezePane: Sheet.unfreeze sets Remove override (not None)") {
+    val sheet = Sheet("Test").freezeAt(ARef.from0(1, 1)).unfreeze
+    assertEquals(
+      sheet.freezePane,
+      Some(FreezePane.Remove),
+      "unfreeze sets Remove, distinct from None (preserve)"
+    )
+  }

--- a/xl-cli/test/src/com/tjclp/xl/cli/InPlaceSpec.scala
+++ b/xl-cli/test/src/com/tjclp/xl/cli/InPlaceSpec.scala
@@ -1,0 +1,91 @@
+package com.tjclp.xl.cli
+
+import java.nio.file.{Files, Path}
+
+import cats.effect.IO
+import munit.CatsEffectSuite
+
+import com.tjclp.xl.{*, given}
+import com.tjclp.xl.cells.CellValue
+import com.tjclp.xl.io.ExcelIO
+import com.tjclp.xl.macros.ref
+
+/**
+ * Tests for the --in-place (-i) flag.
+ *
+ * Verifies:
+ *   - `-i` resolves output to the input file path
+ *   - `-i` and `-o` together produce an error
+ *   - Neither `-i` nor `-o` returns None (no output)
+ *   - In-place write actually modifies the original file
+ */
+@SuppressWarnings(
+  Array(
+    "org.wartremover.warts.Var",
+    "org.wartremover.warts.OptionPartial",
+    "org.wartremover.warts.IterableOps",
+    "org.wartremover.warts.IsInstanceOf"
+  )
+)
+class InPlaceSpec extends CatsEffectSuite:
+
+  private val excel = ExcelIO.instance[IO]
+
+  /** Create a temp xlsx with a single sheet containing A1="Hello", A2=42. */
+  private def withTempExcelFile[A](test: Path => IO[A]): IO[A] =
+    IO.blocking {
+      val tempFile = Files.createTempFile("xl-inplace-test-", ".xlsx")
+      tempFile.toFile.deleteOnExit()
+      tempFile
+    }.flatMap { tempFile =>
+      val sheet = Sheet("Test")
+        .put(ref"A1", CellValue.Text("Hello"))
+        .put(ref"A2", CellValue.Number(BigDecimal(42)))
+      val wb = Workbook(Vector(sheet))
+      excel.write(wb, tempFile) *> test(tempFile)
+    }
+
+  test("resolveOutput: -i sets output to input file") {
+    val file = Path.of("/tmp/test.xlsx")
+    Main.resolveOutput(None, inPlace = true, file).assertEquals(Some(file))
+  }
+
+  test("resolveOutput: -o takes precedence when -i is false") {
+    val file = Path.of("/tmp/input.xlsx")
+    val out = Path.of("/tmp/output.xlsx")
+    Main.resolveOutput(Some(out), inPlace = false, file).assertEquals(Some(out))
+  }
+
+  test("resolveOutput: -i and -o together is an error") {
+    val file = Path.of("/tmp/input.xlsx")
+    val out = Path.of("/tmp/output.xlsx")
+    Main.resolveOutput(Some(out), inPlace = true, file).attempt.map { result =>
+      assert(result.isLeft, "Should be an error")
+      val msg = result.left.toOption.get.getMessage
+      assert(
+        msg.contains("mutually exclusive"),
+        s"Error should mention mutual exclusivity, got: $msg"
+      )
+    }
+  }
+
+  test("resolveOutput: neither -i nor -o returns None") {
+    val file = Path.of("/tmp/test.xlsx")
+    Main.resolveOutput(None, inPlace = false, file).assertEquals(None)
+  }
+
+  test("in-place write modifies original file") {
+    withTempExcelFile { tempFile =>
+      for
+        // Read → modify → write back to same path (this is what -i does)
+        wb <- excel.read(tempFile)
+        sheet = wb.sheets.head.put(ref"A1", CellValue.Text("Updated"))
+        modifiedWb = Workbook(Vector(sheet))
+        _ <- excel.write(modifiedWb, tempFile)
+        // Read back and verify the file was modified
+        wb2 <- excel.read(tempFile)
+        sheet2 = wb2.sheets.head
+        value = sheet2.cells.get(ref"A1").map(_.value)
+      yield assertEquals(value, Some(CellValue.Text("Updated")))
+    }
+  }

--- a/xl-cli/test/src/com/tjclp/xl/cli/InPlaceSpec.scala
+++ b/xl-cli/test/src/com/tjclp/xl/cli/InPlaceSpec.scala
@@ -2,7 +2,7 @@ package com.tjclp.xl.cli
 
 import java.nio.file.{Files, Path}
 
-import cats.effect.IO
+import cats.effect.{ExitCode, IO}
 import munit.CatsEffectSuite
 
 import com.tjclp.xl.{*, given}
@@ -11,20 +11,19 @@ import com.tjclp.xl.io.ExcelIO
 import com.tjclp.xl.macros.ref
 
 /**
- * Tests for the --in-place (-i) flag.
+ * Tests for the `--in-place` (`-i`) flag and its atomic-write semantics.
  *
  * Verifies:
- *   - `-i` resolves output to the input file path
- *   - `-i` and `-o` together produce an error
- *   - Neither `-i` nor `-o` returns None (no output)
- *   - In-place write actually modifies the original file
+ *   - `-i` alone writes to a sibling temp file, then atomically moves onto the input
+ *   - `-i` + `-o` together is an error (mutually exclusive)
+ *   - A failed execution leaves the original file untouched and cleans up the temp
+ *   - A successful execution produces the expected output in place
  */
 @SuppressWarnings(
   Array(
     "org.wartremover.warts.Var",
     "org.wartremover.warts.OptionPartial",
-    "org.wartremover.warts.IterableOps",
-    "org.wartremover.warts.IsInstanceOf"
+    "org.wartremover.warts.IterableOps"
   )
 )
 class InPlaceSpec extends CatsEffectSuite:
@@ -45,47 +44,116 @@ class InPlaceSpec extends CatsEffectSuite:
       excel.write(wb, tempFile) *> test(tempFile)
     }
 
-  test("resolveOutput: -i sets output to input file") {
-    val file = Path.of("/tmp/test.xlsx")
-    Main.resolveOutput(None, inPlace = true, file).assertEquals(Some(file))
-  }
-
-  test("resolveOutput: -o takes precedence when -i is false") {
+  test("runWithOutput: -o alone passes the output path through") {
     val file = Path.of("/tmp/input.xlsx")
     val out = Path.of("/tmp/output.xlsx")
-    Main.resolveOutput(Some(out), inPlace = false, file).assertEquals(Some(out))
+    var captured: Option[Path] = None
+    Main
+      .runWithOutput(Some(out), inPlace = false, file) { received =>
+        captured = received
+        IO.pure(ExitCode.Success)
+      }
+      .map { code =>
+        assertEquals(code, ExitCode.Success)
+        assertEquals(captured, Some(out))
+      }
   }
 
-  test("resolveOutput: -i and -o together is an error") {
+  test("runWithOutput: neither flag passes None through") {
+    val file = Path.of("/tmp/input.xlsx")
+    var captured: Option[Path] = Some(Path.of("/sentinel"))
+    Main
+      .runWithOutput(None, inPlace = false, file) { received =>
+        captured = received
+        IO.pure(ExitCode.Success)
+      }
+      .map { code =>
+        assertEquals(code, ExitCode.Success)
+        assertEquals(captured, None)
+      }
+  }
+
+  test("runWithOutput: -i and -o together exits with error code") {
     val file = Path.of("/tmp/input.xlsx")
     val out = Path.of("/tmp/output.xlsx")
-    Main.resolveOutput(Some(out), inPlace = true, file).attempt.map { result =>
-      assert(result.isLeft, "Should be an error")
-      val msg = result.left.toOption.get.getMessage
-      assert(
-        msg.contains("mutually exclusive"),
-        s"Error should mention mutual exclusivity, got: $msg"
-      )
+    Main
+      .runWithOutput(Some(out), inPlace = true, file)(_ => IO.pure(ExitCode.Success))
+      .map { code => assertEquals(code, ExitCode.Error) }
+  }
+
+  test("runWithOutput: -i writes to temp, atomically moves to input on success") {
+    withTempExcelFile { tempFile =>
+      // Capture the actual path we were asked to write to (should NOT be tempFile)
+      var writePath: Option[Path] = None
+      val result = Main.runWithOutput(None, inPlace = true, tempFile) { outOpt =>
+        val out = outOpt.get
+        writePath = Some(out)
+        // Verify we're writing to a temp file, not the original
+        assert(out != tempFile, s"In-place should write to temp, got: $out")
+        assert(
+          out.getFileName.toString.startsWith(".xl-inplace-"),
+          s"Temp should have .xl-inplace- prefix, got: ${out.getFileName}"
+        )
+        // Simulate a successful write
+        val wb = Workbook(
+          Vector(Sheet("Test").put(ref"A1", CellValue.Text("Updated")))
+        )
+        excel.write(wb, out).as(ExitCode.Success)
+      }
+
+      for
+        code <- result
+        // After success, original file should have new content
+        wb <- excel.read(tempFile)
+        value = wb.sheets.head.cells.get(ref"A1").map(_.value)
+        // And temp file should be gone
+        tempExists = writePath.exists(p => Files.exists(p))
+      yield
+        assertEquals(code, ExitCode.Success)
+        assertEquals(value, Some(CellValue.Text("Updated")))
+        assert(!tempExists, "Temp file should be cleaned up after atomic move")
     }
   }
 
-  test("resolveOutput: neither -i nor -o returns None") {
-    val file = Path.of("/tmp/test.xlsx")
-    Main.resolveOutput(None, inPlace = false, file).assertEquals(None)
+  test("runWithOutput: -i leaves original untouched on error exit") {
+    withTempExcelFile { tempFile =>
+      var writePath: Option[Path] = None
+      val result = Main.runWithOutput(None, inPlace = true, tempFile) { outOpt =>
+        writePath = outOpt
+        // Simulate a failure: return Error exit code without writing anything useful
+        IO.pure(ExitCode.Error)
+      }
+
+      for
+        code <- result
+        // Original file should be unchanged (still has original "Hello" / 42)
+        wb <- excel.read(tempFile)
+        a1 = wb.sheets.head.cells.get(ref"A1").map(_.value)
+        // And temp file should be gone
+        tempExists = writePath.exists(p => Files.exists(p))
+      yield
+        assertEquals(code, ExitCode.Error)
+        assertEquals(a1, Some(CellValue.Text("Hello")))
+        assert(!tempExists, "Temp file should be cleaned up on failure")
+    }
   }
 
-  test("in-place write modifies original file") {
+  test("runWithOutput: -i leaves original untouched when execute throws") {
     withTempExcelFile { tempFile =>
+      var writePath: Option[Path] = None
+      val result = Main.runWithOutput(None, inPlace = true, tempFile) { outOpt =>
+        writePath = outOpt
+        IO.raiseError(new RuntimeException("simulated crash"))
+      }
+
       for
-        // Read → modify → write back to same path (this is what -i does)
+        outcome <- result.attempt
         wb <- excel.read(tempFile)
-        sheet = wb.sheets.head.put(ref"A1", CellValue.Text("Updated"))
-        modifiedWb = Workbook(Vector(sheet))
-        _ <- excel.write(modifiedWb, tempFile)
-        // Read back and verify the file was modified
-        wb2 <- excel.read(tempFile)
-        sheet2 = wb2.sheets.head
-        value = sheet2.cells.get(ref"A1").map(_.value)
-      yield assertEquals(value, Some(CellValue.Text("Updated")))
+        a1 = wb.sheets.head.cells.get(ref"A1").map(_.value)
+        tempExists = writePath.exists(p => Files.exists(p))
+      yield
+        assert(outcome.isLeft, "Expected error to propagate")
+        assertEquals(a1, Some(CellValue.Text("Hello")))
+        assert(!tempExists, "Temp file should be cleaned up on exception")
     }
   }

--- a/xl-core/src/com/tjclp/xl/sheets/FreezePane.scala
+++ b/xl-core/src/com/tjclp/xl/sheets/FreezePane.scala
@@ -1,0 +1,19 @@
+package com.tjclp.xl.sheets
+
+import com.tjclp.xl.addressing.ARef
+
+/**
+ * Freeze pane configuration for a sheet.
+ *
+ * Freeze panes lock rows and/or columns so they remain visible while scrolling. The reference
+ * specifies the top-left cell of the scrollable (unfrozen) area:
+ *   - `At(ref"B2")` freezes row 1 and column A
+ *   - `At(ref"A3")` freezes rows 1-2 (no column freeze)
+ *   - `At(ref"C1")` freezes columns A-B (no row freeze)
+ */
+enum FreezePane derives CanEqual:
+  /** Freeze rows above and columns to the left of the given cell. */
+  case At(topLeftCell: ARef)
+
+  /** Remove any existing freeze panes. */
+  case Remove

--- a/xl-core/src/com/tjclp/xl/sheets/Sheet.scala
+++ b/xl-core/src/com/tjclp/xl/sheets/Sheet.scala
@@ -27,7 +27,8 @@ final case class Sheet(
   styleRegistry: StyleRegistry = StyleRegistry.default,
   comments: Map[ARef, Comment] = Map.empty,
   tables: Map[String, TableSpec] = Map.empty,
-  pageSetup: Option[PageSetup] = None
+  pageSetup: Option[PageSetup] = None,
+  freezePane: Option[FreezePane] = None
 ):
 
   /** Get cell at reference (returns empty cell if not present) */
@@ -463,6 +464,12 @@ final case class Sheet(
           ARef.from0(maxCol, maxRow)
         )
       )
+
+  /** Freeze panes at the given cell (rows above and columns left are frozen). */
+  def freezeAt(ref: ARef): Sheet = copy(freezePane = Some(FreezePane.At(ref)))
+
+  /** Remove freeze panes. */
+  def unfreeze: Sheet = copy(freezePane = Some(FreezePane.Remove))
 
   /** Count of non-empty cells */
   def cellCount: Int = cells.size

--- a/xl-core/src/com/tjclp/xl/sheets/Sheet.scala
+++ b/xl-core/src/com/tjclp/xl/sheets/Sheet.scala
@@ -15,6 +15,16 @@ import scala.util.boundary, boundary.break
  *
  * Immutable design: all operations return new Sheet instances. Uses persistent data structures for
  * efficient updates.
+ *
+ * @param freezePane
+ *   Freeze pane override with three-valued semantics:
+ *   - `None`: preserve existing `<sheetViews>` XML (no change on write)
+ *   - `Some(FreezePane.At(ref))`: inject/replace `<pane>` in sheetViews
+ *   - `Some(FreezePane.Remove)`: strip any existing `<pane>` from sheetViews
+ *
+ * The distinction between `None` and `Some(Remove)` matters: `None` is the passive default
+ * (round-trip preserves the original); `Some(Remove)` is the active intent to remove freeze panes
+ * even when the source XML had them.
  */
 final case class Sheet(
   name: SheetName,

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/OoxmlWorksheet.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/OoxmlWorksheet.scala
@@ -5,7 +5,7 @@ import scala.xml.*
 import com.tjclp.xl.addressing.{ARef, CellRange, Row}
 import com.tjclp.xl.ooxml.XmlUtil.{elem, nsRelationships}
 import com.tjclp.xl.ooxml.{SaxSerializable, SaxWriter, SharedStrings, XmlWritable}
-import com.tjclp.xl.sheets.Sheet
+import com.tjclp.xl.sheets.{FreezePane, Sheet}
 
 /**
  * Worksheet for xl/worksheets/sheet#.xml
@@ -422,7 +422,7 @@ object OoxmlWorksheet extends com.tjclp.xl.ooxml.XmlReadable[OoxmlWorksheet]:
           calculatedDimension.orElse(
             preserved.dimension
           ), // Use calculated dimension, fallback to preserved
-          preserved.sheetViews,
+          applyFreezePaneOverride(preserved.sheetViews, sheet.freezePane),
           preserved.sheetFormatPr,
           generatedCols.orElse(preserved.cols), // Prefer domain props over preserved XML
           preserved.conditionalFormatting,
@@ -450,7 +450,76 @@ object OoxmlWorksheet extends com.tjclp.xl.ooxml.XmlReadable[OoxmlWorksheet]:
           rowsWithCells,
           sheet.mergedRanges,
           dimension = calculatedDimension,
+          sheetViews = applyFreezePaneOverride(None, sheet.freezePane),
           cols = generatedCols,
           legacyDrawing = legacyDrawingElem,
           tableParts = tableParts
         )
+
+  /**
+   * Apply freeze pane override to sheetViews XML.
+   *
+   * When `freezeOverride` is `Some(FreezePane.At(ref))`, injects a `<pane>` element. When
+   * `Some(FreezePane.Remove)`, strips `<pane>` from existing sheetViews. When `None`, preserves
+   * existing sheetViews unchanged.
+   */
+  private def applyFreezePaneOverride(
+    existing: Option[Elem],
+    freezeOverride: Option[FreezePane]
+  ): Option[Elem] =
+    freezeOverride match
+      case None => existing
+      case Some(FreezePane.Remove) =>
+        existing.map { sv =>
+          val newChildren = sv.child.map {
+            case e: Elem if e.label == "sheetView" =>
+              e.copy(child = e.child.filterNot {
+                case c: Elem => c.label == "pane"
+                case _ => false
+              })
+            case other => other
+          }
+          sv.copy(child = newChildren)
+        }
+      case Some(FreezePane.At(ref)) =>
+        val colSplit = ref.col.index0
+        val rowSplit = ref.row.index0
+        if colSplit == 0 && rowSplit == 0 then existing
+        else
+          val activePane = (colSplit > 0, rowSplit > 0) match
+            case (true, true) => "bottomRight"
+            case (false, true) => "bottomLeft"
+            case (true, false) => "topRight"
+            case _ => "bottomLeft"
+
+          val paneAttrs = scala.collection.mutable.ListBuffer[(String, String)]()
+          if colSplit > 0 then paneAttrs += ("xSplit" -> colSplit.toString)
+          if rowSplit > 0 then paneAttrs += ("ySplit" -> rowSplit.toString)
+          paneAttrs += ("topLeftCell" -> ref.toA1)
+          paneAttrs += ("activePane" -> activePane)
+          paneAttrs += ("state" -> "frozen")
+
+          val paneElem = elem("pane", paneAttrs.toSeq*)(
+          )
+
+          // Inject pane into existing sheetViews or create new
+          existing match
+            case Some(sv) =>
+              val newChildren = sv.child.map {
+                case e: Elem if e.label == "sheetView" =>
+                  // Remove old pane, add new one at the beginning (before selection elements)
+                  val withoutPane = e.child.filterNot {
+                    case c: Elem => c.label == "pane"
+                    case _ => false
+                  }
+                  e.copy(child = paneElem +: withoutPane)
+                case other => other
+              }
+              Some(sv.copy(child = newChildren))
+            case None =>
+              // Create minimal sheetViews from scratch
+              val sheetView = elem(
+                "sheetView",
+                "workbookViewId" -> "0"
+              )(paneElem)
+              Some(elem("sheetViews")(sheetView))

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/OoxmlWorksheet.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/OoxmlWorksheet.scala
@@ -492,15 +492,16 @@ object OoxmlWorksheet extends com.tjclp.xl.ooxml.XmlReadable[OoxmlWorksheet]:
             case (true, false) => "topRight"
             case _ => "bottomLeft"
 
-          val paneAttrs = scala.collection.mutable.ListBuffer[(String, String)]()
-          if colSplit > 0 then paneAttrs += ("xSplit" -> colSplit.toString)
-          if rowSplit > 0 then paneAttrs += ("ySplit" -> rowSplit.toString)
-          paneAttrs += ("topLeftCell" -> ref.toA1)
-          paneAttrs += ("activePane" -> activePane)
-          paneAttrs += ("state" -> "frozen")
+          val paneAttrs: Vector[(String, String)] =
+            (if colSplit > 0 then Vector("xSplit" -> colSplit.toString) else Vector.empty) ++
+              (if rowSplit > 0 then Vector("ySplit" -> rowSplit.toString) else Vector.empty) ++
+              Vector(
+                "topLeftCell" -> ref.toA1,
+                "activePane" -> activePane,
+                "state" -> "frozen"
+              )
 
-          val paneElem = elem("pane", paneAttrs.toSeq*)(
-          )
+          val paneElem = elem("pane", paneAttrs*)()
 
           // Inject pane into existing sheetViews or create new
           existing match


### PR DESCRIPTION
## Summary

CLI productivity sweep — 4 features + skill docs update:

- **Range copy** (#124): `xl copy A1:D10 F1` with formula shifting via `FormulaShifter`, `--values-only` mode
- **Freeze/unfreeze panes** (#135): `xl freeze B2` / `xl unfreeze` — new `FreezePane` domain enum in xl-core, OOXML sheetViews manipulation in xl-ooxml
- **In-place edit** (#130): `xl -f data.xlsx -i put A1 100` — `-i` flag makes input = output, mutually exclusive with `-o`
- **CSV auto-split** (#186): `xl put A1:D1 "Q1,Q2,Q3,Q4"` auto-distributes comma-separated values when count matches range
- **Dev version fix**: Local `make install` now shows actual version (e.g., `0.9.7`) instead of `dev` via shared `BuildConfig.version`
- **Batch ops**: `freeze`, `unfreeze`, `copy` added (20 total)
- **SKILL.md + CLAUDE.md**: Updated with new commands and batch ops

## Files changed (11)

**Core**: `FreezePane.scala` (new), `Sheet.scala`
**OOXML**: `OoxmlWorksheet.scala`
**CLI**: `Command.scala`, `Main.scala`, `WriteCommands.scala`, `BatchParser.scala`
**Build**: `build.mill`, `xl-cli/package.mill`
**Docs**: `SKILL.md`, `CLAUDE.md`
**Tests**: `InPlaceSpec.scala` (new), `CsvAutoSplitSpec.scala` (new)

## Test plan

- [x] `./mill __.compile` — 763/763 modules
- [x] `./mill __.test` — 901/901 test tasks
- [x] `./mill __.checkFormat` — passed
- [x] `make install` + `xl --version` shows `0.9.7`
- [x] Dogfood: CSV split, in-place edit, freeze, copy, formula shifting all verified manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)