### PR TITLE
0.10.0 Phase 1 "Author": named ranges + hyperlinks (#235, #236)

### DIFF
--- a/docs/plan/v0.10.0-execution.md
+++ b/docs/plan/v0.10.0-execution.md
@@ -49,7 +49,9 @@
 ## Phase 1 — Author the half-built models (after C1)
 
 - [x] **Named ranges** ✅ **DONE** — `fromDomain` serializes `wb.metadata.definedNames` (shared `buildDefinedNames`/`parseDefinedNames`); domain API `Workbook.withDefinedName`/`removeDefinedName`; **CLI `name add`/`name rm`**; `DefinedNameRoundTripSpec`. Dogfooded: Syndigo 848 names preserved byte-identical to 0.9.7 on surgical write; CLI add→list→rm round-trips. Surgical passthrough unchanged (no regression). Closes #236.
-- [ ] **Hyperlinks** — `<hyperlinks>` emission + read population (`Cell.hyperlink`, `Cell.scala:23`) + batch op. PR: ____
+- [x] **Hyperlinks** ✅ **DONE** — `Cell.hyperlink` now round-trips: read parses `<hyperlinks>` (resolving external `r:id` via sheet rels, internal `location`) into the model; write emits `<hyperlinks>` + `External` relationships (shared `rIdHL{n}` scheme via `collectHyperlinks`, no cross-fn plumbing; old hyperlink rels filtered on surgical merge to avoid orphans). Batch op `{"op":"hyperlink","ref","target"}` (omit target to clear); streaming mode rejects it (needs full rels). `HyperlinkRoundTripSpec` (external + internal). Dogfooded: CLI batch op emits `<hyperlink r:id>` + matching External rel. Closes #235.
+
+> **Phase 1 (Author) COMPLETE** — named ranges + hyperlinks on `feat/v0.10.0-phase1-author`; full suite 901/901, checkFormat clean.
 
 ## Phase 2 — Structural editing (#128 + #129, one PR, after Phase 0)
 

--- a/docs/plan/v0.10.0-execution.md
+++ b/docs/plan/v0.10.0-execution.md
@@ -48,7 +48,7 @@
 
 ## Phase 1 — Author the half-built models (after C1)
 
-- [ ] **Named ranges** — serialize `WorkbookMetadata.definedNames` in `OoxmlWorkbook.fromDomain` (`xl-ooxml/.../Workbook.scala:205`) + CLI `name add/rm`. PR: ____
+- [x] **Named ranges (library)** — `OoxmlWorkbook.fromDomain` now serializes `wb.metadata.definedNames` (shared `buildDefinedNames`/`parseDefinedNames`); domain API `Workbook.withDefinedName`/`removeDefinedName`; `DefinedNameRoundTripSpec` (authoring + surgical preserve + removal). Dogfooded: Syndigo 848 names preserved byte-identical to 0.9.7 on surgical write; programmatic authoring round-trips. Surgical passthrough unchanged (no regression). _Remaining: CLI `name add/rm` verb (decline plumbing)._ Closes #236 (lib).
 - [ ] **Hyperlinks** — `<hyperlinks>` emission + read population (`Cell.hyperlink`, `Cell.scala:23`) + batch op. PR: ____
 
 ## Phase 2 — Structural editing (#128 + #129, one PR, after Phase 0)

--- a/docs/plan/v0.10.0-execution.md
+++ b/docs/plan/v0.10.0-execution.md
@@ -48,7 +48,7 @@
 
 ## Phase 1 — Author the half-built models (after C1)
 
-- [x] **Named ranges (library)** — `OoxmlWorkbook.fromDomain` now serializes `wb.metadata.definedNames` (shared `buildDefinedNames`/`parseDefinedNames`); domain API `Workbook.withDefinedName`/`removeDefinedName`; `DefinedNameRoundTripSpec` (authoring + surgical preserve + removal). Dogfooded: Syndigo 848 names preserved byte-identical to 0.9.7 on surgical write; programmatic authoring round-trips. Surgical passthrough unchanged (no regression). _Remaining: CLI `name add/rm` verb (decline plumbing)._ Closes #236 (lib).
+- [x] **Named ranges** ✅ **DONE** — `fromDomain` serializes `wb.metadata.definedNames` (shared `buildDefinedNames`/`parseDefinedNames`); domain API `Workbook.withDefinedName`/`removeDefinedName`; **CLI `name add`/`name rm`**; `DefinedNameRoundTripSpec`. Dogfooded: Syndigo 848 names preserved byte-identical to 0.9.7 on surgical write; CLI add→list→rm round-trips. Surgical passthrough unchanged (no regression). Closes #236.
 - [ ] **Hyperlinks** — `<hyperlinks>` emission + read population (`Cell.hyperlink`, `Cell.scala:23`) + batch op. PR: ____
 
 ## Phase 2 — Structural editing (#128 + #129, one PR, after Phase 0)

--- a/xl-cli/src/com/tjclp/xl/cli/Command.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/Command.scala
@@ -18,6 +18,15 @@ object SheetsAction:
   /** Show a hidden sheet (make it visible) */
   case class Show(name: String) extends SheetsAction
 
+/** Named-range (defined name) operations: add/replace and remove. */
+sealed trait NameAction derives CanEqual
+object NameAction:
+  /** Add or replace a workbook-scoped named range. */
+  case class Add(name: String, refersTo: String) extends NameAction
+
+  /** Remove a workbook-scoped named range. */
+  case class Remove(name: String) extends NameAction
+
 /**
  * Command ADT representing all CLI operations.
  *
@@ -27,6 +36,8 @@ enum CliCommand:
   // Read-only (workbook-level)
   case Sheets(action: SheetsAction)
   case Names
+  // Mutation (workbook-level)
+  case Name(action: NameAction)
   // Read-only (sheet-level)
   case Bounds(scan: Boolean) // scan=false: instant (dimension element), scan=true: full scan
   case View(

--- a/xl-cli/src/com/tjclp/xl/cli/Main.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/Main.scala
@@ -96,7 +96,7 @@ object Main
     // Sheet-level write: --file, --sheet, and --output (required)
     // --stream uses SAX/StAX workbook writes for modifying commands.
     val sheetWriteSubcmds =
-      putCmd orElse putfCmd orElse styleCmd orElse rowCmd orElse colCmd orElse autoFitCmd orElse batchCmd orElse importCmd orElse addSheetCmd orElse removeSheetCmd orElse renameSheetCmd orElse moveSheetCmd orElse copySheetCmd orElse mergeCmd orElse unmergeCmd orElse commentCmd orElse removeCommentCmd orElse clearCmd orElse fillCmd orElse sortCmd orElse freezeCmd orElse unfreezeCmd orElse copyCmd
+      putCmd orElse putfCmd orElse styleCmd orElse rowCmd orElse colCmd orElse autoFitCmd orElse batchCmd orElse importCmd orElse addSheetCmd orElse removeSheetCmd orElse renameSheetCmd orElse moveSheetCmd orElse copySheetCmd orElse mergeCmd orElse unmergeCmd orElse commentCmd orElse removeCommentCmd orElse clearCmd orElse fillCmd orElse sortCmd orElse freezeCmd orElse unfreezeCmd orElse copyCmd orElse nameCmd
 
     val sheetWriteOpts =
       (
@@ -519,6 +519,19 @@ EXAMPLES:
 
   val namesCmd: Opts[CliCommand] = Opts.subcommand("names", "List defined names (named ranges)") {
     Opts(CliCommand.Names)
+  }
+
+  val nameCmd: Opts[CliCommand] = Opts.subcommand("name", "Manage named ranges: add, rm") {
+    val nameArg = Opts.argument[String]("name")
+    val refArg = Opts.argument[String]("refers-to")
+    val addSub =
+      Opts.subcommand("add", "Add or replace a named range (e.g. name add Tax 'Sheet1!$A$1')") {
+        (nameArg, refArg).mapN(NameAction.Add.apply)
+      }
+    val rmSub = Opts.subcommand("rm", "Remove a named range") {
+      nameArg.map(NameAction.Remove.apply)
+    }
+    (addSub orElse rmSub).map(CliCommand.Name.apply)
   }
 
   val boundsCmd: Opts[CliCommand] = Opts.subcommand(
@@ -1544,6 +1557,15 @@ Use --dry-run to validate JSON without writing."""
       requireOutput(outputOpt, backendOpt, stream)(
         SheetCommands.renameSheet(wb, oldName, newName, _, _, _)
       )
+
+    case CliCommand.Name(action) =>
+      action match
+        case NameAction.Add(nm, refersTo) =>
+          requireOutput(outputOpt, backendOpt, stream)(
+            SheetCommands.nameAdd(wb, nm, refersTo, _, _, _)
+          )
+        case NameAction.Remove(nm) =>
+          requireOutput(outputOpt, backendOpt, stream)(SheetCommands.nameRemove(wb, nm, _, _, _))
 
     case CliCommand.MoveSheet(name, toIndexOpt, afterOpt, beforeOpt) =>
       requireOutput(outputOpt, backendOpt, stream)(

--- a/xl-cli/src/com/tjclp/xl/cli/commands/SheetCommands.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/commands/SheetCommands.scala
@@ -286,6 +286,34 @@ object SheetCommands:
       stateDesc = if veryHide then "very hidden" else "hidden"
     yield s"Sheet '$name' is now $stateDesc\n${saveSuffix(outputPath, stream)}"
 
+  /** Add or replace a workbook-scoped named range, then write (GH-236). */
+  def nameAdd(
+    wb: Workbook,
+    name: String,
+    refersTo: String,
+    outputPath: Path,
+    config: WriterConfig,
+    stream: Boolean = false
+  ): IO[String] =
+    val updated = wb.withDefinedName(name, refersTo)
+    writeWorkbook(updated, outputPath, config, stream)
+      .as(s"Added named range '$name' -> $refersTo\n${saveSuffix(outputPath, stream)}")
+
+  /** Remove a workbook-scoped named range, then write (GH-236). */
+  def nameRemove(
+    wb: Workbook,
+    name: String,
+    outputPath: Path,
+    config: WriterConfig,
+    stream: Boolean = false
+  ): IO[String] =
+    if !wb.metadata.definedNames.exists(d => d.name == name && d.localSheetId.isEmpty) then
+      IO.raiseError(new Exception(s"Named range '$name' not found"))
+    else
+      val updated = wb.removeDefinedName(name)
+      writeWorkbook(updated, outputPath, config, stream)
+        .as(s"Removed named range '$name'\n${saveSuffix(outputPath, stream)}")
+
   /**
    * Show a hidden sheet (make it visible).
    *

--- a/xl-cli/src/com/tjclp/xl/cli/commands/StreamingWriteCommands.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/commands/StreamingWriteCommands.scala
@@ -711,7 +711,7 @@ object StreamingWriteCommands:
             _: BatchParser.BatchOp.Clear | _: BatchParser.BatchOp.AutoFit |
             _: BatchParser.BatchOp.AddSheet | _: BatchParser.BatchOp.RenameSheet |
             _: BatchParser.BatchOp.Freeze | BatchParser.BatchOp.Unfreeze |
-            _: BatchParser.BatchOp.CopyRange =>
+            _: BatchParser.BatchOp.CopyRange | _: BatchParser.BatchOp.Hyperlink =>
           throw new Exception(
             "This batch operation is not supported in streaming mode. " +
               "Remove --stream to use full workbook mode."

--- a/xl-cli/src/com/tjclp/xl/cli/helpers/BatchParser.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/helpers/BatchParser.scala
@@ -94,6 +94,7 @@ object BatchParser:
     case Freeze(ref: String)
     case Unfreeze
     case CopyRange(source: String, target: String, valuesOnly: Boolean)
+    case Hyperlink(ref: String, target: Option[String]) // GH-235: target None clears
 
   /**
    * Result of batch parsing with optional warnings.
@@ -131,6 +132,7 @@ object BatchParser:
         case BatchOp.RowHeight(row, height) => s"  ROWHEIGHT $row = $height"
         case BatchOp.AddComment(ref, text, _) => s"  COMMENT $ref = \"$text\""
         case BatchOp.RemoveComment(ref) => s"  REMOVE-COMMENT $ref"
+        case BatchOp.Hyperlink(ref, target) => s"  HYPERLINK $ref = ${target.getOrElse("(clear)")}"
         case BatchOp.Clear(range, _, _, _) => s"  CLEAR $range"
         case BatchOp.ColHide(col) => s"  COL-HIDE $col"
         case BatchOp.ColShow(col) => s"  COL-SHOW $col"
@@ -307,6 +309,13 @@ object BatchParser:
             val ref = requireString(objMap, "ref", idx)
             BatchOp.RemoveComment(ref)
 
+          case "hyperlink" =>
+            collectUnknownPropsWarning(objMap, knownHyperlinkProps, "hyperlink", idx)
+              .foreach(warnings += _)
+            val ref = requireString(objMap, "ref", idx)
+            val target = objMap.get("target").flatMap(_.strOpt)
+            BatchOp.Hyperlink(ref, target)
+
           case "clear" =>
             collectUnknownPropsWarning(objMap, knownClearProps, "clear", idx)
               .foreach(warnings += _)
@@ -418,6 +427,7 @@ object BatchParser:
 
   /** Known properties for 'comment' operation */
   private val knownCommentProps = Set("op", "ref", "text", "author")
+  private val knownHyperlinkProps = Set("op", "ref", "target")
 
   /** Known properties for 'clear' operation */
   private val knownClearProps = Set("op", "range", "all", "styles", "comments")
@@ -816,6 +826,9 @@ object BatchParser:
           case BatchOp.RemoveComment(refStr) =>
             applyRemoveComment(currentWb, defaultSheetName, refStr)
 
+          case BatchOp.Hyperlink(refStr, target) =>
+            applyHyperlink(currentWb, defaultSheetName, refStr, target)
+
           case BatchOp.Clear(rangeStr, all, stylesFlag, commentsFlag) =>
             applyClear(currentWb, defaultSheetName, rangeStr, all, stylesFlag, commentsFlag)
 
@@ -1208,6 +1221,31 @@ object BatchParser:
     }
 
   /** Remove a comment from a cell. */
+  private def applyHyperlink(
+    wb: Workbook,
+    defaultSheetName: Option[SheetName],
+    refStr: String,
+    target: Option[String]
+  ): IO[Workbook] =
+    def setOn(sheetName: SheetName, ref: ARef): IO[Workbook] =
+      updateSheet(wb, sheetName)(s =>
+        s.put(target.fold(s(ref).clearHyperlink)(s(ref).withHyperlink))
+      )
+    IO.fromEither(RefType.parse(refStr).left.map(e => new Exception(e))).flatMap {
+      case RefType.Cell(ref) =>
+        defaultSheetName match
+          case Some(sheetName) => setOn(sheetName, ref)
+          case None =>
+            IO.raiseError(
+              new Exception(s"batch hyperlink requires --sheet for unqualified ref '$refStr'")
+            )
+      case RefType.QualifiedCell(sheetName, ref) => setOn(sheetName, ref)
+      case _ =>
+        IO.raiseError(
+          new Exception(s"batch hyperlink requires single cell ref, not range: $refStr")
+        )
+    }
+
   private def applyRemoveComment(
     wb: Workbook,
     defaultSheetName: Option[SheetName],

--- a/xl-core/src/com/tjclp/xl/workbooks/Workbook.scala
+++ b/xl-core/src/com/tjclp/xl/workbooks/Workbook.scala
@@ -338,6 +338,27 @@ final case class Workbook(
     val updatedContext = sourceContext.map(_.markMetadataModified)
     copy(metadata = newMetadata, sourceContext = updatedContext)
 
+  /**
+   * Add or replace a workbook-scoped defined name / named range (GH-236).
+   *
+   * `refersTo` is the reference or formula the name points to, e.g. `"Sheet1!$A$1:$A$10"` or
+   * `"0.08"`. A name with the same identifier (workbook-scoped) is replaced. Marks metadata
+   * modified so a surgical write reflects the change.
+   */
+  def withDefinedName(name: String, refersTo: String): Workbook =
+    val dn = DefinedName(name = name, formula = refersTo)
+    val others = metadata.definedNames.filterNot(d => d.name == name && d.localSheetId.isEmpty)
+    val newMetadata = metadata.copy(definedNames = others :+ dn)
+    copy(metadata = newMetadata, sourceContext = sourceContext.map(_.markMetadataModified))
+
+  /** Remove a workbook-scoped defined name by identifier (GH-236). Marks metadata modified. */
+  def removeDefinedName(name: String): Workbook =
+    val newMetadata =
+      metadata.copy(definedNames =
+        metadata.definedNames.filterNot(d => d.name == name && d.localSheetId.isEmpty)
+      )
+    copy(metadata = newMetadata, sourceContext = sourceContext.map(_.markMetadataModified))
+
 object Workbook:
   /**
    * Create workbook from a single sheet.

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/Workbook.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/Workbook.scala
@@ -11,6 +11,7 @@ private val defaultWorkbookScope =
   NamespaceBinding(null, nsSpreadsheetML, NamespaceBinding("r", nsRelationships, TopScope))
 import com.tjclp.xl.addressing.SheetName
 import com.tjclp.xl.api.Workbook
+import com.tjclp.xl.workbooks.DefinedName
 
 /**
  * Sheet reference in workbook.xml
@@ -207,7 +208,45 @@ object OoxmlWorkbook extends XmlReadable[OoxmlWorkbook]:
       val state = wb.metadata.sheetStates.get(sheet.name).flatten
       SheetRef(sheet.name, idx + 1, s"rId${idx + 1}", state)
     }
-    OoxmlWorkbook(sheetRefs)
+    // GH-236: serialize named ranges from the typed model (previously dropped on write)
+    OoxmlWorkbook(sheetRefs, definedNames = buildDefinedNames(wb.metadata.definedNames))
+
+  /**
+   * Build a `<definedNames>` element from the typed model (GH-236), or None when empty. Order
+   * follows the model (preserving the source order on round-trips); attributes are emitted in a
+   * fixed order for deterministic output.
+   */
+  def buildDefinedNames(names: Vector[DefinedName]): Option[Elem] =
+    if names.isEmpty then None
+    else
+      val children = names.map { dn =>
+        val attrs = Seq.newBuilder[(String, String)]
+        attrs += ("name" -> dn.name)
+        dn.comment.foreach(c => attrs += ("comment" -> c))
+        dn.localSheetId.foreach(id => attrs += ("localSheetId" -> id.toString))
+        if dn.hidden then attrs += ("hidden" -> "1")
+        elemOrdered("definedName", attrs.result()*)(Text(dn.formula))
+      }
+      Some(elem("definedNames")(children*))
+
+  /**
+   * Parse `<definedNames>` into the typed model. Single source of truth shared by the reader and
+   * the surgical writer (so the writer can detect whether the model is unchanged and keep raw
+   * bytes).
+   */
+  def parseDefinedNames(rawElem: Option[Elem]): Vector[DefinedName] =
+    rawElem match
+      case None => Vector.empty
+      case Some(dnsElem) =>
+        (dnsElem \ "definedName").collect { case e: Elem =>
+          DefinedName(
+            name = e \@ "name",
+            formula = e.text.trim,
+            localSheetId = Option(e \@ "localSheetId").filter(_.nonEmpty).flatMap(_.toIntOption),
+            hidden = (e \@ "hidden") == "1",
+            comment = Option(e \@ "comment").filter(_.nonEmpty)
+          )
+        }.toVector
 
   def fromXml(elem: Elem): Either[String, OoxmlWorkbook] =
     for

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/XlsxReader.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/XlsxReader.scala
@@ -377,10 +377,10 @@ object XlsxReader:
   private def parseWorksheetRelationships(
     parts: Map[String, String],
     sheetIndex: Int
-  ): XLResult[(Option[String], Seq[String])] =
+  ): XLResult[(Option[String], Seq[String], Map[String, String])] =
     val relsPath = s"xl/worksheets/_rels/sheet$sheetIndex.xml.rels"
     parts.get(relsPath) match
-      case None => Right((None, Seq.empty)) // No relationships for this sheet
+      case None => Right((None, Seq.empty, Map.empty)) // No relationships for this sheet
       case Some(xml) =>
         for
           elem <- parseXml(xml, relsPath)
@@ -398,7 +398,13 @@ object XlsxReader:
           // Extract table relationships (NEW)
           tableRels = rels.relationships.filter(_.`type` == XmlUtil.relTypeTable)
           tableTargets <- resolveTablePaths(tableRels, relsPath)
-        yield (commentTarget, tableTargets)
+
+          // GH-235: hyperlink relationships (rId -> external target URL)
+          hyperlinkRels = rels.relationships
+            .filter(_.`type` == XmlUtil.relTypeHyperlink)
+            .map(r => r.id -> r.target)
+            .toMap
+        yield (commentTarget, tableTargets, hyperlinkRels)
 
   private def resolveCommentPath(target: String, relsPath: String): XLResult[String] =
     val cleanedTarget = if target.startsWith("/") then target.drop(1) else target
@@ -668,7 +674,10 @@ object XlsxReader:
             .left
             .map(err => XLError.ParseError(sheetPath, err): XLError)
           // Parse worksheet relationships to find comment/table references (1-based sheet index)
-          (commentTarget, tableTargets) <- parseWorksheetRelationships(parts, idx + 1)
+          (commentTarget, tableTargets, hyperlinkRels) <- parseWorksheetRelationships(
+            parts,
+            idx + 1
+          )
 
           // Parse comments if relationship exists
           comments <- commentTarget match
@@ -681,7 +690,15 @@ object XlsxReader:
           // Parse tables if relationships exist
           tables <- parseTablesForSheet(parts, tableTargets)
 
-          domainSheet <- convertToDomainSheet(ref.name, ooxmlSheet, sst, styles, comments, tables)
+          domainSheet <- convertToDomainSheet(
+            ref.name,
+            ooxmlSheet,
+            sst,
+            styles,
+            comments,
+            tables,
+            hyperlinkRels
+          )
         yield domainSheet
       }
       .map(sheets => (sheets, commentPathBuilder.result()))
@@ -707,7 +724,8 @@ object XlsxReader:
     sst: Option[SharedStrings],
     styles: WorkbookStyles,
     comments: Map[ARef, com.tjclp.xl.cells.Comment],
-    tables: Map[String, TableSpec]
+    tables: Map[String, TableSpec],
+    hyperlinkRels: Map[String, String]
   ): XLResult[Sheet] =
     val (preRegisteredRegistry, styleMapping) = buildStyleRegistry(styles)
 
@@ -727,6 +745,27 @@ object XlsxReader:
 
     val cellsMap = builder.result()
 
+    // GH-235: populate Cell.hyperlink from the worksheet <hyperlinks> element. External targets
+    // resolve through the sheet rels (rId -> URL); internal targets use the `location` attribute.
+    val cellsWithHyperlinks = ooxmlSheet.preservedKnown.get("hyperlinks") match
+      case None => cellsMap
+      case Some(hls) =>
+        (hls \ "hyperlink").foldLeft(cellsMap) {
+          case (m, e: Elem) =>
+            val refStr = e \@ "ref"
+            val rid = e.attributes.collectFirst {
+              case a: PrefixedAttribute if a.key == "id" => a.value.text
+            }
+            val loc = Option(e \@ "location").filter(_.nonEmpty)
+            val target = rid.flatMap(hyperlinkRels.get).orElse(loc)
+            (ARef.parse(refStr).toOption, target) match
+              case (Some(ref), Some(t)) =>
+                val base = m.getOrElse(ref, Cell(ref, com.tjclp.xl.cells.CellValue.Empty))
+                m.updated(ref, base.withHyperlink(t))
+              case _ => m
+          case (m, _) => m
+        }
+
     // Parse column properties from <cols> element
     val columnProperties = ooxmlSheet.cols match
       case Some(colsElem) => parseColumnProperties(colsElem)
@@ -741,7 +780,7 @@ object XlsxReader:
     Right(
       Sheet(
         name = name,
-        cells = cellsMap,
+        cells = cellsWithHyperlinks,
         mergedRanges = ooxmlSheet.mergedRanges,
         styleRegistry = preRegisteredRegistry,
         comments = comments,

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/XlsxReader.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/XlsxReader.scala
@@ -331,8 +331,8 @@ object XlsxReader:
       // Parse sheets and collect comment path mapping
       (sheets, commentPathMapping) <- parseSheets(parts, ooxmlWb.sheets, sst, styles, workbookRels)
 
-      // Parse defined names from workbook.xml
-      definedNames = parseDefinedNames(ooxmlWb.definedNames)
+      // Parse defined names from workbook.xml (shared with the surgical writer)
+      definedNames = OoxmlWorkbook.parseDefinedNames(ooxmlWb.definedNames)
 
       // Extract sheet visibility states from OOXML
       sheetStates = ooxmlWb.sheets
@@ -892,35 +892,7 @@ object XlsxReader:
   private def parseXml(xmlString: String, location: String): XLResult[Elem] =
     XmlSecurity.parseSafe(xmlString, location)
 
-  /**
-   * Parse defined names from the raw XML element.
-   *
-   * OOXML structure:
-   * {{{
-   * <definedNames>
-   *   <definedName name="SalesTotal" localSheetId="0">Sheet1!$A$1:$A$10</definedName>
-   *   <definedName name="TaxRate" hidden="1">0.08</definedName>
-   * </definedNames>
-   * }}}
-   */
-  private def parseDefinedNames(rawElem: Option[Elem]): Vector[DefinedName] =
-    rawElem match
-      case None => Vector.empty
-      case Some(elem) =>
-        (elem \ "definedName").collect { case e: Elem =>
-          val name = (e \@ "name")
-          val formula = e.text.trim
-          val localSheetId = Option(e \@ "localSheetId").filter(_.nonEmpty).flatMap(_.toIntOption)
-          val hidden = (e \@ "hidden") == "1"
-          val comment = Option(e \@ "comment").filter(_.nonEmpty)
-          DefinedName(
-            name = name,
-            formula = formula,
-            localSheetId = localSheetId,
-            hidden = hidden,
-            comment = comment
-          )
-        }.toVector
+  // parseDefinedNames now lives in OoxmlWorkbook (single source of truth shared with the writer).
 
   /** Extension for traverse on Vector */
   extension [A](vec: Vector[A])

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/XlsxWriter.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/XlsxWriter.scala
@@ -13,6 +13,7 @@ import com.tjclp.xl.error.{XLError, XLResult}
 import com.tjclp.xl.context.{ModificationTracker, SourceContext}
 import com.tjclp.xl.richtext.RichText
 import com.tjclp.xl.tables.TableSpec
+import com.tjclp.xl.ooxml.worksheet.collectHyperlinks
 
 // Re-export writer config types for backward compatibility
 export writer.{
@@ -685,16 +686,18 @@ object XlsxWriter:
         case _ =>
           writeWorksheet(zip, s"xl/worksheets/sheet${idx + 1}.xml", sheet, config)
 
-      // Write worksheet relationships if this sheet has comments or tables
+      // Write worksheet relationships if this sheet has comments, tables, or hyperlinks (GH-235)
       val hasComments = commentsBySheet.contains(idx)
       val tableIds = tablesBySheet.get(idx).map(_.map(_._2)).getOrElse(Seq.empty)
+      val hlRels =
+        domainWorkbook.map(dwb => hyperlinkRelationships(dwb.sheets(idx))).getOrElse(Seq.empty)
 
-      if hasComments || tableIds.nonEmpty then
-        val sheetRels = buildWorksheetRelationshipsWithTables(idx + 1, hasComments, tableIds)
+      if hasComments || tableIds.nonEmpty || hlRels.nonEmpty then
+        val base = buildWorksheetRelationshipsWithTables(idx + 1, hasComments, tableIds)
         writePart(
           zip,
           s"xl/worksheets/_rels/sheet${idx + 1}.xml.rels",
-          sheetRels,
+          Relationships(base.relationships ++ hlRels),
           config
         )
     }
@@ -1046,6 +1049,15 @@ object XlsxWriter:
       val zip = use(new ZipFile(path.toFile))
       f(zip)
     })
+
+  /**
+   * GH-235: external-hyperlink relationships for a sheet (rIdHL{n} <-> URL), matching the
+   * worksheet.
+   */
+  private def hyperlinkRelationships(sheet: Sheet): Seq[Relationship] =
+    collectHyperlinks(sheet).filter(_.external).map { e =>
+      Relationship(e.relId, XmlUtil.relTypeHyperlink, e.target, Some("External"))
+    }
 
   /** Read the contents of a ZIP entry as UTF-8 string if it exists. */
   private def readZipEntry(zip: ZipFile, entryName: String): Option[String] =
@@ -1508,16 +1520,26 @@ object XlsxWriter:
 
           val hasComments = commentsBySheet.contains(idx)
           val tableIds = tablesBySheet.get(idx).map(_.map(_._2)).getOrElse(Seq.empty)
+          val hlRels = hyperlinkRelationships(sheet) // GH-235
 
-          // Copy relationships from source if available (preserves non-comment relationships)
-          // Otherwise regenerate minimal relationships
+          // Copy relationships from source if available (preserves non-comment relationships).
+          // Otherwise regenerate minimal relationships. Authored hyperlinks (hlRels) are merged in.
           sourceContext match
             case Some(ctx) if ctx.partManifest.contains(relsPath) =>
-              copyPreservedPart(ctx.sourcePath, relsPath, zip)
-            case _ if hasComments || tableIds.nonEmpty =>
-              val sheetRels =
+              if hlRels.isEmpty then copyPreservedPart(ctx.sourcePath, relsPath, zip)
+              else
+                // Merge authored hyperlink rels into the preserved sheet rels (parse + append)
+                val preserved = withZipFile(ctx.sourcePath) { z =>
+                  parseOptionalEntry(z, relsPath)(Relationships.fromXml)
+                }.getOrElse(Relationships(Seq.empty))
+                // Drop the source's hyperlink rels (we regenerate them from the model) to avoid
+                // orphans, but keep everything else (printerSettings, drawings, ...).
+                val kept = preserved.relationships.filterNot(_.`type` == XmlUtil.relTypeHyperlink)
+                writePart(zip, relsPath, Relationships(kept ++ hlRels), config)
+            case _ if hasComments || tableIds.nonEmpty || hlRels.nonEmpty =>
+              val base =
                 buildWorksheetRelationshipsWithCommentsPath(commentPath, hasComments, tableIds)
-              writePart(zip, relsPath, sheetRels, config)
+              writePart(zip, relsPath, Relationships(base.relationships ++ hlRels), config)
             case _ => // No relationships needed
 
           // Always regenerate comments/VML from domain model for modified sheets

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/XlsxWriter.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/XlsxWriter.scala
@@ -1340,11 +1340,13 @@ object XlsxWriter:
     // Use preserved workbook structure if available, otherwise create minimal
     val ooxmlWb = preservedWorkbook match
       case Some(preserved) =>
-        // Update sheets in preserved structure (names/order/visibility may have changed)
+        // Update sheets in preserved structure (names/order/visibility may have changed).
+        // Named ranges (definedNames) ride through verbatim here (byte-identical). Authoring a
+        // name marks metadata modified, which routes to the fromDomain branch below (GH-236).
         preserved.updateSheets(workbook.sheets, workbook.metadata.sheetStates)
       case None =>
-        // Fallback to minimal for programmatically created workbooks
-        // (or when metadata modified - we need fresh workbook structure)
+        // Fallback for programmatically created workbooks OR when metadata was modified — fresh
+        // workbook structure; fromDomain now serializes wb.metadata.definedNames (GH-236).
         OoxmlWorkbook.fromDomain(workbook)
 
     // Content types: preserve from source when available, otherwise generate minimal.

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/OoxmlWorksheet.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/OoxmlWorksheet.scala
@@ -452,6 +452,13 @@ object OoxmlWorksheet extends com.tjclp.xl.ooxml.XmlReadable[OoxmlWorksheet]:
         val endRef = ARef.from0(maxCol, maxRow)
         elem("dimension", "ref" -> s"${startRef.toA1}:${endRef.toA1}")()
 
+    // GH-235: build <hyperlinks> from Cell.hyperlink (model-driven). External links also get
+    // matching sheet .rels from the writer via the same rIdHL{n} scheme (collectHyperlinks).
+    val hyperlinksMap: Map[String, Elem] =
+      buildHyperlinksElem(collectHyperlinks(sheet))
+        .map(e => Map("hyperlinks" -> e))
+        .getOrElse(Map.empty)
+
     // If preservedMetadata is provided, use its metadata fields; otherwise use defaults (None)
     preservedMetadata match
       case Some(preserved) =>
@@ -491,7 +498,8 @@ object OoxmlWorksheet extends com.tjclp.xl.ooxml.XmlReadable[OoxmlWorksheet]:
           preserved.otherElements,
           preserved.rootAttributes,
           adjustedScope,
-          preserved.preservedKnown // GH-232: carry preserved inline elements through surgical write
+          // GH-232 preserve inline elements + GH-235 model-driven hyperlinks (overrides any raw)
+          preserved.preservedKnown ++ hyperlinksMap
         )
       case None =>
         // No preserved metadata - create minimal worksheet with cols from domain
@@ -502,7 +510,8 @@ object OoxmlWorksheet extends com.tjclp.xl.ooxml.XmlReadable[OoxmlWorksheet]:
           sheetViews = applyFreezePaneOverride(None, sheet.freezePane),
           cols = generatedCols,
           legacyDrawing = legacyDrawingElem,
-          tableParts = tableParts
+          tableParts = tableParts,
+          preservedKnown = hyperlinksMap
         )
 
   /**

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/WorksheetHelpers.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/WorksheetHelpers.scala
@@ -2,7 +2,7 @@ package com.tjclp.xl.ooxml.worksheet
 
 import scala.xml.*
 
-import com.tjclp.xl.addressing.Column
+import com.tjclp.xl.addressing.{ARef, Column}
 import com.tjclp.xl.ooxml.XmlUtil
 import com.tjclp.xl.ooxml.XmlUtil.nsSpreadsheetML
 import com.tjclp.xl.sheets.{ColumnProperties, RowProperties, Sheet}
@@ -106,6 +106,54 @@ private[ooxml] val worksheetKnownElements: Set[String] = Set(
   "legacyDrawingHF",
   "webPublishItems"
 )
+
+// ===== Hyperlink authoring (GH-235) =====
+// Cell.hyperlink is the typed model. On write we emit a <hyperlinks> element (and, for external
+// targets, sheet .rels relationships) so the model is no longer a silent no-op.
+
+/** A hyperlink to emit: cell ref, target, whether external (needs a rel), and its rel id. */
+private[ooxml] case class HyperlinkEntry(
+  ref: ARef,
+  target: String,
+  external: Boolean,
+  relId: String
+)
+
+/** External hyperlinks (URLs/mailto/file) need a relationship; others are internal `location`s. */
+private[ooxml] def isExternalHyperlink(target: String): Boolean =
+  target.contains("://") || target.startsWith("mailto:") || target.startsWith("file:")
+
+/**
+ * Collect a sheet's hyperlinks in deterministic order (by cell ref). External targets get a stable
+ * relationship id ("rIdHL{n}") used by BOTH the `<hyperlink r:id>` attribute and the sheet .rels,
+ * so the two agree without explicit plumbing (GH-235).
+ */
+private[ooxml] def collectHyperlinks(sheet: Sheet): Seq[HyperlinkEntry] =
+  val sorted = sheet.cells.values.toSeq
+    .filter(_.hyperlink.isDefined)
+    .sortBy(c => (c.ref.row.index0, c.ref.col.index0))
+  val relIdByRef = sorted
+    .filter(c => isExternalHyperlink(c.hyperlink.getOrElse("")))
+    .zipWithIndex
+    .map { case (c, i) => c.ref -> s"rIdHL${i + 1}" }
+    .toMap
+  sorted.map { c =>
+    val target = c.hyperlink.getOrElse("")
+    HyperlinkEntry(c.ref, target, isExternalHyperlink(target), relIdByRef.getOrElse(c.ref, ""))
+  }
+
+/** Build a `<hyperlinks>` element from collected entries (GH-235), or None if empty. */
+private[ooxml] def buildHyperlinksElem(entries: Seq[HyperlinkEntry]): Option[Elem] =
+  if entries.isEmpty then None
+  else
+    val children = entries.map { e =>
+      val tail: MetaData =
+        if e.external then new PrefixedAttribute("r", "id", e.relId, Null)
+        else new UnprefixedAttribute("location", e.target, Null)
+      val attrs = new UnprefixedAttribute("ref", e.ref.toA1, tail)
+      Elem(null, "hyperlink", attrs, TopScope, minimizeEmpty = true)
+    }
+    Some(Elem(null, "hyperlinks", Null, TopScope, minimizeEmpty = false, children*))
 
 /**
  * Group consecutive columns with identical properties into spans.

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/xml.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/xml.scala
@@ -44,6 +44,8 @@ object XmlUtil:
     "http://schemas.openxmlformats.org/officeDocument/2006/relationships/vmlDrawing"
   val relTypeTable =
     "http://schemas.openxmlformats.org/officeDocument/2006/relationships/table"
+  val relTypeHyperlink =
+    "http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink"
 
   /** Content type URIs */
   val ctWorkbook = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/DefinedNameRoundTripSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/DefinedNameRoundTripSpec.scala
@@ -1,0 +1,63 @@
+package com.tjclp.xl.ooxml
+
+import java.nio.file.Files
+
+import com.tjclp.xl.api.*
+import com.tjclp.xl.cells.CellValue
+import com.tjclp.xl.codec.CellCodec.given
+import com.tjclp.xl.macros.ref
+import com.tjclp.xl.unsafe.*
+import munit.FunSuite
+
+/**
+ * GH-236: named ranges (DefinedName) were a read-only model — populated on read but never
+ * serialized. These tests prove they now round-trip via both the fresh-write (fromDomain) and the
+ * surgical (preserve-on-cell-edit) paths.
+ */
+class DefinedNameRoundTripSpec extends FunSuite:
+
+  test("GH-236: programmatically authored named range serializes and round-trips") {
+    val wb = Workbook(Sheet("Sheet1").put(ref"A1" -> 1)).withDefinedName("MyRange", "Sheet1!$A$1:$A$10")
+    val out = Files.createTempFile("named-fresh", ".xlsx")
+    XlsxWriter.write(wb, out).fold(e => fail(s"write failed: $e"), identity)
+
+    val reread = XlsxReader.read(out).fold(e => fail(s"read failed: $e"), identity)
+    val names = reread.metadata.definedNames
+    assertEquals(names.map(_.name), Vector("MyRange"))
+    assertEquals(names.headOption.map(_.formula), Some("Sheet1!$A$1:$A$10"))
+    Files.deleteIfExists(out)
+  }
+
+  test("GH-236: surgical write (cell edit) preserves existing named ranges") {
+    // Author a file with a defined name, then read it, edit an unrelated cell, and write back.
+    val wb0 = Workbook(Sheet("Sheet1").put(ref"A1" -> 1)).withDefinedName("TaxRate", "0.08")
+    val src = Files.createTempFile("named-src", ".xlsx")
+    XlsxWriter.write(wb0, src).fold(e => fail(s"seed write failed: $e"), identity)
+
+    val edited = for
+      wb <- XlsxReader.read(src)
+      sheet <- wb("Sheet1")
+      updated = sheet.put(ref"B1" -> 2)
+    yield wb.put(updated)
+    val wb1 = edited.fold(e => fail(s"edit failed: $e"), identity)
+
+    val out = Files.createTempFile("named-out", ".xlsx")
+    XlsxWriter.write(wb1, out).fold(e => fail(s"write failed: $e"), identity)
+
+    val reread = XlsxReader.read(out).fold(e => fail(s"reread failed: $e"), identity)
+    assertEquals(reread.metadata.definedNames.map(_.name), Vector("TaxRate"))
+    assertEquals(reread.metadata.definedNames.headOption.map(_.formula), Some("0.08"))
+    Files.deleteIfExists(src)
+    Files.deleteIfExists(out)
+  }
+
+  test("GH-236: removeDefinedName drops the name on write") {
+    val wb = Workbook(Sheet("Sheet1").put(ref"A1" -> 1))
+      .withDefinedName("Temp", "Sheet1!$A$1")
+      .removeDefinedName("Temp")
+    val out = Files.createTempFile("named-rm", ".xlsx")
+    XlsxWriter.write(wb, out).fold(e => fail(s"write failed: $e"), identity)
+    val reread = XlsxReader.read(out).fold(e => fail(s"read failed: $e"), identity)
+    assertEquals(reread.metadata.definedNames, Vector.empty)
+    Files.deleteIfExists(out)
+  }

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/HyperlinkRoundTripSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/HyperlinkRoundTripSpec.scala
@@ -1,0 +1,58 @@
+package com.tjclp.xl.ooxml
+
+import java.nio.file.Files
+import java.util.zip.ZipFile
+
+import com.tjclp.xl.api.*
+import com.tjclp.xl.cells.{Cell, CellValue}
+import com.tjclp.xl.macros.ref
+import com.tjclp.xl.unsafe.*
+import munit.FunSuite
+
+/**
+ * GH-235: Cell.hyperlink was modeled with a public API but never serialized (a silent no-op). These
+ * tests prove hyperlinks now write (<hyperlinks> + external-URL relationships) and round-trip back
+ * into the model.
+ */
+class HyperlinkRoundTripSpec extends FunSuite:
+
+  private def entryText(zip: ZipFile, name: String): String =
+    val is = zip.getInputStream(zip.getEntry(name))
+    try new String(is.readAllBytes(), "UTF-8")
+    finally is.close()
+
+  test("GH-235: external hyperlink serializes (<hyperlinks> + External rel) and round-trips") {
+    val cell = Cell(ref"A1", CellValue.Text("Anthropic")).withHyperlink("https://anthropic.com")
+    val wb = Workbook(Sheet("Sheet1").put(cell))
+    val out = Files.createTempFile("hl-ext", ".xlsx")
+    XlsxWriter.write(wb, out).fold(e => fail(s"write failed: $e"), identity)
+
+    // Round-trip: Cell.hyperlink populated on read
+    val reread = XlsxReader.read(out).fold(e => fail(s"read failed: $e"), identity)
+    val sheet = reread("Sheet1").fold(e => fail(s"sheet missing: $e"), identity)
+    assertEquals(sheet(ref"A1").hyperlink, Some("https://anthropic.com"))
+
+    // Raw output: <hyperlinks> in the sheet + an External hyperlink relationship in its .rels
+    val zip = new ZipFile(out.toFile)
+    val sheetXml = entryText(zip, "xl/worksheets/sheet1.xml")
+    val relsXml = entryText(zip, "xl/worksheets/_rels/sheet1.xml.rels")
+    zip.close()
+    assert(sheetXml.contains("<hyperlink "), s"no <hyperlink> in sheet:\n$sheetXml")
+    assert(
+      relsXml.contains("anthropic.com") && relsXml.contains("External"),
+      s"no external hyperlink rel:\n$relsXml"
+    )
+    Files.deleteIfExists(out)
+  }
+
+  test("GH-235: internal location hyperlink uses the location attribute and round-trips") {
+    val cell = Cell(ref"A1", CellValue.Text("Go")).withHyperlink("Sheet1!B2")
+    val wb = Workbook(Sheet("Sheet1").put(cell))
+    val out = Files.createTempFile("hl-int", ".xlsx")
+    XlsxWriter.write(wb, out).fold(e => fail(s"write failed: $e"), identity)
+
+    val reread = XlsxReader.read(out).fold(e => fail(s"read failed: $e"), identity)
+    val sheet = reread("Sheet1").fold(e => fail(s"sheet missing: $e"), identity)
+    assertEquals(sheet(ref"A1").hyperlink, Some("Sheet1!B2"))
+    Files.deleteIfExists(out)
+  }


### PR DESCRIPTION
## Summary

Phase 1 of **0.10.0 "Trust & Author"** — close the "modeled but never serialized" gaps so xl can *author*, not just preserve. Both features were typed models populated on read (or settable via a public API) that silently produced nothing on write.

### Named ranges (#236)
- `OoxmlWorkbook.fromDomain` now serializes `wb.metadata.definedNames` (shared `buildDefinedNames`/`parseDefinedNames`; reader delegates to the same parse).
- Domain API: `Workbook.withDefinedName(name, refersTo)` / `removeDefinedName(name)`.
- CLI: `xl -f in.xlsx -o out.xlsx name add <NAME> <refers-to>` and `name rm <NAME>`.
- Surgical writes pass named ranges through verbatim (byte-identical to 0.9.7) — no round-trip regression.

### Hyperlinks (#235)
- **Write**: `<hyperlinks>` emitted from `Cell.hyperlink`; external targets get `TargetMode="External"` sheet relationships; internal targets use `location`. Worksheet `r:id` and the rels share one deterministic `rIdHL{n}` scheme, so they agree without cross-function plumbing. Surgical merge filters the source's old hyperlink rels before re-adding (no orphans); other rels preserved.
- **Read**: `parseWorksheetRelationships` surfaces hyperlink rels; `convertToDomainSheet` populates `Cell.hyperlink` (external via `r:id`, internal via `location`). Reading into the model is what makes authoring on an existing file safe.
- **CLI**: batch op `{"op":"hyperlink","ref":"A1","target":"https://…"}` (omit `target` to clear). Streaming mode rejects it (needs full rels context).

## Dogfooded (real CLI)
- `name add MyRange 'Dependencies!$A$1:$A$8'` → `<definedName name="MyRange">…</definedName>`; `names` lists it; `name rm` removes it.
- Syndigo (848 named ranges): preserved byte-identical to 0.9.7 on a cell edit.
- `{"op":"hyperlink","ref":"A1","target":"https://anthropic.com"}` → `<hyperlink ref="A1" r:id="rIdHL1"/>` + matching `External` relationship.

## Tests
`DefinedNameRoundTripSpec` (authoring + surgical preserve + removal) and `HyperlinkRoundTripSpec` (external + internal round-trip + raw assertions). Full suite **901/901**; `DeterminismSpec` + `WorksheetPreservationInvariantSpec` green; `./mill __.checkFormat` clean.

## Notes / follow-ups
- Hyperlinks: external authoring on the SaxStax (`--backend saxstax`) fresh-write path emits rels but not the inline `<hyperlinks>` (DirectSaxEmitter); the default ScalaXml backend is fully supported.
- Closes #235, #236. Next: Phase 2 (insert/delete rows+cols).

🤖 Generated with [Claude Code](https://claude.com/claude-code)