### PR TITLE
0.10.0 Phase 0 "Trust": data-loss + calc-engine + write-path correctness

### DIFF
--- a/docs/plan/roadmap.md
+++ b/docs/plan/roadmap.md
@@ -2,7 +2,11 @@
 
 > **Track Progress**: [GitHub Issues](https://github.com/TJC-LP/xl/issues)
 
-**Last Updated**: 2026-01-21
+**Last Updated**: 2026-06-07
+
+> ⚠️ **This file is mid-rewrite (tracked as the 0.10.0 doc-truth pass).** For current release work see
+> **[v0.10.0-execution.md](v0.10.0-execution.md)** (live tracker) and **[v0.10.0-triage.md](v0.10.0-triage.md)** (rationale + per-issue verdicts).
+> Sections below are stale pending that pass.
 
 ---
 
@@ -10,7 +14,7 @@
 
 **Current Status**: Production-ready with **88 formula functions**, SAX streaming (36% faster than POI), Excel tables, and full OOXML round-trip. 1080+ tests passing.
 
-**Current Version**: 0.6.1
+**Current Version**: 0.9.7 → **0.10.0 "Trust & Author"** in progress
 
 ---
 

--- a/docs/plan/v0.10.0-execution.md
+++ b/docs/plan/v0.10.0-execution.md
@@ -17,11 +17,12 @@
 
 ## Phase 0 — Trust & correctness (do first; de-risks all write work)
 
-- [ ] **C2 + C3** — Eq/Neq + scalar equality *(in progress — this session)*
-  - `xl-evaluator/.../parser/FormulaParser.scala:206,219`: replace `left/right.asInstanceOf[TExpr[Any]]` with `TExpr.asResolvedValueExpr(left/right)` (reuse `ast/TExprCoercions.scala:125`). Keep outer `.asInstanceOf[TExpr[Boolean]]`.
-  - `xl-evaluator/.../eval/Evaluator.scala:615`: replace `val eq = x == y` with `ArrayArithmetic.cellValueEquals(ArrayArithmetic.anyToCellValue(x), ArrayArithmetic.anyToCellValue(y))` then apply `negate` (reuse `eval/ArrayArithmetic.scala:262`).
-  - Tests: `=A1=B1`, `=A1<>B1`, `=IF(A1=B1,1,0)`, `="A"="a"`→TRUE, number/bool/date equality, negation, array path unchanged.
-  - GH: closes the C2 + C3 issues. PR: ____
+- [x] **C2 + C3** — Eq/Neq + scalar equality ✅ **commit `10cc388`** (branch `feat/v0.10.0-trust-foundation`)
+  - `FormulaParser.scala`: Eq/Neq operands now resolve via `TExpr.asResolvedValueExpr` (was raw `asInstanceOf`).
+  - `Evaluator.scala`: scalar equality fast path now uses `ArrayArithmetic.cellValueEquals(anyToCellValue(x), anyToCellValue(y))`.
+  - Bonus: added a `DateTime` case to `cellValueEquals` (date-cell equality previously fell through to `false` in **both** scalar and array paths).
+  - Tests: 10 new cases in `SheetEvaluatorSpec`. Full suite green (901/901).
+  - GH: closes #233 (C2) + #234 (C3). PR: _pending_
 - [ ] **C1** — silent data-loss fix (M)
   - Capture every `knownElements` entry (`xl-ooxml/.../worksheet/WorksheetReader.scala:75-118`) as a preserved `Elem` field on `OoxmlWorksheet`; thread through `fromDomainWithMetadata` + `toXml` in canonical (sorted) order.
   - Test: round-trip-after-modify — read a file with `dataValidations` + `sheetProtection` + `autoFilter` + `hyperlinks`, edit one cell, assert all survive. `DeterminismSpec` stays green.
@@ -64,4 +65,4 @@ Charts `#222` (needs `#221`), drawing/image layer `#221`, LET `#193`, LAMBDA, IN
 
 ## Session log
 
-- **2026-06-07**: Triage workflow (run `wf_3c275b61-e33`, 12 agents) → triage doc. C1–C5 verified against source. Plan approved (Trust & Author). Branch `feat/v0.10.0-trust-foundation`. Started Phase 0 C2+C3. GH milestone + issues set up.
+- **2026-06-07**: Triage workflow (run `wf_3c275b61-e33`, 12 agents) → triage doc. C1–C5 verified against source. Plan approved (Trust & Author). GH milestone #1 created; issues #232–243 filed; #75/#51/#90 closed, #17 commented. **Phase 0 C2+C3 landed** (commit `10cc388`, full suite 901/901). Next: C1 data-loss capture.

--- a/docs/plan/v0.10.0-execution.md
+++ b/docs/plan/v0.10.0-execution.md
@@ -23,16 +23,17 @@
   - Bonus: added a `DateTime` case to `cellValueEquals` (date-cell equality previously fell through to `false` in **both** scalar and array paths).
   - Tests: 10 new cases in `SheetEvaluatorSpec`. Full suite green (901/901).
   - GH: closes #233 (C2) + #234 (C3). PR: _pending_
-- [ ] **C1** — silent data-loss fix (M)
-  - Capture every `knownElements` entry (`xl-ooxml/.../worksheet/WorksheetReader.scala:75-118`) as a preserved `Elem` field on `OoxmlWorksheet`; thread through `fromDomainWithMetadata` + `toXml` in canonical (sorted) order.
-  - Test: round-trip-after-modify — read a file with `dataValidations` + `sheetProtection` + `autoFilter` + `hyperlinks`, edit one cell, assert all survive. `DeterminismSpec` stays green.
-  - Also add the #17 surgical-path trailing-space round-trip test, then close #17.
-  - GH: closes the C1 issue. PR: ____
-- [ ] **C4 + C5** — date + XML write correctness (S)
-  - C4: 1900 leap-year in `xl-core/.../cells/CellValue.scala:86-100` + fix Scaladoc `:79`. Property tests pin 1899-12-31 / 1900-01-01 / 1900-02-28 / serial 60 + dt→serial→dt round-trip.
-  - C5a: shared control-char sanitizer applied in both `StaxSaxWriter` + `ScalaXmlSaxWriter`; both-backends-byte-identical test.
-  - C5b: `toPlainString` numeric/serial emission (`DirectSaxEmitter.scala:356+`, `OoxmlCell.scala:51+`); wide-range numeric round-trip test.
-  - GH: closes the C4 + C5 issues. PR: ____
+- [x] **C1** — silent data-loss fix ✅ **commits `4784d80` + `5da0856`**
+  - `OoxmlWorksheet.preservedKnown: Map[label, Elem]` captures the 16 un-fielded `knownElements`; populated in the reader, carried through `fromDomainWithMetadata`, re-emitted at correct schema positions in `writeSax` + `toXml`.
+  - End-to-end round-trip-after-modify test (dataValidations/sheetProtection/autoFilter/hyperlinks survive) + `WorksheetPreservationInvariantSpec` (guards "no tier-3 silent loss" by construction). `DeterminismSpec` green. xl-ooxml 188/188.
+  - **Hardening (answers "always surgical?"):** `worksheetKnownElements` is now a single source of truth; a future un-wired element is a red test, not silent data loss.
+  - GH: closes #232. PR: _pending_. _Remaining: add the #17 surgical trailing-space test, then close #17._
+- [x] **C5** — control-char sanitization + plain-decimal numerics ✅ **commit `aa2871b`**
+  - `XmlUtil.sanitizeXmlText` (keeps tab/LF/CR + emoji; fast-path identity) applied in `OoxmlCell.toXml` (default ScalaXml path) **and** both SaxWriter backends' `writeCharacters`. `XmlUtil.plainNumber` (`toPlainString`) at every numeric `<v>` site in `OoxmlCell` + `DirectSaxEmitter`. `XmlValueSanitizationSpec`. GH: closes #237, #238.
+- [x] **C4** — Excel 1900 leap-year ✅ **commit `1546912`**
+  - `CellValue.dateTimeToExcelSerial`/`excelSerialToDateTime` reproduce the phantom 1900-02-29; modern dates byte-identical. Scaladoc corrected. Boundary + round-trip tests in `DateTimeSpec`. GH: closes #239.
+
+> **Phase 0 (Trust) COMPLETE** — C1–C5 all landed on `feat/v0.10.0-trust-foundation`; full suite 901/901, `./mill __.checkFormat` clean.
 
 ## Phase 1 — Author the half-built models (after C1)
 
@@ -65,4 +66,4 @@ Charts `#222` (needs `#221`), drawing/image layer `#221`, LET `#193`, LAMBDA, IN
 
 ## Session log
 
-- **2026-06-07**: Triage workflow (run `wf_3c275b61-e33`, 12 agents) → triage doc. C1–C5 verified against source. Plan approved (Trust & Author). GH milestone #1 created; issues #232–243 filed; #75/#51/#90 closed, #17 commented. **Phase 0 C2+C3 landed** (commit `10cc388`, full suite 901/901). Next: C1 data-loss capture.
+- **2026-06-07**: Triage workflow (run `wf_3c275b61-e33`, 12 agents) → triage doc. C1–C5 verified against source. Plan approved (Trust & Author). GH milestone #1 created; issues #232–243 filed; #75/#51/#90 closed, #17 commented. **Phase 0 C2+C3 landed** (`10cc388`, 901/901). **C1 data-loss fix + surgical-preservation invariant guard landed** (`4784d80`, `5da0856`; xl-ooxml 188/188). **C5 control-char + plain-decimal landed** (`aa2871b`). **C4 1900 leap-year landed** (`1546912`). **Phase 0 (Trust) COMPLETE** — branch `feat/v0.10.0-trust-foundation` (7 commits), full suite 901/901. Next: Phase 1 (named ranges + hyperlinks) or push branch + open PR(s).

--- a/docs/plan/v0.10.0-execution.md
+++ b/docs/plan/v0.10.0-execution.md
@@ -34,6 +34,17 @@
   - `CellValue.dateTimeToExcelSerial`/`excelSerialToDateTime` reproduce the phantom 1900-02-29; modern dates byte-identical. Scaladoc corrected. Boundary + round-trip tests in `DateTimeSpec`. GH: closes #239.
 
 > **Phase 0 (Trust) COMPLETE** — C1–C5 all landed on `feat/v0.10.0-trust-foundation`; full suite 901/901, `./mill __.checkFormat` clean.
+>
+> **Dogfooded via the real CLI (before/after vs installed 0.9.7), 2026-06-07:**
+> | Fix | 0.9.7 | branch |
+> |---|---|---|
+> | C1 `sheetProtection` (real Syndigo workbook, edit protected sheet) | dropped | preserved |
+> | C2 `=IF(A1=B1,…)` | `Unresolved PolyRef` error | `match` |
+> | C3 `=A2=B2` / `="A"="a"` | (errors) | `TRUE` (case-insensitive) |
+> | C4 `1900-01-01` serial | `2.0` | `1.0` |
+> | C5 `1e20` in `<v>` | `1.0E+20` | `100000000000000000000` |
+>
+> Surgical output re-reads cleanly (9 sheets, edit applied, conditionalFormatting/mergeCells/sheetProtection all preserved).
 
 ## Phase 1 — Author the half-built models (after C1)
 

--- a/docs/plan/v0.10.0-execution.md
+++ b/docs/plan/v0.10.0-execution.md
@@ -1,0 +1,67 @@
+# xl 0.10.0 "Trust & Author" — Execution Tracker
+
+> **This is the living checklist for the 0.10.0 release.** It is the single source of truth for *where we are*.
+> **Rationale & per-issue verdicts**: [`v0.10.0-triage.md`](v0.10.0-triage.md).
+
+## Resume protocol (for a future session)
+
+1. Read this file. Find the first unchecked `[ ]` item **in phase order**.
+2. Create/checkout a branch (`feat/v0.10.0-<item>` or `fix/<item>`).
+3. Implement → tests green (`./mill <module>.test`) → `./mill __.checkFormat` → (CLI changes: `make install`).
+4. Check the box here, append the PR link, commit. Update GH issue state.
+5. Determinism gate on **every** write-path change: re-serialize twice, assert byte-identical (`DeterminismSpec`).
+
+**Scope**: Trust & Author. Charts (#222) + drawing layer (#221) are **deferred to 0.11.0 "Visual"** — do not start them.
+
+---
+
+## Phase 0 — Trust & correctness (do first; de-risks all write work)
+
+- [ ] **C2 + C3** — Eq/Neq + scalar equality *(in progress — this session)*
+  - `xl-evaluator/.../parser/FormulaParser.scala:206,219`: replace `left/right.asInstanceOf[TExpr[Any]]` with `TExpr.asResolvedValueExpr(left/right)` (reuse `ast/TExprCoercions.scala:125`). Keep outer `.asInstanceOf[TExpr[Boolean]]`.
+  - `xl-evaluator/.../eval/Evaluator.scala:615`: replace `val eq = x == y` with `ArrayArithmetic.cellValueEquals(ArrayArithmetic.anyToCellValue(x), ArrayArithmetic.anyToCellValue(y))` then apply `negate` (reuse `eval/ArrayArithmetic.scala:262`).
+  - Tests: `=A1=B1`, `=A1<>B1`, `=IF(A1=B1,1,0)`, `="A"="a"`→TRUE, number/bool/date equality, negation, array path unchanged.
+  - GH: closes the C2 + C3 issues. PR: ____
+- [ ] **C1** — silent data-loss fix (M)
+  - Capture every `knownElements` entry (`xl-ooxml/.../worksheet/WorksheetReader.scala:75-118`) as a preserved `Elem` field on `OoxmlWorksheet`; thread through `fromDomainWithMetadata` + `toXml` in canonical (sorted) order.
+  - Test: round-trip-after-modify — read a file with `dataValidations` + `sheetProtection` + `autoFilter` + `hyperlinks`, edit one cell, assert all survive. `DeterminismSpec` stays green.
+  - Also add the #17 surgical-path trailing-space round-trip test, then close #17.
+  - GH: closes the C1 issue. PR: ____
+- [ ] **C4 + C5** — date + XML write correctness (S)
+  - C4: 1900 leap-year in `xl-core/.../cells/CellValue.scala:86-100` + fix Scaladoc `:79`. Property tests pin 1899-12-31 / 1900-01-01 / 1900-02-28 / serial 60 + dt→serial→dt round-trip.
+  - C5a: shared control-char sanitizer applied in both `StaxSaxWriter` + `ScalaXmlSaxWriter`; both-backends-byte-identical test.
+  - C5b: `toPlainString` numeric/serial emission (`DirectSaxEmitter.scala:356+`, `OoxmlCell.scala:51+`); wide-range numeric round-trip test.
+  - GH: closes the C4 + C5 issues. PR: ____
+
+## Phase 1 — Author the half-built models (after C1)
+
+- [ ] **Named ranges** — serialize `WorkbookMetadata.definedNames` in `OoxmlWorkbook.fromDomain` (`xl-ooxml/.../Workbook.scala:205`) + CLI `name add/rm`. PR: ____
+- [ ] **Hyperlinks** — `<hyperlinks>` emission + read population (`Cell.hyperlink`, `Cell.scala:23`) + batch op. PR: ____
+
+## Phase 2 — Structural editing (#128 + #129, one PR, after Phase 0)
+
+- [ ] Pure `Sheet/Workbook.insertRow/deleteRow` with **conditional** `FormulaShifter` (reuse `xl-evaluator/.../printer/FormulaShifter.scala`), `#REF!` generation (`CellError.Ref`), merge/rowProps/colProps/freeze split-clamp-drop, cross-sheet fold (reuse `DependencyGraph`). Then `insertColumn/deleteColumn` mirror. Then CLI + batch ops. Property test: insert-then-delete = identity on cells. PR: ____
+
+## Phase 3 — Formula breadth (parallelizable; xl-evaluator is low-conflict)
+
+- [ ] Scalar/lookup batch (#76 tier 1, #122 sans INDIRECT, #120, #55): IFS, SWITCH, MAXIFS, MINIFS (reuse `CriteriaMatcher`), HLOOKUP (transpose VLOOKUP), CHOOSE, LARGE/SMALL/RANK/PERCENTILE/QUARTILE (reuse aggregate substrate + BigDecimal PERCENTILE.INC), XLOOKUP modes 2/-2. Additive `FunctionSpec` vals only. PR: ____
+- [ ] Dynamic arrays (#76 tier 2) on existing spill engine (reuse `eval/ArrayResult.scala`, `Patch.PutArray`, `SheetEvaluator.evaluateArrayFormula`): SEQUENCE → SORT → UNIQUE → FILTER. OFFSET last. PR: ____
+
+## Phase 4 — Doc-truth + release readiness (last)
+
+- [ ] Rewrite `roadmap.md` (0.6.1→0.10.0, fix shipped-as-backlog entries); fix `STATUS.md`/`LIMITATIONS.md` self-contradictions + function counts; fill `CHANGELOG.md [Unreleased]`; bump `plugin/.../plugin.json` (0.7.0→0.10.0) + hardcoded versions; fix the release-prep runbook line numbers. Execute remaining close/re-scope (#75, #51, #90). PR: ____
+
+## Stretch (pull by echelon/day; expect 2–4, not all)
+
+`#48` → `#156` → docProps → `#184` → golden-fixture corpus + OOXML round-trip property + streaming-parity property → `#56` → `#137` → `#136` → `#223`.
+> Promote the golden-fixture round-trip property to **must-have** if any write-path change feels risky.
+
+## Deferred → 0.11.0 "Visual" / later
+
+Charts `#222` (needs `#221`), drawing/image layer `#221`, LET `#193`, LAMBDA, INDIRECT, full query `#134`, data-validation/sheet-protection authoring, pivots, 1904 date system, `#40`. (All are non-destructively *preserved* once C1 lands.)
+
+---
+
+## Session log
+
+- **2026-06-07**: Triage workflow (run `wf_3c275b61-e33`, 12 agents) → triage doc. C1–C5 verified against source. Plan approved (Trust & Author). Branch `feat/v0.10.0-trust-foundation`. Started Phase 0 C2+C3. GH milestone + issues set up.

--- a/docs/plan/v0.10.0-triage.md
+++ b/docs/plan/v0.10.0-triage.md
@@ -1,0 +1,201 @@
+# xl 0.10.0 Release Triage — "Trust & Author"
+
+**Date**: 2026-06-07
+**Status**: Proposed (awaiting maintainer sign-off)
+**Current version**: 0.9.7 → **0.10.0**
+**Method**: 12-agent review workflow — 6 issue-cluster reviewers (all 27 open issues, verified against the codebase) + 5 discovery lenses (purity/code-debt, structural parity, doc drift, test coverage, competitive analysis). Flagship findings independently re-verified against source by the maintainer loop.
+
+---
+
+## TL;DR
+
+The 0.9.x line was a bug-fix grind (~15 dogfooding fixes). The foundation is now solid — ~59k LOC, 1080+ tests, security-hardened, byte-identical determinism. **0.10.0 should be a capability leap, not another point release.**
+
+But the review surfaced **two verified defects that quietly falsify xl's two headline promises**, plus a set of "modeled-but-never-serialized" no-op APIs. So the release leads with **TRUST** (make xl safe to point at any real workbook + make the calc engine actually evaluate the most common formulas) and then **AUTHOR** (close the read-but-can't-write asymmetry: named ranges, hyperlinks, insert/delete rows/cols, modern + dynamic-array functions).
+
+> **The thesis**: be the only library where an LLM agent can perform a **complete, correct, byte-stable edit of a real analyst workbook** — preserving its validations/protections, inserting rows with reference-correct formula rewriting, authoring named ranges and hyperlinks, and live-recalculating modern formulas including dynamic arrays — **in one deterministic pass.** POI/ClosedXML have the breadth but are mutable and non-deterministic; openpyxl/ExcelJS don't evaluate formulas at all. None pair a pure calc engine with determinism *and* a first-class agent CLI.
+
+**Charts (#222) and the drawing/image layer (#221) are explicitly deferred to 0.11.0 "Visual."** They are the obvious next echelon, but charts structurally depend on a drawing layer, both are huge, and building visual features on top of a calc engine that errors on `=A1=B1` and a writer that eats dropdowns is backwards. Trust first.
+
+**Effort**: must-have spine ≈ **22–30 engineer-days** (~5–6 weeks solo, ~3 weeks with two: xl-evaluator function work parallelizes against xl-core insert/delete).
+
+---
+
+## Verified critical findings (hidden issues — not yet in GitHub)
+
+These were discovered by the workflow and **re-confirmed by reading the source directly.**
+
+### 🔴 C1 — Silent data loss on surgical modify (flagship-breaking)
+`WorksheetReader.scala:75-115` lists 16 inline worksheet elements in `knownElements` — including `sheetProtection`, `protectedRanges`, `scenarios`, `autoFilter`, `sortState`, `dataConsolidate`, `customSheetViews`, `phoneticPr`, **`dataValidations`**, **`hyperlinks`**, `sheetCalcPr`, `cellWatches`, `ignoredErrors`, `smartTags`, `legacyDrawingHF`, `webPublishItems`. Listing them **excludes them from the `otherElements` preservation catch-all** (`:116-118`), yet `OoxmlWorksheet` captures **none** of them into a field (only `conditionalFormatting` survives, `:44-46`). So they are dropped on read and cannot be re-emitted. **Open a real analyst file with a dropdown / protected sheet / filter, edit one cell, write back → that feature is silently gone.** Zero test coverage (surgical tests only cover charts/images/comments, which are *separate ZIP parts*). This directly contradicts the "surgical modification preserves unknown parts" guarantee marketed in STATUS.md/LIMITATIONS.md. **[M]**
+
+### 🔴 C2 — `=A1=B1`, `=A1<>B1`, `=IF(A1=B1,…)` fail with "Unresolved PolyRef"
+`FormulaParser.scala:206` (Eq) and `:219` (Neq) build nodes with raw `asInstanceOf[TExpr[Any]]`, while the inequality branches `:228-265` (Lt/Lte/Gt/Gte) correctly resolve operands via `TExpr.asNumericExpr(...)`. A bare cell-ref operand therefore stays a `PolyRef`, and the evaluator's `PolyRef` case is a guard that errors (`Evaluator.scala:226`). **The most common formula idiom in existence does not evaluate** — and the xl-agent benchmark hits it immediately. Undocumented, untested (existing Eq tests use only literal/decoded operands). Small, localized fix. **[S]**
+
+### 🟠 C3 — Scalar text equality is case-sensitive (contradicts Excel *and* xl's own array path)
+`Evaluator.scala:615` scalar fast path uses raw `x == y`, so `="A"="a"` → `false`. The array path (`ArrayArithmetic.scala:262`), VLOOKUP/XLOOKUP (`FunctionSpecsLookupSearch.scala:68`), and CriteriaMatcher all use `equalsIgnoreCase`. Same logical comparison, different answer depending on scalar-vs-array context — exactly the determinism/semantics inconsistency the purity charter forbids. Naturally bundled with C2. **[S]**
+
+### 🟠 C4 — Excel 1900 leap-year semantics not implemented; Scaladoc claims they are
+`CellValue.scala:93` does a straight `ChronoUnit.DAYS.between` from epoch `1899-12-30` with no phantom-Feb-29 adjustment. Modern dates are correct (the epoch choice pre-compensates), but **pre-1900-03-01 dates are off by one and serial 60 reads back as 1900-02-28 instead of Excel's phantom 1900-02-29.** The Scaladoc (`:79`) explicitly claims "This implementation matches Excel's behavior" — a documentation lie over wrong code. Low practical impact, outsized credibility for a "mathematically rigorous" library. **[S]**
+
+### 🟠 C5 — XML-illegal control chars dropped (StAX), divergent across backends + scientific-notation numerics
+The two SaxWriter backends pass raw strings with no filtering; the StAX backend silently drops `U+0001`–`U+001F` (data loss) and **the two backends diverge — a byte-identical-determinism breach.** Separately, numbers/date-serials are emitted via `.toString`, producing `1.0E+10` in `<v>` — which Excel never writes and stricter consumers reject (xl's own lenient reader hides it). **[S + S]**
+
+### "Modeled but never serialized" (silent no-op public APIs)
+- **Hyperlinks** — `Cell.hyperlink` has public `withHyperlink`/`clearHyperlink`, used in Generators/Optics, but **no `<hyperlinks>` emission exists anywhere.** `sheet.put(cell.withHyperlink(url))` compiles, type-checks, round-trips in memory, and produces a file with no hyperlink. **[M]**
+- **Named ranges** — `WorkbookMetadata.definedNames` is a fully typed model populated on read and surfaced in the CLI `names` command, but `OoxmlWorkbook.fromDomain` (`Workbook.scala:205`) emits only sheet refs and ignores it. **Cannot author named ranges.** **[M]**
+
+### Test & doc gaps
+- **No OOXML test reads a real-world `.xlsx`** — all reader inputs are synthetic XML the writer itself emits, making round-trips self-fulfilling and hiding divergence from genuine Excel/openpyxl/LibreOffice output. No `forAll { wb => read(write(wb)) ~= wb }` law despite full ScalaCheck generators existing. Streaming vs in-memory parsers never cross-validated (a prior SST regression proves they drift). **[M]**
+- **Doc drift** — `roadmap.md` (declared single source of truth in CLAUDE.md) is frozen at **0.6.1** and lists shipped features as "Planned/Backlog"; STATUS.md/LIMITATIONS.md self-contradict (named ranges + file-size limits shown unsupported but shipped; themes shown "returns 0" but fully implemented); CHANGELOG `[Unreleased]` omits 3 of 4 post-0.9.7 features (incl. the 6 new text functions); `plugin.json` stale at 0.7.0; the release-prep runbook has wrong line numbers (the root cause of recurring drift). The function count of **88 is real and accurate.** **[M]**
+
+---
+
+## Must-have spine (defines the release)
+
+| # | Item | Issues | Effort | Why |
+|---|------|--------|:------:|-----|
+| M1 | **Fix silent data loss (C1)** — capture all `knownElements` as preserved `Elem` fields on `OoxmlWorksheet`, thread through `fromDomainWithMetadata`, + round-trip-after-modify tests | *new* | M | Highest-leverage fix. Prerequisite for the whole echelon claim. "xl eats my spreadsheet" → "xl is safe on any file." |
+| M2 | **Fix Eq/Neq PolyRef (C2)** + **scalar text equality (C3)** — route `=`/`<>` through PolyRef resolution; route scalar Eq through `cellValueEquals` | *new* | S | The calc engine must evaluate `IF(A=B)`. One PR. |
+| M3 | **Write-path correctness (C4 + C5)** — 1900 leap-year fix + property tests; control-char sanitization (shared, both backends byte-identical); plain-decimal numeric emission | *new* | S | Determinism + Excel-parity correctness. Do before adding the round-trip property so it goes green on correct behavior. |
+| M4 | **Insert/delete rows AND columns** with dependency-graph-driven formula-reference rewriting | **#128 + #129** (one PR) | L | THE most common agent edit; every competitor has it. Reachable: `FormulaShifter` + `DependencyGraph` exist. Honestly **L** not M — needs *conditional* shifting, `#REF!` generation, merge/rowProps/colProps/freeze split-clamp-drop, cross-sheet fold. |
+| M5 | **Everyday scalar/lookup functions** — IFS, SWITCH, MAXIFS, MINIFS, HLOOKUP, CHOOSE, LARGE, SMALL, RANK, PERCENTILE, QUARTILE + XLOOKUP binary modes 2/-2 | **#76 (tier 1), #122 (sans INDIRECT), #120, #55** | M | High cumulative parity, low risk, **zero parser/GADT changes** (generic `NAME(args)` parser, macro-driven registration). Reuses CriteriaMatcher + aggregate substrate. |
+| M6 | **Dynamic-array functions on the EXISTING spill engine** — FILTER, SORT, UNIQUE, SEQUENCE (each returns `ArrayResult`, spills via `Patch.PutArray`) | **#76 (tier 2)** | M | The single biggest differentiator vs openpyxl/POI/ExcelJS. **Spill engine is already built and tested** (`ArrayResult`, `Patch.PutArray`, `evaluateArrayFormula`, `ArrayArithmetic`; TRANSPOSE proves it end-to-end, 31 array tests). Collapses 4 functions from an XL project to ~M. |
+| M7 | **Serialize named ranges + hyperlinks** — wire the existing typed models into the writer; add CLI `name add/rm` + hyperlink batch op | *new* (x2) | M | Table-stakes structure with models already shipped; pure read/write wiring (~100-120 LOC each). Fixes credibility-killing no-op public APIs. |
+| M8 | **Documentation truth pass** — rewrite `roadmap.md` (0.6.1→0.10.0); fix STATUS/LIMITATIONS contradictions; fill CHANGELOG `[Unreleased]`; bump `plugin.json` + hardcoded versions; fix the release-prep runbook | *new* | M | CLAUDE.md designates roadmap the scheduling source of truth, yet it's 15 releases stale. An "incredible" release is also correct and well-documented. Fixing the runbook prevents recurrence. |
+
+---
+
+## Stretch (pull in by echelon-per-day, in this order)
+
+| Order | Item | Issues | Effort | Note |
+|:-----:|------|--------|:------:|------|
+| 1 | Eliminate remaining `var`/mutable folds in SheetEvaluator (keystone purity fix) | **#48** | S | Two sites (`:184-185`, `:308-309`); do *before* #56 to avoid double-churn. |
+| 2 | AWT font-metric autofit (engine already exists in `RenderUtils.scala:77-121`) | **#156** | S | Visible agent-output win; openpyxl's autofit is notoriously weak. Mostly already done. |
+| 3 | Document properties (`docProps/core.xml` + `app.xml`) on write — **no volatile GUIDs/timestamps** | *new* | S | Files stop looking machine-generated; preserves reproducibility. |
+| 4 | Formula cells inherit number format from referenced cells | **#184** | M | High dogfooding value (`=B2-B3` over currency cells shows `$400,000.00`). |
+| 5 | Golden real-`.xlsx` fixture corpus + generative OOXML round-trip law + streaming-parity property | *new* | M | Would independently catch C4/C5. Best done *after* the point fixes so it pins final behavior. **Promote to must-have if any write change feels risky.** |
+| 6 | Global AST-level recursion depth limit (turn StackOverflow into clean `XLResult`) | **#56** | M | Totality fix; depends on #48 (same code). |
+| 7 | Workbook diff command (value + formula + JSON) | **#137** | M | A unique wedge *no competitor has*; productizes xl's determinism. Read-only = low risk. |
+| 8 | Conditional formatting **authoring** (typed cellIs/dataBar/colorScale + CLI/batch op) | **#136** | L | Preservation already round-trips; this is pure additive create. Reuse style serializer for dxf. |
+| 9 | Streaming SST dedup + style registry in streaming writes | **#223** | L | Style-registry half is built but unwired (all 3 ExcelIO paths call `.worksheetBody` inline). Also add `<pane>` to streaming. |
+| – | RAND/RANDBETWEEN (needs seeded `Rng` in `EvalContext`, mirroring `Clock` DI) | **#115** | S | Only if the seeded-context lands cleanly (don't use `ThreadLocalRandom`). |
+| – | YEARFRAC parity (basis 0/1 edge cases) | **#93** | M | Self-contained; parametrized test vs known Excel outputs. |
+| – | Markdown table upsert command | **#159** | S | Agent-friendly import; low risk. |
+| – | Native image rendering / renderer edge-case tests | **#86, #47** | L/M | #86's literal "no ImageMagick" goal is already met (Batik is the #1 rasterizer). |
+
+> Realistically expect to land **2–4 stretch items**, not all. #136 and #223 are each L and would justify their own mini-cycle.
+
+---
+
+## Deferred (explicitly out of 0.10.0 — with reasons)
+
+- **Charts (#222)** → **0.11.0.** Largest/riskiest item; structurally depends on the drawing layer. Charts are **preserved byte-for-byte today**, which is enough. Re-scope to a creation-only MVP after #221.
+- **Drawing/image & shape authoring (#221)** → **0.11.0 "Visual" (top item).** Greenfield + real risk (surgical write currently *drops* drawing rels on sheet modify). Read-side preservation already exists. Gates charts.
+- **LET (#193) + LAMBDA (#76 tier 3)** → later. Both need *new* `TExpr` GADT cases (Var/Let/Lambda — verified absent), a variable environment threaded through eval, parser binding syntax, and DependencyGraph awareness. High value, but L/high-risk to core invariants. LET is the *first* thing to pull in if the dynamic-array tier finishes early.
+- **INDIRECT (#122 subset)** → later. Runtime string-to-ref resolution is volatile and breaks the static dependency graph. Ship HLOOKUP/CHOOSE/OFFSET; hold INDIRECT.
+- **Full filter/query language (#134)** → later (streaming-query milestone). The full SELECT/GROUP BY engine is multi-week and duplicates DuckDB-after-CSV-export. **Keep open, do not close.**
+- **Data validation / sheet protection authoring, pivot tables, XLSM macros, 1904 date system, NumFmt.Fraction** → later. Each needs its own typed model + serializer + tests. **The M1 data-loss fix makes all of these non-destructively *preserved*, so 0.10.0 is safe without authoring them.** Sequence authoring post-0.10.0 starting with data validation (highest demand).
+- **JMH batch-put benchmark (#40)** → benchmark-coverage sweep. Proactive, no known problem, doesn't gate CI.
+
+---
+
+## Close now (tracker hygiene)
+
+- **#75** (P2 text/math umbrella) — ~19 of 22 functions already shipped; real remainders are children #122 + #117. Close the umbrella, track via children.
+- **#51** (JMH for macro put) — no-op: the macro (`PutLiteral.scala:42`) lowers to the *exact* direct call the issue proposes as the baseline; the benchmark compares a thing to itself. Close with a note.
+- **#17** (SST whitespace surgical-write bug) — verified no longer reproducible (`XlsxWriterRichTextEdgeCasesSpec` passes; `xml:space="preserve"` emitted; `normalize()` confined to dedup keys). Add one surgical-path trailing-space test, then close.
+- **#90** (higher-fidelity WYSIWYG SVG) — Phase 1 delivered (61 renderer tests, 3-pass layout, merged cells, overflow clipping, 14 border styles, rich text, themes). Close the *rendering framing*; re-file Phase 2/3 (data bars, icon sets, gradient fills) under the CF epic (#136) + a fills epic rather than let it balloon 0.10.0.
+
+---
+
+## New issues to file
+
+| Priority | Title |
+|----------|-------|
+| **critical** | Silent data loss — `dataValidations`/`sheetProtection`/`autoFilter`/`hyperlinks` (+12 more) dropped on any sheet modification (C1) |
+| **critical** | `=A1=B1`, `=A1<>B1`, `=IF(A1=B1,…)` fail with "Unresolved PolyRef" (C2) |
+| **high** | Scalar text equality is case-sensitive, contradicting Excel + xl's own array/VLOOKUP/CriteriaMatcher paths (C3) |
+| **high** | `Cell.hyperlink` modeled with public API but never serialized (silent no-op) |
+| **high** | Typed `DefinedName` (named ranges) is read-only — never serialized, cannot be authored |
+| **high** | XML-illegal control chars silently dropped by StAX, divergent across backends (determinism breach) (C5) |
+| **high** | No OOXML test reads a real `.xlsx`; no generative round-trip law; streaming vs in-memory never cross-validated |
+| **high** | Doc drift: roadmap.md frozen at 0.6.1; STATUS/LIMITATIONS self-contradict; CHANGELOG Unreleased incomplete; plugin.json + release-prep stale |
+| **medium** | Excel 1900 leap-year semantics not implemented; Scaladoc falsely claims they are (C4) |
+| **medium** | Numbers/date-serials serialized via `.toString` emit scientific notation (`1.0E+10`) into `<v>` (C5) |
+| **low** | Document properties (`docProps/core.xml`, `app.xml`) not written on save |
+| **low** | Document-now/implement-later silent gaps: 1904 date system, NumFmt.Fraction, standalone autofilter authoring |
+
+---
+
+## Sequencing (phased build plan)
+
+**Phase 0 — Trust & correctness foundation (do FIRST; mostly small; de-risks everything that writes XML)**
+1. Eq/Neq PolyRef fix + scalar text-equality (M2) — one PR, pure evaluator, no deps. Restores the calc engine immediately.
+2. Inline-element data-loss fix (M1) — independent, highest-leverage. Land early so all later write work runs against a non-destructive writer.
+3. Control-char sanitization + plain-decimal numerics + 1900 leap-year (M3) — before the round-trip property so it goes green on correct behavior.
+
+**Phase 1 — Author the half-built models** (depends on M1 so surgical writes are safe)
+4. Named-range serialization + CLI `name add/rm`; hyperlink `<hyperlinks>` emission + read population + batch op (M7) — independent of each other; both small.
+
+**Phase 2 — Structural editing** (the marquee agent feature; follow Phase 0 so `#REF!`/merge bookkeeping meets a correct writer)
+5. Pure `Sheet/Workbook.insertRow/deleteRow` with conditional `FormulaShifter` + `#REF!` generation + merge/props/freeze split-clamp-drop + cross-sheet fold (the bulk). Then `insertColumn/deleteColumn` as the mirror. Then thin CLI subcommands + batch ops (M4).
+
+**Phase 3 — Formula breadth** (parallelizable, low-risk, additive; xl-evaluator is the low-conflict module — run concurrently with Phases 1–2)
+6. Scalar/lookup batch (M5).
+7. Dynamic arrays in order SEQUENCE → SORT → UNIQUE → FILTER; OFFSET last (M6).
+
+**Phase 4 — Doc-truth pass + release readiness** (do LAST so docs reflect everything; partly mechanical)
+8. Rewrite roadmap; fix STATUS/LIMITATIONS + counts; fill CHANGELOG; bump plugin.json + versions; fix the runbook. Close #75/#51/#17(after 1 test)/#90 (M8).
+
+**Module-conflict note**: Phase 2 (xl-core `Sheet`) is the high-risk serialize point — single author. Phase 3 (xl-evaluator) parallelizes freely. Phase 0#2 + Phase 1 (xl-ooxml writer) are medium-risk — land the data-loss fix *before* hyperlink/named-range emission touches the same files.
+
+---
+
+## Risks
+
+1. **Scope overrun** (primary). The spine is already large. **Insert/delete (#128/#129) is the most likely to slip** — it's honestly L; the trap is underestimating it as "reuse the sort logic." Mitigation: build the pure xl-core core first behind property tests (insert-then-delete is identity on cells; refs shift only at/past the cut); ship rows before columns; columns droppable-to-stretch if rows run long.
+2. **Determinism regressions.** Every write-path change risks breaking byte-identical re-serialization. Mitigation: `DeterminismSpec` + a re-serialization round-trip gate each change; the golden-fixture property (stretch #5) is the real safety net — **promote to must-have if any write change feels risky.** docProps must avoid volatile GUIDs/timestamps.
+3. **Excel-parity correctness** in PERCENTILE.INC, QUARTILE, NumFmt precedence (#184), and the 1900 boundary. Mitigation: parametrized tests sweeping known Excel outputs; pin exact serials at the leap boundary; keep #184 format-inference-only.
+4. **Hidden evaluator invariants.** Dynamic-array functions must interact cleanly with the spill engine, dependency graph, and the Eq/Neq fix. Mitigation: TRANSPOSE proves the pipeline; add each function with both scalar-context and spill-context tests. Keep LET/LAMBDA/INDIRECT firmly out.
+5. **OOXML writer conflict.** M1 + hyperlink + named-range all touch the same files. Mitigation: land M1 first, single owner for the writer surface.
+6. **Doc pass rushed at the end** (the exact failure this audit found). Mitigation: treat CHANGELOG/roadmap/plugin.json/runbook fixes as a *gated checklist* in the release-prep skill, not an afterthought.
+
+---
+
+## Appendix — per-issue verdicts (all 27 open issues)
+
+Ranked by echelon impact, then value. `ech` = how much shipping it pushes xl into a new echelon (0–5); `val` = product value (1–5).
+
+| # | rec | eff | val | ech | status | title |
+|--:|-----|:---:|:---:|:---:|--------|-------|
+| 76 | v0.10.0 (split) | XL | 5 | 4 | valid | P3 modern: IFS/SWITCH/MAXIFS/MINIFS + dynamic arrays + LET/LAMBDA |
+| 128 | v0.10.0 | L | 5 | 4 | valid | Insert/delete rows |
+| 129 | v0.10.0 | M | 5 | 4 | valid | Insert/delete columns |
+| 221 | **defer → 0.11.0** | L | 4 | 4 | valid | Drawing layer — images and shapes |
+| 222 | **defer → 0.11.0** | XL | 3 | 4 | valid | Type-safe chart model (needs #221) |
+| 193 | defer (stretch if slack) | L | 4 | 3 | valid | LET function support |
+| 184 | stretch | M | 4 | 3 | valid | Formula cells inherit number format |
+| 223 | stretch | L | 4 | 3 | partial | SST dedup + style registry in streaming |
+| 136 | stretch | L | 4 | 3 | partial | Conditional formatting (authoring) |
+| 156 | stretch | S | 4 | 3 | partial | AWT-based font measurement for autofit |
+| 137 | stretch | M | 3 | 3 | valid | diff command (compare workbooks) |
+| 90 | **close** (rendering framing) | XL | 3 | 3 | partial | Higher-fidelity WYSIWYG SVG |
+| 122 | v0.10.0 (sans INDIRECT) | M | 4 | 2 | valid | HLOOKUP, CHOOSE, OFFSET, INDIRECT |
+| 120 | v0.10.0 | M | 4 | 2 | valid | LARGE, SMALL, RANK, PERCENTILE, QUARTILE |
+| 48 | stretch | S | 3 | 2 | valid | Refactor SheetEvaluator (eliminate mutable state) |
+| 159 | stretch | S | 3 | 2 | valid | markdown table upsert command |
+| 86 | stretch | L | 3 | 2 | partial | Native JVM image rendering (goal largely met) |
+| 47 | stretch | M | 3 | 2 | valid | renderer edge case tests |
+| 134 | defer | L | 2 | 2 | valid | filter/query command (keep open) |
+| 17 | **close** (add 1 test) | S | 3 | 1 | done | SST whitespace surgical-write bug (not reproducible) |
+| 115 | stretch | S | 2 | 1 | valid | RAND, RANDBETWEEN (needs seeded RNG) |
+| 55 | v0.10.0 | S | 2 | 1 | valid | XLOOKUP binary search modes 2/-2 |
+| 93 | stretch | M | 2 | 1 | valid | YEARFRAC parity edge cases |
+| 56 | stretch | M | 2 | 1 | partial | Global recursion depth limit |
+| 40 | defer | S | 2 | 1 | valid | JMH benchmark for batch put |
+| 75 | **close** | S | 3 | 0 | done | P2 umbrella (children shipped) |
+| 51 | **close** | S | 1 | 0 | valid | JMH for macro put (no-op) |
+
+---
+
+*Generated from a 12-agent review workflow (run `wf_3c275b61-e33`). Flagship findings C1–C5 re-verified against source in the maintainer loop.*

--- a/xl-core/src/com/tjclp/xl/cells/CellValue.scala
+++ b/xl-core/src/com/tjclp/xl/cells/CellValue.scala
@@ -75,8 +75,9 @@ object CellValue:
    * Convert LocalDateTime to Excel serial number.
    *
    * Excel represents dates as the number of days since December 30, 1899, with fractional days
-   * representing time. Note: Excel has a bug where it treats 1900 as a leap year (it wasn't), so
-   * dates before March 1, 1900 are off by one day. This implementation matches Excel's behavior.
+   * representing time. Excel has a bug where it treats 1900 as a leap year (it wasn't); this
+   * implementation reproduces that quirk so serials match Excel exactly: 1900-01-01 = 1, 1900-02-28 =
+   * 59, the phantom 1900-02-29 = 60, 1900-03-01 = 61.
    *
    * @param dt
    *   The LocalDateTime to convert
@@ -90,7 +91,11 @@ object CellValue:
     val epoch1900 = LocalDateTime.of(1899, 12, 30, 0, 0, 0)
 
     // Calculate days since epoch
-    val days = ChronoUnit.DAYS.between(epoch1900, dt)
+    val rawDays = ChronoUnit.DAYS.between(epoch1900, dt)
+    // Excel 1900 leap-year bug: it counts a phantom 1900-02-29 (serial 60), so real dates before
+    // 1900-03-01 (rawDays < 61 from the 1899-12-30 epoch) are one higher than Excel. Subtract it
+    // back so 1900-01-01 -> 1 and 1900-02-28 -> 59. Dates on/after 1900-03-01 are already correct.
+    val days = if rawDays < 61 then rawDays - 1 else rawDays
 
     // Calculate fractional day for time component
     val dayStart = dt.toLocalDate.atStartOfDay
@@ -121,8 +126,10 @@ object CellValue:
     val fractionOfDay = serial - wholeDays
     val seconds = (fractionOfDay * 86400.0).toLong
 
-    // Add days and seconds to epoch
-    epoch1900.plusDays(wholeDays).plusSeconds(seconds)
+    // Inverse of the 1900 leap-year adjustment: serials below 60 are shifted one day forward;
+    // serial 60 is Excel's phantom 1900-02-29, mapped here to 1900-02-28. Serials >= 61 are exact.
+    val dayShift = if wholeDays < 60 then 1L else 0L
+    epoch1900.plusDays(wholeDays + dayShift).plusSeconds(seconds)
 
   /**
    * Characters that trigger formula injection when at the start of a cell value.

--- a/xl-core/test/src/com/tjclp/xl/DateTimeSpec.scala
+++ b/xl-core/test/src/com/tjclp/xl/DateTimeSpec.scala
@@ -43,18 +43,16 @@ class DateTimeSpec extends FunSuite:
     assertEquals(serial, expected, 0.00001)
   }
 
-  test("dateTimeToExcelSerial epoch is 1899-12-30") {
-    // Excel epoch (December 30, 1899) should be serial 0
-    val epoch = LocalDateTime.of(1899, 12, 30, 0, 0, 0)
-    val serial = CellValue.dateTimeToExcelSerial(epoch)
-    assertEquals(serial, 0.0, 0.001)
+  // GH-239: Excel 1900 leap-year parity. (Excel has no serials below 1; dates before 1900-01-01
+  // extend the number line and are outside Excel's representable range.)
+  test("dateTimeToExcelSerial: 1900-01-01 is serial 1 (Excel 1900 leap-year parity)") {
+    val dt = LocalDateTime.of(1900, 1, 1, 0, 0, 0)
+    assertEquals(CellValue.dateTimeToExcelSerial(dt), 1.0, 0.001)
   }
 
-  test("dateTimeToExcelSerial for next day after epoch") {
-    // December 31, 1899 should be serial 1
-    val dt = LocalDateTime.of(1899, 12, 31, 0, 0, 0)
-    val serial = CellValue.dateTimeToExcelSerial(dt)
-    assertEquals(serial, 1.0, 0.001)
+  test("dateTimeToExcelSerial: 1900-02-28 is serial 59 (day before the phantom leap day)") {
+    val dt = LocalDateTime.of(1900, 2, 28, 0, 0, 0)
+    assertEquals(CellValue.dateTimeToExcelSerial(dt), 59.0, 0.001)
   }
 
   test("dateTimeToExcelSerial for year 2020") {
@@ -62,4 +60,35 @@ class DateTimeSpec extends FunSuite:
     val dt = LocalDateTime.of(2020, 1, 1, 0, 0, 0)
     val serial = CellValue.dateTimeToExcelSerial(dt)
     assertEquals(serial, 43831.0, 0.001)
+  }
+
+  test("dateTimeToExcelSerial: 1900-03-01 is serial 61 (after the phantom leap day)") {
+    val dt = LocalDateTime.of(1900, 3, 1, 0, 0, 0)
+    assertEquals(CellValue.dateTimeToExcelSerial(dt), 61.0, 0.001)
+  }
+
+  test("excelSerialToDateTime: serial 60 (Excel's phantom 1900-02-29) maps to 1900-02-28") {
+    assertEquals(
+      CellValue.excelSerialToDateTime(60.0).toLocalDate,
+      java.time.LocalDate.of(1900, 2, 28)
+    )
+  }
+
+  test("date serial round-trips across the 1900 leap-year boundary and for modern dates") {
+    val dates = List(
+      LocalDateTime.of(1900, 1, 1, 0, 0, 0),
+      LocalDateTime.of(1900, 1, 15, 0, 0, 0),
+      LocalDateTime.of(1900, 2, 28, 0, 0, 0),
+      LocalDateTime.of(1900, 3, 1, 0, 0, 0),
+      LocalDateTime.of(2000, 1, 1, 0, 0, 0),
+      LocalDateTime.of(2025, 11, 10, 0, 0, 0)
+    )
+    dates.foreach { dt =>
+      val serial = CellValue.dateTimeToExcelSerial(dt)
+      assertEquals(
+        CellValue.excelSerialToDateTime(serial),
+        dt,
+        s"round-trip failed for $dt (serial $serial)"
+      )
+    }
   }

--- a/xl-evaluator/src/com/tjclp/xl/formula/eval/ArrayArithmetic.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/eval/ArrayArithmetic.scala
@@ -256,14 +256,21 @@ object ArrayArithmetic:
     case b: Boolean => CellValue.Bool(b)
     case _ => CellValue.Text(v.toString)
 
-  /** Compare CellValues for equality (case-insensitive for text). */
-  private def cellValueEquals(a: CellValue, b: CellValue): Boolean = (a, b) match
+  /**
+   * Compare CellValues for equality (case-insensitive for text), matching Excel.
+   *
+   * Shared with the scalar equality fast path in Evaluator (GH-234) so scalar `=A1=B1` and array
+   * `=A1:A3=B1:B3` equality use identical semantics.
+   */
+  def cellValueEquals(a: CellValue, b: CellValue): Boolean = (a, b) match
     case (CellValue.Text(t1), CellValue.Text(t2)) =>
       t1.equalsIgnoreCase(t2)
     case (CellValue.Number(n1), CellValue.Number(n2)) =>
       n1 == n2
     case (CellValue.Bool(b1), CellValue.Bool(b2)) =>
       b1 == b2
+    case (CellValue.DateTime(d1), CellValue.DateTime(d2)) =>
+      d1.isEqual(d2)
     case (CellValue.Empty, CellValue.Empty) =>
       true
     case (CellValue.Formula(_, Some(c1)), other) =>

--- a/xl-evaluator/src/com/tjclp/xl/formula/eval/Evaluator.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/eval/Evaluator.scala
@@ -610,9 +610,15 @@ private class EvaluatorImpl(allowArrayResults: Boolean = false) extends Evaluato
               if allowArrayResults then Right(compared)
               else Left(EvalError.TypeMismatch("comparison", "boolean", "array"))
           }
-        // Both scalars -> plain boolean (fast path)
+        // Both scalars -> plain boolean (fast path).
+        // GH-234: use the same case-insensitive/coercing semantics as the array path
+        // (ArrayArithmetic.cellValueEquals) so scalar and array equality agree with Excel
+        // (e.g. ="A"="a" -> TRUE). Previously used raw `x == y` (case-sensitive).
         case (x, y) =>
-          val eq = x == y
+          val eq = ArrayArithmetic.cellValueEquals(
+            ArrayArithmetic.anyToCellValue(x),
+            ArrayArithmetic.anyToCellValue(y)
+          )
           Right(if negate then !eq else eq)
     yield result
 

--- a/xl-evaluator/src/com/tjclp/xl/formula/parser/FormulaParser.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/parser/FormulaParser.scala
@@ -200,11 +200,12 @@ object FormulaParser:
         case Some('=') =>
           val s3 = skipWhitespace(s2.advance())
           parseComparison(s3).map { case (right, s4) =>
-            // Runtime parsing loses type info - use asInstanceOf
+            // GH-233: resolve PolyRef operands polymorphically (like the inequality
+            // branches use asNumericExpr) so =A1=B1 / =IF(A1=B1,…) evaluate instead of
+            // erroring with "Unresolved PolyRef". asResolvedValueExpr preserves
+            // text/number/bool/date equality (unlike numeric-only asNumericExpr).
             (
-              TExpr
-                .Eq(left.asInstanceOf[TExpr[Any]], right.asInstanceOf[TExpr[Any]])
-                .asInstanceOf[TExpr[Boolean]],
+              TExpr.Eq(TExpr.asResolvedValueExpr(left), TExpr.asResolvedValueExpr(right)),
               s4
             )
           }
@@ -213,11 +214,9 @@ object FormulaParser:
             case Some('>') => // <>
               val s3 = skipWhitespace(s2.advance(2))
               parseComparison(s3).map { case (right, s4) =>
-                // Runtime parsing loses type info - use asInstanceOf
+                // GH-233: resolve PolyRef operands so =A1<>B1 evaluates (see Eq above).
                 (
-                  TExpr
-                    .Neq(left.asInstanceOf[TExpr[Any]], right.asInstanceOf[TExpr[Any]])
-                    .asInstanceOf[TExpr[Boolean]],
+                  TExpr.Neq(TExpr.asResolvedValueExpr(left), TExpr.asResolvedValueExpr(right)),
                   s4
                 )
               }

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/SheetEvaluatorSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/SheetEvaluatorSpec.scala
@@ -65,6 +65,79 @@ class SheetEvaluatorSpec extends FunSuite:
     assertEquals(result, Right(CellValue.Bool(true)))
   }
 
+  // ===== Eq/Neq with cell references (GH-233) + case-insensitive equality (GH-234) =====
+  // Regression: =A1=B1 / =IF(A1=B1,…) previously returned Left("Unresolved PolyRef")
+  // because the parser left bare-ref operands as PolyRef. They must now evaluate.
+
+  test("GH-233: =A1=B1 with equal numeric cells -> TRUE") {
+    val sheet = sheetWith(
+      ref"A1" -> CellValue.Number(BigDecimal(10)),
+      ref"B1" -> CellValue.Number(BigDecimal(10))
+    )
+    assertEquals(sheet.evaluateFormula("=A1=B1"), Right(CellValue.Bool(true)))
+  }
+
+  test("GH-233: =A1=B1 with unequal numeric cells -> FALSE") {
+    val sheet = sheetWith(
+      ref"A1" -> CellValue.Number(BigDecimal(10)),
+      ref"B1" -> CellValue.Number(BigDecimal(20))
+    )
+    assertEquals(sheet.evaluateFormula("=A1=B1"), Right(CellValue.Bool(false)))
+  }
+
+  test("GH-233: =A1<>B1 with unequal cells -> TRUE") {
+    val sheet = sheetWith(
+      ref"A1" -> CellValue.Number(BigDecimal(10)),
+      ref"B1" -> CellValue.Number(BigDecimal(20))
+    )
+    assertEquals(sheet.evaluateFormula("=A1<>B1"), Right(CellValue.Bool(true)))
+  }
+
+  test("GH-233: =IF(A1=B1,...) — the headline regression — evaluates") {
+    val sheet = sheetWith(
+      ref"A1" -> CellValue.Number(BigDecimal(5)),
+      ref"B1" -> CellValue.Number(BigDecimal(5))
+    )
+    assertEquals(sheet.evaluateFormula("=IF(A1=B1,\"match\",\"no\")"), Right(CellValue.Text("match")))
+  }
+
+  test("GH-233: cross-sheet-style ref equality with text cells") {
+    val sheet = sheetWith(
+      ref"A1" -> CellValue.Text("Hello"),
+      ref"B1" -> CellValue.Text("Hello")
+    )
+    assertEquals(sheet.evaluateFormula("=A1=B1"), Right(CellValue.Bool(true)))
+  }
+
+  test("GH-234: text equality is case-INSENSITIVE for cell refs (Excel parity)") {
+    val sheet = sheetWith(
+      ref"A1" -> CellValue.Text("Hello"),
+      ref"B1" -> CellValue.Text("hELLO")
+    )
+    assertEquals(sheet.evaluateFormula("=A1=B1"), Right(CellValue.Bool(true)))
+  }
+
+  test("GH-234: scalar text equality is case-insensitive (=\"A\"=\"a\" -> TRUE)") {
+    assertEquals(emptySheet.evaluateFormula("=\"A\"=\"a\""), Right(CellValue.Bool(true)))
+  }
+
+  test("GH-234: scalar text inequality respects case-insensitivity (=\"A\"<>\"a\" -> FALSE)") {
+    assertEquals(emptySheet.evaluateFormula("=\"A\"<>\"a\""), Right(CellValue.Bool(false)))
+  }
+
+  test("GH-234: number vs text are not equal (=1=\"1\" -> FALSE, Excel parity)") {
+    assertEquals(emptySheet.evaluateFormula("=1=\"1\""), Right(CellValue.Bool(false)))
+  }
+
+  test("GH-233: date cell equality via refs") {
+    val d = LocalDate.of(2025, 6, 1).atStartOfDay()
+    val sheet = sheetWith(
+      ref"A1" -> CellValue.DateTime(d),
+      ref"B1" -> CellValue.DateTime(d)
+    )
+    assertEquals(sheet.evaluateFormula("=A1=B1"), Right(CellValue.Bool(true)))
+  }
+
   test("evaluateFormula: date result with TODAY") {
     val clock = Clock.fixedDate(LocalDate.of(2025, 11, 21))
     val result = emptySheet.evaluateFormula("=TODAY()", clock)

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/DirectSaxEmitter.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/DirectSaxEmitter.scala
@@ -355,7 +355,7 @@ object DirectSaxEmitter:
 
       case CellValue.Number(num) =>
         writer.startElement("v")
-        writer.writeCharacters(num.toString)
+        writer.writeCharacters(XmlUtil.plainNumber(num))
         writer.endElement()
 
       case CellValue.Bool(b) =>
@@ -378,7 +378,7 @@ object DirectSaxEmitter:
       case CellValue.DateTime(dt) =>
         val serial = CellValue.dateTimeToExcelSerial(dt)
         writer.startElement("v")
-        writer.writeCharacters(serial.toString)
+        writer.writeCharacters(XmlUtil.plainNumber(serial))
         writer.endElement()
 
   /**
@@ -388,7 +388,7 @@ object DirectSaxEmitter:
     cachedValue.foreach {
       case CellValue.Number(num) =>
         writer.startElement("v")
-        writer.writeCharacters(num.toString)
+        writer.writeCharacters(XmlUtil.plainNumber(num))
         writer.endElement()
       case CellValue.Text(s) =>
         writer.startElement("v")

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/ScalaXmlSaxWriter.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/ScalaXmlSaxWriter.scala
@@ -40,9 +40,11 @@ class ScalaXmlSaxWriter extends SaxWriter:
       case Nil => ()
 
   def writeCharacters(text: String): Unit =
+    // GH-237: strip XML-illegal control chars so this backend matches StAX byte-for-byte.
+    val safe = XmlUtil.sanitizeXmlText(text)
     stack match
       case head :: tail =>
-        stack = head.copy(children = Text(text) :: head.children) :: tail
+        stack = head.copy(children = Text(safe) :: head.children) :: tail
       case Nil => ()
 
   def endElement(): Unit =

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/StaxSaxWriter.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/StaxSaxWriter.scala
@@ -97,7 +97,10 @@ class StaxSaxWriter(underlying: XMLStreamWriter) extends SaxWriter:
             underlying.writeAttribute(prefix, ns.getOrElse(""), local, value)
           case _ =>
             underlying.writeAttribute(name, value)
-  def writeCharacters(text: String): Unit = underlying.writeCharacters(text)
+  // GH-237: strip XML-illegal control chars (StAX would otherwise silently drop them, diverging
+  // from the ScalaXml backend). XmlUtil.sanitizeXmlText is a no-op fast path for clean text.
+  def writeCharacters(text: String): Unit =
+    underlying.writeCharacters(XmlUtil.sanitizeXmlText(text))
   def endElement(): Unit =
     underlying.writeEndElement()
     if !namespaceStack.isEmpty then popScope()

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/OoxmlCell.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/OoxmlCell.scala
@@ -48,7 +48,7 @@ case class OoxmlCell(
 
         case CellValue.Number(num) =>
           writer.startElement("v")
-          writer.writeCharacters(num.toString)
+          writer.writeCharacters(XmlUtil.plainNumber(num))
           writer.endElement() // v
 
         case CellValue.Bool(b) =>
@@ -64,7 +64,7 @@ case class OoxmlCell(
           cachedValue.foreach {
             case CellValue.Number(num) =>
               writer.startElement("v")
-              writer.writeCharacters(num.toString)
+              writer.writeCharacters(XmlUtil.plainNumber(num))
               writer.endElement()
             case CellValue.Text(s) =>
               writer.startElement("v")
@@ -91,7 +91,7 @@ case class OoxmlCell(
         case CellValue.DateTime(dt) =>
           val serial = CellValue.dateTimeToExcelSerial(dt)
           writer.startElement("v")
-          writer.writeCharacters(serial.toString)
+          writer.writeCharacters(XmlUtil.plainNumber(serial))
           writer.endElement() // v
     }
 
@@ -183,12 +183,14 @@ case class OoxmlCell(
               PrefixedAttribute("xml", "space", "preserve", Null),
               TopScope,
               true,
-              Text(text)
+              Text(XmlUtil.sanitizeXmlText(text))
             )
-          else elem("t")(Text(text))
+          else elem("t")(Text(XmlUtil.sanitizeXmlText(text)))
         Seq(elem("is")(tElem))
       case CellValue.Text(text) => // SST index
-        Seq(elem("v")(Text(text))) // text here would be the SST index as string
+        Seq(
+          elem("v")(Text(XmlUtil.sanitizeXmlText(text)))
+        ) // text here would be the SST index as string
       case CellValue.RichText(richText) =>
         // Rich text: <is> with multiple <r> (text run) elements
         val runElems = richText.runs.map { run =>
@@ -240,9 +242,9 @@ case class OoxmlCell(
                 PrefixedAttribute("xml", "space", "preserve", Null),
                 TopScope,
                 true,
-                Text(run.text)
+                Text(XmlUtil.sanitizeXmlText(run.text))
               )
-            else elem("t")(Text(run.text))
+            else elem("t")(Text(XmlUtil.sanitizeXmlText(run.text)))
 
           elem("r")(
             rPrElems ++ Seq(textElem)*
@@ -251,7 +253,7 @@ case class OoxmlCell(
 
         Seq(elem("is")(runElems*))
       case CellValue.Number(num) =>
-        Seq(elem("v")(Text(num.toString)))
+        Seq(elem("v")(Text(XmlUtil.plainNumber(num))))
       case CellValue.Bool(b) =>
         Seq(elem("v")(Text(if b then "1" else "0")))
       case CellValue.Formula(expr, cachedValue) =>
@@ -259,7 +261,7 @@ case class OoxmlCell(
         val formulaElem = elem("f")(Text(expr))
         // Write cached value if present
         val cachedElem = cachedValue.flatMap {
-          case CellValue.Number(num) => Some(elem("v")(Text(num.toString)))
+          case CellValue.Number(num) => Some(elem("v")(Text(XmlUtil.plainNumber(num))))
           case CellValue.Text(s) => Some(elem("v")(Text(s)))
           case CellValue.Bool(b) => Some(elem("v")(Text(if b then "1" else "0")))
           case CellValue.Error(err) =>
@@ -274,6 +276,6 @@ case class OoxmlCell(
       case CellValue.DateTime(dt) =>
         // DateTime is serialized as number with Excel serial format
         val serial = CellValue.dateTimeToExcelSerial(dt)
-        Seq(elem("v")(Text(serial.toString)))
+        Seq(elem("v")(Text(XmlUtil.plainNumber(serial))))
 
     elemOrdered("c", finalAttrs*)(valueElem*)

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/OoxmlWorksheet.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/OoxmlWorksheet.scala
@@ -80,7 +80,10 @@ case class OoxmlWorksheet(
   extLst: Option[Elem] = None,
   otherElements: Seq[Elem] = Seq.empty,
   rootAttributes: MetaData = Null,
-  rootScope: NamespaceBinding = defaultWorksheetScope
+  rootScope: NamespaceBinding = defaultWorksheetScope,
+  // GH-232: inline CT_Worksheet children (dataValidations, sheetProtection, autoFilter, hyperlinks,
+  // etc.) that have no dedicated field above. Keyed by element label; re-emitted in schema order.
+  preservedKnown: Map[String, Elem] = Map.empty
 ) extends XmlWritable,
       SaxSerializable:
 
@@ -107,6 +110,10 @@ case class OoxmlWorksheet(
       rows.sortBy(_.rowIndex).foreach(_.writeSax(writer))
       writer.endElement() // sheetData
 
+      // GH-232: preserved inline elements between sheetData and mergeCells (schema order):
+      // sheetCalcPr, sheetProtection, protectedRanges, scenarios, autoFilter, sortState, ...
+      preservedAfterSheetData.foreach(l => preservedKnown.get(l).foreach(writer.writeElem))
+
       // mergeCells
       if mergedRanges.nonEmpty then
         writer.startElement("mergeCells")
@@ -120,7 +127,13 @@ case class OoxmlWorksheet(
           }
         writer.endElement() // mergeCells
 
+      // GH-232: phoneticPr (after mergeCells, before conditionalFormatting)
+      preservedAfterMergeCells.foreach(l => preservedKnown.get(l).foreach(writer.writeElem))
+
       conditionalFormatting.foreach(writer.writeElem)
+
+      // GH-232: dataValidations, hyperlinks (after conditionalFormatting)
+      preservedAfterCondFmt.foreach(l => preservedKnown.get(l).foreach(writer.writeElem))
 
       printOptions.foreach(writer.writeElem)
       pageMargins.foreach(writer.writeElem)
@@ -131,11 +144,18 @@ case class OoxmlWorksheet(
       colBreaks.foreach(writer.writeElem)
       customPropertiesWs.foreach(writer.writeElem)
 
+      // GH-232: cellWatches, ignoredErrors, smartTags (after customProperties)
+      preservedAfterCustomProps.foreach(l => preservedKnown.get(l).foreach(writer.writeElem))
+
       drawing.foreach(writer.writeElem)
       legacyDrawing.foreach(writer.writeElem)
+      // GH-232: legacyDrawingHF (drawingHF, after legacyDrawing)
+      preservedAfterLegacyDrawing.foreach(l => preservedKnown.get(l).foreach(writer.writeElem))
       picture.foreach(writer.writeElem)
       oleObjects.foreach(writer.writeElem)
       controls.foreach(writer.writeElem)
+      // GH-232: webPublishItems (after controls, before tableParts)
+      preservedAfterControls.foreach(l => preservedKnown.get(l).foreach(writer.writeElem))
 
       tableParts.foreach(writer.writeElem)
 
@@ -164,6 +184,11 @@ case class OoxmlWorksheet(
     )
     children += sheetDataElem
 
+    // GH-232: preserved inline elements between sheetData and mergeCells (schema order)
+    preservedAfterSheetData.foreach(l =>
+      preservedKnown.get(l).foreach(e => children += cleanNamespaces(e))
+    )
+
     // mergeCells (regenerated if present)
     if mergedRanges.nonEmpty then
       val mergeCellElems = mergedRanges.toSeq
@@ -171,8 +196,18 @@ case class OoxmlWorksheet(
         .map(range => elem("mergeCell", "ref" -> range.toA1)())
       children += elem("mergeCells", "count" -> mergedRanges.size.toString)(mergeCellElems*)
 
+    // GH-232: phoneticPr (after mergeCells, before conditionalFormatting)
+    preservedAfterMergeCells.foreach(l =>
+      preservedKnown.get(l).foreach(e => children += cleanNamespaces(e))
+    )
+
     // Conditional formatting (multiple allowed)
     conditionalFormatting.foreach(e => children += cleanNamespaces(e))
+
+    // GH-232: dataValidations, hyperlinks (after conditionalFormatting)
+    preservedAfterCondFmt.foreach(l =>
+      preservedKnown.get(l).foreach(e => children += cleanNamespaces(e))
+    )
 
     // Page layout (after sheetData/mergeCells)
     printOptions.foreach(e => children += cleanNamespaces(e))
@@ -184,12 +219,25 @@ case class OoxmlWorksheet(
     colBreaks.foreach(e => children += cleanNamespaces(e))
     customPropertiesWs.foreach(e => children += cleanNamespaces(e))
 
+    // GH-232: cellWatches, ignoredErrors, smartTags (after customProperties)
+    preservedAfterCustomProps.foreach(l =>
+      preservedKnown.get(l).foreach(e => children += cleanNamespaces(e))
+    )
+
     // Drawings and objects
     drawing.foreach(e => children += cleanNamespaces(e))
     legacyDrawing.foreach(e => children += cleanNamespaces(e))
+    // GH-232: legacyDrawingHF (after legacyDrawing)
+    preservedAfterLegacyDrawing.foreach(l =>
+      preservedKnown.get(l).foreach(e => children += cleanNamespaces(e))
+    )
     picture.foreach(e => children += cleanNamespaces(e))
     oleObjects.foreach(e => children += cleanNamespaces(e))
     controls.foreach(e => children += cleanNamespaces(e))
+    // GH-232: webPublishItems (after controls, before tableParts)
+    preservedAfterControls.foreach(l =>
+      preservedKnown.get(l).foreach(e => children += cleanNamespaces(e))
+    )
 
     // Tables
     tableParts.foreach(e => children += cleanNamespaces(e))
@@ -442,7 +490,8 @@ object OoxmlWorksheet extends com.tjclp.xl.ooxml.XmlReadable[OoxmlWorksheet]:
           preserved.extLst,
           preserved.otherElements,
           preserved.rootAttributes,
-          adjustedScope
+          adjustedScope,
+          preserved.preservedKnown // GH-232: carry preserved inline elements through surgical write
         )
       case None =>
         // No preserved metadata - create minimal worksheet with cols from domain

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/WorksheetHelpers.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/WorksheetHelpers.scala
@@ -53,9 +53,59 @@ private[worksheet] val preservedAfterLegacyDrawing: Seq[String] = Seq("legacyDra
 private[worksheet] val preservedAfterControls: Seq[String] = Seq("webPublishItems")
 
 /** Union of all inline labels preserved via OoxmlWorksheet.preservedKnown (used by the reader). */
-private[worksheet] val preservedKnownLabels: Set[String] =
+private[ooxml] val preservedKnownLabels: Set[String] =
   (preservedAfterSheetData ++ preservedAfterMergeCells ++ preservedAfterCondFmt ++
     preservedAfterCustomProps ++ preservedAfterLegacyDrawing ++ preservedAfterControls).toSet
+
+/**
+ * All inline CT_Worksheet child labels the reader recognizes (excluded from the `otherElements`
+ * verbatim catch-all). INVARIANT: every label here MUST be either modeled by a dedicated
+ * OoxmlWorksheet field, regenerated (sheetData, mergeCells), OR captured in `preservedKnownLabels`.
+ * A label that is none of these is silently dropped on modification — the GH-232 class of bug. The
+ * invariant is enforced by WorksheetPreservationInvariantSpec.
+ */
+private[ooxml] val worksheetKnownElements: Set[String] = Set(
+  // Modeled by a dedicated field or regenerated
+  "sheetPr",
+  "dimension",
+  "sheetViews",
+  "sheetFormatPr",
+  "cols",
+  "sheetData",
+  "mergeCells",
+  "conditionalFormatting",
+  "printOptions",
+  "rowBreaks",
+  "colBreaks",
+  "customProperties",
+  "pageMargins",
+  "pageSetup",
+  "headerFooter",
+  "drawing",
+  "legacyDrawing",
+  "picture",
+  "oleObjects",
+  "controls",
+  "tableParts",
+  "extLst",
+  // Preserved via OoxmlWorksheet.preservedKnown (GH-232)
+  "sheetCalcPr",
+  "sheetProtection",
+  "protectedRanges",
+  "scenarios",
+  "autoFilter",
+  "sortState",
+  "dataConsolidate",
+  "customSheetViews",
+  "phoneticPr",
+  "dataValidations",
+  "hyperlinks",
+  "cellWatches",
+  "ignoredErrors",
+  "smartTags",
+  "legacyDrawingHF",
+  "webPublishItems"
+)
 
 /**
  * Group consecutive columns with identical properties into spans.

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/WorksheetHelpers.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/WorksheetHelpers.scala
@@ -28,6 +28,35 @@ private[ooxml] def cleanNamespaces(elem: Elem): Elem =
   }
   elem.copy(scope = TopScope, child = cleanedChildren)
 
+// ===== Preserved inline worksheet elements (GH-232) =====
+// Inline CT_Worksheet children that are listed in WorksheetReader.knownElements (so they are
+// excluded from the `otherElements` catch-all) but have NO dedicated field on OoxmlWorksheet.
+// Without capturing these, any modification of a sheet silently DROPS data validations, sheet
+// protection, autofilters, hyperlinks, etc. They are captured into OoxmlWorksheet.preservedKnown
+// and re-emitted at their correct OOXML schema positions (ECMA-376 18.3.1.99) by the groups below.
+private[worksheet] val preservedAfterSheetData: Seq[String] =
+  Seq(
+    "sheetCalcPr",
+    "sheetProtection",
+    "protectedRanges",
+    "scenarios",
+    "autoFilter",
+    "sortState",
+    "dataConsolidate",
+    "customSheetViews"
+  )
+private[worksheet] val preservedAfterMergeCells: Seq[String] = Seq("phoneticPr")
+private[worksheet] val preservedAfterCondFmt: Seq[String] = Seq("dataValidations", "hyperlinks")
+private[worksheet] val preservedAfterCustomProps: Seq[String] =
+  Seq("cellWatches", "ignoredErrors", "smartTags")
+private[worksheet] val preservedAfterLegacyDrawing: Seq[String] = Seq("legacyDrawingHF")
+private[worksheet] val preservedAfterControls: Seq[String] = Seq("webPublishItems")
+
+/** Union of all inline labels preserved via OoxmlWorksheet.preservedKnown (used by the reader). */
+private[worksheet] val preservedKnownLabels: Set[String] =
+  (preservedAfterSheetData ++ preservedAfterMergeCells ++ preservedAfterCondFmt ++
+    preservedAfterCustomProps ++ preservedAfterLegacyDrawing ++ preservedAfterControls).toSet
+
 /**
  * Group consecutive columns with identical properties into spans.
  *

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/WorksheetReader.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/WorksheetReader.scala
@@ -116,6 +116,11 @@ object WorksheetReader extends XmlReadable[OoxmlWorksheet]:
       otherElements = elem.child.collect {
         case e: Elem if !knownElements.contains(e.label) => e
       }
+      // GH-232: capture inline known elements that have NO dedicated field (dataValidations,
+      // sheetProtection, autoFilter, hyperlinks, ...) so they survive a sheet modification.
+      preservedKnownMap = elem.child.collect {
+        case e: Elem if preservedKnownLabels.contains(e.label) => e.label -> cleanNamespaces(e)
+      }.toMap
     yield OoxmlWorksheet(
       rows,
       mergedRanges,
@@ -141,7 +146,8 @@ object WorksheetReader extends XmlReadable[OoxmlWorksheet]:
       extLst,
       otherElements.toSeq,
       rootAttributes = elem.attributes,
-      rootScope = Option(elem.scope).getOrElse(defaultWorksheetScope)
+      rootScope = Option(elem.scope).getOrElse(defaultWorksheetScope),
+      preservedKnown = preservedKnownMap
     )
 
   private def parseMergeCells(worksheetElem: Elem): Either[String, Set[CellRange]] =

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/WorksheetReader.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/WorksheetReader.scala
@@ -71,50 +71,10 @@ object WorksheetReader extends XmlReadable[OoxmlWorksheet]:
 
       extLst = (elem \ "extLst").headOption.collect { case e: Elem => cleanNamespaces(e) }
 
-      // Collect any other elements we don't explicitly handle
-      knownElements = Set(
-        "sheetPr",
-        "dimension",
-        "sheetViews",
-        "sheetFormatPr",
-        "cols",
-        "sheetData",
-        "mergeCells",
-        "pageMargins",
-        "pageSetup",
-        "headerFooter",
-        "drawing",
-        "legacyDrawing",
-        "picture",
-        "oleObjects",
-        "controls",
-        "extLst",
-        // Additional elements from OOXML spec
-        "sheetCalcPr",
-        "sheetProtection",
-        "protectedRanges",
-        "scenarios",
-        "autoFilter",
-        "sortState",
-        "dataConsolidate",
-        "customSheetViews",
-        "phoneticPr",
-        "conditionalFormatting",
-        "dataValidations",
-        "hyperlinks",
-        "printOptions",
-        "rowBreaks",
-        "colBreaks",
-        "customProperties",
-        "cellWatches",
-        "ignoredErrors",
-        "smartTags",
-        "legacyDrawingHF",
-        "webPublishItems",
-        "tableParts"
-      )
+      // Inline labels we recognize (single source of truth in WorksheetHelpers so the
+      // preservation invariant can be guarded by a test — see worksheetKnownElements).
       otherElements = elem.child.collect {
-        case e: Elem if !knownElements.contains(e.label) => e
+        case e: Elem if !worksheetKnownElements.contains(e.label) => e
       }
       // GH-232: capture inline known elements that have NO dedicated field (dataValidations,
       // sheetProtection, autoFilter, hyperlinks, ...) so they survive a sheet modification.

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/xml.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/xml.scala
@@ -164,6 +164,36 @@ object XmlUtil:
       s.contains("\n") || s.contains("\r") || s.contains("\t"))
 
   /**
+   * True if `c` is a valid XML 1.0 character. Tab/LF/CR are allowed; the other C0 control chars
+   * (U+0000–08, 0B, 0C, 0E–1F) are forbidden. Everything >= U+0020 is kept — including surrogate
+   * code units, so astral characters (emoji) encoded as surrogate pairs survive intact.
+   */
+  def isLegalXmlChar(c: Char): Boolean =
+    c == '\t' || c == '\n' || c == '\r' || c >= ' '
+
+  /**
+   * Strip XML 1.0-illegal control characters from text content (GH-237). Such characters occur in
+   * DB/CSV-imported data; left raw, the StAX backend silently DROPS them while the ScalaXml backend
+   * emits them raw — divergent, and a determinism/validity breach. Applying this identically on
+   * both write paths makes output backend-independent. Fast path returns the input unchanged.
+   */
+  def sanitizeXmlText(s: String): String =
+    if s.forall(isLegalXmlChar) then s else s.filter(isLegalXmlChar)
+
+  /**
+   * Format a BigDecimal for an OOXML `<v>` element as a plain decimal, never scientific notation
+   * (GH-238). Excel never writes `1.0E+10` in `<v>` and stricter consumers reject it.
+   */
+  def plainNumber(n: BigDecimal): String = n.bigDecimal.toPlainString
+
+  /**
+   * Plain-decimal rendering of a Double serial (date/time). Routes through the Double's shortest
+   * round-trip string so normal serials are byte-identical to the previous `toString` output while
+   * scientific notation (if it ever arose) is expanded.
+   */
+  def plainNumber(d: Double): String = BigDecimal(d.toString).bigDecimal.toPlainString
+
+  /**
    * Extract text content from XML element, preserving whitespace.
    *
    * Unlike `.text` which normalizes whitespace, this method preserves exact whitespace (including

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/XlsxWriterSurgicalSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/XlsxWriterSurgicalSpec.scala
@@ -548,11 +548,109 @@ class XlsxWriterSurgicalSpec extends FunSuite:
     Files.deleteIfExists(outputPath)
   }
 
+  test(
+    "GH-232: surgical modify preserves inline elements (dataValidations, sheetProtection, autoFilter, hyperlinks)"
+  ) {
+    val source = createWorkbookWithInlineElements()
+
+    // Read, edit one cell (forces surgical regeneration of the sheet), write back
+    val modified = for
+      wb <- XlsxReader.read(source)
+      sheet <- wb("Sheet1")
+      updated = sheet.put(ref"A1" -> "Modified")
+    yield wb.put(updated)
+    val wb = modified.fold(err => fail(s"Failed to modify: $err"), identity)
+
+    val output = Files.createTempFile("inline-preserve", ".xlsx")
+    XlsxWriter.write(wb, output).fold(err => fail(s"Failed to write: $err"), identity)
+
+    val outputZip = new ZipFile(output.toFile)
+    val sheetXml =
+      new String(readEntryBytes(outputZip, outputZip.getEntry("xl/worksheets/sheet1.xml")), "UTF-8")
+    outputZip.close()
+
+    assert(sheetXml.contains("Modified"), s"cell edit not applied:\n$sheetXml")
+    // Before GH-232 these were silently dropped on any modification:
+    assert(sheetXml.contains("sheetProtection"), s"sheetProtection DROPPED:\n$sheetXml")
+    assert(sheetXml.contains("autoFilter"), s"autoFilter DROPPED:\n$sheetXml")
+    assert(sheetXml.contains("dataValidation"), s"dataValidations DROPPED:\n$sheetXml")
+    assert(sheetXml.contains("hyperlink"), s"hyperlinks DROPPED:\n$sheetXml")
+
+    Files.deleteIfExists(source)
+    Files.deleteIfExists(output)
+  }
+
   // Helper: Read entry bytes from ZIP
   private def readEntryBytes(zip: ZipFile, entry: ZipEntry): Array[Byte] =
     val is = zip.getInputStream(entry)
     try is.readAllBytes()
     finally is.close()
+
+  // Helper: Create workbook whose sheet1 has inline elements with NO dedicated OoxmlWorksheet field
+  // (sheetProtection, autoFilter, dataValidations, hyperlinks) — GH-232 regression scaffold.
+  private def createWorkbookWithInlineElements(): Path =
+    val path = Files.createTempFile("test-inline", ".xlsx")
+    val out = new ZipOutputStream(Files.newOutputStream(path))
+    out.setLevel(1)
+    try
+      writeEntry(
+        out,
+        "[Content_Types].xml",
+        """<?xml version="1.0"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+  <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+</Types>"""
+      )
+      writeEntry(
+        out,
+        "_rels/.rels",
+        """<?xml version="1.0"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>"""
+      )
+      writeEntry(
+        out,
+        "xl/workbook.xml",
+        """<?xml version="1.0"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <sheets>
+    <sheet name="Sheet1" sheetId="1" r:id="rId1"/>
+  </sheets>
+</workbook>"""
+      )
+      writeEntry(
+        out,
+        "xl/_rels/workbook.xml.rels",
+        """<?xml version="1.0"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+</Relationships>"""
+      )
+      // Worksheet with inline elements in OOXML schema order (after sheetData)
+      writeEntry(
+        out,
+        "xl/worksheets/sheet1.xml",
+        """<?xml version="1.0"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <sheetData>
+    <row r="1"><c r="A1" t="inlineStr"><is><t>Orig</t></is></c></row>
+  </sheetData>
+  <sheetProtection sheet="1" objects="1" scenarios="1"/>
+  <autoFilter ref="A1:A1"/>
+  <dataValidations count="1">
+    <dataValidation type="list" sqref="A1"><formula1>"Yes,No"</formula1></dataValidation>
+  </dataValidations>
+  <hyperlinks>
+    <hyperlink ref="A1" location="Sheet1!A1"/>
+  </hyperlinks>
+</worksheet>"""
+      )
+    finally out.close()
+    path
 
   // Helper: Create minimal workbook with chart (unknown part)
   private def createMinimalWorkbookWithChart(): Path =

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/XmlValueSanitizationSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/XmlValueSanitizationSpec.scala
@@ -1,0 +1,60 @@
+package com.tjclp.xl.ooxml
+
+import com.tjclp.xl.cells.CellValue
+import com.tjclp.xl.macros.ref
+import com.tjclp.xl.ooxml.worksheet.OoxmlCell
+import munit.FunSuite
+
+/**
+ * GH-237 (control-char sanitization) + GH-238 (plain-decimal numerics).
+ *
+ * Both write paths (ScalaXml `toXml` + SaxStax `writeCharacters`) share `XmlUtil.sanitizeXmlText`
+ * and `XmlUtil.plainNumber`, so output is backend-independent and OOXML-valid.
+ */
+class XmlValueSanitizationSpec extends FunSuite:
+
+  // ===== plainNumber: never scientific notation in <v> (GH-238) =====
+
+  test("plainNumber renders large/small magnitudes as plain decimals") {
+    assertEquals(XmlUtil.plainNumber(BigDecimal("1E20")), "100000000000000000000")
+    assertEquals(XmlUtil.plainNumber(BigDecimal("1E-7")), "0.0000001")
+    assertEquals(XmlUtil.plainNumber(BigDecimal(30)), "30")
+    assertEquals(XmlUtil.plainNumber(BigDecimal("1234.50")), "1234.50")
+  }
+
+  test("plainNumber(Double) keeps normal serials identical to the old toString") {
+    assertEquals(XmlUtil.plainNumber(45292.0), "45292.0")
+    assertEquals(XmlUtil.plainNumber(45292.5), "45292.5")
+  }
+
+  test("OoxmlCell number cell emits a plain decimal in <v> (no E)") {
+    val cell = OoxmlCell(ref"A1", CellValue.Number(BigDecimal("1E20")), None, "n")
+    val v = (cell.toXml \\ "v").text
+    assertEquals(v, "100000000000000000000")
+    assert(!v.toUpperCase.contains("E"), s"scientific notation leaked into <v>: $v")
+  }
+
+  // ===== sanitizeXmlText: strip XML-illegal control chars (GH-237) =====
+
+  test("sanitizeXmlText strips C0 control chars but keeps tab/newline/CR") {
+    // U+0001 and U+001F are XML-illegal; tab/newline/CR are legal and must survive.
+    val withControls = "a" + 1.toChar + "b" + 31.toChar + "c"
+    assertEquals(XmlUtil.sanitizeXmlText(withControls), "abc")
+    val withWhitespace = "a" + 9.toChar + "b" + 10.toChar + "c" + 13.toChar + "d"
+    assertEquals(XmlUtil.sanitizeXmlText(withWhitespace), withWhitespace)
+  }
+
+  test("sanitizeXmlText returns the same instance for already-clean text (fast path)") {
+    val s = "clean text"
+    assert(XmlUtil.sanitizeXmlText(s) eq s)
+  }
+
+  test("sanitizeXmlText preserves astral characters (emoji surrogate pairs)") {
+    val emoji = "hi " + new String(Character.toChars(0x1F600)) // grinning face
+    assertEquals(XmlUtil.sanitizeXmlText(emoji), emoji)
+  }
+
+  test("OoxmlCell text cell strips control chars from <t>") {
+    val cell = OoxmlCell(ref"A1", CellValue.Text("a" + 1.toChar + "b"), None, "inlineStr")
+    assertEquals((cell.toXml \\ "t").text, "ab")
+  }

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/worksheet/WorksheetPreservationInvariantSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/worksheet/WorksheetPreservationInvariantSpec.scala
@@ -1,0 +1,45 @@
+package com.tjclp.xl.ooxml.worksheet
+
+import munit.FunSuite
+
+/**
+ * Guards the surgical-modify preservation invariant (GH-232).
+ *
+ * Every inline worksheet element the reader recognizes (`worksheetKnownElements`) is excluded from
+ * the `otherElements` verbatim catch-all, so each MUST be either modeled by a dedicated
+ * `OoxmlWorksheet` field / regenerated, OR captured in `preservedKnown`. An element that is neither
+ * is silently dropped on any sheet modification — the exact "xl ate my dropdowns" failure GH-232
+ * fixed.
+ *
+ * If this fails after you add a label to `worksheetKnownElements`, either give it a dedicated field
+ * (and list it in `modeledOrRegenerated` below) or add it to a `preservedAfter*` group in
+ * WorksheetHelpers.
+ */
+class WorksheetPreservationInvariantSpec extends FunSuite:
+
+  // Labels backed by a dedicated OoxmlWorksheet field, or regenerated from the domain model
+  // (sheetData from cells, mergeCells from mergedRanges).
+  private val modeledOrRegenerated: Set[String] = Set(
+    "sheetPr", "dimension", "sheetViews", "sheetFormatPr", "cols", "sheetData", "mergeCells",
+    "conditionalFormatting", "printOptions", "rowBreaks", "colBreaks", "customProperties",
+    "pageMargins", "pageSetup", "headerFooter", "drawing", "legacyDrawing", "picture",
+    "oleObjects", "controls", "tableParts", "extLst"
+  )
+
+  test("every known worksheet element is modeled or preserved (no tier-3 silent data loss)") {
+    val orphans = worksheetKnownElements -- modeledOrRegenerated -- preservedKnownLabels
+    assert(
+      orphans.isEmpty,
+      "These knownElements are excluded from verbatim copy but neither modeled nor preserved, so " +
+        s"they are silently dropped on modify (GH-232 class): ${orphans.toSeq.sorted.mkString(", ")}"
+    )
+  }
+
+  test("preservedKnown labels are disjoint from modeled labels (no double emit)") {
+    val overlap = modeledOrRegenerated.intersect(preservedKnownLabels)
+    assert(overlap.isEmpty, s"labels both modeled and preserved would emit twice: $overlap")
+  }
+
+  test("worksheetKnownElements is exactly modeled + preserved (no stragglers either way)") {
+    assertEquals(worksheetKnownElements, modeledOrRegenerated ++ preservedKnownLabels)
+  }


### PR DESCRIPTION
## Summary

First phase of the **0.10.0 "Trust & Author"** release (see `docs/plan/v0.10.0-triage.md` + `docs/plan/v0.10.0-execution.md`). A 12-agent review surfaced — and this PR fixes — five verified defects that quietly undercut xl's two flagship promises (deterministic surgical preservation + a pure calc engine). The motto becomes true: **only modify what needs modifying, and never lose what we didn't.**

| ID | Fix | Closes |
|----|-----|--------|
| **C1** | Surgical modify silently dropped 16 inline worksheet elements (dataValidations, sheetProtection, autoFilter, hyperlinks, …) — they were excluded from the verbatim catch-all but never captured. Now preserved at correct OOXML schema positions, with a `WorksheetPreservationInvariantSpec` that makes the bug-class a red test by construction. | #232 |
| **C2** | `=A1=B1`, `=A1<>B1`, `=IF(A1=B1,…)` returned `Left("Unresolved PolyRef")` — the most common formula idiom didn't evaluate. Eq/Neq now resolve cell-ref operands via `asResolvedValueExpr`. | #233 |
| **C3** | Scalar text equality was case-sensitive (`="A"="a"` → FALSE) while the array path / VLOOKUP / CriteriaMatcher were case-insensitive. Unified on `ArrayArithmetic.cellValueEquals` (also fixed date-cell equality). | #234 |
| **C5** | XML-illegal control chars were silently dropped by StAX and emitted raw by ScalaXml (divergent, invalid); numbers emitted scientific notation (`1.0E+10`) in `<v>`. Added shared `XmlUtil.sanitizeXmlText` + `plainNumber`. | #237, #238 |
| **C4** | Excel 1900 leap-year not reproduced (`1900-01-01` → serial 2, not 1); Scaladoc falsely claimed parity. Now faithful; modern dates byte-identical. | #239 |

## Dogfooded via the real CLI (before/after vs installed 0.9.7)

On a real 343 KB analyst workbook (`Syndigo`) and small fixtures:

| Fix | 0.9.7 | this branch |
|-----|-------|-------------|
| C1 `sheetProtection` (edit the protected sheet) | ❌ dropped | ✅ preserved |
| C2 `=IF(A1=B1,…)` | ❌ `Unresolved PolyRef` | ✅ `match` |
| C3 `=A2=B2` / `="A"="a"` | (errors) | ✅ `TRUE` |
| C4 `1900-01-01` serial | ❌ `2.0` | ✅ `1.0` |
| C5 `1e20` in `<v>` | ❌ `1.0E+20` | ✅ `100000000000000000000` |

Surgical output re-reads cleanly (9 sheets, edit applied; conditionalFormatting/mergeCells/sheetProtection all intact — no corruption).

## Tests
- Full suite **901/901** green; `./mill __.checkFormat` clean.
- New: `XmlValueSanitizationSpec`, `WorksheetPreservationInvariantSpec`, surgical round-trip-after-modify test, 10 Eq/Neq+equality cases, 1900 boundary + round-trip cases.

## Not in this PR
Phase 1+ (named ranges #236, hyperlinks #235 authoring, insert/delete rows/cols, functions, dynamic arrays) and the doc-truth pass (#241) follow in subsequent PRs per the execution tracker. Charts/drawings remain deferred to 0.11.0 "Visual".

🤖 Generated with [Claude Code](https://claude.com/claude-code)