### PR TITLE
chore(release): Bump version to 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### 0.10.0 "Trust & Author" (in progress)
+## [0.10.0] "Trust & Author" - 2026-06-09
 
 A correctness-and-authoring release: fix defects that silently corrupted data or
 falsified flagship guarantees, close the read↔write asymmetry, and broaden the

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ```scala 3 raw
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.9.7
+//> using dep com.tjclp::xl:0.10.0
 
 import com.tjclp.xl.{*, given}
 
@@ -55,13 +55,13 @@ import com.tjclp.xl.{*, given}
 
 ```scala 3 ignore
 // build.mill — single dependency for everything
-def ivyDeps = Agg(ivy"com.tjclp::xl:0.9.7")
+def ivyDeps = Agg(ivy"com.tjclp::xl:0.10.0")
 
 // Or individual modules for minimal footprint:
-// ivy"com.tjclp::xl-core:0.9.7"        — Pure domain model only
-// ivy"com.tjclp::xl-ooxml:0.9.7"       — Add OOXML read/write
-// ivy"com.tjclp::xl-cats-effect:0.9.7" — Add IO streaming
-// ivy"com.tjclp::xl-evaluator:0.9.7"   — Add formula evaluation
+// ivy"com.tjclp::xl-core:0.10.0"        — Pure domain model only
+// ivy"com.tjclp::xl-ooxml:0.10.0"       — Add OOXML read/write
+// ivy"com.tjclp::xl-cats-effect:0.10.0" — Add IO streaming
+// ivy"com.tjclp::xl-evaluator:0.10.0"   — Add formula evaluation
 ```
 
 ### Basic Usage

--- a/build.mill
+++ b/build.mill
@@ -14,7 +14,7 @@ val organization = "com.tjclp"
 /** Shared build configuration constants */
 object BuildConfig {
   /** Project version: CI sets PUBLISH_VERSION; local builds use this fallback */
-  val version: String = sys.env.getOrElse("PUBLISH_VERSION", "0.9.7")
+  val version: String = sys.env.getOrElse("PUBLISH_VERSION", "0.10.0")
 
   /** JVM options to silence Scala 3 LazyVals sun.misc.Unsafe deprecation warnings (JDK 21+) */
   val lazyValsJvmArgs: Seq[String] = Seq(

--- a/docs/QUICK-START.md
+++ b/docs/QUICK-START.md
@@ -12,19 +12,19 @@ import mill._, scalalib._
 
 object myproject extends ScalaModule {
   def scalaVersion = "3.8.3"
-  def ivyDeps = Agg(ivy"com.tjclp::xl:0.9.7")
+  def ivyDeps = Agg(ivy"com.tjclp::xl:0.10.0")
 }
 ```
 
 ### With sbt (build.sbt)
 ```scala
 scalaVersion := "3.8.3"
-libraryDependencies += "com.tjclp" %% "xl" % "0.9.7"
+libraryDependencies += "com.tjclp" %% "xl" % "0.10.0"
 ```
 
 ### With Scala CLI
 ```scala
-//> using dep com.tjclp::xl:0.9.7
+//> using dep com.tjclp::xl:0.10.0
 ```
 
 ### Individual Modules (Optional)

--- a/docs/plan/roadmap.md
+++ b/docs/plan/roadmap.md
@@ -12,7 +12,7 @@
 
 **Current Status**: Production-ready with **104 formula functions** (incl. dynamic arrays SEQUENCE/SORT/UNIQUE/FILTER and OFFSET), **structural editing** (insert/delete rows & columns with formula rewriting), named-range & hyperlink authoring, SAX streaming (36% faster than POI), Excel tables, and full OOXML round-trip. 1100+ tests passing. **0.10.0 "Trust & Author"** is the active release — see [v0.10.0-execution.md](v0.10.0-execution.md).
 
-**Current Version**: 0.9.7 → **0.10.0 "Trust & Author"** in progress
+**Current Version**: **0.10.0 "Trust & Author"** (released 2026-06-09)
 
 ---
 
@@ -20,7 +20,7 @@
 
 ### v0.10.0 "Trust & Author" (Current)
 
-Build version 0.9.7 → **0.10.0 in progress**. Focus: trust (surgical-edit fidelity) and authoring (write the parts XL previously only read).
+Build version **0.10.0**. Focus: trust (surgical-edit fidelity) and authoring (write the parts XL previously only read).
 
 | Feature | Status |
 |---------|--------|

--- a/examples/README.md
+++ b/examples/README.md
@@ -141,4 +141,4 @@ chmod +x examples/my_example.sc
 ./examples/my_example.sc
 ```
 
-The `project.scala` file centralizes dependencies (`com.tjclp::xl:0.9.7`) for all examples.
+The `project.scala` file centralizes dependencies (`com.tjclp::xl:0.10.0`) for all examples.

--- a/examples/project.scala
+++ b/examples/project.scala
@@ -2,4 +2,4 @@
 //> using repository ivy2Local
 
 // XL aggregate - includes all modules (core, ooxml, cats-effect, evaluator)
-//> using dep com.tjclp::xl:0.9.7
+//> using dep com.tjclp::xl:0.10.0

--- a/xl-core/src/com/tjclp/xl/workbooks/WorkbookMetadata.scala
+++ b/xl-core/src/com/tjclp/xl/workbooks/WorkbookMetadata.scala
@@ -16,7 +16,7 @@ final case class WorkbookMetadata(
   modified: Option[java.time.LocalDateTime] = None,
   lastModifiedBy: Option[String] = None,
   application: Option[String] = Some("XL - Pure Scala 3.8 Excel Library"),
-  appVersion: Option[String] = Some("0.9.7"),
+  appVersion: Option[String] = Some("0.10.0"),
   theme: ThemePalette = ThemePalette.office,
   definedNames: Vector[DefinedName] = Vector.empty,
   sheetStates: Map[SheetName, Option[String]] = Map.empty


### PR DESCRIPTION
Release prep for **0.10.0 "Trust & Author"** (per the release-prep runbook).

- Version strings 0.9.7 → 0.10.0: `build.mill` fallback, `WorkbookMetadata.appVersion`, README, QUICK-START, examples. `plugin/.claude-plugin/plugin.json` already 0.10.0.
- CHANGELOG `[Unreleased]` → `[0.10.0] "Trust & Author" - 2026-06-09`.
- roadmap current-version marked released.

Full suite **901/901**, `./mill __.checkFormat` clean. Tag `v0.10.0` follows once merged (triggers the release workflow: native binaries + Maven Central + GitHub Release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)