### PR TITLE
feat(evaluator): OFFSET with SUM(OFFSET(...)) composition (103→104)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,11 @@ formula library. See `docs/plan/v0.10.0-triage.md` for rationale.
   Shifts cells, merges, row/column properties and freeze panes, then rewrites
   every affected formula (including cross-sheet) with correct `#REF!` generation
   and range shrinking. Pure `Workbook => Workbook`, byte-identical on re-run.
-- **15 formula functions** (#76, #120, #122) — IFS, SWITCH, CHOOSE, LARGE, SMALL,
-  RANK, PERCENTILE, QUARTILE, HLOOKUP, MAXIFS, MINIFS, and the dynamic-array
-  functions SEQUENCE, SORT, UNIQUE, FILTER. **Registry 88 → 103.**
+- **16 formula functions** (#76, #120, #122) — IFS, SWITCH, CHOOSE, LARGE, SMALL,
+  RANK, PERCENTILE, QUARTILE, HLOOKUP, MAXIFS, MINIFS, OFFSET, and the dynamic-array
+  functions SEQUENCE, SORT, UNIQUE, FILTER. **Registry 88 → 104.** OFFSET returns a
+  range (spills standalone, collapses to a scalar when 1×1) and composes with
+  aggregates — `SUM(OFFSET(...))` works.
 - **XLOOKUP binary-search modes** (#55) — `search_mode` 2 (ascending) and -2
   (descending) now accepted with correct iteration direction.
 - **Named ranges** — `DefinedName` serialization (previously read-only) plus a

--- a/docs/plan/v0.10.0-execution.md
+++ b/docs/plan/v0.10.0-execution.md
@@ -74,9 +74,10 @@
 ## Phase 3 — Formula breadth (parallelizable; xl-evaluator is low-conflict)
 
 - [x] Scalar/lookup batch (#76 tier 1, #122, #120, #55): IFS, SWITCH, CHOOSE, LARGE, SMALL, RANK, PERCENTILE (PERCENTILE.INC), QUARTILE, HLOOKUP (transpose VLOOKUP), MAXIFS/MINIFS (shared `collectIfsValues`, SUMIFS-style), XLOOKUP modes 2/-2. **PR #246 (MERGED).** Closes #120, #55.
-- [x] Dynamic arrays (#76 tier 2) on the existing spill engine: SEQUENCE, SORT, UNIQUE, FILTER (reuse `ArrayResult`/`evaluateArrayFormula`). **PR #246 (MERGED).** _Remaining (follow-up): OFFSET (returns a range — separate mechanism)._
+- [x] Dynamic arrays (#76 tier 2) on the existing spill engine: SEQUENCE, SORT, UNIQUE, FILTER (reuse `ArrayResult`/`evaluateArrayFormula`). **PR #246 (MERGED).**
+- [x] OFFSET (#122) — returns `ArrayResult` (spills standalone, 1×1→scalar), `#REF!` on out-of-bounds/non-positive size, and **composes with aggregates** via an array-aware arm in `evalVariadicAggregate` (so `SUM/AVERAGE/MAX/COUNT(OFFSET(...))` work, mirroring SUMPRODUCT). Registry **103 → 104**. PR: ____ . _Remaining for #122: INDIRECT (→ 0.11.0)._
 
-> **Phase 3 (Formula breadth) COMPLETE** (modulo OFFSET) — registry **88 → 103**; dogfooded via `evala`. PR #246 merged.
+> **Phase 3 (Formula breadth) COMPLETE** — registry **88 → 104**; dogfooded via `evala`. PRs #246 + OFFSET.
 
 ## Phase 4 — Doc-truth + release readiness (last)
 

--- a/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpecsAggregate.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpecsAggregate.scala
@@ -1,7 +1,14 @@
 package com.tjclp.xl.formula.functions
 
 import com.tjclp.xl.formula.ast.{TExpr, ExprValue}
-import com.tjclp.xl.formula.eval.{EvalError, Evaluator, CriteriaMatcher, Aggregator, ArrayResult}
+import com.tjclp.xl.formula.eval.{
+  EvalError,
+  Evaluator,
+  CriteriaMatcher,
+  Aggregator,
+  ArrayResult,
+  ArrayArithmetic
+}
 import com.tjclp.xl.formula.{Clock, Arity}
 
 import com.tjclp.xl.addressing.{ARef, CellRange, Column, Row}
@@ -195,12 +202,32 @@ trait FunctionSpecsAggregate extends FunctionSpecsBase:
             }
           }
         case (Right(acc), Right(expr)) =>
-          // Individual numeric expression - evaluate it
-          ctx.evalExpr(expr).map { value =>
-            if agg.countsNonEmpty || agg.countsEmpty then
-              // For COUNT/COUNTA/COUNTBLANK, individual values always count
-              acc :+ BigDecimal(1)
-            else acc :+ value
+          // GH-122: evaluate array-aware so a range-returning call (e.g. OFFSET) flattens into the
+          // aggregate exactly like a literal range would; scalars keep their existing behavior.
+          ctx.evalArrayExpr(expr.asInstanceOf[TExpr[Any]]).map {
+            case ar: ArrayResult =>
+              ar.values.flatten.foldLeft(acc) { (values, cellValue) =>
+                if agg.countsNonEmpty then
+                  cellValue match
+                    case CellValue.Empty => values
+                    case _ => values :+ BigDecimal(1)
+                else if agg.countsEmpty then
+                  cellValue match
+                    case CellValue.Empty => values :+ BigDecimal(1)
+                    case _ => values
+                else
+                  extractNumericValue(cellValue) match
+                    case Some(n) => values :+ n
+                    case None => values
+              }
+            case value: BigDecimal =>
+              if agg.countsNonEmpty || agg.countsEmpty then acc :+ BigDecimal(1) else acc :+ value
+            case other =>
+              if agg.countsNonEmpty || agg.countsEmpty then acc :+ BigDecimal(1)
+              else
+                extractNumericValue(ArrayArithmetic.anyToCellValue(other)) match
+                  case Some(n) => acc :+ n
+                  case None => acc
           }
       }
 

--- a/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpecsArray.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpecsArray.scala
@@ -4,7 +4,7 @@ import com.tjclp.xl.formula.ast.TExpr
 import com.tjclp.xl.formula.eval.{ArrayResult, EvalError, Evaluator}
 import com.tjclp.xl.formula.Arity
 
-import com.tjclp.xl.addressing.{ARef, CellRange}
+import com.tjclp.xl.addressing.{ARef, CellRange, Column, Row}
 import com.tjclp.xl.cells.{CellValue, CellError}
 import com.tjclp.xl.sheets.Sheet
 import com.tjclp.xl.syntax.*
@@ -34,6 +34,40 @@ trait FunctionSpecsArray extends FunctionSpecsBase:
           val range = location.range
           val values = extractRangeAsMatrix(range, targetSheet)
           Right(ArrayResult(values.transpose))
+    }
+
+  /**
+   * OFFSET(reference, rows, cols, [height], [width])
+   *
+   * Returns the range `rows`/`cols` away from the anchor reference, sized height×width (both
+   * default to 1). Returned as an ArrayResult, so it spills standalone, collapses to a scalar when
+   * 1×1, and composes with aggregates (e.g. SUM(OFFSET(...))). Out-of-bounds or non-positive size
+   * yields #REF!. Note: a cross-sheet anchor's sheet is not tracked (same-sheet result).
+   */
+  val offset: FunctionSpec[ArrayResult] { type Args = OffsetArgs } =
+    FunctionSpec.simple[ArrayResult, OffsetArgs]("OFFSET", Arity.Range(3, 5)) { (args, ctx) =>
+      val (refExpr, rowsExpr, colsExpr, hOpt, wOpt) = args
+      extractARef(refExpr) match
+        case None =>
+          Left(EvalError.EvalFailed("OFFSET requires a cell reference", Some("OFFSET(...)")))
+        case Some(anchor) =>
+          for
+            dRows <- ctx.evalExpr(rowsExpr)
+            dCols <- ctx.evalExpr(colsExpr)
+            height <- hOpt.map(e => ctx.evalExpr(e)).getOrElse(Right(1))
+            width <- wOpt.map(e => ctx.evalExpr(e)).getOrElse(Right(1))
+            result <-
+              val r0 = anchor.row.index0 + dRows
+              val c0 = anchor.col.index0 + dCols
+              if height < 1 || width < 1 ||
+                r0 < 0 || c0 < 0 ||
+                r0 + height - 1 > Row.MaxIndex0 || c0 + width - 1 > Column.MaxIndex0
+              then Right(ArrayResult.single(CellValue.Error(CellError.Ref)))
+              else
+                val range =
+                  CellRange(ARef.from0(c0, r0), ARef.from0(c0 + width - 1, r0 + height - 1))
+                Right(ArrayResult(extractRangeAsMatrix(range, ctx.sheet)))
+          yield result
     }
 
   /**

--- a/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpecsBase.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpecsBase.scala
@@ -5,7 +5,7 @@ import com.tjclp.xl.formula.eval.{EvalError, Evaluator, ArrayArithmetic}
 import com.tjclp.xl.formula.parser.ParseError
 import com.tjclp.xl.formula.{Clock, Arity}
 
-import com.tjclp.xl.addressing.CellRange
+import com.tjclp.xl.addressing.{ARef, CellRange}
 import com.tjclp.xl.cells.CellValue
 import java.time.LocalDate
 
@@ -87,6 +87,8 @@ trait FunctionSpecsBase:
   type SortArgs = (TExpr.RangeLocation, Option[TExpr[Int]], Option[TExpr[Int]])
   type UniqueArgs = (TExpr.RangeLocation, Option[TExpr[Boolean]], Option[TExpr[Boolean]])
   type FilterArgs = (TExpr.RangeLocation, TExpr.RangeLocation, Option[TExpr[Any]])
+  // GH-122 OFFSET: anchor ref + row/col offsets + optional height/width
+  type OffsetArgs = (AnyExpr, TExpr[Int], TExpr[Int], Option[TExpr[Int]], Option[TExpr[Int]])
   type IfErrorArgs = (TExpr[CellValue], TExpr[CellValue])
   type NoArgs = EmptyTuple
   type DateTripleInt = (TExpr[Int], TExpr[Int], TExpr[Int])
@@ -171,6 +173,17 @@ trait FunctionSpecsBase:
     value match
       case CellValue.Number(n) => Some(n)
       case CellValue.Formula(_, Some(CellValue.Number(n))) => Some(n)
+      case _ => None
+
+  /** Extract the anchor ARef from a reference expression (cell ref, or the start of a range). */
+  protected def extractARef(expr: TExpr[?]): Option[ARef] =
+    expr match
+      case TExpr.PolyRef(ref, _) => Some(ref)
+      case TExpr.Ref(ref, _, _) => Some(ref)
+      case TExpr.SheetPolyRef(_, ref, _) => Some(ref)
+      case TExpr.SheetRef(_, ref, _, _) => Some(ref)
+      case TExpr.RangeRef(range) => Some(range.start)
+      case TExpr.SheetRange(_, range) => Some(range.start)
       case _ => None
 
   /** Extract text for matching, coercing numbers and booleans to strings. */

--- a/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpecsReference.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpecsReference.scala
@@ -5,17 +5,10 @@ import com.tjclp.xl.formula.eval.{EvalError, Evaluator}
 import com.tjclp.xl.formula.parser.ParseError
 import com.tjclp.xl.formula.{Clock, Arity}
 
-import com.tjclp.xl.addressing.{ARef, CellRange}
+import com.tjclp.xl.addressing.CellRange
 
 trait FunctionSpecsReference extends FunctionSpecsBase:
-  private def extractARef(expr: TExpr[?]): Option[ARef] = expr match
-    case TExpr.PolyRef(ref, _) => Some(ref)
-    case TExpr.Ref(ref, _, _) => Some(ref)
-    case TExpr.SheetPolyRef(_, ref, _) => Some(ref)
-    case TExpr.SheetRef(_, ref, _, _) => Some(ref)
-    case TExpr.RangeRef(range) => Some(range.start)
-    case TExpr.SheetRange(_, range) => Some(range.start)
-    case _ => None
+  // extractARef is inherited from FunctionSpecsBase (shared with OFFSET).
 
   private def extractCellRange(expr: TExpr[?]): Option[CellRange] = expr match
     case TExpr.RangeRef(range) => Some(range)

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/ArrayFunctionsSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/ArrayFunctionsSpec.scala
@@ -286,3 +286,18 @@ class ArrayFunctionsSpec extends FunSuite:
     val (s, _) = sheet.evaluateArrayFormula("=FILTER(A1:A2,B1:B2,\"none\")", ref"E1").toOption.get
     assertEquals(s(ref"E1").value, CellValue.Text("none"))
   }
+
+  test("OFFSET spills a block (=OFFSET(A1,0,0,2,2))") {
+    val sheet = Sheet("Test")
+      .put(ref"A1", CellValue.Number(1))
+      .put(ref"B1", CellValue.Number(2))
+      .put(ref"A2", CellValue.Number(3))
+      .put(ref"B2", CellValue.Number(4))
+    val (s, range) = sheet.evaluateArrayFormula("=OFFSET(A1,0,0,2,2)", ref"E1").toOption.get
+    assertEquals(range.height, 2)
+    assertEquals(range.width, 2)
+    assertEquals(s(ref"E1").value, CellValue.Number(1))
+    assertEquals(s(ref"F1").value, CellValue.Number(2))
+    assertEquals(s(ref"E2").value, CellValue.Number(3))
+    assertEquals(s(ref"F2").value, CellValue.Number(4))
+  }

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/FormulaParserSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/FormulaParserSpec.scala
@@ -1114,7 +1114,7 @@ class FormulaParserSpec extends ScalaCheckSuite:
     }
   }
 
-  test("Known functions include all 103 functions") {
+  test("Known functions include all 104 functions") {
     val functions = FunctionRegistry.allNames
     assert(functions.contains("SUM"))
     assert(functions.contains("MIN"))
@@ -1225,7 +1225,8 @@ class FormulaParserSpec extends ScalaCheckSuite:
     assert(functions.contains("HLOOKUP"))
     assert(functions.contains("MAXIFS"))
     assert(functions.contains("MINIFS"))
-    assertEquals(functions.length, 103)
+    assert(functions.contains("OFFSET"))
+    assertEquals(functions.length, 104)
   }
 
   test("FunctionRegistry.lookup finds spec-based functions") {

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/Phase3FunctionsSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/Phase3FunctionsSpec.scala
@@ -143,3 +143,40 @@ class Phase3FunctionsSpec extends FunSuite:
       Right(CellValue.Number(BigDecimal(0)))
     )
   }
+
+  // GH-122: OFFSET — single cell, #REF!, and composition with aggregates.
+  test("OFFSET single cell returns the shifted value") {
+    val grid = s.put("D3" -> 99)
+    // A1 + (2 rows, 3 cols) = D3
+    assertEquals(grid.evaluateFormula("=OFFSET(A1,2,3)"), Right(CellValue.Number(BigDecimal(99))))
+  }
+
+  test("OFFSET out-of-bounds or non-positive size yields #REF!") {
+    assertEquals(s.evaluateFormula("=OFFSET(A1,-1,0)"), Right(CellValue.Error(CellError.Ref)))
+    assertEquals(s.evaluateFormula("=OFFSET(A1,0,0,0,1)"), Right(CellValue.Error(CellError.Ref)))
+  }
+
+  test("aggregates consume OFFSET as a range") {
+    // crit A1:A5 = 10,20,30,40,50; OFFSET(A1,0,0,3,1) = A1:A3
+    assertEquals(
+      crit.evaluateFormula("=SUM(OFFSET(A1,0,0,3,1))"),
+      Right(CellValue.Number(BigDecimal(60)))
+    )
+    assertEquals(
+      crit.evaluateFormula("=AVERAGE(OFFSET(A1,0,0,3,1))"),
+      Right(CellValue.Number(BigDecimal(20)))
+    )
+    assertEquals(
+      crit.evaluateFormula("=MAX(OFFSET(A1,0,0,3,1))"),
+      Right(CellValue.Number(BigDecimal(30)))
+    )
+    assertEquals(
+      crit.evaluateFormula("=COUNT(OFFSET(A1,0,0,3,1))"),
+      Right(CellValue.Number(BigDecimal(3)))
+    )
+  }
+
+  test("aggregate scalar/range fast paths still work (regression guard)") {
+    assertEquals(crit.evaluateFormula("=SUM(A1:A5)"), Right(CellValue.Number(BigDecimal(150))))
+    assertEquals(crit.evaluateFormula("=SUM(1,2,3)"), Right(CellValue.Number(BigDecimal(6))))
+  }


### PR DESCRIPTION
## Summary

Adds **OFFSET** — the last Phase 3 lookup/reference function — including the canonical `SUM(OFFSET(...))` idiom. Registry **103 → 104**. Closes the OFFSET part of #122 (INDIRECT remains, deferred to 0.11.0).

`OFFSET(reference, rows, cols, [height], [width])` returns a **range**, which is new territory: the engine previously had no way for a function to yield a range that aggregates consume. Exploration showed the gap was small — the spill path and the 1×1→scalar unwrap already exist — so OFFSET returns `ArrayResult` and:
- **spills standalone**: `=OFFSET(A1,0,0,3,3)` fills a 3×3 block;
- **collapses to a scalar** when 1×1: `=OFFSET(A1,2,3)` → the value at the shifted cell;
- yields **`#REF!`** (`CellValue.Error(Ref)`) on out-of-bounds or non-positive size;
- **composes with aggregates**: `=SUM/AVERAGE/MAX/COUNT(OFFSET(...))`.

## How `SUM(OFFSET(...))` works (the one core change)

`SUM(OFFSET(...))` already *parsed* (a nested `Call` routes through `asNumericExpr`); it only failed at eval because the variadic-aggregate expr branch used scalar-only `ctx.evalExpr`, which rejects `ArrayResult`. The fix is **one arm** of `evalVariadicAggregate`: evaluate array-aware (`ctx.evalArrayExpr`, exactly as SUMPRODUCT already does) and, for an `ArrayResult`, flatten each cell through the **same per-cell rules the range branch uses**. The literal-range and scalar fast paths are untouched — the new branch is only reachable on array-valued args, which previously errored — so all 12 aggregates behave identically for existing formulas (regression-guarded by a test).

`extractARef` was lifted from `FunctionSpecsReference` to `FunctionSpecsBase` so OFFSET (in `FunctionSpecsArray`, where `extractRangeAsMatrix` lives) can reuse it.

## Tests
`Phase3FunctionsSpec` (scalar, `#REF!`, SUM/AVERAGE/MAX/COUNT composition, fast-path regression guard), `ArrayFunctionsSpec` (block spill), registry count → 104. **xl-evaluator 188/188, full suite 901/901**, `./mill __.checkFormat` clean.

## Dogfooded (`make install` + `evala`)
`=OFFSET(A1,0,0,3,1)` spills `[10,20,30]`; `=SUM(OFFSET(A1,0,0,3,1))` → `60`; `=OFFSET(A1,2,0)` → `30`; `=OFFSET(A1,-1,0)` → `#REF!`.

## Limitations (documented)
Cross-sheet anchor `OFFSET(Sheet2!A1,…)` resolves on the current sheet (the ref's sheet name isn't tracked); OFFSET inside criteria/lookup arg specs (`SUMIF`/`VLOOKUP`/`INDEX`) is unaffected; INDIRECT → 0.11.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)