### PR TITLE
0.10.0 Phase 3: formula breadth — 15 functions + XLOOKUP binary modes (88→103)

### DIFF
--- a/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpecsAggregate.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpecsAggregate.scala
@@ -345,6 +345,59 @@ trait FunctionSpecsAggregate extends FunctionSpecsBase:
       yield result
     }
 
+  /** Excel PERCENTILE.INC linear interpolation over a sorted-ascending vector; None if invalid. */
+  private def percentileInc(sortedAsc: Vector[BigDecimal], p: BigDecimal): Option[BigDecimal] =
+    if sortedAsc.isEmpty || p < 0 || p > 1 then None
+    else
+      val n = sortedAsc.length
+      if n == 1 then Some(sortedAsc(0))
+      else
+        val rank = p * BigDecimal(n - 1)
+        val lo = rank.toInt
+        if lo >= n - 1 then Some(sortedAsc(n - 1))
+        else
+          val frac = rank - BigDecimal(lo)
+          Some(sortedAsc(lo) + frac * (sortedAsc(lo + 1) - sortedAsc(lo)))
+
+  /** PERCENTILE(range, p) — p in [0,1], inclusive linear interpolation. */
+  val percentile: FunctionSpec[BigDecimal] { type Args = RangeNumArgs } =
+    FunctionSpec.simple[BigDecimal, RangeNumArgs](
+      "PERCENTILE",
+      Arity.Exact(2),
+      flags = FunctionFlags(returnsNumeric = true)
+    ) { (args, ctx) =>
+      val (loc, pExpr) = args
+      for
+        nums <- collectRangeNumerics(loc, ctx)
+        p <- ctx.evalExpr(pExpr)
+        result <- percentileInc(nums.sorted, p) match
+          case Some(v) => Right(v)
+          case None =>
+            Left(EvalError.EvalFailed(s"PERCENTILE: invalid p=$p or empty range (#NUM!)", None))
+      yield result
+    }
+
+  /** QUARTILE(range, quart) — quart 0..4 maps to PERCENTILE p = quart/4. */
+  val quartile: FunctionSpec[BigDecimal] { type Args = RangeIntArgs } =
+    FunctionSpec.simple[BigDecimal, RangeIntArgs](
+      "QUARTILE",
+      Arity.Exact(2),
+      flags = FunctionFlags(returnsNumeric = true)
+    ) { (args, ctx) =>
+      val (loc, qExpr) = args
+      for
+        nums <- collectRangeNumerics(loc, ctx)
+        q <- ctx.evalExpr(qExpr)
+        result <-
+          if q < 0 || q > 4 then
+            Left(EvalError.EvalFailed(s"QUARTILE: quart=$q must be 0-4 (#NUM!)", None))
+          else
+            percentileInc(nums.sorted, BigDecimal(q) / 4) match
+              case Some(v) => Right(v)
+              case None => Left(EvalError.EvalFailed("QUARTILE: empty range (#NUM!)", None))
+      yield result
+    }
+
   val sumif: FunctionSpec[BigDecimal] { type Args = SumIfArgs } =
     FunctionSpec.simple[BigDecimal, SumIfArgs](
       "SUMIF",

--- a/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpecsAggregate.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpecsAggregate.scala
@@ -587,6 +587,116 @@ trait FunctionSpecsAggregate extends FunctionSpecsBase:
         }
     }
 
+  /**
+   * GH-76: Collect the numeric values from `valueRangeLocation` at positions where ALL criteria
+   * match. Mirrors the SUMIFS resolve/constrain/iterate pipeline but accumulates the matched values
+   * (rather than summing) so MAXIFS/MINIFS can reduce them. Empty result = no matches.
+   */
+  private def collectIfsValues(
+    valueRangeLocation: TExpr.RangeLocation,
+    conditions: RangeCriteriaList,
+    fnName: String,
+    ctx: EvalContext
+  ): Either[EvalError, Vector[BigDecimal]] =
+    evalCriteriaValues(ctx, conditions).flatMap { criteriaValues =>
+      val parsedConditions = parseConditions(conditions, criteriaValues)
+      val dimensionError = parsedConditions.collectFirst {
+        case (loc, _)
+            if loc.range.width != valueRangeLocation.range.width ||
+              loc.range.height != valueRangeLocation.range.height =>
+          EvalError.EvalFailed(
+            s"$fnName: all ranges must have same dimensions (value_range is ${valueRangeLocation.range.height}×${valueRangeLocation.range.width}, criteria_range is ${loc.range.height}×${loc.range.width})",
+            Some(s"$fnName(${valueRangeLocation.toA1}, ...)")
+          )
+      }
+      dimensionError match
+        case Some(err) => Left(err)
+        case None =>
+          Evaluator.resolveRangeLocation(valueRangeLocation, ctx.sheet, ctx.workbook).flatMap {
+            valueSheet =>
+              val resolvedConditions: Either[
+                EvalError,
+                List[(com.tjclp.xl.sheets.Sheet, TExpr.RangeLocation, CriteriaMatcher.Criterion)]
+              ] =
+                parsedConditions.foldLeft[Either[
+                  EvalError,
+                  List[(com.tjclp.xl.sheets.Sheet, TExpr.RangeLocation, CriteriaMatcher.Criterion)]
+                ]](Right(List.empty)) {
+                  case (Left(err), _) => Left(err)
+                  case (Right(acc), (loc, criterion)) =>
+                    Evaluator.resolveRangeLocation(loc, ctx.sheet, ctx.workbook).map { sheet =>
+                      acc :+ (sheet, loc, criterion)
+                    }
+                }
+              resolvedConditions.flatMap { resolved =>
+                val bounds = computeBounds(
+                  (valueRangeLocation.range, valueSheet) ::
+                    resolved.map { case (sheet, loc, _) => (loc.range, sheet) }
+                )
+                val constrainedValueRange = constrainRange(valueRangeLocation.range, bounds)
+                val constrainedConditions = resolved.map { case (sheet, loc, criterion) =>
+                  (sheet, constrainRange(loc.range, bounds), criterion)
+                }
+                val valueCells = constrainedValueRange.cells.toVector
+                val criteriaCells = constrainedConditions.map { case (sheet, range, criterion) =>
+                  (sheet, range.cells.toVector, criterion)
+                }
+                valueCells.indices.foldLeft[Either[EvalError, Vector[BigDecimal]]](
+                  Right(Vector.empty)
+                ) {
+                  case (Left(err), _) => Left(err)
+                  case (Right(acc), idx) =>
+                    val matchResult =
+                      criteriaCells.foldLeft[Either[EvalError, Boolean]](Right(true)) {
+                        case (Left(err), _) => Left(err)
+                        case (Right(false), _) => Right(false)
+                        case (Right(true), (criteriaSheet, cells, criterion)) =>
+                          evalCellValueForMatch(
+                            criteriaSheet(cells(idx)).value,
+                            criteriaSheet,
+                            ctx
+                          ).map(tv => CriteriaMatcher.matches(tv, criterion))
+                      }
+                    matchResult.flatMap { allMatch =>
+                      if allMatch then
+                        extractOrEvalNumeric(valueSheet(valueCells(idx)).value, valueSheet, ctx)
+                          .map {
+                            case Some(n) => acc :+ n
+                            case None => acc
+                          }
+                      else Right(acc)
+                    }
+                }
+              }
+          }
+    }
+
+  /** MAXIFS(max_range, criteria_range1, criteria1, ...) — max over matching cells, 0 if none. */
+  val maxifs: FunctionSpec[BigDecimal] { type Args = SumIfsArgs } =
+    FunctionSpec.simple[BigDecimal, SumIfsArgs](
+      "MAXIFS",
+      Arity.AtLeast(3),
+      flags = FunctionFlags(returnsNumeric = true)
+    ) { (args, ctx) =>
+      val (valueRange, conditions) = args
+      collectIfsValues(valueRange, conditions, "MAXIFS", ctx).map { vs =>
+        if vs.isEmpty then BigDecimal(0) else vs.max
+      }
+    }
+
+  /** MINIFS(min_range, criteria_range1, criteria1, ...) — min over matching cells, 0 if none. */
+  val minifs: FunctionSpec[BigDecimal] { type Args = SumIfsArgs } =
+    FunctionSpec.simple[BigDecimal, SumIfsArgs](
+      "MINIFS",
+      Arity.AtLeast(3),
+      flags = FunctionFlags(returnsNumeric = true)
+    ) { (args, ctx) =>
+      val (valueRange, conditions) = args
+      collectIfsValues(valueRange, conditions, "MINIFS", ctx).map { vs =>
+        if vs.isEmpty then BigDecimal(0) else vs.min
+      }
+    }
+
   val countifs: FunctionSpec[BigDecimal] { type Args = CountIfsArgs } =
     FunctionSpec.simple[BigDecimal, CountIfsArgs](
       "COUNTIFS",

--- a/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpecsAggregate.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpecsAggregate.scala
@@ -267,6 +267,84 @@ trait FunctionSpecsAggregate extends FunctionSpecsBase:
   val variancep: FunctionSpec[BigDecimal] { type Args = List[NumericArg] } =
     variadicAggregateSpec("VARP")
 
+  // ===== GH-120: statistical functions over a single range =====
+
+  /** Collect numeric values from one range (standard numeric mode), for LARGE/SMALL/RANK/etc. */
+  private def collectRangeNumerics(
+    location: TExpr.RangeLocation,
+    ctx: EvalContext
+  ): Either[EvalError, Vector[BigDecimal]] =
+    Evaluator.resolveRangeLocation(location, ctx.sheet, ctx.workbook).flatMap { targetSheet =>
+      val bounds = computeBounds(List((location.range, targetSheet)))
+      val constrainedRange = constrainRange(location.range, bounds)
+      constrainedRange.cells.foldLeft[Either[EvalError, Vector[BigDecimal]]](Right(Vector.empty)) {
+        case (Left(err), _) => Left(err)
+        case (Right(values), cellRef) =>
+          extractOrEvalNumeric(targetSheet(cellRef).value, targetSheet, ctx).map {
+            case Some(n) => values :+ n
+            case None => values
+          }
+      }
+    }
+
+  /** LARGE(range, k) — k-th largest value (1-based). */
+  val large: FunctionSpec[BigDecimal] { type Args = RangeIntArgs } =
+    FunctionSpec.simple[BigDecimal, RangeIntArgs](
+      "LARGE",
+      Arity.Exact(2),
+      flags = FunctionFlags(returnsNumeric = true)
+    ) { (args, ctx) =>
+      val (loc, kExpr) = args
+      for
+        nums <- collectRangeNumerics(loc, ctx)
+        k <- ctx.evalExpr(kExpr)
+        result <-
+          val desc = nums.sorted.reverse
+          if k >= 1 && k <= desc.length then Right(desc(k - 1))
+          else Left(EvalError.EvalFailed(s"LARGE: k=$k out of range (#NUM!)", None))
+      yield result
+    }
+
+  /** SMALL(range, k) — k-th smallest value (1-based). */
+  val small: FunctionSpec[BigDecimal] { type Args = RangeIntArgs } =
+    FunctionSpec.simple[BigDecimal, RangeIntArgs](
+      "SMALL",
+      Arity.Exact(2),
+      flags = FunctionFlags(returnsNumeric = true)
+    ) { (args, ctx) =>
+      val (loc, kExpr) = args
+      for
+        nums <- collectRangeNumerics(loc, ctx)
+        k <- ctx.evalExpr(kExpr)
+        result <-
+          val asc = nums.sorted
+          if k >= 1 && k <= asc.length then Right(asc(k - 1))
+          else Left(EvalError.EvalFailed(s"SMALL: k=$k out of range (#NUM!)", None))
+      yield result
+    }
+
+  /** RANK(number, ref, [order]) — rank of number in ref; order 0/omitted = descending. */
+  val rank: FunctionSpec[BigDecimal] { type Args = RankArgs } =
+    FunctionSpec.simple[BigDecimal, RankArgs](
+      "RANK",
+      Arity.Range(2, 3),
+      flags = FunctionFlags(returnsNumeric = true)
+    ) { (args, ctx) =>
+      val (numExpr, loc, orderOpt) = args
+      for
+        num <- ctx.evalExpr(numExpr)
+        nums <- collectRangeNumerics(loc, ctx)
+        order <- orderOpt match
+          case Some(e) => ctx.evalExpr(e)
+          case None => Right(0)
+        result <-
+          if !nums.contains(num) then
+            Left(EvalError.EvalFailed(s"RANK: $num not found in range (#N/A)", None))
+          else if order == 0 then Right(BigDecimal(nums.count(_ > num) + 1))
+          else Right(BigDecimal(nums.count(_ < num) + 1))
+      yield result
+    }
+
   val sumif: FunctionSpec[BigDecimal] { type Args = SumIfArgs } =
     FunctionSpec.simple[BigDecimal, SumIfArgs](
       "SUMIF",

--- a/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpecsArray.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpecsArray.scala
@@ -5,7 +5,7 @@ import com.tjclp.xl.formula.eval.{ArrayResult, EvalError, Evaluator}
 import com.tjclp.xl.formula.Arity
 
 import com.tjclp.xl.addressing.{ARef, CellRange}
-import com.tjclp.xl.cells.CellValue
+import com.tjclp.xl.cells.{CellValue, CellError}
 import com.tjclp.xl.sheets.Sheet
 import com.tjclp.xl.syntax.*
 
@@ -35,6 +35,145 @@ trait FunctionSpecsArray extends FunctionSpecsBase:
           val values = extractRangeAsMatrix(range, targetSheet)
           Right(ArrayResult(values.transpose))
     }
+
+  /**
+   * SEQUENCE(rows, [cols], [start], [step])
+   *
+   * Generates a row-major grid of sequential numbers. Defaults: cols=1, start=1, step=1.
+   */
+  val sequence: FunctionSpec[ArrayResult] { type Args = SequenceArgs } =
+    FunctionSpec.simple[ArrayResult, SequenceArgs]("SEQUENCE", Arity.Range(1, 4)) { (args, ctx) =>
+      val (rowsExpr, colsOpt, startOpt, stepOpt) = args
+      for
+        nRows <- ctx.evalExpr(rowsExpr)
+        nCols <- colsOpt.map(e => ctx.evalExpr(e)).getOrElse(Right(1))
+        start <- startOpt.map(e => ctx.evalExpr(e)).getOrElse(Right(BigDecimal(1)))
+        step <- stepOpt.map(e => ctx.evalExpr(e)).getOrElse(Right(BigDecimal(1)))
+        result <-
+          if nRows < 1 || nCols < 1 then
+            Left(EvalError.EvalFailed("SEQUENCE: rows and columns must be >= 1", None))
+          else if nRows.toLong * nCols.toLong > 1048576L then
+            Left(EvalError.EvalFailed("SEQUENCE: result exceeds 1,048,576 cells", None))
+          else
+            val values = (0 until nRows).toVector.map { r =>
+              (0 until nCols).toVector.map { c =>
+                (CellValue.Number(start + step * BigDecimal(r * nCols + c)): CellValue)
+              }
+            }
+            Right(ArrayResult(values))
+      yield result
+    }
+
+  /**
+   * SORT(array, [sort_index], [sort_order])
+   *
+   * Sorts the rows of a range by a 1-based column index (default 1). sort_order 1 = ascending
+   * (default), -1 = descending. Sort key: numbers < text (case-insensitive) < booleans.
+   */
+  val sortFn: FunctionSpec[ArrayResult] { type Args = SortArgs } =
+    FunctionSpec.simple[ArrayResult, SortArgs]("SORT", Arity.Range(1, 3)) { (args, ctx) =>
+      val (location, idxOpt, orderOpt) = args
+      for
+        sortIndex <- idxOpt.map(e => ctx.evalExpr(e)).getOrElse(Right(1))
+        sortOrder <- orderOpt.map(e => ctx.evalExpr(e)).getOrElse(Right(1))
+        targetSheet <- Evaluator.resolveRangeLocation(location, ctx.sheet, ctx.workbook)
+        result <-
+          val matrix = extractRangeAsMatrix(location.range, targetSheet)
+          val width = matrix.headOption.map(_.size).getOrElse(0)
+          val colIdx = sortIndex - 1
+          if matrix.isEmpty then Right(ArrayResult(matrix))
+          else if colIdx < 0 || colIdx >= width then
+            Left(EvalError.EvalFailed(s"SORT: sort_index $sortIndex is outside 1..$width", None))
+          else
+            val asc = matrix.sortBy(row => cellSortKey(row(colIdx)))
+            Right(ArrayResult(if sortOrder < 0 then asc.reverse else asc))
+      yield result
+    }
+
+  /**
+   * UNIQUE(array, [by_col], [exactly_once])
+   *
+   * Returns distinct rows (or columns when by_col=TRUE), preserving first-seen order. When
+   * exactly_once=TRUE, returns only the rows that occur exactly once. Text comparison is
+   * case-insensitive (Excel parity).
+   */
+  val unique: FunctionSpec[ArrayResult] { type Args = UniqueArgs } =
+    FunctionSpec.simple[ArrayResult, UniqueArgs]("UNIQUE", Arity.Range(1, 3)) { (args, ctx) =>
+      val (location, byColOpt, onceOpt) = args
+      for
+        byCol <- byColOpt.map(e => ctx.evalExpr(e)).getOrElse(Right(false))
+        exactlyOnce <- onceOpt.map(e => ctx.evalExpr(e)).getOrElse(Right(false))
+        targetSheet <- Evaluator.resolveRangeLocation(location, ctx.sheet, ctx.workbook)
+      yield
+        val matrix0 = extractRangeAsMatrix(location.range, targetSheet)
+        val matrix = if byCol then matrix0.transpose else matrix0
+        val resultRows =
+          if exactlyOnce then
+            val keys = matrix.map(_.map(cellKey))
+            val counts = keys.groupBy(identity).view.mapValues(_.size).toMap
+            matrix.zip(keys).collect { case (row, k) if counts.getOrElse(k, 0) == 1 => row }
+          else
+            matrix
+              .foldLeft((Vector.empty[Vector[CellValue]], Set.empty[Vector[String]])) {
+                case ((acc, seen), row) =>
+                  val k = row.map(cellKey)
+                  if seen.contains(k) then (acc, seen) else (acc :+ row, seen + k)
+              }
+              ._1
+        ArrayResult(if byCol then resultRows.transpose else resultRows)
+    }
+
+  /**
+   * FILTER(array, include, [if_empty])
+   *
+   * Keeps the rows of `array` whose corresponding entry in the single-column `include` range is
+   * truthy (TRUE or a non-zero number). Returns `if_empty` (or #N/A) when nothing matches.
+   */
+  val filterFn: FunctionSpec[ArrayResult] { type Args = FilterArgs } =
+    FunctionSpec.simple[ArrayResult, FilterArgs]("FILTER", Arity.Range(2, 3)) { (args, ctx) =>
+      val (arrayLoc, includeLoc, ifEmptyOpt) = args
+      for
+        arraySheet <- Evaluator.resolveRangeLocation(arrayLoc, ctx.sheet, ctx.workbook)
+        includeSheet <- Evaluator.resolveRangeLocation(includeLoc, ctx.sheet, ctx.workbook)
+        result <-
+          val matrix = extractRangeAsMatrix(arrayLoc.range, arraySheet)
+          val flags = extractRangeAsMatrix(includeLoc.range, includeSheet)
+            .map(row => row.headOption.exists(isTruthy))
+          val kept = matrix.zip(flags).collect { case (row, true) => row }
+          if kept.nonEmpty then Right(ArrayResult(kept))
+          else
+            ifEmptyOpt match
+              case Some(expr) => evalValue(ctx, expr).map(v => ArrayResult.single(toCellValue(v)))
+              case None => Right(ArrayResult.single(CellValue.Error(CellError.NA)))
+      yield result
+    }
+
+  /** Sort key: numbers (by value) < text (case-insensitive) < booleans < everything else. */
+  private def cellSortKey(cv: CellValue): (Int, BigDecimal, String) =
+    cv match
+      case CellValue.Number(n) => (0, n, "")
+      case CellValue.Text(s) => (1, BigDecimal(0), s.toLowerCase)
+      case CellValue.Bool(b) => (2, if b then BigDecimal(1) else BigDecimal(0), "")
+      case CellValue.Formula(_, Some(c)) => cellSortKey(c)
+      case _ => (3, BigDecimal(0), "")
+
+  /** Canonical equality key for UNIQUE (case-insensitive text, normalized numbers). */
+  private def cellKey(cv: CellValue): String =
+    cv match
+      case CellValue.Number(n) => "n:" + n.bigDecimal.stripTrailingZeros.toPlainString
+      case CellValue.Text(s) => "t:" + s.toLowerCase
+      case CellValue.Bool(b) => "b:" + b
+      case CellValue.Empty => "e:"
+      case CellValue.Formula(_, Some(c)) => cellKey(c)
+      case other => "o:" + other.toString
+
+  /** Truthiness for FILTER include flags. */
+  private def isTruthy(cv: CellValue): Boolean =
+    cv match
+      case CellValue.Bool(b) => b
+      case CellValue.Number(n) => n.signum != 0
+      case CellValue.Formula(_, Some(c)) => isTruthy(c)
+      case _ => false
 
   /**
    * Extract a range from sheet as a 2D matrix of CellValues.

--- a/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpecsBase.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpecsBase.scala
@@ -77,6 +77,9 @@ trait FunctionSpecsBase:
   type DateIntOptRange = (TExpr[LocalDate], TExpr[Int], Option[CellRange])
   type DatePairOptBasis = (TExpr[LocalDate], TExpr[LocalDate], Option[TExpr[Int]])
   type IfArgs = (TExpr[Boolean], TExpr[Any], TExpr[Any])
+  // GH-120 statistical functions over a range
+  type RangeIntArgs = (TExpr.RangeLocation, TExpr[Int])
+  type RankArgs = (TExpr[BigDecimal], TExpr.RangeLocation, Option[TExpr[Int]])
   type IfErrorArgs = (TExpr[CellValue], TExpr[CellValue])
   type NoArgs = EmptyTuple
   type DateTripleInt = (TExpr[Int], TExpr[Int], TExpr[Int])

--- a/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpecsBase.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpecsBase.scala
@@ -80,6 +80,7 @@ trait FunctionSpecsBase:
   // GH-120 statistical functions over a range
   type RangeIntArgs = (TExpr.RangeLocation, TExpr[Int])
   type RankArgs = (TExpr[BigDecimal], TExpr.RangeLocation, Option[TExpr[Int]])
+  type RangeNumArgs = (TExpr.RangeLocation, TExpr[BigDecimal])
   type IfErrorArgs = (TExpr[CellValue], TExpr[CellValue])
   type NoArgs = EmptyTuple
   type DateTripleInt = (TExpr[Int], TExpr[Int], TExpr[Int])

--- a/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpecsBase.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpecsBase.scala
@@ -81,6 +81,12 @@ trait FunctionSpecsBase:
   type RangeIntArgs = (TExpr.RangeLocation, TExpr[Int])
   type RankArgs = (TExpr[BigDecimal], TExpr.RangeLocation, Option[TExpr[Int]])
   type RangeNumArgs = (TExpr.RangeLocation, TExpr[BigDecimal])
+  // GH-76 dynamic arrays (spill engine)
+  type SequenceArgs =
+    (TExpr[Int], Option[TExpr[Int]], Option[TExpr[BigDecimal]], Option[TExpr[BigDecimal]])
+  type SortArgs = (TExpr.RangeLocation, Option[TExpr[Int]], Option[TExpr[Int]])
+  type UniqueArgs = (TExpr.RangeLocation, Option[TExpr[Boolean]], Option[TExpr[Boolean]])
+  type FilterArgs = (TExpr.RangeLocation, TExpr.RangeLocation, Option[TExpr[Any]])
   type IfErrorArgs = (TExpr[CellValue], TExpr[CellValue])
   type NoArgs = EmptyTuple
   type DateTripleInt = (TExpr[Int], TExpr[Int], TExpr[Int])

--- a/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpecsConditional.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpecsConditional.scala
@@ -1,9 +1,10 @@
 package com.tjclp.xl.formula.functions
 
 import com.tjclp.xl.formula.ast.{TExpr, ExprValue}
-import com.tjclp.xl.formula.eval.{EvalError, Evaluator}
+import com.tjclp.xl.formula.eval.{EvalError, Evaluator, ArrayArithmetic}
 import com.tjclp.xl.formula.parser.ParseError
 import com.tjclp.xl.formula.{Clock, Arity}
+import com.tjclp.xl.cells.{CellError, CellValue}
 
 trait FunctionSpecsConditional extends FunctionSpecsBase:
   val ifFn: FunctionSpec[Any] { type Args = IfArgs } =
@@ -13,4 +14,61 @@ trait FunctionSpecsConditional extends FunctionSpecsBase:
         cond <- ctx.evalExpr(condExpr)
         result <- if cond then evalAny(ctx, ifTrueExpr) else evalAny(ctx, ifFalseExpr)
       yield result
+    }
+
+  // GH-76 (tier 1): variadic conditional / selection functions. Args are a flat List[TExpr[Any]].
+
+  /** IFS(cond1, val1, cond2, val2, ...) — first TRUE condition's value, else #N/A. */
+  val ifs: FunctionSpec[Any] { type Args = List[TExpr[Any]] } =
+    FunctionSpec.simple[Any, List[TExpr[Any]]]("IFS", Arity.AtLeast(2)) { (args, ctx) =>
+      @annotation.tailrec
+      def loop(pairs: List[TExpr[Any]]): Either[EvalError, Any] =
+        pairs match
+          case cond :: value :: rest =>
+            ctx.evalExpr(TExpr.asBooleanExpr(cond)) match
+              case Left(err) => Left(err)
+              case Right(true) => evalAny(ctx, value)
+              case Right(false) => loop(rest)
+          case _ => Right(CellValue.Error(CellError.NA))
+      loop(args)
+    }
+
+  /**
+   * SWITCH(expr, case1, val1, ..., [default]) — value for the first matching case, else
+   * default/#N/A.
+   */
+  val switchFn: FunctionSpec[Any] { type Args = List[TExpr[Any]] } =
+    FunctionSpec.simple[Any, List[TExpr[Any]]]("SWITCH", Arity.AtLeast(3)) { (args, ctx) =>
+      args match
+        case target :: rest =>
+          evalAny(ctx, target).flatMap { targetVal =>
+            val tcv = ArrayArithmetic.anyToCellValue(targetVal)
+            @annotation.tailrec
+            def loop(pairs: List[TExpr[Any]]): Either[EvalError, Any] =
+              pairs match
+                case caseExpr :: value :: rest2 =>
+                  evalAny(ctx, caseExpr) match
+                    case Left(err) => Left(err)
+                    case Right(cv) =>
+                      if ArrayArithmetic.cellValueEquals(tcv, ArrayArithmetic.anyToCellValue(cv))
+                      then evalAny(ctx, value)
+                      else loop(rest2)
+                case default :: Nil => evalAny(ctx, default) // trailing default
+                case _ => Right(CellValue.Error(CellError.NA))
+            loop(rest)
+          }
+        case _ => Right(CellValue.Error(CellError.NA))
+    }
+
+  /** CHOOSE(index, val1, val2, ...) — 1-based selection; out-of-range → #VALUE!. */
+  val choose: FunctionSpec[Any] { type Args = List[TExpr[Any]] } =
+    FunctionSpec.simple[Any, List[TExpr[Any]]]("CHOOSE", Arity.AtLeast(2)) { (args, ctx) =>
+      args match
+        case idxExpr :: values =>
+          ctx.evalExpr(TExpr.asNumericExpr(idxExpr)).flatMap { n =>
+            values.lift(n.toInt - 1) match
+              case Some(v) => evalAny(ctx, v)
+              case None => Right(CellValue.Error(CellError.Value))
+          }
+        case _ => Right(CellValue.Error(CellError.Value))
     }

--- a/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpecsLookupSearch.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpecsLookupSearch.scala
@@ -211,6 +211,114 @@ trait FunctionSpecsLookupSearch extends FunctionSpecsBase:
       yield result
     }
 
+  /** Render an ExprValue to text for HLOOKUP text matching / diagnostics. */
+  private def exprValueToText(value: ExprValue): String =
+    value match
+      case ExprValue.Text(s) => s
+      case ExprValue.Number(n) => n.toString
+      case ExprValue.Bool(b) => b.toString
+      case ExprValue.Date(d) => d.toString
+      case ExprValue.DateTime(dt) => dt.toString
+      case ExprValue.Cell(cv) => cv.toString
+      case ExprValue.Opaque(other) => other.toString
+
+  /**
+   * HLOOKUP(lookup, table, row_index_num, [range_lookup])
+   *
+   * Horizontal transpose of VLOOKUP: searches the first ROW of the table, returns the cell from the
+   * 1-based row_index_num in the matched COLUMN. range_lookup TRUE (default) = approximate.
+   */
+  val hlookup: FunctionSpec[CellValue] { type Args = VlookupArgs } =
+    FunctionSpec.simple[CellValue, VlookupArgs]("HLOOKUP", Arity.Range(3, 4)) { (args, ctx) =>
+      val (lookupExpr, table, rowIndexExpr, rangeLookupOpt) = args
+      val rangeLookupExpr = rangeLookupOpt.getOrElse(TExpr.Lit(true))
+      for
+        lookupValue <- evalValue(ctx, lookupExpr)
+        rowIndex <- ctx.evalExpr(rowIndexExpr)
+        rangeMatch <- ctx.evalExpr(rangeLookupExpr)
+        targetSheet <- Evaluator.resolveRangeLocation(table, ctx.sheet, ctx.workbook)
+        result <-
+          if rowIndex < 1 || rowIndex > table.range.height then
+            Left(
+              EvalError.EvalFailed(
+                s"HLOOKUP: row_index_num $rowIndex is outside 1..${table.range.height}",
+                Some(s"HLOOKUP(…, ${table.range.toA1})")
+              )
+            )
+          else
+            val colIndices = 0 until table.range.width
+            val keyRow0 = table.range.rowStart.index0
+            val colStart0 = table.range.colStart.index0
+            val resultRow0 = keyRow0 + (rowIndex - 1)
+
+            val normalizedLookup: ExprValue = lookupValue match
+              case ExprValue.Cell(cv) =>
+                cv match
+                  case CellValue.Number(n) => ExprValue.Number(n)
+                  case CellValue.Text(s) => ExprValue.Text(s)
+                  case CellValue.Bool(b) => ExprValue.Bool(b)
+                  case CellValue.Formula(_, Some(cached)) =>
+                    cached match
+                      case CellValue.Number(n) => ExprValue.Number(n)
+                      case CellValue.Text(s) => ExprValue.Text(s)
+                      case CellValue.Bool(b) => ExprValue.Bool(b)
+                      case other => ExprValue.Cell(other)
+                  case other => ExprValue.Cell(other)
+              case other => other
+
+            val isTextLookup = normalizedLookup match
+              case ExprValue.Text(_) => true
+              case ExprValue.Number(_) => false
+              case ExprValue.Bool(_) => false
+              case _ => true
+
+            val chosenColOpt: Option[Int] =
+              if rangeMatch then
+                val numericLookup: Option[BigDecimal] = normalizedLookup match
+                  case ExprValue.Number(n) => Some(n)
+                  case ExprValue.Text(s) => scala.util.Try(BigDecimal(s.trim)).toOption
+                  case _ => None
+                numericLookup.flatMap { lookup =>
+                  val keyedCols: List[(Int, BigDecimal)] =
+                    colIndices.toList.flatMap { i =>
+                      val keyRef = ARef.from0(colStart0 + i, keyRow0)
+                      extractNumericForMatch(targetSheet(keyRef).value).map(k => (i, k))
+                    }
+                  keyedCols.filter(_._2 <= lookup).sortBy(_._2).lastOption.map(_._1)
+                }
+              else if isTextLookup then
+                val lookupText = exprValueToText(normalizedLookup).toLowerCase
+                colIndices.find { i =>
+                  val keyRef = ARef.from0(colStart0 + i, keyRow0)
+                  extractTextForMatch(targetSheet(keyRef).value).exists(_.toLowerCase == lookupText)
+                }
+              else
+                val numericLookup: Option[BigDecimal] = normalizedLookup match
+                  case ExprValue.Number(n) => Some(n)
+                  case _ => None
+                numericLookup.flatMap { lookup =>
+                  colIndices.find { i =>
+                    val keyRef = ARef.from0(colStart0 + i, keyRow0)
+                    extractNumericForMatch(targetSheet(keyRef).value).contains(lookup)
+                  }
+                }
+
+            chosenColOpt match
+              case Some(colIdx) =>
+                Right(targetSheet(ARef.from0(colStart0 + colIdx, resultRow0)).value)
+              case None =>
+                Left(
+                  EvalError.EvalFailed(
+                    if rangeMatch then "HLOOKUP approximate match not found"
+                    else "HLOOKUP exact match not found",
+                    Some(
+                      s"HLOOKUP(${exprValueToText(normalizedLookup)}, ${table.range.toA1}, $rowIndex, $rangeMatch)"
+                    )
+                  )
+                )
+      yield result
+    }
+
   val xlookup: FunctionSpec[CellValue] { type Args = XLookupArgs } =
     FunctionSpec.simple[CellValue, XLookupArgs]("XLOOKUP", Arity.Range(3, 6)) { (args, ctx) =>
       val (lookupValue, lookupArray, returnArray, ifNotFoundOpt, matchModeOpt, searchModeOpt) =

--- a/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpecsLookupSearch.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpecsLookupSearch.scala
@@ -22,8 +22,10 @@ trait FunctionSpecsLookupSearch extends FunctionSpecsBase:
     val lookupCells = lookupArray.cells.toVector
     val returnCells = returnArray.cells.toVector
 
+    // GH-55: accept binary-search modes 2 (ascending) and -2 (descending). Linear iteration in the
+    // correct direction yields correct results; -2 iterates reversed like -1 (descending order).
     val indices =
-      if searchMode == -1 then lookupCells.indices.reverse
+      if searchMode == -1 || searchMode == -2 then lookupCells.indices.reverse
       else lookupCells.indices
 
     val wildcardCriterionOpt = lookupValue match

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/ArrayFunctionsSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/ArrayFunctionsSpec.scala
@@ -186,3 +186,103 @@ class ArrayFunctionsSpec extends FunSuite:
     assertEquals(updated(ref"B3").value, CellValue.Number(3))
     assertEquals(updated(ref"C3").value, CellValue.Number(4))
   }
+
+  // ========== GH-76 Dynamic Arrays ==========
+
+  test("SEQUENCE(2,3) generates a 2x3 grid 1..6") {
+    val result = Sheet("Test").evaluateArrayFormula("=SEQUENCE(2,3)", ref"E1")
+    assert(result.isRight, s"$result")
+    val (s, range) = result.toOption.get
+    assertEquals(range.height, 2)
+    assertEquals(range.width, 3)
+    assertEquals(s(ref"E1").value, CellValue.Number(1))
+    assertEquals(s(ref"G1").value, CellValue.Number(3))
+    assertEquals(s(ref"E2").value, CellValue.Number(4))
+    assertEquals(s(ref"G2").value, CellValue.Number(6))
+  }
+
+  test("SEQUENCE(3,1,10,5) honors start and step") {
+    val (s, _) = Sheet("Test").evaluateArrayFormula("=SEQUENCE(3,1,10,5)", ref"E1").toOption.get
+    assertEquals(s(ref"E1").value, CellValue.Number(10))
+    assertEquals(s(ref"E2").value, CellValue.Number(15))
+    assertEquals(s(ref"E3").value, CellValue.Number(20))
+  }
+
+  test("SORT sorts rows ascending by the first column") {
+    val sheet = Sheet("Test")
+      .put(ref"A1", CellValue.Number(3))
+      .put(ref"B1", CellValue.Text("c"))
+      .put(ref"A2", CellValue.Number(1))
+      .put(ref"B2", CellValue.Text("a"))
+      .put(ref"A3", CellValue.Number(2))
+      .put(ref"B3", CellValue.Text("b"))
+    val (s, range) = sheet.evaluateArrayFormula("=SORT(A1:B3)", ref"E1").toOption.get
+    assertEquals(range.height, 3)
+    assertEquals(range.width, 2)
+    assertEquals(s(ref"E1").value, CellValue.Number(1))
+    assertEquals(s(ref"F1").value, CellValue.Text("a"))
+    assertEquals(s(ref"E3").value, CellValue.Number(3))
+  }
+
+  test("SORT descending with sort_order -1") {
+    val sheet = Sheet("Test")
+      .put(ref"A1", CellValue.Number(1))
+      .put(ref"A2", CellValue.Number(3))
+      .put(ref"A3", CellValue.Number(2))
+    val (s, _) = sheet.evaluateArrayFormula("=SORT(A1:A3,1,-1)", ref"E1").toOption.get
+    assertEquals(s(ref"E1").value, CellValue.Number(3))
+    assertEquals(s(ref"E2").value, CellValue.Number(2))
+    assertEquals(s(ref"E3").value, CellValue.Number(1))
+  }
+
+  test("UNIQUE returns distinct rows in first-seen order") {
+    val sheet = Sheet("Test")
+      .put(ref"A1", CellValue.Number(1))
+      .put(ref"A2", CellValue.Number(1))
+      .put(ref"A3", CellValue.Number(2))
+      .put(ref"A4", CellValue.Number(3))
+      .put(ref"A5", CellValue.Number(3))
+    val (s, range) = sheet.evaluateArrayFormula("=UNIQUE(A1:A5)", ref"E1").toOption.get
+    assertEquals(range.height, 3)
+    assertEquals(s(ref"E1").value, CellValue.Number(1))
+    assertEquals(s(ref"E2").value, CellValue.Number(2))
+    assertEquals(s(ref"E3").value, CellValue.Number(3))
+  }
+
+  test("UNIQUE exactly_once keeps only singletons") {
+    val sheet = Sheet("Test")
+      .put(ref"A1", CellValue.Number(1))
+      .put(ref"A2", CellValue.Number(1))
+      .put(ref"A3", CellValue.Number(2))
+      .put(ref"A4", CellValue.Number(3))
+      .put(ref"A5", CellValue.Number(3))
+    val (s, range) = sheet.evaluateArrayFormula("=UNIQUE(A1:A5,FALSE,TRUE)", ref"E1").toOption.get
+    assertEquals(range.height, 1)
+    assertEquals(s(ref"E1").value, CellValue.Number(2))
+  }
+
+  test("FILTER keeps rows where include is truthy") {
+    val sheet = Sheet("Test")
+      .put(ref"A1", CellValue.Number(10))
+      .put(ref"A2", CellValue.Number(20))
+      .put(ref"A3", CellValue.Number(30))
+      .put(ref"A4", CellValue.Number(40))
+      .put(ref"B1", CellValue.Number(1))
+      .put(ref"B2", CellValue.Number(0))
+      .put(ref"B3", CellValue.Number(1))
+      .put(ref"B4", CellValue.Number(0))
+    val (s, range) = sheet.evaluateArrayFormula("=FILTER(A1:A4,B1:B4)", ref"E1").toOption.get
+    assertEquals(range.height, 2)
+    assertEquals(s(ref"E1").value, CellValue.Number(10))
+    assertEquals(s(ref"E2").value, CellValue.Number(30))
+  }
+
+  test("FILTER returns if_empty when nothing matches") {
+    val sheet = Sheet("Test")
+      .put(ref"A1", CellValue.Number(10))
+      .put(ref"A2", CellValue.Number(20))
+      .put(ref"B1", CellValue.Number(0))
+      .put(ref"B2", CellValue.Number(0))
+    val (s, _) = sheet.evaluateArrayFormula("=FILTER(A1:A2,B1:B2,\"none\")", ref"E1").toOption.get
+    assertEquals(s(ref"E1").value, CellValue.Text("none"))
+  }

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/FormulaParserSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/FormulaParserSpec.scala
@@ -1114,7 +1114,7 @@ class FormulaParserSpec extends ScalaCheckSuite:
     }
   }
 
-  test("Known functions include all 91 functions") {
+  test("Known functions include all 94 functions") {
     val functions = FunctionRegistry.allNames
     assert(functions.contains("SUM"))
     assert(functions.contains("MIN"))
@@ -1210,7 +1210,11 @@ class FormulaParserSpec extends ScalaCheckSuite:
     assert(functions.contains("IFS"))
     assert(functions.contains("SWITCH"))
     assert(functions.contains("CHOOSE"))
-    assertEquals(functions.length, 91)
+    // GH-120 statistical functions
+    assert(functions.contains("LARGE"))
+    assert(functions.contains("SMALL"))
+    assert(functions.contains("RANK"))
+    assertEquals(functions.length, 94)
   }
 
   test("FunctionRegistry.lookup finds spec-based functions") {

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/FormulaParserSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/FormulaParserSpec.scala
@@ -1114,7 +1114,7 @@ class FormulaParserSpec extends ScalaCheckSuite:
     }
   }
 
-  test("Known functions include all 100 functions") {
+  test("Known functions include all 103 functions") {
     val functions = FunctionRegistry.allNames
     assert(functions.contains("SUM"))
     assert(functions.contains("MIN"))
@@ -1221,7 +1221,11 @@ class FormulaParserSpec extends ScalaCheckSuite:
     assert(functions.contains("SORT"))
     assert(functions.contains("UNIQUE"))
     assert(functions.contains("FILTER"))
-    assertEquals(functions.length, 100)
+    // GH-122 lookup + criteria
+    assert(functions.contains("HLOOKUP"))
+    assert(functions.contains("MAXIFS"))
+    assert(functions.contains("MINIFS"))
+    assertEquals(functions.length, 103)
   }
 
   test("FunctionRegistry.lookup finds spec-based functions") {

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/FormulaParserSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/FormulaParserSpec.scala
@@ -1114,7 +1114,7 @@ class FormulaParserSpec extends ScalaCheckSuite:
     }
   }
 
-  test("Known functions include all 88 functions") {
+  test("Known functions include all 91 functions") {
     val functions = FunctionRegistry.allNames
     assert(functions.contains("SUM"))
     assert(functions.contains("MIN"))
@@ -1206,7 +1206,11 @@ class FormulaParserSpec extends ScalaCheckSuite:
     assert(functions.contains("SUBSTITUTE"))
     assert(functions.contains("VALUE"))
     assert(functions.contains("TEXT"))
-    assertEquals(functions.length, 88)
+    // GH-76 tier 1: conditional / selection functions
+    assert(functions.contains("IFS"))
+    assert(functions.contains("SWITCH"))
+    assert(functions.contains("CHOOSE"))
+    assertEquals(functions.length, 91)
   }
 
   test("FunctionRegistry.lookup finds spec-based functions") {

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/FormulaParserSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/FormulaParserSpec.scala
@@ -1114,7 +1114,7 @@ class FormulaParserSpec extends ScalaCheckSuite:
     }
   }
 
-  test("Known functions include all 96 functions") {
+  test("Known functions include all 100 functions") {
     val functions = FunctionRegistry.allNames
     assert(functions.contains("SUM"))
     assert(functions.contains("MIN"))
@@ -1216,7 +1216,12 @@ class FormulaParserSpec extends ScalaCheckSuite:
     assert(functions.contains("RANK"))
     assert(functions.contains("PERCENTILE"))
     assert(functions.contains("QUARTILE"))
-    assertEquals(functions.length, 96)
+    // GH-76 dynamic arrays
+    assert(functions.contains("SEQUENCE"))
+    assert(functions.contains("SORT"))
+    assert(functions.contains("UNIQUE"))
+    assert(functions.contains("FILTER"))
+    assertEquals(functions.length, 100)
   }
 
   test("FunctionRegistry.lookup finds spec-based functions") {

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/FormulaParserSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/FormulaParserSpec.scala
@@ -1114,7 +1114,7 @@ class FormulaParserSpec extends ScalaCheckSuite:
     }
   }
 
-  test("Known functions include all 94 functions") {
+  test("Known functions include all 96 functions") {
     val functions = FunctionRegistry.allNames
     assert(functions.contains("SUM"))
     assert(functions.contains("MIN"))
@@ -1214,7 +1214,9 @@ class FormulaParserSpec extends ScalaCheckSuite:
     assert(functions.contains("LARGE"))
     assert(functions.contains("SMALL"))
     assert(functions.contains("RANK"))
-    assertEquals(functions.length, 94)
+    assert(functions.contains("PERCENTILE"))
+    assert(functions.contains("QUARTILE"))
+    assertEquals(functions.length, 96)
   }
 
   test("FunctionRegistry.lookup finds spec-based functions") {

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/Phase3FunctionsSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/Phase3FunctionsSpec.scala
@@ -58,3 +58,16 @@ class Phase3FunctionsSpec extends FunSuite:
     assertEquals(nums.evaluateFormula("=RANK(4,A1:A5)"), Right(CellValue.Number(BigDecimal(2))))
     assertEquals(nums.evaluateFormula("=RANK(4,A1:A5,1)"), Right(CellValue.Number(BigDecimal(4))))
   }
+
+  test("PERCENTILE inclusive, with interpolation") {
+    // A1:A5 sorted = 1,1,3,4,5
+    assertEquals(nums.evaluateFormula("=PERCENTILE(A1:A5,0.5)"), Right(CellValue.Number(BigDecimal(3))))
+    assertEquals(nums.evaluateFormula("=PERCENTILE(A1:A5,0)"), Right(CellValue.Number(BigDecimal(1))))
+    // A1:A4 sorted = 1,1,3,4; p=0.5 → 1 + 0.5*(3-1) = 2
+    assertEquals(nums.evaluateFormula("=PERCENTILE(A1:A4,0.5)"), Right(CellValue.Number(BigDecimal(2))))
+  }
+
+  test("QUARTILE maps quart to percentiles") {
+    assertEquals(nums.evaluateFormula("=QUARTILE(A1:A5,2)"), Right(CellValue.Number(BigDecimal(3))))
+    assertEquals(nums.evaluateFormula("=QUARTILE(A1:A5,4)"), Right(CellValue.Number(BigDecimal(5))))
+  }

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/Phase3FunctionsSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/Phase3FunctionsSpec.scala
@@ -82,3 +82,64 @@ class Phase3FunctionsSpec extends FunSuite:
       Right(CellValue.Number(BigDecimal(4)))
     )
   }
+
+  // GH-122: HLOOKUP (transpose of VLOOKUP).
+  private val htable = s
+    .put("A1" -> "a")
+    .put("B1" -> "b")
+    .put("C1" -> "c")
+    .put("A2" -> 10)
+    .put("B2" -> 20)
+    .put("C2" -> 30)
+    .put("A3" -> 100)
+    .put("B3" -> 200)
+    .put("C3" -> 300)
+
+  test("HLOOKUP exact match returns from the given row index") {
+    assertEquals(
+      htable.evaluateFormula("=HLOOKUP(\"b\",A1:C3,2,FALSE)"),
+      Right(CellValue.Number(BigDecimal(20)))
+    )
+    assertEquals(
+      htable.evaluateFormula("=HLOOKUP(\"c\",A1:C3,3,FALSE)"),
+      Right(CellValue.Number(BigDecimal(300)))
+    )
+  }
+
+  test("HLOOKUP approximate (default) finds the largest key <= lookup") {
+    val t = s.put("A1" -> 1).put("B1" -> 5).put("C1" -> 10).put("A2" -> "x").put("B2" -> "y").put(
+      "C2" -> "z"
+    )
+    assertEquals(t.evaluateFormula("=HLOOKUP(7,A1:C2,2)"), Right(CellValue.Text("y")))
+  }
+
+  // GH-122: MAXIFS / MINIFS (criteria aggregates).
+  private val crit = s
+    .put("A1" -> 10)
+    .put("A2" -> 20)
+    .put("A3" -> 30)
+    .put("A4" -> 40)
+    .put("A5" -> 50)
+    .put("B1" -> "x")
+    .put("B2" -> "y")
+    .put("B3" -> "x")
+    .put("B4" -> "y")
+    .put("B5" -> "x")
+
+  test("MAXIFS / MINIFS reduce over matching cells") {
+    assertEquals(
+      crit.evaluateFormula("=MAXIFS(A1:A5,B1:B5,\"x\")"),
+      Right(CellValue.Number(BigDecimal(50)))
+    )
+    assertEquals(
+      crit.evaluateFormula("=MINIFS(A1:A5,B1:B5,\"x\")"),
+      Right(CellValue.Number(BigDecimal(10)))
+    )
+  }
+
+  test("MAXIFS returns 0 when nothing matches") {
+    assertEquals(
+      crit.evaluateFormula("=MAXIFS(A1:A5,B1:B5,\"z\")"),
+      Right(CellValue.Number(BigDecimal(0)))
+    )
+  }

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/Phase3FunctionsSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/Phase3FunctionsSpec.scala
@@ -1,0 +1,41 @@
+package com.tjclp.xl.formula
+
+import com.tjclp.xl.{*, given}
+import com.tjclp.xl.addressing.SheetName
+import com.tjclp.xl.cells.{CellError, CellValue}
+import munit.FunSuite
+
+/** GH-76 (tier 1): conditional/selection functions IFS, SWITCH, CHOOSE. */
+class Phase3FunctionsSpec extends FunSuite:
+  private val s = new Sheet(name = SheetName.unsafe("S"))
+
+  test("IFS returns the first TRUE branch") {
+    assertEquals(s.evaluateFormula("=IFS(1>2,\"a\",2>1,\"b\")"), Right(CellValue.Text("b")))
+  }
+
+  test("IFS with no TRUE condition returns #N/A") {
+    assertEquals(
+      s.evaluateFormula("=IFS(1>2,\"a\",3>4,\"b\")"),
+      Right(CellValue.Error(CellError.NA))
+    )
+  }
+
+  test("SWITCH matches a case") {
+    assertEquals(s.evaluateFormula("=SWITCH(2,1,\"a\",2,\"b\",\"def\")"), Right(CellValue.Text("b")))
+  }
+
+  test("SWITCH falls back to the trailing default") {
+    assertEquals(s.evaluateFormula("=SWITCH(9,1,\"a\",\"def\")"), Right(CellValue.Text("def")))
+  }
+
+  test("SWITCH with no match and no default returns #N/A") {
+    assertEquals(s.evaluateFormula("=SWITCH(9,1,\"a\")"), Right(CellValue.Error(CellError.NA)))
+  }
+
+  test("CHOOSE selects the 1-based index") {
+    assertEquals(s.evaluateFormula("=CHOOSE(2,\"a\",\"b\",\"c\")"), Right(CellValue.Text("b")))
+  }
+
+  test("CHOOSE out of range returns #VALUE!") {
+    assertEquals(s.evaluateFormula("=CHOOSE(9,\"a\")"), Right(CellValue.Error(CellError.Value)))
+  }

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/Phase3FunctionsSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/Phase3FunctionsSpec.scala
@@ -71,3 +71,14 @@ class Phase3FunctionsSpec extends FunSuite:
     assertEquals(nums.evaluateFormula("=QUARTILE(A1:A5,2)"), Right(CellValue.Number(BigDecimal(3))))
     assertEquals(nums.evaluateFormula("=QUARTILE(A1:A5,4)"), Right(CellValue.Number(BigDecimal(5))))
   }
+
+  test("GH-55: XLOOKUP accepts binary search modes 2 and -2") {
+    assertEquals(
+      nums.evaluateFormula("=XLOOKUP(4,A1:A5,A1:A5,\"NA\",0,2)"),
+      Right(CellValue.Number(BigDecimal(4)))
+    )
+    assertEquals(
+      nums.evaluateFormula("=XLOOKUP(4,A1:A5,A1:A5,\"NA\",0,-2)"),
+      Right(CellValue.Number(BigDecimal(4)))
+    )
+  }

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/Phase3FunctionsSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/Phase3FunctionsSpec.scala
@@ -39,3 +39,22 @@ class Phase3FunctionsSpec extends FunSuite:
   test("CHOOSE out of range returns #VALUE!") {
     assertEquals(s.evaluateFormula("=CHOOSE(9,\"a\")"), Right(CellValue.Error(CellError.Value)))
   }
+
+  // GH-120: statistical functions over a range. Data A1:A5 = 3,1,4,1,5.
+  private val nums =
+    s.put("A1" -> 3).put("A2" -> 1).put("A3" -> 4).put("A4" -> 1).put("A5" -> 5)
+
+  test("LARGE returns the k-th largest") {
+    assertEquals(nums.evaluateFormula("=LARGE(A1:A5,1)"), Right(CellValue.Number(BigDecimal(5))))
+    assertEquals(nums.evaluateFormula("=LARGE(A1:A5,2)"), Right(CellValue.Number(BigDecimal(4))))
+  }
+
+  test("SMALL returns the k-th smallest") {
+    assertEquals(nums.evaluateFormula("=SMALL(A1:A5,1)"), Right(CellValue.Number(BigDecimal(1))))
+    assertEquals(nums.evaluateFormula("=SMALL(A1:A5,3)"), Right(CellValue.Number(BigDecimal(3))))
+  }
+
+  test("RANK descending (default) and ascending") {
+    assertEquals(nums.evaluateFormula("=RANK(4,A1:A5)"), Right(CellValue.Number(BigDecimal(2))))
+    assertEquals(nums.evaluateFormula("=RANK(4,A1:A5,1)"), Right(CellValue.Number(BigDecimal(4))))
+  }


### PR DESCRIPTION
## Summary

Phase 3 "formula breadth" — **15 new functions + XLOOKUP binary-search modes**, all additive `FunctionSpec` vals (no parser/GADT changes). Registry **88 → 103**.

### Conditional / statistical
| Function(s) | Notes | Issue |
|-------------|-------|-------|
| **IFS, SWITCH, CHOOSE** | Variadic conditional/selection | #76 (tier 1), #122 |
| **LARGE, SMALL, RANK** | Single-range via shared `collectRangeNumerics` | #120 |
| **PERCENTILE, QUARTILE** | PERCENTILE.INC linear interpolation (BigDecimal) | #120 |

### Lookup / criteria
| Function(s) | Notes | Issue |
|-------------|-------|-------|
| **HLOOKUP** | Transpose of VLOOKUP (search first row, return from row index); exact + approximate | #122 |
| **MAXIFS, MINIFS** | Max/min over matching cells via shared `collectIfsValues` (SUMIFS-style, cross-sheet + full-column aware); 0 when none | #122 |
| **XLOOKUP modes 2/-2** | Binary-search modes accepted (correct iteration direction) | #55 |

### Dynamic arrays (spill engine — reuses `ArrayResult`/`evaluateArrayFormula`)
| Function | Notes |
|----------|-------|
| **SEQUENCE**(rows,[cols],[start],[step]) | Row-major numeric grid; caps at 1,048,576 cells |
| **SORT**(array,[index],[order]) | Stable; numbers < text (case-insensitive) < booleans; -1 desc |
| **UNIQUE**(array,[by_col],[exactly_once]) | Distinct rows, first-seen order; case-insensitive |
| **FILTER**(array,include,[if_empty]) | Keeps truthy rows; if_empty / #N/A when empty |

## Tests
`Phase3FunctionsSpec` + `ArrayFunctionsSpec` (8 dynamic-array cases via `evaluateArrayFormula`). Registry count test → 103. **xl-evaluator 188/188**, full suite green, `./mill __.checkFormat` clean.

## Dogfooded
Built via `make install`; verified the dynamic arrays through the real CLI `evala` on a `xl new` workbook (SEQUENCE grid, SORT stability, UNIQUE first-seen dedup, FILTER truthy-keep).

## Closes / advances
Closes #120, #55. Advances #76 (tier 1 + dynamic arrays) and #122 (CHOOSE/HLOOKUP/MAXIFS/MINIFS). OFFSET (returns a range — separate mechanism) deferred to a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)