### PR TITLE
Scripting hardening: prelude, total DSL, recalc error reporting + xl-scripting skill (#252)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "xl",
       "source": "./plugin",
-      "description": "LLM-friendly Excel CLI for reading, writing, styling, and analyzing spreadsheets"
+      "description": "LLM-friendly Excel tooling: CLI operations (xl-cli) and type-safe Scala scripting (xl-scripting)"
     }
   ]
 }

--- a/.claude/commands/release-prep.md
+++ b/.claude/commands/release-prep.md
@@ -39,6 +39,13 @@ Update all version references from current SNAPSHOT/version to the new release v
 7. **`examples/README.md`** (~line 144)
    - Update the `com.tjclp::xl:...` reference in prose
 
+8. **`plugin/skills/xl-scripting/SKILL.md` + `plugin/skills/xl-scripting/reference/RECIPES.md`**
+   - Update every `//> using dep com.tjclp::xl:...` line (the recipe headers are intentionally
+     byte-identical, so a single find-replace covers all of them). The release workflow has a
+     gate that **fails the release** if these pins don't match the tag.
+   - After bumping, run `./scripts/verify-skill-snippets.sh --local` — this also catches "new
+     version breaks documented patterns" before tagging.
+
 ### Files to SKIP
 
 - **`plugin/skills/xl-cli/SKILL.md`** - Auto-detects latest release from GitHub API (no version to update)
@@ -51,7 +58,9 @@ After updating all files:
 
 1. Run `./mill __.compile` to verify compilation
 2. Run `./mill __.test` to verify tests pass
-3. Run this to verify no SNAPSHOT refs remain:
+3. Run `./scripts/test-examples.sh` (version drift guard + examples against the local build)
+4. Run `./scripts/verify-skill-snippets.sh --local` (xl-scripting skill snippets compile)
+5. Run this to verify no SNAPSHOT refs remain:
    ```bash
    grep -r "SNAPSHOT" --include="*.scala" --include="*.mill" --include="*.md" . | grep -v RELEASING.md | grep -v ".scala-build" | grep -v "out/"
    ```

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,3 +46,39 @@ jobs:
 
       - name: Test
         run: ./mill -i __.test
+
+  examples:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK + scala-cli
+        uses: coursier/setup-action@v1
+        with:
+          jvm: temurin:25
+          apps: scala-cli
+
+      - name: Cache Coursier
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/coursier
+            ~/.ivy2/cache
+          key: ${{ runner.os }}-coursier-${{ hashFiles('**/build.mill', '**/.scalafmt.conf', '**/.scalafix.conf') }}
+          restore-keys: |
+            ${{ runner.os }}-coursier-
+
+      - name: Cache Mill
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.mill
+          key: ${{ runner.os }}-mill-${{ hashFiles('**/build.mill') }}
+          restore-keys: |
+            ${{ runner.os }}-mill-
+
+      # Compile every examples/*.sc against the local build and run the curated subset.
+      # This is the anti-rot guarantee for examples and the xl-scripting skill snippets.
+      - name: Verify examples
+        run: ./scripts/test-examples.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -254,6 +254,33 @@ jobs:
           # Create zip (flat skill structure for Claude.ai)
           cd skill-dist && zip -r ../xl-skill-$VERSION.zip . && cd ..
 
+      - name: Package xl-scripting skill for Claude.ai
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+
+          # Version gate: the skill's pinned dependency must match the release tag.
+          # The pin is bumped by release-prep; a mismatch means the docs teach a stale API.
+          if ! grep -rq "com.tjclp::xl:$VERSION" plugin/skills/xl-scripting/SKILL.md plugin/skills/xl-scripting/reference/; then
+            echo "::error::xl-scripting skill does not pin com.tjclp::xl:$VERSION — run release-prep version bump"
+            exit 1
+          fi
+          STALE=$(grep -rEoh "com\.tjclp::xl:[0-9A-Za-z.+-]+" plugin/skills/xl-scripting/ | sort -u | grep -v ":$VERSION$" || true)
+          if [ -n "$STALE" ]; then
+            echo "::error::xl-scripting skill contains stale version pins: $STALE"
+            exit 1
+          fi
+
+          mkdir -p scripting-skill-dist/reference
+          cp plugin/skills/xl-scripting/SKILL.md scripting-skill-dist/
+          cp plugin/skills/xl-scripting/reference/*.md scripting-skill-dist/reference/
+
+          cat > scripting-skill-dist/VERSION << EOF
+          version=$VERSION
+          released=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          EOF
+
+          cd scripting-skill-dist && zip -r ../xl-scripting-skill-$VERSION.zip . && cd ..
+
       - name: Download native binaries
         uses: actions/download-artifact@v4
         with:
@@ -265,8 +292,9 @@ jobs:
           mkdir -p release-assets
           # Copy JAR tarball
           cp xl-cli-$VERSION.tar.gz release-assets/
-          # Copy skill zip (for Claude.ai upload)
+          # Copy skill zips (for Claude.ai upload)
           cp xl-skill-$VERSION.zip release-assets/
+          cp xl-scripting-skill-$VERSION.zip release-assets/
           # Copy native binaries (versioned names)
           cp native-binaries/xl-$VERSION-linux-amd64/xl-$VERSION-linux-amd64 release-assets/
           cp native-binaries/xl-$VERSION-darwin-amd64/xl-$VERSION-darwin-amd64 release-assets/
@@ -286,6 +314,7 @@ jobs:
           files: |
             release-assets/xl-cli-${{ steps.version.outputs.version }}.tar.gz
             release-assets/xl-skill-${{ steps.version.outputs.version }}.zip
+            release-assets/xl-scripting-skill-${{ steps.version.outputs.version }}.zip
             release-assets/xl-${{ steps.version.outputs.version }}-linux-amd64
             release-assets/xl-${{ steps.version.outputs.version }}-darwin-amd64
             release-assets/xl-${{ steps.version.outputs.version }}-darwin-arm64

--- a/.github/workflows/skill-verify.yml
+++ b/.github/workflows/skill-verify.yml
@@ -1,0 +1,49 @@
+name: Skill Verify
+
+# Compile-verify every complete-script snippet in the xl-scripting skill against the local
+# build. This is the anti-rot guarantee: documented patterns that stop compiling fail CI.
+
+on:
+  pull_request:
+    paths:
+      - "plugin/skills/xl-scripting/**"
+      - "scripts/verify-skill-snippets.sh"
+      - "xl*/src/**"
+  workflow_dispatch:
+
+jobs:
+  snippets:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK + scala-cli
+        uses: coursier/setup-action@v1
+        with:
+          jvm: temurin:25
+          apps: scala-cli
+
+      - name: Cache Coursier
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/coursier
+            ~/.ivy2/cache
+          key: ${{ runner.os }}-coursier-${{ hashFiles('**/build.mill', '**/.scalafmt.conf', '**/.scalafix.conf') }}
+          restore-keys: |
+            ${{ runner.os }}-coursier-
+
+      - name: Cache Mill
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.mill
+          key: ${{ runner.os }}-mill-${{ hashFiles('**/build.mill') }}
+          restore-keys: |
+            ${{ runner.os }}-mill-
+
+      # --local publishes the current build to ivy2Local and substitutes the version pin, so
+      # snippets are verified against the code in this PR (the contract the next release ships).
+      - name: Verify skill snippets
+        run: ./scripts/verify-skill-snippets.sh --local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added (scripting hardening, #252)
+
+- **Scripting prelude** `com.tjclp.xl.scripting.{*, given}`: one import for scripts — core API,
+  DSL, compile-time literals, formula evaluation, sync `Excel`, streaming `ExcelIO` + `RowData`,
+  smart detection sugar (`String.toFormatted`), and the `.unsafe` boundary. The plain
+  `com.tjclp.xl.{*, given}` import stays 100% pure.
+- **Range fill**: `range := value` puts the value in every cell (Excel Ctrl+Enter semantics) —
+  new `:=` overloads on `CellRange`, total `:=` on `RefType`.
+- **Total ARef navigation**: `down`/`up`/`right`/`left` (default 1) for Either-free loops.
+- **`Workbook.upsert(name, f)`**: total update-or-create counterpart of `update` (string
+  literals compile-time validated; runtime strings return `XLResult`).
+- **Typed read helpers**: `Sheet.readTypedOr(ref, default)` and `Sheet.readTypedOpt(ref)`.
+- **Workbook-level evaluation**: `wb.evaluateFormula(formula, onSheet)` wires cross-sheet
+  context automatically.
+- **`Workbook.recalculate(clock)`**: total whole-workbook recalculation returning
+  `RecalcResult` (cached workbook + per-sheet values + per-cell `CellEvalError`s); reference
+  cycles are isolated (participants circular, downstream dependents blocked) while the acyclic
+  remainder evaluates.
+- **`FormattedParsers.detect`**: total smart value detection (currency/accounting/percent/ISO
+  date/number/boolean/text) promoted from CLI-internal code; the CLI delegates.
+- **xl-scripting skill** (`plugin/skills/xl-scripting/`): SKILL.md + API reference + 7 runnable
+  recipes; packaged as `xl-scripting-skill-<version>.zip` on release with a version-pin gate.
+- **Anti-rot CI**: `scripts/test-examples.sh` (compiles every `examples/*.sc` against the local
+  build, runs a curated subset) and `scripts/verify-skill-snippets.sh` (compiles every complete
+  snippet in the skill), wired into GitHub Actions (`examples` job, `skill-verify` workflow).
+
+### Fixed (scripting hardening, #252)
+
+- **Opaque-type extensions unusable outside the package**: export forwarders for extension
+  methods and companion factories on opaque types (`ARef.toA1/shift/col/row`, `Column`/`Row`
+  arithmetic, `SheetName.value`, style units) produced path-dependent proxy types or failed
+  extension lookup for any consumer outside `com.tjclp.xl` (e.g. `Column.from0(0).toLetter` in
+  `examples/demo.sc` did not compile against 0.10.0). Fixed via explicit alias + singleton-val
+  pairs in `api`, de-inlined opaque extensions/factories (still static methods on primitives),
+  and companion-scope resolution. Guarded by new external-consumer probes
+  (`xl/test/src/xlprelude/`).
+- **`withCachedFormulas` uncached entire sheets**: one failing formula dropped caching for the
+  whole sheet, and cross-sheet formulas always failed (no workbook context), silently uncaching
+  their sheet. Now per-cell and cross-sheet aware (implemented on `recalculate`).
+- **Silent no-op `range := value`**: previously returned `Patch.empty` (documented wart); now
+  fills the range. Code relying on the no-op behavior must filter ranges explicitly.
+- **Scripts hung at exit after `toHtml`/`toSvg`**: render text measurement initialized
+  non-headless AWT, whose non-daemon AWT-Shutdown thread kept the JVM alive after main
+  completed. AWT now defaults to headless unless the embedder set `java.awt.headless`
+  explicitly (font metrics don't need a display).
+
 ## [0.10.0] "Trust & Author" - 2026-06-09
 
 A correctness-and-authoring release: fix defects that silently corrupted data or

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -430,6 +430,8 @@ extension (sheet: Sheet)
 
 **Import order**: Java/javax → Scala stdlib → Cats → Project → Tests
 
+**AWT headless default (render)**: the first `toHtml`/`toSvg` call sets `java.awt.headless=true` unless the embedder set it explicitly — non-headless AWT keeps script JVMs alive after main completes (non-daemon AWT-Shutdown thread). GUI embedders: set `-Djava.awt.headless=false` or initialize your toolkit before rendering. A deliberate, guarded global side effect (see `RenderUtils`).
+
 ## CI/CD
 
 GitHub Actions: `./mill __.checkFormat` → `./mill __.compile` → `./mill __.test`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,8 +40,12 @@ xl-agent/        → AI agent benchmark runner (Anthropic API, skill comparison)
 ## Import Patterns
 
 ```scala
-import com.tjclp.xl.{*, given}     // Everything: core + formula + display + type class instances
+import com.tjclp.xl.{*, given}     // Everything: core + formula + display + type class instances (pure)
 import com.tjclp.xl.unsafe.*       // .unsafe boundary (explicit opt-in)
+
+// Scripts: ONE import for everything above + sync Excel + ExcelIO + unsafe + String.toFormatted.
+// Never combine with com.tjclp.xl.{*, given} in the same file (ambiguous forwarders).
+import com.tjclp.xl.scripting.{*, given}
 
 // Core API
 val sheet = Sheet("Demo").put("A1" -> 100)
@@ -288,7 +292,7 @@ See `docs/reference/cli.md` for full command reference.
 - `.claude/` - Dev-only commands (release-prep, docs-cleanup-xl)
 - `plugin/` - User-facing skill distributed via plugin marketplace
 
-The CLI skill (`plugin/skills/xl-cli/SKILL.md`) auto-detects the latest release from GitHub API—no version placeholders to maintain.
+The CLI skill (`plugin/skills/xl-cli/SKILL.md`) auto-detects the latest release from GitHub API—no version placeholders to maintain. The scripting skill (`plugin/skills/xl-scripting/SKILL.md`) pins the library version instead (bumped by release-prep; release workflow gates on it) and its snippets are compile-verified by `scripts/verify-skill-snippets.sh`.
 
 ## Code Style
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ SHAREDIR ?= $(PREFIX)/share/xl
 JAR_PATH = out/xl-cli/assembly.dest/out.jar
 NATIVE_PATH = out/xl-cli/nativeImage.dest/native-executable
 
-.PHONY: build build-native install install-jar uninstall clean help package-skill package-dist
+.PHONY: build build-native install install-jar uninstall clean help package-skill package-dist publish-local examples
 
 help:
 	@echo "XL CLI Makefile"
@@ -134,3 +134,11 @@ package-dist: build
 	@echo ""
 	@echo "Install:"
 	@echo "  tar xzf xl-cli.tar.gz && cd xl-dist && ./install.sh"
+
+# Publish all library modules to ~/.ivy2/local for scala-cli script development
+publish-local:
+	./mill __.publishLocal
+
+# Compile-verify all examples/*.sc against the local build and run the curated subset
+examples:
+	./scripts/test-examples.sh

--- a/README.md
+++ b/README.md
@@ -179,19 +179,24 @@ See [docs/reference/cli.md](docs/reference/cli.md) for full command reference.
 
 ## Claude Code Plugin
 
-Install the xl-cli skill in [Claude Code](https://claude.ai/code) for AI-assisted Excel operations:
+Install the xl plugin in [Claude Code](https://claude.ai/code) for AI-assisted Excel operations:
 
 ```
 /plugin marketplace add TJC-LP/xl
 /plugin install xl-marketplace@xl
 ```
 
-The skill provides Claude with comprehensive knowledge of xl CLI commands, enabling natural language Excel manipulation:
+The plugin ships **two skills**:
+
+- **xl-cli** — CLI operations: quick reads, single edits, search, visual exports (PNG/PDF/HTML)
+- **xl-scripting** — type-safe Scala scripts against the library (via scala-cli): bulk transformations, multi-file pipelines, typed extraction, formula models with recalculation, streaming 100k+ row files
+
+Rule of thumb: one-shot operations → CLI; anything with loops, intermediate computation, or many dependent edits → scripting.
 
 - "Read the data from sales.xlsx and show me the first 10 rows"
 - "Add a SUM formula to cell B10 that totals B2:B9"
-- "Style the header row with bold text and a blue background"
-- "Search for all cells containing 'Revenue'"
+- "Apply a 5% price increase to column C in every workbook in this folder"
+- "Build a 3-year projection model, recalculate it, and flag any formula errors"
 
 ## Documentation
 

--- a/docs/plan/roadmap.md
+++ b/docs/plan/roadmap.md
@@ -18,6 +18,23 @@
 
 ## Release Roadmap
 
+### v0.11.0 "Scripting" (Next)
+
+Make library scripting (scala-cli + `com.tjclp.xl.scripting` prelude) the turbo-charged agent path — goal: the best functional Excel scripting DSL. Tracked in [#252](https://github.com/TJC-LP/xl/issues/252).
+
+| Feature | Status |
+|---------|--------|
+| `com.tjclp.xl.scripting` prelude (one import; pure base import unchanged) | ✅ Done |
+| Opaque-type extension fix for external consumers (toA1/shift/col/row...) + `xlprelude` probes | ✅ Done |
+| Total DSL: `range := v` fill (Ctrl+Enter), ARef `down/up/right/left` | ✅ Done |
+| `Workbook.upsert`, `readTypedOr`/`readTypedOpt`, `wb.evaluateFormula(formula, onSheet)` | ✅ Done |
+| `Workbook.recalculate` — total, per-cell `CellEvalError`s, cycle isolation, cross-sheet fix | ✅ Done |
+| `FormattedParsers.detect` promotion (CLI delegates) + prelude `String.toFormatted` | ✅ Done |
+| xl-scripting skill (SKILL.md + API.md + 7 recipes) + release packaging & version gate | ✅ Done |
+| Anti-rot CI: examples job + skill-verify workflow | ✅ Done |
+| Future: typed row/record extraction (RowCodec derivation) | 🔵 Proposed |
+| Future: bounds-checked `shift`/navigation variants | 🔵 Proposed |
+
 ### v0.10.0 "Trust & Author" (Current)
 
 Build version **0.10.0**. Focus: trust (surgical-edit fidelity) and authoring (write the parts XL previously only read).

--- a/examples/README.md
+++ b/examples/README.md
@@ -142,3 +142,13 @@ chmod +x examples/my_example.sc
 ```
 
 The `project.scala` file centralizes dependencies (`com.tjclp::xl:0.10.0`) for all examples.
+
+## Scripting Prelude & Skill
+
+`scripting_tour.sc` is the canonical tour of the one-import scripting prelude
+(`import com.tjclp.xl.scripting.{*, given}`). Self-contained, Maven-pinned recipe scripts
+(bulk transforms, typed extraction, streaming filters, diffs, CSV ingest) live in the
+xl-scripting Claude Code skill: [`plugin/skills/xl-scripting/reference/RECIPES.md`](../plugin/skills/xl-scripting/reference/RECIPES.md).
+
+All examples here are compile-verified against the local build by `scripts/test-examples.sh`
+(CI: the `examples` job).

--- a/examples/data_validation.sc
+++ b/examples/data_validation.sc
@@ -18,8 +18,7 @@
  * Run with: scala-cli examples/data_validation.sc
  */
 
-import com.tjclp.xl.{*, given}
-import com.tjclp.xl.unsafe.*
+import com.tjclp.xl.scripting.{*, given} // One-import scripting prelude (core + IO + evaluator + unsafe)
 // SheetEvaluator extension methods now available from com.tjclp.xl.{*, given}
 
 // ============================================================================

--- a/examples/dependency_test.sc
+++ b/examples/dependency_test.sc
@@ -11,9 +11,7 @@
  * - D1 should show dependencies: C1, C2, C3
  */
 
-import com.tjclp.xl.{*, given}
-import com.tjclp.xl.macros.ref
-import com.tjclp.xl.unsafe.*
+import com.tjclp.xl.scripting.{*, given} // One-import scripting prelude (core + IO + evaluator + unsafe)
 
 val sheet = Sheet("Dependencies")
   // Data cells (these will show as dependents of formulas)

--- a/examples/easy_mode_demo.sc
+++ b/examples/easy_mode_demo.sc
@@ -6,8 +6,7 @@
 //   1. Publish locally: ./mill xl-core.publishLocal && ./mill xl-cats-effect.publishLocal
 //   2. Run script: scala-cli run examples/easy_mode_demo.sc
 
-import com.tjclp.xl.{*, given}  // Unified API: domain + extensions + macros + Excel IO + type classes
-import com.tjclp.xl.unsafe.*         // .unsafe boundary (explicit opt-in)
+import com.tjclp.xl.scripting.{*, given} // One-import scripting prelude (core + IO + evaluator + unsafe)
 import java.time.LocalDate
 
 println("🚀 XL Easy Mode API Demo\n")

--- a/examples/financial_model.sc
+++ b/examples/financial_model.sc
@@ -17,8 +17,7 @@
  * Run with: scala-cli examples/financial_model.sc
  */
 
-import com.tjclp.xl.{*, given}
-import com.tjclp.xl.unsafe.*
+import com.tjclp.xl.scripting.{*, given} // One-import scripting prelude (core + IO + evaluator + unsafe)
 // SheetEvaluator extension methods now available from com.tjclp.xl.{*, given}
 import java.time.LocalDate
 

--- a/examples/readme_test.sc
+++ b/examples/readme_test.sc
@@ -10,8 +10,7 @@
  */
 
 // Unified import - everything from core + formula + IO + display
-import com.tjclp.xl.{*, given}
-import com.tjclp.xl.unsafe.*
+import com.tjclp.xl.scripting.{*, given} // One-import scripting prelude (core + IO + evaluator + unsafe)
 // SheetEvaluator extension methods now available from com.tjclp.xl.{*, given}
 
 var passed = 0

--- a/examples/sales_pipeline.sc
+++ b/examples/sales_pipeline.sc
@@ -17,8 +17,7 @@
  * Run with: scala-cli examples/sales_pipeline.sc
  */
 
-import com.tjclp.xl.{*, given}
-import com.tjclp.xl.unsafe.*
+import com.tjclp.xl.scripting.{*, given} // One-import scripting prelude (core + IO + evaluator + unsafe)
 // SheetEvaluator extension methods now available from com.tjclp.xl.{*, given}
 import java.time.LocalDate
 

--- a/examples/scripting_tour.sc
+++ b/examples/scripting_tour.sc
@@ -44,10 +44,11 @@ println(s"  ✓ Built ${filled.cells.size} cells from ${products.size} records")
 // ========== 3. Range fill: Excel Ctrl+Enter semantics, := is total ==========
 val zeroed = filled.put(ref"E2:E4" := 0) // every cell in E2:E4 gets 0
 
-// ========== 4. Typed values: codecs infer formats (dates, decimals) ==========
+// ========== 4. Typed values: codecs infer formats; smart detection for raw strings ==========
 val stamped = zeroed
   .put(ref"F1", "As of")
   .put(ref"G1", LocalDate.of(2026, 6, 9))
+  .put(ref"F2", "$1,234.56".toFormatted) // detected: Currency (also: percents, ISO dates)
 
 // ========== 5. Recalculate: total, per-cell errors, cross-sheet aware ==========
 val recalc = Workbook(stamped).recalculate()

--- a/examples/scripting_tour.sc
+++ b/examples/scripting_tour.sc
@@ -49,8 +49,10 @@ val stamped = zeroed
   .put(ref"F1", "As of")
   .put(ref"G1", LocalDate.of(2026, 6, 9))
 
-// ========== 4. Evaluate formulas: whole-workbook recalc with cached results ==========
-val wb = Workbook(stamped).withCachedFormulas()
+// ========== 5. Recalculate: total, per-cell errors, cross-sheet aware ==========
+val recalc = Workbook(stamped).recalculate()
+if !recalc.isClean then recalc.errors.foreach(e => println(s"  ⚠ ${e.render}"))
+val wb = recalc.workbook
 val sheet = wb.sheets.headOption.getOrElse(sys.exit(1))
 
 // Single-formula evaluation returns XLResult — compose with for-comprehensions

--- a/examples/scripting_tour.sc
+++ b/examples/scripting_tour.sc
@@ -1,0 +1,77 @@
+#!/usr/bin/env -S scala-cli shebang
+//> using file project.scala
+
+// Canonical tour of the scripting prelude — ONE import gives a script everything.
+// This file is compile-verified by scripts/test-examples.sh and is the source of truth
+// for snippets in the xl-scripting skill (plugin/skills/xl-scripting/).
+//
+// Run: ./mill __.publishLocal && scala-cli run examples/scripting_tour.sc
+
+import com.tjclp.xl.scripting.{*, given}
+import java.time.LocalDate
+
+println("🧭 XL Scripting Tour\n")
+
+// ========== 1. Build a sheet: compile-time literals are infallible ==========
+// ref"A1" / fx"..." / money"..." are validated at compile time — typos fail the build.
+
+val header = CellStyle.default.bold.size(12.0).center
+
+val sales = Sheet("Sales")
+  .put(ref"A1", "Product")
+  .put(ref"B1", "Units")
+  .put(ref"C1", "Price")
+  .put(ref"D1", "Revenue")
+  .style(ref"A1:D1", header)
+
+// ========== 2. Bulk generation: fold data into a Patch (monoid composition) ==========
+val products = List(("Widget", 150, 19.99), ("Gadget", 75, 29.99), ("Doohickey", 25, 49.99))
+
+val rows = products.zipWithIndex.foldLeft(Patch.empty) { case (acc, ((name, units, price), i)) =>
+  val r = ref"A2".shift(0, i) // total navigation — no Either in the loop
+  // fx"" with literals validates at compile time and returns CellValue directly; with runtime
+  // interpolation ($i) it validates at runtime and returns Either — unwrap at the boundary.
+  acc ++
+    (r := name) ++
+    (r.shift(1, 0) := units) ++
+    (r.shift(2, 0) := price) ++
+    (r.shift(3, 0) := fx"=B${i + 2}*C${i + 2}".unsafe)
+}
+
+val filled = sales.put(rows)
+println(s"  ✓ Built ${filled.cells.size} cells from ${products.size} records")
+
+// ========== 3. Typed values: codecs infer formats (dates, decimals) ==========
+val stamped = filled
+  .put(ref"F1", "As of")
+  .put(ref"G1", LocalDate.of(2026, 6, 9))
+
+// ========== 4. Evaluate formulas: whole-workbook recalc with cached results ==========
+val wb = Workbook(stamped).withCachedFormulas()
+val sheet = wb.sheets.headOption.getOrElse(sys.exit(1))
+
+// Single-formula evaluation returns XLResult — compose with for-comprehensions
+val total = sheet.evaluateFormula("=SUM(D2:D4)")
+println(s"  ✓ Total revenue: $total")
+
+// ========== 5. Typed extraction: readTyped returns Either[CodecError, Option[A]] ==========
+val firstUnits = sheet.readTyped[Int](ref"B2")
+println(s"  ✓ First product units: $firstUnits")
+
+// ========== 6. Display: excel interpolator formats through NumFmt ==========
+given Sheet = sheet
+println(excel"  ✓ A2 = ${ref"A2"}, B2 = ${ref"B2"}")
+
+// ========== 7. IO at the edge: sync Excel facade, ONE .unsafe boundary ==========
+val out = "/tmp/scripting-tour.xlsx"
+Excel.write(wb, out)
+val loaded = Excel.read(out)
+println(s"  ✓ Round-trip: ${loaded.sheets.size} sheet(s), ${loaded.sheets.headOption.map(_.cells.size).getOrElse(0)} cells")
+
+// Runtime strings return XLResult — unwrap once, at the edge, explicitly
+val updated = loaded
+  .update("Sales", _.put(ref"F2", "verified"))
+  .unsafe
+println(s"  ✓ Updated via XLResult + .unsafe boundary")
+
+println("\n✨ One import. Compile-time refs. Total loops. Either at the edges.")

--- a/examples/scripting_tour.sc
+++ b/examples/scripting_tour.sc
@@ -41,8 +41,11 @@ val rows = products.zipWithIndex.foldLeft(Patch.empty) { case (acc, ((name, unit
 val filled = sales.put(rows)
 println(s"  ✓ Built ${filled.cells.size} cells from ${products.size} records")
 
-// ========== 3. Typed values: codecs infer formats (dates, decimals) ==========
-val stamped = filled
+// ========== 3. Range fill: Excel Ctrl+Enter semantics, := is total ==========
+val zeroed = filled.put(ref"E2:E4" := 0) // every cell in E2:E4 gets 0
+
+// ========== 4. Typed values: codecs infer formats (dates, decimals) ==========
+val stamped = zeroed
   .put(ref"F1", "As of")
   .put(ref"G1", LocalDate.of(2026, 6, 9))
 

--- a/examples/table_demo.sc
+++ b/examples/table_demo.sc
@@ -6,8 +6,7 @@
 //   1. Publish locally: ./mill xl-core.publishLocal xl-ooxml.publishLocal
 //   2. Run script: scala-cli run examples/table_demo.sc
 
-import com.tjclp.xl.{*, given}
-import com.tjclp.xl.unsafe.*
+import com.tjclp.xl.scripting.{*, given} // One-import scripting prelude (core + IO + evaluator + unsafe)
 import com.tjclp.xl.tables.{TableSpec, TableAutoFilter, TableStyle}
 import com.tjclp.xl.ooxml.{XlsxWriter, XlsxReader}
 import java.nio.file.{Files, Path}

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "xl",
-  "description": "LLM-friendly Excel CLI for reading, writing, styling, and analyzing spreadsheets. Run `xl <command> --help` for comprehensive usage.",
+  "description": "LLM-friendly Excel tooling: the xl CLI for reading, writing, styling, and analyzing spreadsheets (xl-cli skill), plus type-safe Scala scripting against the xl library via scala-cli for bulk transformations, pipelines, and formula models (xl-scripting skill).",
   "version": "0.10.0",
   "author": {
     "name": "TJC L.P.",
@@ -9,5 +9,5 @@
   "repository": "https://github.com/TJC-LP/xl",
   "homepage": "https://github.com/TJC-LP/xl",
   "license": "Apache-2.0",
-  "keywords": ["excel", "xlsx", "spreadsheet", "cli", "ooxml", "formula", "styling"]
+  "keywords": ["excel", "xlsx", "spreadsheet", "cli", "ooxml", "formula", "styling", "scala", "scala-cli", "scripting", "library"]
 }

--- a/plugin/skills/xl-scripting/SKILL.md
+++ b/plugin/skills/xl-scripting/SKILL.md
@@ -310,6 +310,8 @@ Switch to streaming above ~100k rows; `Excel.read` loads the whole workbook. Str
 - **Compose patches with `++`**, not Cats `|+|` (the latter needs type ascription on enum cases).
 - **`fx` with runtime interpolation returns `Either`** — there is deliberately no `:=` overload that swallows a `Left`; unwrap with `.unsafe` or sequence it.
 - **`wb.update` fails on a missing sheet; `wb.upsert` creates it.** Pick by intent.
+- **Range fill cost = range size**: `ref"A:A" := 0` really creates 1,048,576 cells (that's what a fill means) — size fill ranges to your data.
+- **Navigation is unchecked at the edges**: `ref"A1".up()` produces an invalid "A0" ref that corrupts output if written; keep loop bounds inside your data extent.
 - **First run is slow** (dependency download); afterwards scala-cli caches everything.
 - **`.sc` files**: top-level statements, no `@main`. A `.scala` file needs `@main def run(): Unit`.
 

--- a/plugin/skills/xl-scripting/SKILL.md
+++ b/plugin/skills/xl-scripting/SKILL.md
@@ -1,0 +1,321 @@
+---
+name: xl-scripting
+description: "Write type-safe Scala scripts against the xl library (com.tjclp::xl, via scala-cli) for complex Excel/.xlsx work: bulk or conditional transformations, multi-file pipelines, typed data extraction into Scala types, formula-heavy model building, and streaming 100k+ row files. Prefer over the xl-cli skill when a task needs loops, intermediate computation, or many dependent edits that would round-trip the file repeatedly; use xl-cli for quick reads, single edits, and visual exports."
+---
+
+# XL Scripting - Type-Safe Excel in Scala
+
+xl is a purely functional Excel library for Scala 3: compile-time validated cell references, total APIs, and structured errors (`Either`, never exceptions). A script is a `.sc` file run with `scala-cli` — no project setup, no JDK install (scala-cli provisions one).
+
+## When to Use This Skill (vs xl-cli)
+
+| Task | Use |
+|------|-----|
+| Quick look at a sheet, single cell edit, search | `xl-cli` |
+| Export to PNG/PDF/HTML, visual verification | `xl-cli` |
+| Bulk generation (100s of cells from data) | **xl-scripting** |
+| Loops, conditionals, or computation over cell values | **xl-scripting** |
+| Multi-file pipelines (merge N workbooks, batch convert) | **xl-scripting** |
+| Typed extraction into Scala values for further logic | **xl-scripting** |
+| Build a formula model + recalculate + inspect failures | **xl-scripting** |
+| Streaming filters/aggregates over 100k+ rows | **xl-scripting** |
+
+The stateless CLI re-reads and re-writes the file on every invocation; a script holds the workbook in memory across the whole transformation. The two compose well: **generate with a script, verify visually with the CLI** (`xl -f out.xlsx -s Sheet1 view A1:F20 --format png`).
+
+## Setup
+
+Check: `which scala-cli || echo "not installed"`
+
+**macOS:** `brew install Virtuslab/scala-cli/scala-cli`
+**Linux:** `curl -sSLf https://scala-cli.virtuslab.org/get | sh`
+**Windows:** `winget install virtuslab.scalacli`
+
+No JDK prerequisite — scala-cli auto-provisions a JVM via coursier. The first run downloads dependencies (~30-60s); subsequent runs are cached.
+
+## Script Skeleton & Version
+
+The canonical header for every script (this is the single source of truth — recipes in `reference/RECIPES.md` use the identical header):
+
+```scala
+//> using scala 3.8.3
+//> using dep com.tjclp::xl:0.11.0
+
+import com.tjclp.xl.scripting.{*, given}
+
+val sheet = Sheet("Demo").put(ref"A1", "Hello").put(ref"B1", 42)
+Excel.write(Workbook(sheet), "/tmp/demo.xlsx")
+println(s"wrote ${sheet.cells.size} cells")
+```
+
+- **One import.** `com.tjclp.xl.scripting.{*, given}` bundles the core API, DSL operators, compile-time literals, formula evaluation, sync `Excel` IO, streaming `ExcelIO`, smart value detection, and the `.unsafe` boundary. Never combine it with `import com.tjclp.xl.{*, given}` in the same file (ambiguous forwarders).
+- `.sc` files run **top-level statements** — no `@main`, no object wrapper. Run with `scala-cli run script.sc`.
+- For multi-script pipelines, put the two `//> using` directives in a shared `project.scala` and start each script with `//> using file project.scala`.
+- To use a release newer than this skill documents: `curl -s https://api.github.com/repos/TJC-LP/xl/releases/latest | grep '"tag_name"' | cut -d'"' -f4` and bump the dep line. Maven artifacts are immutable, so the pinned version above always resolves.
+
+## Quick Reference
+
+```scala
+// Create / read / write (sync facade; throws only at this IO edge)
+val wb  = Excel.read("in.xlsx")                    // Workbook
+Excel.write(wb, "out.xlsx")                        // also accepts XLResult[Workbook]
+Excel.modify("file.xlsx")(_.upsert("Log", identity)) // atomic in-place read→transform→write
+
+// Sheets in a workbook
+wb.sheets                                          // Vector[Sheet]
+wb("Sales")                                        // XLResult[Sheet] (literal name compile-checked)
+wb.upsert("Summary", _.put(ref"A1", "Total"))      // total: update-or-create, returns Workbook
+wb.update("Sales", f)                              // XLResult[Workbook] (errors if absent)
+
+// Cell writes (literal refs are compile-time validated and infallible)
+sheet.put(ref"A1", "Title")                        // Sheet
+sheet.put("A1", "Title")                           // literal string: Sheet; runtime string: XLResult[Sheet]
+sheet.put(ref"B1", 42)                             // Int/Long/Double/BigDecimal/Boolean/LocalDate(Time)/RichText
+sheet.put(ref"C1", "$1,234.56".toFormatted)        // smart detection → Currency format
+sheet.style(ref"A1:D1", CellStyle.default.bold)    // Sheet
+
+// Patch DSL (compose pure values, apply once)
+val patch = (ref"A1" := "Report") ++ ref"A1:C1".merge ++ ref"A1".styled(CellStyle.default.bold)
+sheet.put(patch)                                   // Sheet
+ref"E2:E9" := 0                                    // range fill: every cell (Ctrl+Enter semantics)
+ref"A2".down(3).right(1)                           // total navigation → B5
+
+// Typed reads
+sheet.readTyped[BigDecimal](ref"C1")               // Either[CodecError, Option[BigDecimal]]
+sheet.readTypedOr[Int](ref"B1", 0)                 // total, with default
+sheet.readTypedOpt[LocalDate](ref"D1")             // flat Option
+
+// Formulas
+sheet.put(ref"D2", fx"=B2*C2")                     // compile-time validated literal
+wb.evaluateFormula("=SUM(Sales!A1:A9)", "Summary") // XLResult[CellValue], cross-sheet aware
+val r = wb.recalculate()                           // RecalcResult: total, per-cell errors
+r.isClean; r.errors.map(_.render); r.workbook      // inspect, then write r.workbook
+
+// Errors: XLResult[A] = Either[XLError, A]; unwrap ONCE at the edge
+wb.update("Sales", f).unsafe                       // throws structured XLException if Left
+```
+
+## Essential Patterns
+
+### Read → modify → write
+
+```scala
+//> using scala 3.8.3
+//> using dep com.tjclp::xl:0.11.0
+import com.tjclp.xl.scripting.{*, given}
+
+val wb = Excel.read("input.xlsx")
+val updated = wb
+  .upsert("Audit", _.put(ref"A1", "reviewed"))         // total: creates sheet if missing
+  .update("Data", _.put(ref"B2", 99))                  // XLResult: Data must exist
+  .unsafe                                              // one unwrap, at the edge
+Excel.write(updated, "output.xlsx")
+```
+
+`Excel.modify("file.xlsx")(f)` does the same in place with atomic file replacement.
+
+### Compile-time literals vs runtime refs
+
+Literal refs/formulas are validated **at compile time** — a typo fails the build, not the workbook:
+
+```scala
+val a = ref"A1"               // ARef
+val rng = ref"A1:B10"         // CellRange
+val f = fx"=SUM(A1:B10)"      // CellValue.Formula (parens/syntax checked)
+val m = money"$$1,234.56"     // Formatted(Number, Currency) — note $$ escapes $ in interpolators
+```
+
+Runtime interpolation returns `Either` because validation must happen at runtime:
+
+```scala
+val row = 5
+val cellE = ref"A$row"                    // Either[XLError, RefType]
+val formE = fx"=B$row*C$row"              // Either[XLError, CellValue]
+// sequence with for-comprehensions, or unwrap explicitly:
+val patch = (ref"A$row").map(_ := "x").getOrElse(Patch.empty)
+val cell2 = fx"=B$row*2".unsafe           // explicit boundary
+```
+
+**Prefer total navigation over interpolated refs in loops** — no Either at all:
+
+```scala
+val base = ref"A2"
+val r3 = base.down(2)         // A4
+val c2 = base.right(1)        // B2
+val shifted = base.shift(1, 2) // B4
+```
+
+### Bulk generation: fold data into a Patch
+
+Patches are pure values forming a monoid (`++`). Build the whole change set, apply once:
+
+```scala
+val products = List(("Widget", 150, 19.99), ("Gadget", 75, 29.99))
+
+val rows = products.zipWithIndex.foldLeft(Patch.empty) { case (acc, ((name, units, price), i)) =>
+  val r = ref"A2".down(i)
+  acc ++ (r := name) ++ (r.right(1) := units) ++ (r.right(2) := price) ++
+    (r.right(3) := fx"=B${i + 2}*C${i + 2}".unsafe)
+}
+val sheet = Sheet("Sales").put(rows)
+```
+
+`range := value` fills every cell in the range (Excel Ctrl+Enter): `ref"E2:E100" := 0`.
+
+### Typed extraction
+
+```scala
+final case class Product(name: String, units: Int, price: BigDecimal)
+
+val products = (2 to 10).toList.flatMap { row =>
+  val r = ref"A1".down(row - 1)
+  for
+    name <- sheet.readTypedOpt[String](r)
+    units <- sheet.readTypedOpt[Int](r.right(1))
+    price <- sheet.readTypedOpt[BigDecimal](r.right(2))
+  yield Product(name, units, price)
+}
+```
+
+9 codec types: String, Int, Long, Double, BigDecimal, Boolean, LocalDate, LocalDateTime, RichText. Use `readTyped` (full `Either[CodecError, Option[A]]`) when you must distinguish a type mismatch from an empty cell; `readTypedOr(ref, default)` when you just need a value.
+
+### Styling
+
+```scala
+val header = CellStyle.default.bold.size(12.0).center.bgBlue.white
+val pct = CellStyle.default.withNumFmt(NumFmt.Percent)
+
+sheet
+  .style(ref"A1:D1", header)
+  .put(ref"E2", 0.345, pct)                     // put with inline style
+  .put(ref"A3", "OK ".green.bold + "ship it")   // rich text runs
+```
+
+Smart detection for raw strings preserves formats: `"45.5%".toFormatted` stores `0.455` with Percent format; `"$1,234.56".toFormatted` → Currency; `"2025-01-15".toFormatted` → Date. (Also available everywhere as `FormattedParsers.detect`.)
+
+### Formulas & recalculation
+
+```scala
+val model = Sheet("Model")
+  .put(ref"A1", 1000)
+  .put(ref"A2", fx"=A1*1.08")
+  .put(ref"A3", fx"=A2*1.08")
+
+val result = Workbook(model).recalculate()       // total: never throws, never partial-silently
+if !result.isClean then
+  result.errors.foreach(e => println(s"⚠ ${e.render}"))   // e.g. "Model!A7: Circular reference"
+Excel.write(result.workbook, "model.xlsx")       // computed values cached for Excel/viewers
+```
+
+`recalculate` evaluates every formula across all sheets in dependency order, resolves cross-sheet references automatically, isolates reference cycles (the rest of the workbook still computes), and reports failures per cell in `result.errors`. `result.toEither` gives `Left(errors)` for fail-hard pipelines. For one-off questions: `wb.evaluateFormula("=SUM(Data!A:A)", "Summary")`.
+
+104 functions supported (SUM/SUMIFS/VLOOKUP/XLOOKUP/INDEX/MATCH/NPV/IRR/...) — full list in `reference/API.md`.
+
+### Error handling: Either everywhere, unsafe once
+
+Everything fallible returns `XLResult[A]` (= `Either[XLError, A]`). Compose with for-comprehensions; unwrap **once** at the script edge:
+
+```scala
+val result: XLResult[Workbook] =
+  for
+    wb <- Right(Excel.read("in.xlsx"))
+    s <- wb("Sales")                      // sheet lookup may fail
+    upd <- wb.update("Sales", _.put(ref"A1", s.cells.size))
+  yield upd
+
+result match
+  case Right(wb) => Excel.write(wb, "out.xlsx")
+  case Left(err) => println(s"failed: ${err.message}"); sys.exit(1)
+```
+
+Or lean on totality so there is nothing to unwrap: literal refs, `upsert`, range fill, `readTypedOr`, `recalculate` are all total. `.unsafe` throws a structured `XLException` (wraps the `XLError`) — fine for scripts where fail-fast is correct.
+
+## Workflows
+
+### Merge many workbooks into one
+
+```scala
+//> using scala 3.8.3
+//> using dep com.tjclp::xl:0.11.0
+import com.tjclp.xl.scripting.{*, given}
+import java.nio.file.{Files, Paths}
+import scala.jdk.CollectionConverters.*
+
+val inputs = Files.list(Paths.get("reports")).iterator.asScala
+  .filter(_.toString.endsWith(".xlsx")).toList.sortBy(_.toString)
+
+val merged = inputs.foldLeft(Workbook.empty) { (acc, path) =>
+  val wb = Excel.read(path.toString)
+  wb.sheets.foldLeft(acc) { (a, sheet) =>
+    a.put(sheet.copy(name = SheetName.unsafe(s"${path.getFileName.toString.stripSuffix(".xlsx")}-${sheet.name.value}".take(31))))
+  }
+}
+Excel.write(merged.remove("Sheet1").getOrElse(merged), "merged.xlsx")
+println(s"merged ${inputs.size} files, ${merged.sheets.size} sheets")
+```
+
+### Data → styled report
+
+```scala
+//> using scala 3.8.3
+//> using dep com.tjclp::xl:0.11.0
+import com.tjclp.xl.scripting.{*, given}
+
+val data = List(("North", 125000.50), ("South", 98000.25), ("West", 143500.00))
+val header = CellStyle.default.bold.size(12.0).center
+val currency = CellStyle.default.withNumFmt(NumFmt.Currency)
+
+val body = data.zipWithIndex.foldLeft(Patch.empty) { case (acc, ((region, sales), i)) =>
+  val r = ref"A4".down(i)
+  acc ++ (r := region) ++ (r.right(1) := BigDecimal(sales)) ++ r.right(1).styled(currency)
+}
+
+val report = Sheet("Q2")
+  .put(
+    (ref"A1" := "Q2 Regional Sales") ++ ref"A1:B1".merge ++ ref"A1".styled(header) ++
+      (ref"A3" := "Region") ++ (ref"B3" := "Sales") ++ body ++
+      (ref"A8" := "Total") ++ (ref"B8" := fx"=SUM(B4:B6)") ++ ref"B8".styled(currency)
+  )
+
+val result = Workbook(report).recalculate()
+Excel.write(result.workbook, "/tmp/q2-report.xlsx")
+println(if result.isClean then "✓ report written" else result.errors.map(_.render).mkString("\n"))
+```
+
+### Streaming a 500k-row file (constant memory)
+
+```scala
+//> using scala 3.8.3
+//> using dep com.tjclp::xl:0.11.0
+import com.tjclp.xl.scripting.{*, given}
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import java.nio.file.Paths
+
+val excel = ExcelIO.instance[IO]
+val total = excel.readStream(Paths.get("huge.xlsx"))      // fs2.Stream[IO, RowData], O(1) memory
+  .map(_.cells.get(2))                                    // column C (0-based)
+  .collect { case Some(CellValue.Number(n)) => n }
+  .compile.fold(BigDecimal(0))(_ + _)
+  .unsafeRunSync()
+println(s"column C total: $total")
+```
+
+Switch to streaming above ~100k rows; `Excel.read` loads the whole workbook. Streaming writes: `Stream.emits(rows).through(excel.writeStream(path, "Sheet1")).compile.drain` with `RowData(rowIndex, Map(colIdx -> CellValue))`.
+
+## Gotchas
+
+- **`{*, given}` is required** on the prelude import — plain `*` misses the given instances (codecs, conversions, display).
+- **Never combine** `com.tjclp.xl.scripting.{*, given}` with `com.tjclp.xl.{*, given}` in one file.
+- **`$$` escapes `$`** inside `money""` and other interpolated literals: `money"$$1,234.56"`.
+- **Compose patches with `++`**, not Cats `|+|` (the latter needs type ascription on enum cases).
+- **`fx` with runtime interpolation returns `Either`** — there is deliberately no `:=` overload that swallows a `Left`; unwrap with `.unsafe` or sequence it.
+- **`wb.update` fails on a missing sheet; `wb.upsert` creates it.** Pick by intent.
+- **First run is slow** (dependency download); afterwards scala-cli caches everything.
+- **`.sc` files**: top-level statements, no `@main`. A `.scala` file needs `@main def run(): Unit`.
+
+## Reference
+
+- `reference/API.md` — types, extension methods, style builders, all 104 formula functions, streaming API
+- `reference/RECIPES.md` — 7 complete, runnable scripts (bulk transform, typed extraction, model build, merge, streaming, diff, CSV ingest)
+- Repo examples: `examples/*.sc` in https://github.com/TJC-LP/xl (start with `scripting_tour.sc`)
+- The `xl-cli` skill for CLI operations (visual exports, quick inspection)

--- a/plugin/skills/xl-scripting/reference/API.md
+++ b/plugin/skills/xl-scripting/reference/API.md
@@ -1,0 +1,194 @@
+# XL Scripting API Reference
+
+Everything below is in scope after `import com.tjclp.xl.scripting.{*, given}`.
+
+## Key Types
+
+| Type | Description |
+|------|-------------|
+| `ARef` | Cell reference (opaque, 64-bit packed). `ref"A1"` |
+| `CellRange` | Inclusive rectangular range, auto-normalized. `ref"A1:B10"` |
+| `RefType` | Cell \| Range \| QualifiedCell \| QualifiedRange — what runtime `ref"$s"` parses to |
+| `SheetName` | Validated sheet name (≤31 chars, no `:\/?*[]`). `SheetName("Q1")` → `Either` |
+| `Cell` | `(ref, value, styleId, ...)` |
+| `CellValue` | enum: `Text`, `Number(BigDecimal)`, `Bool`, `DateTime`, `Formula(expr, cached)`, `RichText`, `Error`, `Empty` |
+| `Sheet` | Immutable sheet: `cells: Map[ARef, Cell]`, name, merges, comments, col/row properties |
+| `Workbook` | `sheets: Vector[Sheet]` + metadata |
+| `Patch` | Composable change set (monoid): `Put`, `SetCellStyle`, `SetRangeStyle`, `Merge`, `Remove`, `Batch`, ... |
+| `CellStyle` | font, fill, border, numFmt, alignment |
+| `NumFmt` | `General`, `Currency`, `Percent`, `Date`, `DateTime`, `Decimal`, custom |
+| `Formatted` | `(value: CellValue, numFmt: NumFmt)` — value + display format pair |
+| `XLResult[A]` | `Either[XLError, A]` — every fallible operation |
+| `XLError` | Structured error enum (`SheetNotFound`, `InvalidCellRef`, `FormulaError`, ...) with `.message` |
+| `RecalcResult` | `(workbook, evaluated, errors)` from `wb.recalculate()` |
+| `CellEvalError` | `(sheet, ref, error)` with `.render` → `"Sales!B2: ..."` |
+
+## Compile-Time Literals (macros)
+
+Invalid literals **fail compilation**. Runtime-interpolated forms return `Either[XLError, _]`.
+
+| Literal | Result | Example |
+|---------|--------|---------|
+| `ref"A1"` | `ARef` | `ref"XFD1048576"` |
+| `ref"A1:B10"` | `CellRange` | `ref"A:A"` rejected at compile time if malformed |
+| `ref"A$i"` / `ref"$s"` | `Either[XLError, RefType]` | runtime validation |
+| `fx"=SUM(A1:B10)"` | `CellValue.Formula` | parens/syntax checked |
+| `fx"=B$i*2"` | `Either[XLError, CellValue]` | runtime validation |
+| `money"$$1,234.56"` | `Formatted(Number, Currency)` | `$$` escapes `$` |
+| `percent"45.5%"` | `Formatted(Number(0.455), Percent)` | stored as fraction |
+| `date"2025-01-15"` | `Formatted(DateTime, Date)` | ISO format |
+| `accounting"($$1,234)"` | `Formatted(Number(-1234), Currency)` | parens = negative |
+| `col"A"` / `col(0)` | `Column` | |
+
+## ARef / CellRange / Column / Row
+
+```scala
+ref"B3".toA1                 // "B3"
+ref"B3".col / ref"B3".row    // Column / Row
+ref"B3".shift(1, 2)          // D5 (colOffset, rowOffset) — unchecked bounds
+ref"B3".down(2)              // B5   (also up/right/left, default n=1)
+ref"B3".col.toLetter         // "B"
+ref"B3".col.index0           // 1    (also index1)
+ref"A1:B10".cells            // Iterator[ARef], row-major
+ref"A1:B10".width / .height / .size
+ARef.parse("C3")             // Either[String, ARef]
+ARef.from0(colIdx, rowIdx)   // 0-based construction
+"C3".asCell                  // XLResult[ARef]   (String helpers; also .asRange, .asSheetName)
+```
+
+## Sheet Operations
+
+| Method | Returns | Notes |
+|--------|---------|-------|
+| `Sheet("Name")` | `Sheet` | literal validated at compile time |
+| `sheet.put(ref"A1", value)` | `Sheet` | value: String, Int, Long, Double, BigDecimal, Boolean, LocalDate, LocalDateTime, RichText, CellValue, Formatted |
+| `sheet.put(ref"A1", value, style)` | `Sheet` | put with inline style |
+| `sheet.put("A1", value)` | `Sheet` (literal) / `XLResult[Sheet]` (runtime string) | |
+| `sheet.put(patch)` | `Sheet` | apply a composed Patch |
+| `sheet.style(ref"A1:D1", style)` | `Sheet` | merges into existing style |
+| `sheet.cell("A1")` / `sheet.range("A1:B3")` | `Option[Cell]` / `Iterable[Cell]` | safe lookups |
+| `sheet.cells` | `Map[ARef, Cell]` | |
+| `sheet.readTyped[A](ref)` | `Either[CodecError, Option[A]]` | distinguish mismatch from empty |
+| `sheet.readTypedOr[A](ref, default)` | `A` | total |
+| `sheet.readTypedOpt[A](ref)` | `Option[A]` | total, flat |
+| `sheet.comment(ref, Comment.plainText("note", Some("author")))` | `Sheet` | |
+| `sheet.toHtml(ref"A1:B10")` | `String` | inline-CSS HTML table |
+| `sheet.usedRange` | `Option[CellRange]` | |
+
+Codec types for `put`/`readTyped*`: String, Int, Long, Double, BigDecimal, Boolean, LocalDate (→ Date format), LocalDateTime (→ DateTime format), RichText.
+
+## Workbook Operations
+
+| Method | Returns | Notes |
+|--------|---------|-------|
+| `Workbook(sheet1, sheet2)` | `Workbook` | |
+| `Workbook("Name")` | `Workbook` (literal) | one named sheet |
+| `Workbook.empty` | `Workbook` | contains default "Sheet1" |
+| `wb.sheets` | `Vector[Sheet]` | |
+| `wb("Sales")` / `wb(SheetName)` / `wb(0)` | `XLResult[Sheet]` | |
+| `wb.put(sheet)` | `Workbook` | add-or-replace by name, total |
+| `wb.upsert("Name", f: Sheet => Sheet)` | `Workbook` (literal) / `XLResult` (runtime) | update-or-create, total |
+| `wb.update("Name", f)` | `XLResult[Workbook]` | fails if sheet absent |
+| `wb.remove("Name")` | `XLResult[Workbook]` | can't remove last sheet |
+| `wb.rename(old, new)` | `XLResult[Workbook]` | |
+
+## Patch DSL
+
+Patches are pure values; `++` composes (monoid, last-write-wins per cell). Apply with `sheet.put(patch)`.
+
+```scala
+(ref"A1" := "Title")            // Put — overloads: CellValue, String, Int, Long, Double, BigDecimal, Boolean, LocalDateTime
+(ref"A1:C10" := 0)              // range fill: every cell gets the value (Excel Ctrl+Enter)
+ref"A1".styled(style)           // style one cell
+ref"A1:C1".styled(style)        // style a range
+ref"A1:C1".merge                // merge cells (also .unmerge)
+ref"A1:C10".remove              // clear cells
+ref"A1".clearStyle
+Patch.empty                     // identity — fold seed
+```
+
+Runtime `RefType` (from `ref"$s"`) supports the same `:=` / `.styled` / `.merge` / `.remove`; `:=` on a parsed range fills it.
+
+## Styling
+
+```scala
+CellStyle.default
+  .bold.italic.underline
+  .size(12.0).fontFamily("Calibri")
+  .red / .green / .blue / .black / .white / .yellow / .hex("FF8800") / .rgb(255, 136, 0)
+  .bgBlue / .bgGray / .bgGreen / .bgRed / .bgWhite / .bgYellow / .bgHex("EEEEEE") / .bgNone
+  .center / .left / .right          // horizontal align
+  .top / .middle / .bottom          // vertical align
+  .wrap
+  .bordered / .borderedMedium / .borderedThick / .borderNone
+  .currency / .percent / .decimal / .dateFormat / .dateTime   // numFmt shortcuts
+  .withNumFmt(NumFmt.Percent)
+```
+
+Rich text: `"Bold ".bold + "red".red + " plain"` → `RichText`, put directly into a cell.
+
+Smart detection: `FormattedParsers.detect(s)` / `s.toFormatted` (prelude) — total: `"$1,234.56"` → Currency, `"45.5%"` → Percent (stored 0.455), `"2025-01-15"` → Date, `"123.4"`/`"true"` → Number/Bool (General), anything else → Text (General).
+
+## Formula Evaluation
+
+| Method | Returns | Notes |
+|--------|---------|-------|
+| `wb.evaluateFormula(formula, onSheet[, clock])` | `XLResult[CellValue]` | cross-sheet context automatic; onSheet: String or SheetName |
+| `wb.recalculate([clock])` | `RecalcResult` | total whole-workbook recalc, per-cell errors, cycle isolation |
+| `wb.withCachedFormulas([clock])` | `Workbook` | = `recalculate(clock).workbook` |
+| `sheet.evaluateFormula(formula[, clock][, workbook])` | `XLResult[CellValue]` | pass `Some(wb)` iff formula references other sheets |
+| `sheet.evaluateWithDependencyCheck([clock])` | `XLResult[Map[ARef, CellValue]]` | fail-fast on first error/cycle |
+| `FormulaParser.parse("=A1+B1")` | `Either[ParseError, TExpr[?]]` | AST access |
+| `DependencyGraph.fromSheet(sheet)` | `DependencyGraph` | `.precedents(ref)` / `.dependents(ref)` |
+| `Clock.system` / `Clock.fixedDate(LocalDate)` | `Clock` | deterministic TODAY()/NOW() |
+
+`RecalcResult`: `.workbook` (successful formulas cached), `.evaluated: Map[SheetName, Map[ARef, CellValue]]`, `.errors: Vector[CellEvalError]`, `.isClean`, `.toEither`.
+
+### All 104 functions
+
+SUM, SUMIF, SUMIFS, SUMPRODUCT, COUNT, COUNTA, COUNTBLANK, COUNTIF, COUNTIFS, AVERAGE, AVERAGEIF, AVERAGEIFS, MAXIFS, MINIFS, MEDIAN, STDEV, STDEVP, VAR, VARP, LARGE, SMALL, RANK, PERCENTILE, QUARTILE, MIN, MAX, IF, IFS, IFERROR, SWITCH, CHOOSE, AND, OR, NOT, ISNUMBER, ISTEXT, ISBLANK, ISERR, ISERROR, CONCATENATE, LEFT, RIGHT, MID, LEN, UPPER, LOWER, TRIM, FIND, SUBSTITUTE, TEXT, VALUE, TODAY, NOW, DATE, YEAR, MONTH, DAY, EOMONTH, EDATE, DATEDIF, NETWORKDAYS, WORKDAY, YEARFRAC, ABS, ROUND, ROUNDUP, ROUNDDOWN, INT, MOD, POWER, SQRT, LOG, LN, EXP, FLOOR, CEILING, TRUNC, SIGN, PMT, FV, PV, RATE, NPER, NPV, IRR, XNPV, XIRR, VLOOKUP, HLOOKUP, XLOOKUP, INDEX, MATCH, OFFSET, PI, ROW, COLUMN, ROWS, COLUMNS, ADDRESS, TRANSPOSE, SEQUENCE, SORT, UNIQUE, FILTER
+
+## IO
+
+### Sync facade (`Excel`) — for scripts
+
+| Method | Notes |
+|--------|-------|
+| `Excel.read(path: String): Workbook` | throws `XLException`/IO errors at this edge |
+| `Excel.write(wb, path: String): Unit` | also accepts `XLResult[Workbook]` |
+| `Excel.modify(path)(f: Workbook => Workbook): Unit` | atomic in-place replacement |
+
+### Streaming (`ExcelIO`) — 100k+ rows, O(1) memory
+
+```scala
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import java.nio.file.Paths
+
+val excel = ExcelIO.instance[IO]
+excel.readStream(path)                        // Stream[IO, RowData] — first sheet
+excel.readSheetStream(path, "Sales")          // by name
+excel.writeStream(path, "Sheet1")             // fs2.Pipe[IO, RowData, Unit]
+excel.writeStreamsSeq(path, Seq("S1" -> rows1, "S2" -> rows2))  // multi-sheet, sequential
+
+case class RowData(rowIndex: Int /* 1-based */, cells: Map[Int /* 0-based col */, CellValue])
+```
+
+Run effects at the script edge with `.unsafeRunSync()`.
+
+## Display
+
+```scala
+given Sheet = sheet
+println(excel"A1 = ${ref"A1"}")     // formats through NumFmt ($1,234.56, 45.5%, ...)
+sheet.displayCell(ref"A1")          // String
+```
+
+## Errors
+
+```scala
+XLResult[A]                  // = Either[XLError, A]
+err.message                  // human-readable
+result.unsafe                // throws XLException(err) — the one sanctioned unwrap (prelude)
+result.getOrElse(fallback)
+```

--- a/plugin/skills/xl-scripting/reference/RECIPES.md
+++ b/plugin/skills/xl-scripting/reference/RECIPES.md
@@ -1,0 +1,225 @@
+# XL Scripting Recipes
+
+Seven complete, runnable scripts. Save as `recipe.sc`, adjust paths, run `scala-cli run recipe.sc`.
+
+Convention: every fenced block starting with `//> using` is a complete script and is compile-verified in CI; the headers are byte-identical so a release bump is a mechanical substitution.
+
+## 1. Bulk transform across many files
+
+Apply a 5% price increase to column C of every workbook in a directory, in place (atomic).
+
+```scala
+//> using scala 3.8.3
+//> using dep com.tjclp::xl:0.11.0
+import com.tjclp.xl.scripting.{*, given}
+import java.nio.file.{Files, Paths}
+import scala.jdk.CollectionConverters.*
+
+val dir = Paths.get("invoices")
+val files = Files.list(dir).iterator.asScala.filter(_.toString.endsWith(".xlsx")).toList
+
+files.foreach { path =>
+  Excel.modify(path.toString) { wb =>
+    wb.sheets.foldLeft(wb) { (acc, sheet) =>
+      val bumped = sheet.cells.keys
+        .filter(r => r.col.index0 == 2 && r.row.index0 > 0) // column C, skip header
+        .foldLeft(Patch.empty) { (p, r) =>
+          sheet.readTypedOpt[BigDecimal](r) match
+            case Some(price) => p ++ (r := price * BigDecimal("1.05"))
+            case None => p
+        }
+      acc.put(sheet.put(bumped))
+    }
+  }
+  println(s"✓ ${path.getFileName}")
+}
+println(s"updated ${files.size} files")
+```
+
+## 2. Typed extraction + validation report
+
+Read rows into case classes; collect per-cell validation failures into a new Issues sheet.
+
+```scala
+//> using scala 3.8.3
+//> using dep com.tjclp::xl:0.11.0
+import com.tjclp.xl.scripting.{*, given}
+
+final case class Order(id: Int, customer: String, amount: BigDecimal)
+
+val wb = Excel.read("orders.xlsx")
+val sheet = wb("Orders").unsafe
+
+val rows = sheet.usedRange.map(_.end.row.index0).getOrElse(0)
+val (orders, issues) = (1 to rows).foldLeft((List.empty[Order], List.empty[String])) {
+  case ((ok, bad), i) =>
+    val r = ref"A1".down(i)
+    (
+      sheet.readTypedOpt[Int](r),
+      sheet.readTypedOpt[String](r.right(1)),
+      sheet.readTypedOpt[BigDecimal](r.right(2))
+    ) match
+      case (Some(id), Some(c), Some(a)) if a > 0 => (Order(id, c, a) :: ok, bad)
+      case _ => (ok, s"row ${i + 1}: missing or invalid fields" :: bad)
+}
+
+val issueSheet = issues.reverse.zipWithIndex.foldLeft(Sheet("Issues").put(ref"A1", "Issue")) {
+  case (s, (msg, i)) => s.put(ref"A2".down(i), msg)
+}
+Excel.write(wb.put(issueSheet), "orders-validated.xlsx")
+println(s"${orders.size} valid orders, ${issues.size} issues")
+```
+
+## 3. Financial model: build, recalculate, verify
+
+Three-year projection with growth formulas; fail the script if any formula errors.
+
+```scala
+//> using scala 3.8.3
+//> using dep com.tjclp::xl:0.11.0
+import com.tjclp.xl.scripting.{*, given}
+
+val header = CellStyle.default.bold.size(12.0).center
+val currency = CellStyle.default.currency
+
+val model = Sheet("Projection").put(
+  (ref"A1" := "3-Year Revenue Projection") ++ ref"A1:D1".merge ++ ref"A1".styled(header) ++
+    (ref"A3" := "") ++ (ref"B3" := "Y1") ++ (ref"C3" := "Y2") ++ (ref"D3" := "Y3") ++
+    ref"A3:D3".styled(CellStyle.default.bold) ++
+    (ref"A4" := "Revenue") ++ (ref"B4" := 1000000) ++
+    (ref"C4" := fx"=B4*1.15") ++ (ref"D4" := fx"=C4*1.15") ++
+    (ref"A5" := "Costs") ++ (ref"B5" := fx"=B4*0.6") ++
+    (ref"C5" := fx"=C4*0.6") ++ (ref"D5" := fx"=D4*0.6") ++
+    (ref"A6" := "Profit") ++ (ref"B6" := fx"=B4-B5") ++
+    (ref"C6" := fx"=C4-C5") ++ (ref"D6" := fx"=D4-D5") ++
+    ref"B4:D6".styled(currency)
+)
+
+Workbook(model).recalculate().toEither match
+  case Right(wb) =>
+    Excel.write(wb, "projection.xlsx")
+    given Sheet = wb.sheets.headOption.getOrElse(sys.exit(1))
+    println(excel"Y3 profit: ${ref"D6"}")
+  case Left(errors) =>
+    errors.foreach(e => println(s"✗ ${e.render}"))
+    sys.exit(1)
+```
+
+## 4. Append many workbooks into one sheet
+
+Stack the data rows of every input file under one header.
+
+```scala
+//> using scala 3.8.3
+//> using dep com.tjclp::xl:0.11.0
+import com.tjclp.xl.scripting.{*, given}
+import java.nio.file.{Files, Paths}
+import scala.jdk.CollectionConverters.*
+
+val files = Files.list(Paths.get("monthly")).iterator.asScala
+  .filter(_.toString.endsWith(".xlsx")).toList.sortBy(_.toString)
+
+val (combined, _) = files.foldLeft((Sheet("Combined").put(ref"A1", "Source"), 1)) {
+  case ((acc, nextRow), path) =>
+    val src = Excel.read(path.toString).sheets.headOption.getOrElse(sys.exit(1))
+    val dataRefs = src.cells.keys.filter(_.row.index0 > 0).toList // skip per-file header
+    val byRow = dataRefs.groupBy(_.row.index0).toList.sortBy(_._1)
+    byRow.zipWithIndex.foldLeft((acc, nextRow)) { case ((s, row), ((_, refs), i)) =>
+      val tagged = refs.foldLeft(
+        s.put(ref"A1".down(row + i), path.getFileName.toString)
+      ) { (s2, srcRef) =>
+        srcRef.col.index0 match
+          case c =>
+            src.cells.get(srcRef).map(_.value) match
+              case Some(v) => s2.put(ref"A1".down(row + i).right(c + 1), v)
+              case None => s2
+      }
+      (tagged, row)
+    } match
+      case (s, row) => (s, row + byRow.size)
+}
+
+Excel.write(Workbook(combined), "combined.xlsx")
+println(s"combined ${files.size} files, ${combined.cells.size} cells")
+```
+
+## 5. Streaming filter: 500k rows in, matching rows out (O(1) memory)
+
+```scala
+//> using scala 3.8.3
+//> using dep com.tjclp::xl:0.11.0
+import com.tjclp.xl.scripting.{*, given}
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import java.nio.file.Paths
+
+val excel = ExcelIO.instance[IO]
+val isLarge: RowData => Boolean = row =>
+  row.cells.get(3).exists {
+    case CellValue.Number(n) => n > 10000
+    case _ => false
+  }
+
+excel
+  .readStream(Paths.get("transactions.xlsx"))
+  .filter(row => row.rowIndex == 1 || isLarge(row)) // keep header + matches
+  .zipWithIndex
+  .map { case (row, i) => row.copy(rowIndex = i.toInt + 1) } // reindex contiguously
+  .through(excel.writeStream(Paths.get("large-transactions.xlsx"), "Filtered"))
+  .compile
+  .drain
+  .unsafeRunSync()
+println("✓ filtered (constant memory)")
+```
+
+## 6. Cell-level workbook diff
+
+```scala
+//> using scala 3.8.3
+//> using dep com.tjclp::xl:0.11.0
+import com.tjclp.xl.scripting.{*, given}
+
+val before = Excel.read("before.xlsx")
+val after = Excel.read("after.xlsx")
+
+val sheetNames = (before.sheets.map(_.name) ++ after.sheets.map(_.name)).distinct
+val diffs = sheetNames.flatMap { name =>
+  val b = before.sheets.find(_.name == name).map(_.cells).getOrElse(Map.empty)
+  val a = after.sheets.find(_.name == name).map(_.cells).getOrElse(Map.empty)
+  (b.keySet ++ a.keySet).toList.sortBy(r => (r.row.index0, r.col.index0)).flatMap { ref =>
+    val left = b.get(ref).map(_.value)
+    val right = a.get(ref).map(_.value)
+    if left == right then None
+    else Some(s"${name.value}!${ref.toA1}: ${left.getOrElse("∅")} → ${right.getOrElse("∅")}")
+  }
+}
+
+if diffs.isEmpty then println("identical")
+else
+  diffs.foreach(println)
+  println(s"${diffs.size} difference(s)")
+```
+
+## 7. CSV ingest → styled workbook (smart format detection)
+
+```scala
+//> using scala 3.8.3
+//> using dep com.tjclp::xl:0.11.0
+import com.tjclp.xl.scripting.{*, given}
+import java.nio.file.{Files, Paths}
+import scala.jdk.CollectionConverters.*
+
+val lines = Files.readAllLines(Paths.get("data.csv")).asScala.toList
+val headerStyle = CellStyle.default.bold.bgGray
+
+val sheet = lines.zipWithIndex.foldLeft(Sheet("Imported")) { case (s, (line, rowIdx)) =>
+  line.split(',').toList.zipWithIndex.foldLeft(s) { case (s2, (raw, colIdx)) =>
+    val target = ref"A1".down(rowIdx).right(colIdx)
+    if rowIdx == 0 then s2.put(target, raw.trim, headerStyle)
+    else s2.put(target, raw.trim.toFormatted) // "$1,234.56" → Currency, "45.5%" → Percent, ...
+  }
+}
+
+Excel.write(Workbook(sheet), "imported.xlsx")
+println(s"imported ${lines.size} rows × ${lines.headOption.map(_.split(',').length).getOrElse(0)} cols")
+```

--- a/scripts/test-examples.sh
+++ b/scripts/test-examples.sh
@@ -58,9 +58,15 @@ for sc in examples/*.sc; do
 done
 
 # ---------- 4. Run the curated fast subset ----------
+# Per-example timeout: a hung example must fail loudly, never block CI. (`timeout` is coreutils;
+# present on ubuntu runners and via brew coreutils locally — fall back to no timeout if absent.)
+RUN_TIMEOUT=()
+if command -v timeout > /dev/null 2>&1; then
+  RUN_TIMEOUT=(timeout 300)
+fi
 if ! $COMPILE_ONLY; then
   for name in "${RUN_SET[@]}"; do
-    if scala-cli run "examples/$name" > /dev/null 2>&1; then
+    if "${RUN_TIMEOUT[@]}" scala-cli run "examples/$name" > /dev/null 2>&1; then
       echo "✓ run     $name"
     else
       echo "✗ run     $name" >&2

--- a/scripts/test-examples.sh
+++ b/scripts/test-examples.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Compile-verify every example script against the LOCAL build, and run a curated fast subset.
+# This is the anti-rot guarantee for examples/*.sc and for the xl-scripting skill snippets
+# derived from them (plugin/skills/xl-scripting/).
+#
+# Usage: scripts/test-examples.sh [--compile-only]
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+COMPILE_ONLY=false
+[[ "${1:-}" == "--compile-only" ]] && COMPILE_ONLY=true
+
+# ---------- 1. Version drift guard ----------
+# examples/project.scala must pin the same version build.mill falls back to, so publishLocal
+# artifacts resolve. Both bump together at release-prep time.
+PROJECT_VERSION=$(grep -oE 'com\.tjclp::xl:[0-9A-Za-z.+-]+' examples/project.scala | cut -d: -f4)
+BUILD_VERSION=$(grep -oE '"PUBLISH_VERSION", "[^"]+"' build.mill | sed -E 's/.*"PUBLISH_VERSION", "([^"]+)".*/\1/')
+
+if [[ -z "$PROJECT_VERSION" || -z "$BUILD_VERSION" ]]; then
+  echo "✗ Could not extract versions (project.scala: '$PROJECT_VERSION', build.mill: '$BUILD_VERSION')" >&2
+  exit 1
+fi
+if [[ "$PROJECT_VERSION" != "$BUILD_VERSION" ]]; then
+  echo "✗ Version drift: examples/project.scala pins $PROJECT_VERSION but build.mill falls back to $BUILD_VERSION" >&2
+  echo "  Bump both together (see .claude/commands/release-prep.md)" >&2
+  exit 1
+fi
+echo "✓ Version drift guard: $PROJECT_VERSION"
+
+# ---------- 2. Publish the local build ----------
+echo "→ Publishing local build ($BUILD_VERSION) to ivy2Local..."
+./mill __.publishLocal > /dev/null
+
+# Resolve ivy2Local first so the just-published artifacts win over Maven Central.
+export COURSIER_REPOSITORIES="ivy2Local|central"
+
+# ---------- 3. Compile every example ----------
+# Perf/large-data scripts are compile-verified but never run.
+RUN_SET=(
+  quick_start.sc
+  demo.sc
+  easy_mode_demo.sc
+  scripting_tour.sc
+  financial_model.sc
+  data_validation.sc
+)
+
+FAILED=()
+for sc in examples/*.sc; do
+  name=$(basename "$sc")
+  if scala-cli compile "$sc" > /dev/null 2>&1; then
+    echo "✓ compile $name"
+  else
+    echo "✗ compile $name" >&2
+    FAILED+=("compile:$name")
+  fi
+done
+
+# ---------- 4. Run the curated fast subset ----------
+if ! $COMPILE_ONLY; then
+  for name in "${RUN_SET[@]}"; do
+    if scala-cli run "examples/$name" > /dev/null 2>&1; then
+      echo "✓ run     $name"
+    else
+      echo "✗ run     $name" >&2
+      FAILED+=("run:$name")
+    fi
+  done
+fi
+
+# ---------- 5. Report ----------
+if (( ${#FAILED[@]} > 0 )); then
+  echo "" >&2
+  echo "✗ ${#FAILED[@]} example check(s) failed:" >&2
+  printf '  %s\n' "${FAILED[@]}" >&2
+  exit 1
+fi
+echo ""
+echo "✓ All example checks passed"

--- a/scripts/verify-skill-snippets.sh
+++ b/scripts/verify-skill-snippets.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Extract every fenced ```scala block that begins with `//> using` from the xl-scripting skill
+# and compile it with scala-cli. Blocks without the directive header are fragments and skipped.
+#
+# Usage:
+#   scripts/verify-skill-snippets.sh           # compile against the pinned Maven version
+#   scripts/verify-skill-snippets.sh --local   # publishLocal first, substitute the local version
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+LOCAL=false
+[[ "${1:-}" == "--local" ]] && LOCAL=true
+
+SKILL_DIR="plugin/skills/xl-scripting"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+for md in "$SKILL_DIR/SKILL.md" "$SKILL_DIR/reference/RECIPES.md" "$SKILL_DIR/reference/API.md"; do
+  [[ -f "$md" ]] || continue
+  awk -v outdir="$TMP" -v src="$(basename "$md" .md)" '
+    BEGIN { inblock = 0; n = 0 }
+    /^```scala$/ { inblock = 1; buf = ""; next }
+    /^```$/ {
+      if (inblock) {
+        inblock = 0
+        if (buf ~ /^\/\/> using/) {
+          n++
+          file = outdir "/" src "-" n ".sc"
+          printf "%s", buf > file
+          close(file)
+        }
+      }
+      next
+    }
+    { if (inblock) buf = buf $0 "\n" }
+  ' "$md"
+done
+
+COUNT=$(ls "$TMP"/*.sc 2>/dev/null | wc -l | tr -d ' ')
+if [[ "$COUNT" == "0" ]]; then
+  echo "✗ No compilable snippets found — extraction is broken" >&2
+  exit 1
+fi
+echo "→ Extracted $COUNT complete-script snippet(s)"
+
+if $LOCAL; then
+  BUILD_VERSION=$(grep -oE '"PUBLISH_VERSION", "[^"]+"' build.mill | sed -E 's/.*"PUBLISH_VERSION", "([^"]+)".*/\1/')
+  echo "→ Publishing local build ($BUILD_VERSION) and substituting the pin for verification..."
+  ./mill __.publishLocal > /dev/null
+  export COURSIER_REPOSITORIES="ivy2Local|central"
+  sed -i.bak -E "s|(//> using dep com.tjclp::xl:)[0-9A-Za-z.+-]+|\\1$BUILD_VERSION|" "$TMP"/*.sc
+  rm -f "$TMP"/*.bak
+fi
+
+FAILED=()
+for sc in "$TMP"/*.sc; do
+  name=$(basename "$sc")
+  if scala-cli compile "$sc" > "$TMP/$name.log" 2>&1; then
+    echo "✓ $name"
+  else
+    echo "✗ $name" >&2
+    sed 's/^/    /' "$TMP/$name.log" | grep -iE "error" -A4 | head -20 >&2
+    FAILED+=("$name")
+  fi
+done
+
+if (( ${#FAILED[@]} > 0 )); then
+  echo "" >&2
+  echo "✗ ${#FAILED[@]} skill snippet(s) failed to compile" >&2
+  exit 1
+fi
+echo "✓ All skill snippets compile"

--- a/xl-cli/src/com/tjclp/xl/cli/helpers/BatchParser.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/helpers/BatchParser.scala
@@ -624,46 +624,17 @@ object BatchParser:
    *   - Text: everything else
    */
   private def detectAndParse(s: String): ParsedValue =
-    val trimmed = s.trim
-
-    // Currency: starts with $ or parenthesized with $
-    if trimmed.startsWith("$") || (trimmed.startsWith("(") && trimmed.contains("$")) then
-      FormattedParsers
-        .parseMoney(trimmed)
-        .orElse(FormattedParsers.parseAccounting(trimmed))
-        .map(f => ParsedValue(f.value, Some(f.numFmt)))
-        .getOrElse(ParsedValue(CellValue.Text(s), None))
-
-    // Percent: ends with %
-    else if trimmed.endsWith("%") then
-      FormattedParsers
-        .parsePercent(trimmed)
-        .map(f => ParsedValue(f.value, Some(f.numFmt)))
-        .getOrElse(ParsedValue(CellValue.Text(s), None))
-
-    // ISO Date: YYYY-MM-DD pattern
-    else if trimmed.matches("""\d{4}-\d{2}-\d{2}""") then
-      FormattedParsers
-        .parseDate(trimmed)
-        .map(f => ParsedValue(f.value, Some(f.numFmt)))
-        .getOrElse(ParsedValue(CellValue.Text(s), None))
-
-    // Try number
-    else
-      scala.util.Try(BigDecimal(trimmed)).toOption match
-        case Some(n) => ParsedValue(CellValue.Number(n), None)
-        case None =>
-          // Boolean detection
-          trimmed.toLowerCase match
-            case "true" => ParsedValue(CellValue.Bool(true), None)
-            case "false" => ParsedValue(CellValue.Bool(false), None)
-            case _ =>
-              // Strip quotes if present
-              val text =
-                if trimmed.startsWith("\"") && trimmed.endsWith("\"") then
-                  trimmed.drop(1).dropRight(1)
-                else s
-              ParsedValue(CellValue.Text(text), None)
+    // Delegates to the core's total detection (one source of truth); the CLI adds JSON-specific
+    // quote-stripping for text results and maps NumFmt.General to "no explicit format".
+    FormattedParsers.detect(s) match
+      case Formatted(CellValue.Text(_), _) =>
+        val trimmed = s.trim
+        val text =
+          if trimmed.startsWith("\"") && trimmed.endsWith("\"") then trimmed.drop(1).dropRight(1)
+          else s
+        ParsedValue(CellValue.Text(text), None)
+      case Formatted(value, NumFmt.General) => ParsedValue(value, None)
+      case Formatted(value, numFmt) => ParsedValue(value, Some(numFmt))
 
   /**
    * Parse a single JSON value element (from a "values" array).

--- a/xl-core/src/com/tjclp/xl/addressing/ARef.scala
+++ b/xl-core/src/com/tjclp/xl/addressing/ARef.scala
@@ -46,19 +46,25 @@ object ARef:
 
   extension (ref: ARef)
     /** Extract column */
-    inline def col: Column = Column.from0((ref & 0xffffffffL).toInt)
+    def col: Column = Column.from0((ref & 0xffffffffL).toInt)
 
     /** Extract row */
-    inline def row: Row = Row.from0((ref >> 32).toInt)
+    def row: Row = Row.from0((ref >> 32).toInt)
 
     /** Convert to A1 notation */
-    inline def toA1: String =
+    def toA1: String =
+      // Deliberately NOT inline: the body calls the non-inline extension Column.toLetter, and
+      // inline expansion re-elaborates that call at external call sites where Column is opaque,
+      // failing with "expression does not take parameters". A regular def elaborates here, where
+      // the representation is visible; the call cost is noise next to the string allocation.
       import Column.toLetter
       import Row.index1
       s"${toLetter(ref.col)}${index1(ref.row)}"
 
     /** Shift reference by column and row offsets */
-    inline def shift(colOffset: Int, rowOffset: Int): ARef =
+    def shift(colOffset: Int, rowOffset: Int): ARef =
+      // Non-inline for the same reason as toA1: the nested inline expansion of ARef.apply fails
+      // to re-elaborate at call sites outside this package.
       ARef(ref.col + colOffset, ref.row + rowOffset)
 
 end ARef

--- a/xl-core/src/com/tjclp/xl/addressing/ARef.scala
+++ b/xl-core/src/com/tjclp/xl/addressing/ARef.scala
@@ -15,15 +15,15 @@ object ARef:
   import Row.index0 as rowIndex
 
   /** Create cell reference from column and row */
-  inline def apply(col: Column, row: Row): ARef =
+  def apply(col: Column, row: Row): ARef =
     (rowIndex(row).toLong << 32) | (colIndex(col).toLong & 0xffffffffL)
 
   /** Create cell reference from 0-based indices */
-  inline def from0(colIndex: Int, rowIndex: Int): ARef =
+  def from0(colIndex: Int, rowIndex: Int): ARef =
     apply(Column.from0(colIndex), Row.from0(rowIndex))
 
   /** Create cell reference from 1-based indices */
-  inline def from1(colIndex: Int, rowIndex: Int): ARef =
+  def from1(colIndex: Int, rowIndex: Int): ARef =
     apply(Column.from1(colIndex), Row.from1(rowIndex))
 
   /** Parse cell reference from A1 notation */

--- a/xl-core/src/com/tjclp/xl/addressing/ARef.scala
+++ b/xl-core/src/com/tjclp/xl/addressing/ARef.scala
@@ -53,18 +53,16 @@ object ARef:
 
     /** Convert to A1 notation */
     def toA1: String =
-      // Deliberately NOT inline: the body calls the non-inline extension Column.toLetter, and
-      // inline expansion re-elaborates that call at external call sites where Column is opaque,
-      // failing with "expression does not take parameters". A regular def elaborates here, where
-      // the representation is visible; the call cost is noise next to the string allocation.
+      // NOTE: every member here (and in Column/Row/SheetName/style units) that touches the
+      // opaque representation must stay NON-inline: inline bodies fail to re-elaborate at call
+      // sites outside this package, where the representation is hidden (issue #252). Do not
+      // "optimize" these back to `inline` — the JIT/AOT inlines trivial static methods anyway.
       import Column.toLetter
       import Row.index1
       s"${toLetter(ref.col)}${index1(ref.row)}"
 
     /** Shift reference by column and row offsets */
     def shift(colOffset: Int, rowOffset: Int): ARef =
-      // Non-inline for the same reason as toA1: the nested inline expansion of ARef.apply fails
-      // to re-elaborate at call sites outside this package.
       ARef(ref.col + colOffset, ref.row + rowOffset)
 
 end ARef

--- a/xl-core/src/com/tjclp/xl/addressing/Column.scala
+++ b/xl-core/src/com/tjclp/xl/addressing/Column.scala
@@ -30,10 +30,10 @@ object Column:
 
   extension (col: Column)
     /** Get 0-based index (0 = A, 1 = B, ...) */
-    inline def index0: Int = col
+    def index0: Int = col
 
     /** Get 1-based index (1 = A, 2 = B, ...) */
-    inline def index1: Int = col + 1
+    def index1: Int = col + 1
 
     /** Convert to Excel letter notation (A, B, AA, etc.) */
     def toLetter: String =
@@ -43,9 +43,9 @@ object Column:
       loop(col, "")
 
     /** Shift column by offset */
-    inline def +(offset: Int): Column = col + offset
+    def +(offset: Int): Column = col + offset
 
     /** Shift column by negative offset */
-    inline def -(offset: Int): Column = col - offset
+    def -(offset: Int): Column = col - offset
 
 end Column

--- a/xl-core/src/com/tjclp/xl/addressing/Column.scala
+++ b/xl-core/src/com/tjclp/xl/addressing/Column.scala
@@ -12,10 +12,10 @@ object Column:
   val MaxIndex0: Int = 16383
 
   /** Create a Column from 0-based index (0 = A, 1 = B, ...) */
-  inline def from0(index: Int): Column = index
+  def from0(index: Int): Column = index
 
   /** Create a Column from 1-based index (1 = A, 2 = B, ...) */
-  inline def from1(index: Int): Column = index - 1
+  def from1(index: Int): Column = index - 1
 
   /** Create a Column from Excel letter notation (A, B, AA, etc.) */
   def fromLetter(input: String): Either[String, Column] =

--- a/xl-core/src/com/tjclp/xl/addressing/Row.scala
+++ b/xl-core/src/com/tjclp/xl/addressing/Row.scala
@@ -10,10 +10,10 @@ object Row:
   val MaxIndex0: Int = 1048575
 
   /** Create a Row from 0-based index (0 = row 1, 1 = row 2, ...) */
-  inline def from0(index: Int): Row = index
+  def from0(index: Int): Row = index
 
   /** Create a Row from 1-based index (1 = row 1, 2 = row 2, ...) */
-  inline def from1(index: Int): Row = index - 1
+  def from1(index: Int): Row = index - 1
 
   extension (row: Row)
     /** Get 0-based index */

--- a/xl-core/src/com/tjclp/xl/addressing/Row.scala
+++ b/xl-core/src/com/tjclp/xl/addressing/Row.scala
@@ -17,15 +17,15 @@ object Row:
 
   extension (row: Row)
     /** Get 0-based index */
-    inline def index0: Int = row
+    def index0: Int = row
 
     /** Get 1-based index */
-    inline def index1: Int = row + 1
+    def index1: Int = row + 1
 
     /** Shift row by offset */
-    inline def +(offset: Int): Row = row + offset
+    def +(offset: Int): Row = row + offset
 
     /** Shift row by negative offset */
-    inline def -(offset: Int): Row = row - offset
+    def -(offset: Int): Row = row - offset
 
 end Row

--- a/xl-core/src/com/tjclp/xl/addressing/SheetName.scala
+++ b/xl-core/src/com/tjclp/xl/addressing/SheetName.scala
@@ -22,6 +22,6 @@ object SheetName:
   /** Create an unsafe sheet name (use only when validation is guaranteed) */
   inline def unsafe(name: String): SheetName = name
 
-  extension (name: SheetName) inline def value: String = name
+  extension (name: SheetName) def value: String = name
 
 end SheetName

--- a/xl-core/src/com/tjclp/xl/addressing/SheetName.scala
+++ b/xl-core/src/com/tjclp/xl/addressing/SheetName.scala
@@ -20,7 +20,7 @@ object SheetName:
     else Right(name)
 
   /** Create an unsafe sheet name (use only when validation is guaranteed) */
-  inline def unsafe(name: String): SheetName = name
+  def unsafe(name: String): SheetName = name
 
   extension (name: SheetName) def value: String = name
 

--- a/xl-core/src/com/tjclp/xl/api.scala
+++ b/xl-core/src/com/tjclp/xl/api.scala
@@ -24,14 +24,23 @@ object api:
   // Cell types
   export cells.{Cell, CellValue, CellError, Comment}
 
-  // Addressing types
-  export addressing.{Column, Row, SheetName, ARef, CellRange, RefType, Anchor}
+  // Addressing types — non-opaque types use export forwarders as usual
+  export addressing.{CellRange, RefType, Anchor}
 
-  // ARef extension methods (toA1, col, row, shift) resolve through ARef's companion implicit
-  // scope — no export needed. Export forwarders for inline extensions on opaque types generate
-  // path-dependent proxy types ($proxy.ARef) that fail to unify at use sites outside this
-  // package, and the broken forwarder shadows the companion-scope lookup that would otherwise
-  // succeed. (Removed in 0.11.0; was: export addressing.ARef.{toA1, shift})
+  // Opaque addressing types use explicit alias + singleton-typed companion val pairs instead of
+  // exports (0.11.0). Export-generated term forwarders give factory results path-dependent types
+  // that defeat extension lookup at external call sites (`Column.from0(0).toLetter` fails), and
+  // export forwarders for the extension methods themselves produce proxy types ($proxy.ARef)
+  // that never unify. With explicit singleton vals, factory results are properly anchored and
+  // the extensions resolve through each opaque type's companion implicit scope.
+  type ARef = addressing.ARef
+  val ARef: addressing.ARef.type = addressing.ARef
+  type Column = addressing.Column
+  val Column: addressing.Column.type = addressing.Column
+  type Row = addressing.Row
+  val Row: addressing.Row.type = addressing.Row
+  type SheetName = addressing.SheetName
+  val SheetName: addressing.SheetName.type = addressing.SheetName
 
   // Rich text types
   export richtext.{TextRun, RichText}
@@ -81,8 +90,15 @@ object api:
   // Style types - patch
   export styles.patch.StylePatch
 
-  // Style types - units
-  export styles.units.{Pt, Px, Emu, StyleId}
+  // Style types - units: opaque, same explicit alias + singleton val treatment as addressing
+  type Pt = styles.units.Pt
+  val Pt: styles.units.Pt.type = styles.units.Pt
+  type Px = styles.units.Px
+  val Px: styles.units.Px.type = styles.units.Px
+  type Emu = styles.units.Emu
+  val Emu: styles.units.Emu.type = styles.units.Emu
+  type StyleId = styles.units.StyleId
+  val StyleId: styles.units.StyleId.type = styles.units.StyleId
 
   // Column.toLetter resolves through Column's companion implicit scope (see ARef note above)
 

--- a/xl-core/src/com/tjclp/xl/api.scala
+++ b/xl-core/src/com/tjclp/xl/api.scala
@@ -60,8 +60,8 @@ object api:
   // Optics types
   export optics.{Lens, Optional, Optics}
 
-  // Formatted type
-  export formatted.Formatted
+  // Formatted type + runtime parsers (incl. total smart detection: FormattedParsers.detect)
+  export formatted.{Formatted, FormattedParsers}
 
   // Codec types
   export codec.{CellCodec, CellReader, CellWriter, CodecError}

--- a/xl-core/src/com/tjclp/xl/api.scala
+++ b/xl-core/src/com/tjclp/xl/api.scala
@@ -27,9 +27,11 @@ object api:
   // Addressing types
   export addressing.{Column, Row, SheetName, ARef, CellRange, RefType, Anchor}
 
-  // ARef extension methods (toA1, row, shift)
-  // Note: col/row extension methods work via extension syntax (aref.col), not direct import
-  export addressing.ARef.{toA1, shift}
+  // ARef extension methods (toA1, col, row, shift) resolve through ARef's companion implicit
+  // scope — no export needed. Export forwarders for inline extensions on opaque types generate
+  // path-dependent proxy types ($proxy.ARef) that fail to unify at use sites outside this
+  // package, and the broken forwarder shadows the companion-scope lookup that would otherwise
+  // succeed. (Removed in 0.11.0; was: export addressing.ARef.{toA1, shift})
 
   // Rich text types
   export richtext.{TextRun, RichText}
@@ -82,8 +84,7 @@ object api:
   // Style types - units
   export styles.units.{Pt, Px, Emu, StyleId}
 
-  // Surface Column helpers at the root package for single-import ergonomics
-  export addressing.Column.toLetter
+  // Column.toLetter resolves through Column's companion implicit scope (see ARef note above)
 
   // Export renderers and render syntax
   export render.{HtmlRenderer, SvgRenderer}

--- a/xl-core/src/com/tjclp/xl/codec/syntax.scala
+++ b/xl-core/src/com/tjclp/xl/codec/syntax.scala
@@ -33,4 +33,21 @@ object syntax:
         case None => Right(None) // Cell doesn't exist
         case Some(c) => CellCodec[A].read(c)
 
+    /**
+     * Read a typed value, falling back to a default on missing cell, empty cell, or type mismatch.
+     * Total — the scripting counterpart of `readTyped`.
+     *
+     * Naming convention: verb + totality-strategy suffix (`readTyped` / `readTypedOr` /
+     * `readTypedOpt`).
+     */
+    def readTypedOr[A: CellCodec](ref: ARef, default: => A): A =
+      readTyped[A](ref).toOption.flatten.getOrElse(default)
+
+    /**
+     * Read a typed value as a flat Option: None on missing cell, empty cell, or type mismatch.
+     * Total. Use `readTyped` when decode errors must be distinguished from absence.
+     */
+    def readTypedOpt[A: CellCodec](ref: ARef): Option[A] =
+      readTyped[A](ref).toOption.flatten
+
 export syntax.*

--- a/xl-core/src/com/tjclp/xl/dsl/syntax.scala
+++ b/xl-core/src/com/tjclp/xl/dsl/syntax.scala
@@ -71,7 +71,11 @@ object syntax:
 
     /**
      * Navigate down by n rows (default 1). Total; like `shift`, staying in bounds is the caller's
-     * responsibility (Excel rows end at 1048576).
+     * responsibility (Excel rows end at 1048576, columns at XFD).
+     *
+     * Out-of-bounds navigation produces an invalid reference that is NOT flagged here — e.g.
+     * `ref"A1".up()` renders as the non-existent "A0" and would corrupt output if written. Guard
+     * loop bounds against your data extent (bounds-checked variants are on the roadmap).
      */
     def down(n: Int = 1): ARef = ref.shift(0, n)
 
@@ -98,6 +102,10 @@ object syntax:
      *
      * Desugars to a Batch of Puts — no new Patch case, so monoid laws and exhaustive matches are
      * unaffected. A 1x1 range is equivalent to a single-cell `:=`.
+     *
+     * Cost is proportional to `range.size`: one Put (and ultimately one cell) per address, by
+     * design — that is what a fill means. Filling a full column (`A:A` = 1,048,576 cells)
+     * materializes a million-cell sheet; prefer a bounded range sized to your data.
      */
     @annotation.targetName("rangeAssignCellValue")
     def :=(cv: CellValue): Patch =

--- a/xl-core/src/com/tjclp/xl/dsl/syntax.scala
+++ b/xl-core/src/com/tjclp/xl/dsl/syntax.scala
@@ -69,6 +69,21 @@ object syntax:
     /** Create a ClearStyle patch to remove styling from a cell */
     def clearStyle: Patch = Patch.ClearStyle(ref)
 
+    /**
+     * Navigate down by n rows (default 1). Total; like `shift`, staying in bounds is the caller's
+     * responsibility (Excel rows end at 1048576).
+     */
+    def down(n: Int = 1): ARef = ref.shift(0, n)
+
+    /** Navigate up by n rows (default 1). Total; see `down` for the bounds contract. */
+    def up(n: Int = 1): ARef = ref.shift(0, -n)
+
+    /** Navigate right by n columns (default 1). Total; see `down` for the bounds contract. */
+    def right(n: Int = 1): ARef = ref.shift(n, 0)
+
+    /** Navigate left by n columns (default 1). Total; see `down` for the bounds contract. */
+    def left(n: Int = 1): ARef = ref.shift(-n, 0)
+
   // ========== CellRange Extensions ==========
 
   /**
@@ -78,6 +93,44 @@ object syntax:
    * before application.
    */
   extension (range: CellRange)
+    /**
+     * Fill every cell in the range with the same value (Excel Ctrl+Enter semantics).
+     *
+     * Desugars to a Batch of Puts — no new Patch case, so monoid laws and exhaustive matches are
+     * unaffected. A 1x1 range is equivalent to a single-cell `:=`.
+     */
+    @annotation.targetName("rangeAssignCellValue")
+    def :=(cv: CellValue): Patch =
+      Patch.Batch(range.cells.map(r => Patch.Put(r, cv): Patch).toVector)
+
+    /** Fill every cell in the range with a String (Excel Ctrl+Enter semantics). */
+    @annotation.targetName("rangeAssignString")
+    def :=(value: String): Patch = range := CellValue.Text(value)
+
+    /** Fill every cell in the range with an Int (Excel Ctrl+Enter semantics). */
+    @annotation.targetName("rangeAssignInt")
+    def :=(value: Int): Patch = range := CellValue.Number(BigDecimal(value))
+
+    /** Fill every cell in the range with a Long (Excel Ctrl+Enter semantics). */
+    @annotation.targetName("rangeAssignLong")
+    def :=(value: Long): Patch = range := CellValue.Number(BigDecimal(value))
+
+    /** Fill every cell in the range with a Double (Excel Ctrl+Enter semantics). */
+    @annotation.targetName("rangeAssignDouble")
+    def :=(value: Double): Patch = range := CellValue.Number(BigDecimal(value))
+
+    /** Fill every cell in the range with a BigDecimal (Excel Ctrl+Enter semantics). */
+    @annotation.targetName("rangeAssignBigDecimal")
+    def :=(value: BigDecimal): Patch = range := CellValue.Number(value)
+
+    /** Fill every cell in the range with a Boolean (Excel Ctrl+Enter semantics). */
+    @annotation.targetName("rangeAssignBoolean")
+    def :=(value: Boolean): Patch = range := CellValue.Bool(value)
+
+    /** Fill every cell in the range with a LocalDateTime (Excel Ctrl+Enter semantics). */
+    @annotation.targetName("rangeAssignLocalDateTime")
+    def :=(value: java.time.LocalDateTime): Patch = range := CellValue.DateTime(value)
+
     /** Create a Merge patch */
     def merge: Patch = Patch.Merge(range)
 
@@ -98,36 +151,21 @@ object syntax:
    * These extensions allow `ref"$var"` (which returns `Either[XLError, RefType]`) to work directly
    * with patch DSL operators without manual extraction of ARef/CellRange.
    *
-   * '''Important Limitation: Assignment operators (`:=`) only work on single cells'''
+   * `:=` is total across all RefType cases: cells produce a single Put; ranges fill every cell with
+   * the value (Excel Ctrl+Enter semantics, a Batch of Puts). Before 0.11.0, ranges silently
+   * returned `Patch.empty` — that was a bug, fixed by fill semantics.
    *
-   * When applied to ranges, assignment operators return `Patch.empty` (silent no-op) rather than
-   * throwing errors. This is intentional for composability in fold operations, but users should be
-   * aware of this behavior.
-   *
-   * '''Working examples (single cells):'''
    * {{{
    *   val row = "5"
-   *   for {
-   *     cellRef <- ref"A$row"      // RefType.Cell
-   *   } yield (cellRef := "Value")  // ✓ Works - creates Put patch
+   *   for cellRef <- ref"A$row"        // RefType.Cell
+   *   yield (cellRef := "Value")       // single Put
+   *
+   *   for rangeRef <- ref"A1:B$row"    // RefType.Range
+   *   yield (rangeRef := 0)            // fills A1:B5 with 0
    * }}}
    *
-   * '''Silent no-op examples (ranges):'''
-   * {{{
-   *   val rangeRef = ref"A1:B10"    // RefType.Range
-   *   rangeRef := "Value"            // ✗ Silent no-op - returns Patch.empty
-   *
-   *   // To style ranges, use .styled() or apply to individual cells:
-   *   rangeRef.styled(style)         // ✓ Works for ranges
-   * }}}
-   *
-   * '''Other operations work on both cells and ranges:'''
-   * {{{
-   *   cellRef.styled(style)          // ✓ Works
-   *   rangeRef.styled(style)         // ✓ Works (cells only, not ranges in current impl)
-   *   rangeRef.merge                 // ✓ Works
-   *   rangeRef.remove                // ✓ Works
-   * }}}
+   * `styled`, `merge`, and `remove` also work on both cells and ranges (merge of a single cell is
+   * meaningless and returns the empty patch).
    */
   extension (refType: RefType)
     /** Create Put patch from RefType (delegates to underlying ARef) */
@@ -135,56 +173,64 @@ object syntax:
     inline def :=(cv: CellValue): Patch = refType match
       case RefType.Cell(aref) => aref := cv
       case RefType.QualifiedCell(_, aref) => aref := cv
-      case _ => Patch.empty // Ranges can't be assigned single values
+      case RefType.Range(range) => range := cv
+      case RefType.QualifiedRange(_, range) => range := cv
 
     /** Create Put patch with automatic conversion from String */
     @annotation.targetName("refTypeAssignString")
     inline def :=(value: String): Patch = refType match
       case RefType.Cell(aref) => aref := value
       case RefType.QualifiedCell(_, aref) => aref := value
-      case _ => Patch.empty
+      case RefType.Range(range) => range := value
+      case RefType.QualifiedRange(_, range) => range := value
 
     /** Create Put patch with automatic conversion from Int */
     @annotation.targetName("refTypeAssignInt")
     inline def :=(value: Int): Patch = refType match
       case RefType.Cell(aref) => aref := value
       case RefType.QualifiedCell(_, aref) => aref := value
-      case _ => Patch.empty
+      case RefType.Range(range) => range := value
+      case RefType.QualifiedRange(_, range) => range := value
 
     /** Create Put patch with automatic conversion from Long */
     @annotation.targetName("refTypeAssignLong")
     inline def :=(value: Long): Patch = refType match
       case RefType.Cell(aref) => aref := value
       case RefType.QualifiedCell(_, aref) => aref := value
-      case _ => Patch.empty
+      case RefType.Range(range) => range := value
+      case RefType.QualifiedRange(_, range) => range := value
 
     /** Create Put patch with automatic conversion from Double */
     @annotation.targetName("refTypeAssignDouble")
     inline def :=(value: Double): Patch = refType match
       case RefType.Cell(aref) => aref := value
       case RefType.QualifiedCell(_, aref) => aref := value
-      case _ => Patch.empty
+      case RefType.Range(range) => range := value
+      case RefType.QualifiedRange(_, range) => range := value
 
     /** Create Put patch with automatic conversion from BigDecimal */
     @annotation.targetName("refTypeAssignBigDecimal")
     inline def :=(value: BigDecimal): Patch = refType match
       case RefType.Cell(aref) => aref := value
       case RefType.QualifiedCell(_, aref) => aref := value
-      case _ => Patch.empty
+      case RefType.Range(range) => range := value
+      case RefType.QualifiedRange(_, range) => range := value
 
     /** Create Put patch with automatic conversion from Boolean */
     @annotation.targetName("refTypeAssignBoolean")
     inline def :=(value: Boolean): Patch = refType match
       case RefType.Cell(aref) => aref := value
       case RefType.QualifiedCell(_, aref) => aref := value
-      case _ => Patch.empty
+      case RefType.Range(range) => range := value
+      case RefType.QualifiedRange(_, range) => range := value
 
     /** Create Put patch with automatic conversion from LocalDateTime */
     @annotation.targetName("refTypeAssignLocalDateTime")
     inline def :=(value: java.time.LocalDateTime): Patch = refType match
       case RefType.Cell(aref) => aref := value
       case RefType.QualifiedCell(_, aref) => aref := value
-      case _ => Patch.empty
+      case RefType.Range(range) => range := value
+      case RefType.QualifiedRange(_, range) => range := value
 
     /** Apply style to RefType (works for both cells and ranges) */
     @annotation.targetName("refTypeStyled")

--- a/xl-core/src/com/tjclp/xl/formatted/FormattedParsers.scala
+++ b/xl-core/src/com/tjclp/xl/formatted/FormattedParsers.scala
@@ -149,3 +149,36 @@ object FormattedParsers:
       }.toEither.left.map { err =>
         XLError.AccountingFormatError(s, err.getMessage)
       }
+
+  /**
+   * Total smart detection: infer the value type and number format from a raw string.
+   *
+   * Detection order — currency ($1,234.56 / accounting ($1,234.56)) → percent (45.5%) → ISO date
+   * (2025-01-15) → number → boolean → text. Never fails: anything unrecognized is Text with
+   * NumFmt.General. Mirrors the CLI's batch `put` smart detection (the CLI delegates here).
+   *
+   * {{{
+   * FormattedParsers.detect("$1,234.56")  // Formatted(Number(1234.56), Currency)
+   * FormattedParsers.detect("45.5%")      // Formatted(Number(0.455), Percent)
+   * FormattedParsers.detect("2025-01-15") // Formatted(DateTime(...), Date)
+   * FormattedParsers.detect("hello")      // Formatted(Text("hello"), General)
+   * }}}
+   */
+  def detect(s: String): Formatted =
+    val trimmed = s.trim
+    if trimmed.startsWith("$") || (trimmed.startsWith("(") && trimmed.contains("$")) then
+      parseMoney(trimmed)
+        .orElse(parseAccounting(trimmed))
+        .getOrElse(Formatted(CellValue.Text(s), NumFmt.General))
+    else if trimmed.endsWith("%") then
+      parsePercent(trimmed).getOrElse(Formatted(CellValue.Text(s), NumFmt.General))
+    else if trimmed.matches("""\d{4}-\d{2}-\d{2}""") then
+      parseDate(trimmed).getOrElse(Formatted(CellValue.Text(s), NumFmt.General))
+    else
+      Try(BigDecimal(trimmed)).toOption match
+        case Some(n) => Formatted(CellValue.Number(n), NumFmt.General)
+        case None =>
+          trimmed.toLowerCase match
+            case "true" => Formatted(CellValue.Bool(true), NumFmt.General)
+            case "false" => Formatted(CellValue.Bool(false), NumFmt.General)
+            case _ => Formatted(CellValue.Text(s), NumFmt.General)

--- a/xl-core/src/com/tjclp/xl/macros/WorkbookMacros.scala
+++ b/xl-core/src/com/tjclp/xl/macros/WorkbookMacros.scala
@@ -156,6 +156,37 @@ object WorkbookMacros:
         }
 
   /**
+   * Macro impl for workbook.upsert(name: String, f: Sheet => Sheet).
+   *
+   * Returns Workbook for literal names (format validated at compile time; upsert itself is total).
+   * Returns XLResult[Workbook] for runtime names (format is runtime-dependent).
+   */
+  def upsertImpl(
+    workbook: Expr[Workbook],
+    name: Expr[String],
+    f: Expr[Sheet => Sheet]
+  )(using Quotes): Expr[Workbook | XLResult[Workbook]] =
+    import quotes.reflect.*
+
+    name.value match
+      case Some(literal) =>
+        // Compile-time literal - validate name format now
+        validateSheetName(literal) match
+          case Some(err) =>
+            report.errorAndAbort(s"Invalid sheet name '$literal': $err")
+          case None =>
+            // Valid name format - emit direct upsert call (total, returns Workbook)
+            '{ $workbook.upsert(SheetName.unsafe(${ Expr(literal) }), $f) }
+
+      case None =>
+        // Runtime expression - defer validation (returns XLResult[Workbook])
+        '{
+          SheetName($name) match
+            case Right(sn) => Right($workbook.upsert(sn, $f))
+            case Left(err) => Left(XLError.InvalidSheetName($name, err))
+        }
+
+  /**
    * Macro impl for workbook.delete(name: String).
    *
    * Validates name format at compile time for literals. Always returns XLResult[Workbook] because

--- a/xl-core/src/com/tjclp/xl/render/RenderUtils.scala
+++ b/xl-core/src/com/tjclp/xl/render/RenderUtils.scala
@@ -69,6 +69,13 @@ object RenderUtils:
   /** Graphics context for text measurement (lazy, with headless fallback). */
   private lazy val graphics: Option[Graphics2D] =
     try
+      // Default AWT to headless unless the embedder explicitly chose otherwise. Font metrics
+      // don't need a display, and non-headless AWT (notably on macOS) starts a non-daemon
+      // AWT-Shutdown thread that keeps script JVMs alive after main completes — any script
+      // calling toHtml/toSvg would hang at exit. GUI embedders that need a display can set
+      // -Djava.awt.headless=false (or initialize their toolkit before calling xl rendering).
+      if System.getProperty("java.awt.headless") == null then
+        System.setProperty("java.awt.headless", "true")
       val img = new BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB)
       Some(img.createGraphics())
     catch case _: Throwable => None // Headless environment (catches UnsatisfiedLinkError too)

--- a/xl-core/src/com/tjclp/xl/styles/units/Emu.scala
+++ b/xl-core/src/com/tjclp/xl/styles/units/Emu.scala
@@ -4,7 +4,7 @@ package com.tjclp.xl.styles.units
 opaque type Emu = Long
 
 object Emu:
-  inline def apply(value: Long): Emu = value
+  def apply(value: Long): Emu = value
 
   extension (emu: Emu)
     def value: Long = emu

--- a/xl-core/src/com/tjclp/xl/styles/units/Emu.scala
+++ b/xl-core/src/com/tjclp/xl/styles/units/Emu.scala
@@ -7,10 +7,10 @@ object Emu:
   inline def apply(value: Long): Emu = value
 
   extension (emu: Emu)
-    inline def value: Long = emu
+    def value: Long = emu
 
     /** Convert to points */
-    inline def toPt: Pt = Pt((emu * 72.0) / 914400.0)
+    def toPt: Pt = Pt((emu * 72.0) / 914400.0)
 
     /** Convert to pixels */
-    inline def toPx: Px = Px((emu * 96.0) / 914400.0)
+    def toPx: Px = Px((emu * 96.0) / 914400.0)

--- a/xl-core/src/com/tjclp/xl/styles/units/Pt.scala
+++ b/xl-core/src/com/tjclp/xl/styles/units/Pt.scala
@@ -4,7 +4,7 @@ package com.tjclp.xl.styles.units
 opaque type Pt = Double
 
 object Pt:
-  inline def apply(value: Double): Pt = value
+  def apply(value: Double): Pt = value
 
   extension (pt: Pt)
     def value: Double = pt

--- a/xl-core/src/com/tjclp/xl/styles/units/Pt.scala
+++ b/xl-core/src/com/tjclp/xl/styles/units/Pt.scala
@@ -7,10 +7,10 @@ object Pt:
   inline def apply(value: Double): Pt = value
 
   extension (pt: Pt)
-    inline def value: Double = pt
+    def value: Double = pt
 
     /** Convert to pixels (assumes 96 DPI) */
-    inline def toPx: Px = Px(pt * 96.0 / 72.0)
+    def toPx: Px = Px(pt * 96.0 / 72.0)
 
     /** Convert to EMUs (English Metric Units) */
-    inline def toEmu: Emu = Emu((pt * 914400.0 / 72.0).toLong)
+    def toEmu: Emu = Emu((pt * 914400.0 / 72.0).toLong)

--- a/xl-core/src/com/tjclp/xl/styles/units/Px.scala
+++ b/xl-core/src/com/tjclp/xl/styles/units/Px.scala
@@ -7,10 +7,10 @@ object Px:
   inline def apply(value: Double): Px = value
 
   extension (px: Px)
-    inline def value: Double = px
+    def value: Double = px
 
     /** Convert to points */
-    inline def toPt: Pt = Pt(px * 72.0 / 96.0)
+    def toPt: Pt = Pt(px * 72.0 / 96.0)
 
     /** Convert to EMUs */
-    inline def toEmu: Emu = Emu((px * 914400.0 / 96.0).toLong)
+    def toEmu: Emu = Emu((px * 914400.0 / 96.0).toLong)

--- a/xl-core/src/com/tjclp/xl/styles/units/Px.scala
+++ b/xl-core/src/com/tjclp/xl/styles/units/Px.scala
@@ -4,7 +4,7 @@ package com.tjclp.xl.styles.units
 opaque type Px = Double
 
 object Px:
-  inline def apply(value: Double): Px = value
+  def apply(value: Double): Px = value
 
   extension (px: Px)
     def value: Double = px

--- a/xl-core/src/com/tjclp/xl/styles/units/StyleId.scala
+++ b/xl-core/src/com/tjclp/xl/styles/units/StyleId.scala
@@ -4,6 +4,6 @@ package com.tjclp.xl.styles.units
 opaque type StyleId = Int
 
 object StyleId:
-  inline def apply(i: Int): StyleId = i
+  def apply(i: Int): StyleId = i
 
   extension (s: StyleId) def value: Int = s

--- a/xl-core/src/com/tjclp/xl/styles/units/StyleId.scala
+++ b/xl-core/src/com/tjclp/xl/styles/units/StyleId.scala
@@ -6,4 +6,4 @@ opaque type StyleId = Int
 object StyleId:
   inline def apply(i: Int): StyleId = i
 
-  extension (s: StyleId) inline def value: Int = s
+  extension (s: StyleId) def value: Int = s

--- a/xl-core/src/com/tjclp/xl/workbooks/Workbook.scala
+++ b/xl-core/src/com/tjclp/xl/workbooks/Workbook.scala
@@ -195,6 +195,38 @@ final case class Workbook(
   transparent inline def update(inline name: String, f: Sheet => Sheet): XLResult[Workbook] =
     ${ com.tjclp.xl.macros.WorkbookMacros.updateImpl('{ this }, 'name, 'f) }
 
+  /**
+   * Update the named sheet, or create it by applying f to a fresh empty sheet when absent.
+   *
+   * The total counterpart of `update`, parallel to `put`'s add-or-replace semantics: totality comes
+   * from create-on-missing, never from silently doing nothing.
+   *
+   * Example:
+   * {{{
+   * wb.upsert(SheetName.unsafe("Summary"), _.put(ref"A1" -> "Total"))  // creates Summary if absent
+   * }}}
+   */
+  def upsert(name: SheetName, f: Sheet => Sheet): Workbook =
+    sheets.indexWhere(_.name == name) match
+      case -1 => put(f(Sheet(name)))
+      case idx =>
+        val updatedContext = sourceContext.map(_.markSheetModified(idx))
+        copy(sheets = sheets.updated(idx, f(sheets(idx))), sourceContext = updatedContext)
+
+  /**
+   * Upsert by name (string variant).
+   *
+   * When called with a string literal, the name format is validated at compile time and returns
+   * Workbook directly (the operation itself is total). Runtime strings return XLResult[Workbook]
+   * because the name format is runtime-dependent.
+   */
+  @annotation.targetName("upsertByString")
+  transparent inline def upsert(
+    inline name: String,
+    f: Sheet => Sheet
+  ): Workbook | XLResult[Workbook] =
+    ${ com.tjclp.xl.macros.WorkbookMacros.upsertImpl('{ this }, 'name, 'f) }
+
   /** Update sheet by index while tracking modification state. */
   def updateAt(idx: Int, f: Sheet => Sheet): XLResult[Workbook] =
     if idx < 0 || idx >= sheets.size then

--- a/xl-core/test/src/com/tjclp/xl/RangeFillSpec.scala
+++ b/xl-core/test/src/com/tjclp/xl/RangeFillSpec.scala
@@ -1,0 +1,99 @@
+package com.tjclp.xl
+
+import munit.ScalaCheckSuite
+import org.scalacheck.Prop.*
+import Generators.given
+import Generators.genCellRange
+import com.tjclp.xl.api.*
+import com.tjclp.xl.addressing.{ARef, CellRange, SheetName}
+import com.tjclp.xl.cells.CellValue
+import com.tjclp.xl.dsl.syntax.*
+import com.tjclp.xl.macros.ref
+import com.tjclp.xl.patch.Patch
+import com.tjclp.xl.sheets.syntax.*
+
+/**
+ * Properties for range fill semantics (`range := value`, Excel Ctrl+Enter) and total ARef
+ * navigation, added in 0.11.0. Before 0.11.0, `:=` on a RefType range silently returned
+ * Patch.empty and CellRange had no `:=` at all.
+ */
+class RangeFillSpec extends ScalaCheckSuite:
+
+  def emptySheet: Sheet = Sheet(SheetName.unsafe("Test"))
+
+  // genCellRange builds from genSmallARef (cols 0-25, rows 0-99), so size is bounded.
+
+  property("range := v puts v in every cell of the range") {
+    forAll(genCellRange) { (range: CellRange) =>
+      val sheet = emptySheet.put(range := 42)
+      assertEquals(sheet.cells.size, range.size)
+      assert(range.cells.forall { r =>
+        sheet.cells.get(r).map(_.value).contains(CellValue.Number(BigDecimal(42)))
+      })
+    }
+  }
+
+  property("fill on a 1x1 range is equivalent to a single-cell Put") {
+    forAll { (aref: ARef) =>
+      val single = CellRange(aref, aref)
+      val viaFill = emptySheet.put(single := "x")
+      val viaPut = emptySheet.put(aref := "x")
+      assertEquals(viaFill.cells, viaPut.cells)
+    }
+  }
+
+  property("fill composes with the Patch monoid: later fill wins on overlap") {
+    forAll(genCellRange) { (range: CellRange) =>
+      val sheet = emptySheet.put((range := 1) ++ (range := 2))
+      assert(range.cells.forall { r =>
+        sheet.cells.get(r).map(_.value).contains(CellValue.Number(BigDecimal(2)))
+      })
+    }
+  }
+
+  test("RefType range := fills (runtime-interpolated refs)") {
+    val end = "3"
+    val patch = (for refType <- ref"A1:B$end" yield refType := true).getOrElse(Patch.empty)
+    val sheet = emptySheet.put(patch)
+    assertEquals(sheet.cells.size, 6)
+    assert(sheet.cells.values.forall(_.value == CellValue.Bool(true)))
+  }
+
+  test("compile-time range literal supports := directly") {
+    val sheet = emptySheet.put(ref"A1:C2" := 0)
+    assertEquals(sheet.cells.size, 6)
+  }
+
+  test("range := accepts all conversion overloads") {
+    val r = ref"A1:A2"
+    val patches = List(
+      r := CellValue.Text("cv"),
+      r := "s",
+      r := 1,
+      r := 1L,
+      r := 1.5,
+      r := BigDecimal(2),
+      r := false,
+      r := java.time.LocalDateTime.of(2026, 6, 9, 0, 0)
+    )
+    patches.foreach(p => assertEquals(emptySheet.put(p).cells.size, 2))
+  }
+
+  // ========== ARef navigation ==========
+
+  property("down/up and right/left are inverses (within bounds)") {
+    forAll(Generators.genSmallARef) { (aref: ARef) =>
+      forAll(org.scalacheck.Gen.choose(0, 50)) { (n: Int) =>
+        assertEquals(aref.down(n).up(n), aref)
+        assertEquals(aref.right(n).left(n), aref)
+      }
+    }
+  }
+
+  test("navigation defaults move by one") {
+    assertEquals(ref"B2".down(), ref"B3")
+    assertEquals(ref"B2".up(), ref"B1")
+    assertEquals(ref"B2".right(), ref"C2")
+    assertEquals(ref"B2".left(), ref"A2")
+    assertEquals(ref"A1".down(3).right(2), ref"C4")
+  }

--- a/xl-core/test/src/com/tjclp/xl/RangeFillSpec.scala
+++ b/xl-core/test/src/com/tjclp/xl/RangeFillSpec.scala
@@ -97,3 +97,9 @@ class RangeFillSpec extends ScalaCheckSuite:
     assertEquals(ref"B2".left(), ref"A2")
     assertEquals(ref"A1".down(3).right(2), ref"C4")
   }
+
+  test("large range fill: one cell per address, by design (cost is range.size)"):
+    // Pins the documented contract for big fills: ref"A1:D2500" materializes 10,000 cells.
+    // Full-column fills (A:A = 1,048,576 cells) follow the same rule — prefer bounded ranges.
+    val sheet = emptySheet.put(ref"A1:D2500" := 0)
+    assertEquals(sheet.cells.size, 10000)

--- a/xl-core/test/src/com/tjclp/xl/UpsertSpec.scala
+++ b/xl-core/test/src/com/tjclp/xl/UpsertSpec.scala
@@ -1,0 +1,74 @@
+package com.tjclp.xl
+
+import munit.FunSuite
+import com.tjclp.xl.api.*
+import com.tjclp.xl.addressing.SheetName
+import com.tjclp.xl.cells.CellValue
+import com.tjclp.xl.codec.CellCodec.given
+import com.tjclp.xl.codec.syntax.*
+import com.tjclp.xl.dsl.syntax.*
+import com.tjclp.xl.macros.ref
+import com.tjclp.xl.sheets.syntax.*
+
+/** Workbook.upsert (total update-or-create) and readTypedOr/readTypedOpt (0.11.0). */
+class UpsertSpec extends FunSuite:
+
+  private val sales = SheetName.unsafe("Sales")
+  private val absent = SheetName.unsafe("New")
+
+  test("upsert updates an existing sheet in place"):
+    val wb = Workbook(Sheet(sales).put(ref"A1" := 1))
+    val updated = wb.upsert(sales, _.put(ref"B1" := 2))
+    assertEquals(updated.sheets.size, 1)
+    assertEquals(updated.sheets.headOption.map(_.cells.size), Some(2))
+
+  test("upsert creates the sheet by applying f to a fresh empty sheet when absent"):
+    val wb = Workbook(Sheet(sales))
+    val updated = wb.upsert(absent, _.put(ref"A1" := "created"))
+    assertEquals(updated.sheets.size, 2)
+    assertEquals(
+      updated.sheets.find(_.name == absent).map(_.cells.size),
+      Some(1)
+    )
+
+  test("upsert with a literal string name is total and chains"):
+    val wb = Workbook(Sheet(sales))
+      .upsert("Summary", _.put(ref"A1" := "Total"))
+      .upsert("Summary", _.put(ref"A2" := 100))
+    assertEquals(wb.sheets.size, 2)
+    assertEquals(
+      wb.sheets.find(_.name.value == "Summary").map(_.cells.size),
+      Some(2)
+    )
+
+  test("upsert with a runtime string returns XLResult and rejects invalid names"):
+    val wb = Workbook(Sheet(sales))
+    val bad = "Invalid:Name"
+    wb.upsert(bad, identity) match
+      case Left(err) => assert(err.message.nonEmpty)
+      case Right(_) => fail("invalid runtime sheet name should be rejected")
+    val good = "Runtime"
+    assertEquals(wb.upsert(good, identity).map(_.sheets.size), Right(2))
+
+  test("upsert preserves sheet order on update"):
+    val wb = Workbook(Sheet(SheetName.unsafe("A")), Sheet(sales), Sheet(SheetName.unsafe("Z")))
+    val updated = wb.upsert(sales, _.put(ref"A1" := 1))
+    assertEquals(updated.sheets.map(_.name.value), Vector("A", "Sales", "Z"))
+
+  // ========== readTypedOr / readTypedOpt ==========
+
+  private val typedSheet = Sheet(sales)
+    .put(ref"A1" := 42)
+    .put(ref"B1" := "text")
+
+  test("readTypedOr returns the value when present and decodable"):
+    assertEquals(typedSheet.readTypedOr[Int](ref"A1", 0), 42)
+
+  test("readTypedOr falls back on missing cell and on type mismatch"):
+    assertEquals(typedSheet.readTypedOr[Int](ref"Z9", -1), -1)
+    assertEquals(typedSheet.readTypedOr[Int](ref"B1", -1), -1)
+
+  test("readTypedOpt flattens absence and mismatch to None"):
+    assertEquals(typedSheet.readTypedOpt[Int](ref"A1"), Some(42))
+    assertEquals(typedSheet.readTypedOpt[Int](ref"Z9"), None)
+    assertEquals(typedSheet.readTypedOpt[Int](ref"B1"), None)

--- a/xl-core/test/src/com/tjclp/xl/formatted/FormattedParsersSpec.scala
+++ b/xl-core/test/src/com/tjclp/xl/formatted/FormattedParsersSpec.scala
@@ -257,3 +257,60 @@ class FormattedParsersSpec extends FunSuite:
         assertEquals(f.value, CellValue.Number(-1000000.00))
       case Left(err) => fail(s"Should parse: $err")
   }
+
+  // ========== detect: total smart detection (0.11.0) ==========
+
+  test("detect: currency") {
+    assertEquals(
+      FormattedParsers.detect("$1,234.56"),
+      Formatted(CellValue.Number(BigDecimal("1234.56")), NumFmt.Currency)
+    )
+  }
+
+  test("detect: accounting negative") {
+    assertEquals(
+      FormattedParsers.detect("($1,000.00)"),
+      Formatted(CellValue.Number(BigDecimal("-1000.00")), NumFmt.Currency)
+    )
+  }
+
+  test("detect: percent stores fraction") {
+    assertEquals(
+      FormattedParsers.detect("45.5%"),
+      Formatted(CellValue.Number(BigDecimal("0.455")), NumFmt.Percent)
+    )
+  }
+
+  test("detect: ISO date") {
+    FormattedParsers.detect("2025-01-15") match
+      case Formatted(CellValue.DateTime(_), fmt) => assert(fmt != NumFmt.General)
+      case other => fail(s"expected date, got $other")
+  }
+
+  test("detect: plain number, boolean, and text fall through to General") {
+    assertEquals(
+      FormattedParsers.detect("123.45"),
+      Formatted(CellValue.Number(BigDecimal("123.45")), NumFmt.General)
+    )
+    assertEquals(FormattedParsers.detect("TRUE"), Formatted(CellValue.Bool(true), NumFmt.General))
+    assertEquals(
+      FormattedParsers.detect("hello"),
+      Formatted(CellValue.Text("hello"), NumFmt.General)
+    )
+  }
+
+  test("detect: is total — malformed lookalikes degrade to Text, never fail") {
+    assertEquals(
+      FormattedParsers.detect("$ABC"),
+      Formatted(CellValue.Text("$ABC"), NumFmt.General)
+    )
+    assertEquals(
+      FormattedParsers.detect("ABC%"),
+      Formatted(CellValue.Text("ABC%"), NumFmt.General)
+    )
+    assertEquals(
+      FormattedParsers.detect("9999-99-99"),
+      Formatted(CellValue.Text("9999-99-99"), NumFmt.General)
+    )
+    assertEquals(FormattedParsers.detect(""), Formatted(CellValue.Text(""), NumFmt.General))
+  }

--- a/xl-evaluator/src/com/tjclp/xl/exports.scala
+++ b/xl-evaluator/src/com/tjclp/xl/exports.scala
@@ -39,9 +39,12 @@ object formulaExports:
   export formula.eval.SheetEvaluator
   export formula.eval.SheetEvaluator.*
 
-  // WorkbookEvaluator extension methods (withCachedFormulas)
+  // WorkbookEvaluator extension methods (withCachedFormulas, recalculate, evaluateFormula)
   export formula.eval.WorkbookEvaluator
   export formula.eval.WorkbookEvaluator.*
+
+  // Recalc result types (workbook-level total recalculation with per-cell errors)
+  export formula.eval.{CellEvalError, RecalcResult}
 
   // DependentRecalculation extension methods (GH-163)
   // Note: Extension methods with default parameters must be imported directly,

--- a/xl-evaluator/src/com/tjclp/xl/formula/eval/Recalc.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/eval/Recalc.scala
@@ -1,0 +1,48 @@
+package com.tjclp.xl.formula.eval
+
+import com.tjclp.xl.addressing.{ARef, SheetName}
+import com.tjclp.xl.cells.CellValue
+import com.tjclp.xl.error.XLError
+import com.tjclp.xl.workbooks.Workbook
+
+/**
+ * A formula cell that failed to evaluate during `Workbook.recalculate`, with its location and
+ * structured error. The cell is left uncached — Excel recalculates it on open.
+ */
+final case class CellEvalError(
+  sheet: SheetName,
+  ref: ARef,
+  error: XLError
+) derives CanEqual:
+  /** Human-readable one-liner: `Sales!B2: Formula error in '=A1/0': ...` */
+  def render: String = s"${sheet.value}!${ref.toA1}: ${error.message}"
+
+/**
+ * Result of a total, whole-workbook recalculation (`wb.recalculate()`).
+ *
+ * Evaluation is per-cell: a failing or cyclic formula is collected into `errors` and left uncached,
+ * while every other formula — including those on the same sheet — still evaluates and caches.
+ * Cross-sheet references are resolved against the workbook automatically.
+ *
+ * @param workbook
+ *   The workbook with every successfully evaluated formula cached (`Formula(expr, Some(value))`)
+ * @param evaluated
+ *   Computed values per sheet for inspection without re-reading cells
+ * @param errors
+ *   Per-cell failures: parse/eval errors, cycle participants, and cells blocked by a cycle
+ */
+final case class RecalcResult(
+  workbook: Workbook,
+  evaluated: Map[SheetName, Map[ARef, CellValue]],
+  errors: Vector[CellEvalError]
+) derives CanEqual:
+
+  /** True when every formula in the workbook evaluated successfully. */
+  def isClean: Boolean = errors.isEmpty
+
+  /**
+   * Right(workbook) when clean, Left(errors) otherwise — for scripts that must not proceed on
+   * partial results.
+   */
+  def toEither: Either[Vector[CellEvalError], Workbook] =
+    if isClean then Right(workbook) else Left(errors)

--- a/xl-evaluator/src/com/tjclp/xl/formula/eval/SheetEvaluator.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/eval/SheetEvaluator.scala
@@ -55,6 +55,10 @@ object SheetEvaluator:
      *   Excel formula string (with or without leading =)
      * @param clock
      *   Clock for date/time functions (defaults to system clock)
+     * @param workbook
+     *   Pass `Some(wb)` iff the formula references other sheets (`='Other'!A1`); intra-sheet
+     *   formulas don't need it. Or use `wb.evaluateFormula(formula, onSheet)` which wires the
+     *   context automatically.
      * @return
      *   Either XLError or evaluated CellValue
      *

--- a/xl-evaluator/src/com/tjclp/xl/formula/eval/WorkbookEvaluator.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/eval/WorkbookEvaluator.scala
@@ -107,6 +107,13 @@ object WorkbookEvaluator:
      * Excel.write(result.workbook, "out.xlsx")  // partial results; failed cells stay uncached
      * result.toEither                           // Left(errors) when not clean
      * }}}
+     *
+     * Scope notes: cycle isolation is per-sheet (Tarjan over each sheet's graph) — a cycle that
+     * spans sheets is caught instead by the evaluator's recursion depth guard and surfaces as a
+     * generic per-cell eval error (still total, still collected; see RecalcSpec). Cross-sheet
+     * references to upstream formulas evaluate on demand against the original workbook snapshot and
+     * are not memoized across sheets — fine for typical workbooks; a workbook-level topological
+     * order is future work for deep cross-sheet fan-out.
      */
     def recalculate(clock: Clock = Clock.system): RecalcResult =
       val perSheet = wb.sheets.map(sheet => recalcSheet(sheet, wb, clock))

--- a/xl-evaluator/src/com/tjclp/xl/formula/eval/WorkbookEvaluator.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/eval/WorkbookEvaluator.scala
@@ -148,7 +148,8 @@ object WorkbookEvaluator:
         XLError.FormulaError(formulaText(sheet, ref), "Circular reference")
       )
     }
-    val blockedErrors = (blocked -- cyclicCore).toVector.map { ref =>
+    // transitiveDependents excludes its seed set, so `blocked` is already disjoint from the core
+    val blockedErrors = blocked.toVector.map { ref =>
       CellEvalError(
         sheet.name,
         ref,

--- a/xl-evaluator/src/com/tjclp/xl/formula/eval/WorkbookEvaluator.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/eval/WorkbookEvaluator.scala
@@ -7,9 +7,10 @@ import com.tjclp.xl.formula.printer.FormulaPrinter
 import com.tjclp.xl.formula.parser.{FormulaParser, ParseError}
 import com.tjclp.xl.formula.Clock
 
-import com.tjclp.xl.addressing.SheetName
+import com.tjclp.xl.addressing.{ARef, SheetName}
 import com.tjclp.xl.cells.CellValue
-import com.tjclp.xl.error.XLResult
+import com.tjclp.xl.error.{XLError, XLResult}
+import com.tjclp.xl.sheets.Sheet
 import com.tjclp.xl.workbooks.Workbook
 
 // Import SheetEvaluator extension methods
@@ -81,28 +82,105 @@ object WorkbookEvaluator:
      * Formulas that fail to evaluate (unsupported functions, circular refs) are left without cached
      * values - Excel will recalculate on open.
      *
+     * Implemented as `recalculate(clock).workbook`; use `recalculate` directly when you need to
+     * know which cells failed.
+     *
      * @param clock
      *   Clock for volatile functions (TODAY, NOW). Defaults to system clock.
      * @return
      *   Workbook with formula cells containing cached values
      */
     def withCachedFormulas(clock: Clock = Clock.system): Workbook =
-      val updatedSheets = wb.sheets.map { sheet =>
-        sheet.evaluateWithDependencyCheck(clock) match
-          case Right(results) =>
-            // Update formula cells with cached values
-            results.foldLeft(sheet) { case (s, (ref, computedValue)) =>
-              s.cells.get(ref) match
-                case Some(cell) =>
-                  cell.value match
-                    case CellValue.Formula(expr, _) =>
-                      s.put(ref, CellValue.Formula(expr, Some(computedValue)))
-                    case _ => s
-                case None => s
-            }
-          case Left(_) =>
-            // Circular reference or evaluation error - leave formulas uncached
-            // Excel will recalculate on open
-            sheet
-      }
-      wb.copy(sheets = updatedSheets)
+      recalculate(clock).workbook
+
+    /**
+     * Total whole-workbook recalculation with per-cell error reporting.
+     *
+     * Evaluates every formula in every sheet in dependency order, with cross-sheet references
+     * resolved against this workbook. Failures never propagate: a failing cell becomes a
+     * [[CellEvalError]] and stays uncached; cycle participants are isolated (reported as circular,
+     * their downstream dependents as blocked) while the acyclic remainder still evaluates.
+     *
+     * {{{
+     * val result = wb.recalculate()
+     * result.errors.foreach(e => println(e.render))
+     * Excel.write(result.workbook, "out.xlsx")  // partial results; failed cells stay uncached
+     * result.toEither                           // Left(errors) when not clean
+     * }}}
+     */
+    def recalculate(clock: Clock = Clock.system): RecalcResult =
+      val perSheet = wb.sheets.map(sheet => recalcSheet(sheet, wb, clock))
+      RecalcResult(
+        workbook = wb.copy(sheets = perSheet.map(_.sheet)),
+        evaluated = perSheet.map(r => r.sheet.name -> r.evaluated).toMap,
+        errors = perSheet.flatMap(_.errors).toVector
+      )
+
+  // ========== recalculate internals ==========
+
+  private final case class SheetRecalc(
+    sheet: Sheet,
+    evaluated: Map[ARef, CellValue],
+    errors: Vector[CellEvalError]
+  )
+
+  private def formulaText(sheet: Sheet, ref: ARef): String =
+    sheet.cells.get(ref).map(_.value) match
+      case Some(CellValue.Formula(expr, _)) => expr
+      case _ => ref.toA1
+
+  private def recalcSheet(sheet: Sheet, wb: Workbook, clock: Clock): SheetRecalc =
+    val graph = DependencyGraph.fromSheet(sheet)
+    val cyclicCore = DependencyGraph.cyclicNodes(graph)
+    val blocked = DependencyGraph.transitiveDependents(graph, cyclicCore)
+
+    val cycleErrors = cyclicCore.toVector.map { ref =>
+      CellEvalError(
+        sheet.name,
+        ref,
+        XLError.FormulaError(formulaText(sheet, ref), "Circular reference")
+      )
+    }
+    val blockedErrors = (blocked -- cyclicCore).toVector.map { ref =>
+      CellEvalError(
+        sheet.name,
+        ref,
+        XLError.FormulaError(formulaText(sheet, ref), "Blocked by an upstream circular reference")
+      )
+    }
+
+    val removed = cyclicCore ++ blocked
+    val pruned = DependencyGraph(
+      dependencies = (graph.dependencies -- removed).view.mapValues(_ -- removed).toMap,
+      dependents = (graph.dependents -- removed).view.mapValues(_ -- removed).toMap
+    )
+
+    DependencyGraph.topologicalSort(pruned) match
+      case Left(circular) =>
+        // Unreachable: cyclicNodes removed every cycle participant. Stay total regardless.
+        val residual = pruned.dependencies.keySet.toVector.map { ref =>
+          CellEvalError(
+            sheet.name,
+            ref,
+            XLError.FormulaError(formulaText(sheet, ref), s"Unresolvable order: $circular")
+          )
+        }
+        SheetRecalc(sheet, Map.empty, cycleErrors ++ blockedErrors ++ residual)
+
+      case Right(evalOrder) =>
+        val (tempSheet, results, evalErrors) = evalOrder.foldLeft(
+          (sheet, Map.empty[ARef, CellValue], Vector.empty[CellEvalError])
+        ) { case ((temp, acc, errs), ref) =>
+          temp.evaluateCell(ref, clock, Some(wb)) match
+            case Right(value) => (temp.put(ref, value), acc + (ref -> value), errs)
+            case Left(error) => (temp, acc, errs :+ CellEvalError(sheet.name, ref, error))
+        }
+
+        // Cache computed values into formula cells; failed cells stay uncached
+        val cachedSheet = results.foldLeft(sheet) { case (s, (ref, computed)) =>
+          s.cells.get(ref).map(_.value) match
+            case Some(CellValue.Formula(expr, _)) =>
+              s.put(ref, CellValue.Formula(expr, Some(computed)))
+            case _ => s
+        }
+        SheetRecalc(cachedSheet, results, cycleErrors ++ blockedErrors ++ evalErrors)

--- a/xl-evaluator/src/com/tjclp/xl/formula/eval/WorkbookEvaluator.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/eval/WorkbookEvaluator.scala
@@ -7,7 +7,9 @@ import com.tjclp.xl.formula.printer.FormulaPrinter
 import com.tjclp.xl.formula.parser.{FormulaParser, ParseError}
 import com.tjclp.xl.formula.Clock
 
+import com.tjclp.xl.addressing.SheetName
 import com.tjclp.xl.cells.CellValue
+import com.tjclp.xl.error.XLResult
 import com.tjclp.xl.workbooks.Workbook
 
 // Import SheetEvaluator extension methods
@@ -27,6 +29,46 @@ import SheetEvaluator.*
 object WorkbookEvaluator:
 
   extension (wb: Workbook)
+
+    /**
+     * Evaluate a formula in the context of the named sheet, with cross-sheet references resolved
+     * against this workbook.
+     *
+     * Prefer this over `Sheet.evaluateFormula` in scripts: the workbook context is wired
+     * automatically, so formulas like `='Other Sheet'!A1 * 2` just work.
+     *
+     * Note: explicit overloads instead of a default clock parameter — extension methods with
+     * default arguments crash the compiler when merged through the formulaExports wildcard export
+     * (see the DependentRecalculation note in exports.scala).
+     */
+    def evaluateFormula(
+      formula: String,
+      onSheet: SheetName,
+      clock: Clock
+    ): XLResult[CellValue] =
+      wb(onSheet).flatMap(s => SheetEvaluator.evaluateFormula(s)(formula, clock, Some(wb)))
+
+    /** Evaluate a formula on the named sheet with the system clock. */
+    @annotation.targetName("evaluateFormulaOnSheetDefaultClock")
+    def evaluateFormula(formula: String, onSheet: SheetName): XLResult[CellValue] =
+      evaluateFormula(formula, onSheet, Clock.system)
+
+    /**
+     * Evaluate a formula on the named sheet (string variant). The sheet name is resolved at
+     * runtime.
+     */
+    @annotation.targetName("evaluateFormulaOnSheetString")
+    def evaluateFormula(
+      formula: String,
+      onSheet: String,
+      clock: Clock
+    ): XLResult[CellValue] =
+      wb(onSheet).flatMap(s => SheetEvaluator.evaluateFormula(s)(formula, clock, Some(wb)))
+
+    /** Evaluate a formula on the named sheet (string variant, system clock). */
+    @annotation.targetName("evaluateFormulaOnSheetStringDefaultClock")
+    def evaluateFormula(formula: String, onSheet: String): XLResult[CellValue] =
+      evaluateFormula(formula, onSheet, Clock.system)
 
     /**
      * Evaluate all formulas and cache their computed values.

--- a/xl-evaluator/src/com/tjclp/xl/formula/graph/DependencyGraph.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/graph/DependencyGraph.scala
@@ -516,14 +516,63 @@ object DependencyGraph:
       transitiveDependentsImpl(graph, originalRefs, directDeps, visited ++ toVisit)
 
   /**
+   * Iterative Tarjan SCC engine shared by `detectCycles` and `cyclicNodes`.
+   *
+   * Uses an explicit work stack instead of recursion: `recalculate` promises totality, and a deep
+   * linear dependency chain (e.g. 100k sequential formulas) must not throw StackOverflowError.
+   * Invokes `onScc` for every completed component in Tarjan pop order (deepest member first,
+   * component root last).
+   */
+  @SuppressWarnings(Array("org.wartremover.warts.Var"))
+  private def foreachScc(graph: DependencyGraph)(onScc: List[ARef] => Unit): Unit =
+    var index = 0
+    var indices = Map.empty[ARef, Int]
+    var lowLinks = Map.empty[ARef, Int]
+    var stack = List.empty[ARef]
+    var onStack = Set.empty[ARef]
+    // DFS frames: (node, successors not yet examined)
+    var frames = List.empty[(ARef, List[ARef])]
+
+    def push(v: ARef): Unit =
+      indices = indices.updated(v, index)
+      lowLinks = lowLinks.updated(v, index)
+      index += 1
+      stack = v :: stack
+      onStack = onStack + v
+      frames = (v, graph.dependencies.getOrElse(v, Set.empty).toList) :: frames
+
+    graph.dependencies.keySet.foreach { root =>
+      if !indices.contains(root) then
+        push(root)
+        while frames.nonEmpty do
+          frames match
+            case (v, w :: rest) :: tail =>
+              frames = (v, rest) :: tail
+              if !indices.contains(w) then push(w)
+              else if onStack.contains(w) then
+                lowLinks = lowLinks.updated(v, math.min(lowLinks(v), indices(w)))
+            case (v, Nil) :: tail =>
+              frames = tail
+              if lowLinks(v) == indices(v) then
+                val (sccTail, remaining) = stack.span(_ != v)
+                stack = remaining.drop(1)
+                val scc = sccTail :+ v
+                onStack = onStack -- scc
+                onScc(scc)
+              frames match
+                case (p, _) :: _ =>
+                  lowLinks = lowLinks.updated(p, math.min(lowLinks(p), lowLinks(v)))
+                case Nil => ()
+            case Nil => () // unreachable: guarded by frames.nonEmpty
+    }
+
+  /**
    * Detect circular references using Tarjan's strongly connected components algorithm.
    *
    * A circular reference occurs when a cell's formula depends (directly or transitively) on its own
    * value. For example: A1="=B1", B1="=C1", C1="=A1" forms a cycle.
    *
-   * This uses Tarjan's SCC algorithm which runs in O(V + E) time with a single DFS traversal. The
-   * algorithm maintains a stack and low-link values to detect strongly connected components
-   * (cycles).
+   * Runs in O(V + E) with an explicit work stack (stack-safe on deep dependency chains).
    *
    * @param graph
    *   The dependency graph to analyze
@@ -539,88 +588,21 @@ object DependencyGraph:
    * detectCycles(graph) // Left(EvalError.CircularRef(List(A1, B1, A1)))
    * }}}
    */
-  @SuppressWarnings(
-    Array(
-      "org.wartremover.warts.Var",
-      "org.wartremover.warts.IterableOps",
-      "org.wartremover.warts.Return",
-      "org.wartremover.warts.IsInstanceOf",
-      "org.wartremover.warts.AsInstanceOf"
-    )
-  )
+  @SuppressWarnings(Array("org.wartremover.warts.Var"))
   def detectCycles(graph: DependencyGraph): Either[EvalError.CircularRef, Unit] =
-    // Tarjan's SCC algorithm: Intentional imperative implementation
-    // Rationale: Classic algorithm uses mutable state for O(V+E) performance.
-    // Functional version sacrifices clarity without benefit. Compile-time only.
-    var index = 0
-    var stack = List.empty[ARef]
-    var indices = Map.empty[ARef, Int]
-    var lowLinks = Map.empty[ARef, Int]
-    var onStack = Set.empty[ARef]
-
-    def strongConnect(v: ARef): Option[List[ARef]] =
-      // Set the depth index for v
-      indices = indices.updated(v, index)
-      lowLinks = lowLinks.updated(v, index)
-      index += 1
-      stack = v :: stack
-      onStack = onStack + v
-
-      // Consider successors of v (cells that v depends on)
-      val successors = graph.dependencies.getOrElse(v, Set.empty)
-      val cycleFound = successors.foldLeft(Option.empty[List[ARef]]) { (acc, w) =>
-        acc match
-          case Some(cycle) => Some(cycle) // Already found cycle, propagate
-          case None =>
-            if !indices.contains(w) then
-              // Successor w has not yet been visited; recurse on it
-              strongConnect(w) match
-                case Some(cycle) => Some(cycle)
-                case None =>
-                  lowLinks = lowLinks.updated(v, math.min(lowLinks(v), lowLinks(w)))
-                  None
-            else if onStack.contains(w) then
-              // Successor w is on stack and hence in the current SCC
-              lowLinks = lowLinks.updated(v, math.min(lowLinks(v), indices(w)))
-              // Found a cycle! Reconstruct it from stack (w to top of stack forms the cycle)
-              val cycleNodes = (stack.takeWhile(_ != w) :+ w).reverse
-              Some(cycleNodes :+ cycleNodes.head) // Add first node again to show cycle closes
-            else None // w is not on stack, already processed
-      }
-
-      cycleFound match
-        case Some(cycle) => Some(cycle)
-        case None =>
-          // If v is a root node, pop the stack and check for SCC
-          if lowLinks(v) == indices(v) then
-            // Pop nodes from stack until v
-            val (scc, remaining) = stack.span(_ != v)
-            stack = remaining.tail // Remove v from stack
-            onStack = onStack -- (scc :+ v)
-
-            // Check if SCC has more than one node (cycle)
-            if scc.nonEmpty then
-              // Multiple nodes in SCC means cycle
-              val cycleNodes = (scc :+ v).reverse
-              Some(cycleNodes :+ cycleNodes.head) // Add first node again to show cycle closes
-            else
-              // Single node - only a cycle if it has self-loop
-              if graph.dependencies.get(v).exists(_.contains(v)) then
-                Some(List(v, v)) // Self-loop: v -> v
-              else None
-          else None
-
-    // Run Tarjan's algorithm on all unvisited nodes
-    val allNodes = graph.dependencies.keySet
-    val cycleFound = allNodes.foldLeft(Option.empty[List[ARef]]) { (acc, node) =>
-      acc match
-        case Some(cycle) => Some(cycle) // Already found cycle
-        case None =>
-          if !indices.contains(node) then strongConnect(node)
-          else None
+    var found = Option.empty[List[ARef]]
+    foreachScc(graph) { scc =>
+      if found.isEmpty then
+        scc match
+          case single :: Nil =>
+            if graph.dependencies.get(single).exists(_.contains(single)) then
+              found = Some(List(single, single)) // Self-loop: v -> v
+          case multi =>
+            val cycleNodes = multi.reverse
+            found =
+              Some(cycleNodes :+ cycleNodes.headOption.getOrElse(multi.last)) // close the cycle
     }
-
-    cycleFound match
+    found match
       case Some(cycle) => scala.util.Left(EvalError.CircularRef(cycle))
       case None => scala.util.Right(())
 
@@ -631,44 +613,19 @@ object DependencyGraph:
    * of cells inside strongly connected components of size > 1, plus self-loops. Used by
    * `Workbook.recalculate` to isolate cyclic cells while still evaluating the acyclic remainder.
    *
+   * Stack-safe: shares the iterative Tarjan engine with `detectCycles`.
+   *
    * @return
    *   The set of cycle participants (empty when the graph is acyclic)
    */
   @SuppressWarnings(Array("org.wartremover.warts.Var"))
   def cyclicNodes(graph: DependencyGraph): Set[ARef] =
-    // Tarjan's SCC, same imperative style as detectCycles, but collecting all SCCs.
-    var index = 0
-    var stack = List.empty[ARef]
-    var indices = Map.empty[ARef, Int]
-    var lowLinks = Map.empty[ARef, Int]
-    var onStack = Set.empty[ARef]
     var cyclic = Set.empty[ARef]
-
-    def strongConnect(v: ARef): Unit =
-      indices = indices.updated(v, index)
-      lowLinks = lowLinks.updated(v, index)
-      index += 1
-      stack = v :: stack
-      onStack = onStack + v
-
-      graph.dependencies.getOrElse(v, Set.empty).foreach { w =>
-        if !indices.contains(w) then
-          strongConnect(w)
-          lowLinks = lowLinks.updated(v, math.min(lowLinks(v), lowLinks(w)))
-        else if onStack.contains(w) then
-          lowLinks = lowLinks.updated(v, math.min(lowLinks(v), indices(w)))
-      }
-
-      if lowLinks(v) == indices(v) then
-        val (sccTail, remaining) = stack.span(_ != v)
-        val scc = sccTail :+ v
-        stack = remaining.drop(1)
-        onStack = onStack -- scc
-        if sccTail.nonEmpty then cyclic = cyclic ++ scc
-        else if graph.dependencies.get(v).exists(_.contains(v)) then cyclic = cyclic + v
-
-    graph.dependencies.keySet.foreach { node =>
-      if !indices.contains(node) then strongConnect(node)
+    foreachScc(graph) { scc =>
+      scc match
+        case single :: Nil =>
+          if graph.dependencies.get(single).exists(_.contains(single)) then cyclic = cyclic + single
+        case multi => cyclic = cyclic ++ multi
     }
     cyclic
 

--- a/xl-evaluator/src/com/tjclp/xl/formula/graph/DependencyGraph.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/graph/DependencyGraph.scala
@@ -625,6 +625,54 @@ object DependencyGraph:
       case None => scala.util.Right(())
 
   /**
+   * Collect every node that participates in a reference cycle.
+   *
+   * Unlike `detectCycles` (which fails fast on the first cycle), this identifies the complete set
+   * of cells inside strongly connected components of size > 1, plus self-loops. Used by
+   * `Workbook.recalculate` to isolate cyclic cells while still evaluating the acyclic remainder.
+   *
+   * @return
+   *   The set of cycle participants (empty when the graph is acyclic)
+   */
+  @SuppressWarnings(Array("org.wartremover.warts.Var"))
+  def cyclicNodes(graph: DependencyGraph): Set[ARef] =
+    // Tarjan's SCC, same imperative style as detectCycles, but collecting all SCCs.
+    var index = 0
+    var stack = List.empty[ARef]
+    var indices = Map.empty[ARef, Int]
+    var lowLinks = Map.empty[ARef, Int]
+    var onStack = Set.empty[ARef]
+    var cyclic = Set.empty[ARef]
+
+    def strongConnect(v: ARef): Unit =
+      indices = indices.updated(v, index)
+      lowLinks = lowLinks.updated(v, index)
+      index += 1
+      stack = v :: stack
+      onStack = onStack + v
+
+      graph.dependencies.getOrElse(v, Set.empty).foreach { w =>
+        if !indices.contains(w) then
+          strongConnect(w)
+          lowLinks = lowLinks.updated(v, math.min(lowLinks(v), lowLinks(w)))
+        else if onStack.contains(w) then
+          lowLinks = lowLinks.updated(v, math.min(lowLinks(v), indices(w)))
+      }
+
+      if lowLinks(v) == indices(v) then
+        val (sccTail, remaining) = stack.span(_ != v)
+        val scc = sccTail :+ v
+        stack = remaining.drop(1)
+        onStack = onStack -- scc
+        if sccTail.nonEmpty then cyclic = cyclic ++ scc
+        else if graph.dependencies.get(v).exists(_.contains(v)) then cyclic = cyclic + v
+
+    graph.dependencies.keySet.foreach { node =>
+      if !indices.contains(node) then strongConnect(node)
+    }
+    cyclic
+
+  /**
    * Topological sort using Kahn's algorithm.
    *
    * Returns a linear ordering of cells such that for every dependency A → B, cell B appears before

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/RecalcSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/RecalcSpec.scala
@@ -1,0 +1,116 @@
+package com.tjclp.xl.formula
+
+import com.tjclp.xl.{*, given}
+import com.tjclp.xl.addressing.{ARef, SheetName}
+import com.tjclp.xl.cells.CellValue
+import com.tjclp.xl.sheets.Sheet
+import com.tjclp.xl.workbooks.Workbook
+import munit.FunSuite
+
+/**
+ * Tests for Workbook.recalculate (0.11.0): total whole-workbook recalculation with per-cell
+ * error reporting, cycle isolation, and automatic cross-sheet context.
+ *
+ * Also covers the latent bugs in the pre-0.11.0 withCachedFormulas this replaces: one failing
+ * formula uncached the ENTIRE sheet, and cross-sheet formulas always failed (no workbook
+ * context), silently uncaching their sheet.
+ */
+class RecalcSpec extends FunSuite:
+
+  private def num(i: Int): CellValue = CellValue.Number(BigDecimal(i))
+  private def formula(expr: String): CellValue = CellValue.Formula(expr, None)
+  private val a1 = ARef.from0(0, 0)
+  private val a2 = ARef.from0(0, 1)
+  private val a3 = ARef.from0(0, 2)
+  private val a4 = ARef.from0(0, 3)
+
+  private def cached(wb: Workbook, sheetName: String, ref: ARef): Option[CellValue] =
+    wb.sheets
+      .find(_.name.value == sheetName)
+      .flatMap(_.cells.get(ref))
+      .map(_.value)
+      .collect { case CellValue.Formula(_, Some(v)) => v }
+
+  test("clean workbook: every formula evaluates, caches, and isClean holds"):
+    val sheet = Sheet(SheetName.unsafe("S"))
+      .put(a1, num(10))
+      .put(a2, formula("=A1*2"))
+      .put(a3, formula("=A2+5"))
+    val result = Workbook(sheet).recalculate()
+    assert(result.isClean)
+    assertEquals(cached(result.workbook, "S", a2), Some(num(20)))
+    assertEquals(cached(result.workbook, "S", a3), Some(num(25)))
+    assertEquals(result.toEither.map(_.sheets.size), Right(1))
+
+  test("sibling survival: one failing formula doesn't uncache the rest of the sheet"):
+    val sheet = Sheet(SheetName.unsafe("S"))
+      .put(a1, num(10))
+      .put(a2, formula("=A1*2"))
+      .put(a3, formula("=NOSUCHFN(A1)"))
+    val result = Workbook(sheet).recalculate()
+    assertEquals(cached(result.workbook, "S", a2), Some(num(20)), "sibling must stay cached")
+    assertEquals(cached(result.workbook, "S", a3), None, "failed cell must stay uncached")
+    assertEquals(result.errors.map(_.ref), Vector(a3))
+    assert(!result.isClean)
+
+  test("cycle isolation: participants reported circular, acyclic remainder still evaluates"):
+    val sheet = Sheet(SheetName.unsafe("S"))
+      .put(a1, formula("=A2+1")) // A1 -> A2
+      .put(a2, formula("=A1+1")) // A2 -> A1 (cycle)
+      .put(a3, num(7))
+      .put(a4, formula("=A3*3")) // independent of the cycle
+    val result = Workbook(sheet).recalculate()
+    assertEquals(cached(result.workbook, "S", a4), Some(num(21)), "acyclic cell must evaluate")
+    assertEquals(cached(result.workbook, "S", a1), None)
+    assertEquals(cached(result.workbook, "S", a2), None)
+    assertEquals(result.errors.map(_.ref).toSet, Set(a1, a2))
+    assert(result.errors.forall(_.error.message.contains("Circular")))
+
+  test("dependents of a cycle are reported as blocked, not evaluated"):
+    val sheet = Sheet(SheetName.unsafe("S"))
+      .put(a1, formula("=A2+1"))
+      .put(a2, formula("=A1+1")) // cycle A1<->A2
+      .put(a3, formula("=A1*2")) // depends on the cycle
+    val result = Workbook(sheet).recalculate()
+    assertEquals(cached(result.workbook, "S", a3), None)
+    val byRef = result.errors.map(e => e.ref -> e.error.message).toMap
+    assert(byRef(a3).contains("Blocked"))
+    assertEquals(result.errors.size, 3)
+
+  test("self-referencing formula is circular"):
+    val sheet = Sheet(SheetName.unsafe("S")).put(a1, formula("=A1+1"))
+    val result = Workbook(sheet).recalculate()
+    assertEquals(result.errors.map(_.ref), Vector(a1))
+    assert(result.errors.forall(_.error.message.contains("Circular")))
+
+  test("cross-sheet formulas recalculate and cache (latent pre-0.11.0 bug)"):
+    val data = Sheet(SheetName.unsafe("Data")).put(a1, num(10)).put(a2, num(20))
+    val summary = Sheet(SheetName.unsafe("Summary"))
+      .put(a1, formula("=SUM(Data!A1:A2)"))
+      .put(a2, formula("=A1*2")) // intra-sheet, downstream of the cross-sheet result
+    val result = Workbook(data, summary).recalculate()
+    assert(result.isClean, s"expected clean, got: ${result.errors.map(_.render)}")
+    assertEquals(cached(result.workbook, "Summary", a1), Some(num(30)))
+    assertEquals(cached(result.workbook, "Summary", a2), Some(num(60)))
+
+  test("withCachedFormulas ≡ recalculate(_).workbook"):
+    val sheet = Sheet(SheetName.unsafe("S"))
+      .put(a1, num(10))
+      .put(a2, formula("=A1*2"))
+      .put(a3, formula("=NOSUCHFN(A1)"))
+    val wb = Workbook(sheet)
+    val clock = Clock.fixedDate(java.time.LocalDate.of(2026, 6, 9))
+    assertEquals(wb.withCachedFormulas(clock), wb.recalculate(clock).workbook)
+
+  test("evaluated map exposes computed values per sheet"):
+    val sheet = Sheet(SheetName.unsafe("S")).put(a1, num(2)).put(a2, formula("=A1+3"))
+    val result = Workbook(sheet).recalculate()
+    assertEquals(
+      result.evaluated.get(SheetName.unsafe("S")).flatMap(_.get(a2)),
+      Some(num(5))
+    )
+
+  test("CellEvalError.render is location-qualified"):
+    val sheet = Sheet(SheetName.unsafe("S")).put(a1, formula("=A1"))
+    val result = Workbook(sheet).recalculate()
+    assert(result.errors.headOption.exists(_.render.startsWith("S!A1:")))

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/RecalcSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/RecalcSpec.scala
@@ -114,3 +114,19 @@ class RecalcSpec extends FunSuite:
     val sheet = Sheet(SheetName.unsafe("S")).put(a1, formula("=A1"))
     val result = Workbook(sheet).recalculate()
     assert(result.errors.headOption.exists(_.render.startsWith("S!A1:")))
+
+  test("cross-sheet cycle stays total: caught by depth guard, reported per cell (not Tarjan)"):
+    // Cycle spanning sheets is invisible to the per-sheet Tarjan pass — pin the graceful path:
+    // both cells error (recursion guard), nothing throws, the acyclic remainder still evaluates.
+    val s1 = Sheet(SheetName.unsafe("S1"))
+      .put(a1, formula("=S2!A1+1"))
+      .put(a2, num(5))
+      .put(a3, formula("=A2*2")) // acyclic, must survive
+    val s2 = Sheet(SheetName.unsafe("S2")).put(a1, formula("=S1!A1+1"))
+    val result = Workbook(s1, s2).recalculate()
+    assertEquals(cached(result.workbook, "S1", a3), Some(num(10)))
+    val errorRefs = result.errors.map(e => (e.sheet.value, e.ref)).toSet
+    assert(errorRefs.contains(("S1", a1)), s"S1!A1 should error, got: ${result.errors.map(_.render)}")
+    assert(errorRefs.contains(("S2", a1)), s"S2!A1 should error, got: ${result.errors.map(_.render)}")
+    assertEquals(cached(result.workbook, "S1", a1), None)
+    assertEquals(cached(result.workbook, "S2", a1), None)

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/RecalcSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/RecalcSpec.scala
@@ -130,3 +130,38 @@ class RecalcSpec extends FunSuite:
     assert(errorRefs.contains(("S2", a1)), s"S2!A1 should error, got: ${result.errors.map(_.render)}")
     assertEquals(cached(result.workbook, "S1", a1), None)
     assertEquals(cached(result.workbook, "S2", a1), None)
+
+  test("stack safety: 100k-deep dependency chain neither overflows nor reports cycles"):
+    // Graph built directly (no parsing) — pins the iterative Tarjan engine. The recursive
+    // strongConnect this replaces overflowed around ~10k frames, violating recalculate's
+    // totality promise on deep-but-legal generated models.
+    val n = 100000
+    val deps = (0 until n).map { i =>
+      val node = ARef.from0(0, i)
+      val next = if i + 1 < n then Set(ARef.from0(0, i + 1)) else Set.empty[ARef]
+      node -> next
+    }.toMap
+    val graph = com.tjclp.xl.formula.graph.DependencyGraph(deps, Map.empty)
+    assertEquals(com.tjclp.xl.formula.graph.DependencyGraph.cyclicNodes(graph), Set.empty[ARef])
+    assert(com.tjclp.xl.formula.graph.DependencyGraph.detectCycles(graph).isRight)
+
+  test("stack safety: 100k-node cycle is fully collected without overflow"):
+    val n = 100000
+    val deps = (0 until n).map { i =>
+      ARef.from0(0, i) -> Set(ARef.from0(0, (i + 1) % n)) // last points back to first
+    }.toMap
+    val graph = com.tjclp.xl.formula.graph.DependencyGraph(deps, Map.empty)
+    assertEquals(com.tjclp.xl.formula.graph.DependencyGraph.cyclicNodes(graph).size, n)
+    assert(com.tjclp.xl.formula.graph.DependencyGraph.detectCycles(graph).isLeft)
+
+  test("recalculate end-to-end on a 3k-deep formula chain stays total and clean"):
+    val n = 3000
+    val sheet = (1 until n).foldLeft(Sheet(SheetName.unsafe("Deep")).put(a1, num(1))) {
+      (s, i) => s.put(ARef.from0(0, i), formula(s"=A$i+1"))
+    }
+    val result = Workbook(sheet).recalculate()
+    assert(result.isClean, s"expected clean, got ${result.errors.take(3).map(_.render)}")
+    assertEquals(
+      result.evaluated.values.headOption.flatMap(_.get(ARef.from0(0, n - 1))),
+      Some(num(n))
+    )

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/WorkbookEvaluateFormulaSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/WorkbookEvaluateFormulaSpec.scala
@@ -1,0 +1,44 @@
+package com.tjclp.xl.formula
+
+import com.tjclp.xl.{*, given}
+import com.tjclp.xl.addressing.{ARef, SheetName}
+import com.tjclp.xl.cells.CellValue
+import com.tjclp.xl.sheets.Sheet
+import com.tjclp.xl.workbooks.Workbook
+import munit.FunSuite
+
+/**
+ * Tests for the workbook-level evaluateFormula (0.11.0): cross-sheet context is wired
+ * automatically, so scripts never touch Sheet.evaluateFormula's Option[Workbook] parameter.
+ */
+class WorkbookEvaluateFormulaSpec extends FunSuite:
+
+  private def num(i: Int): CellValue = CellValue.Number(BigDecimal(i))
+
+  private val sales = Sheet(SheetName.unsafe("Sales"))
+    .put(ARef.from0(0, 0), num(10))
+    .put(ARef.from0(0, 1), num(20))
+
+  private val summary = Sheet(SheetName.unsafe("Summary"))
+    .put(ARef.from0(0, 0), num(5))
+
+  private val wb = Workbook(sales, summary)
+
+  test("evaluates intra-sheet formula on the named sheet"):
+    assertEquals(wb.evaluateFormula("=SUM(A1:A2)", "Sales"), Right(num(30)))
+    assertEquals(wb.evaluateFormula("=A1*2", "Summary"), Right(num(10)))
+
+  test("cross-sheet references resolve without passing workbook explicitly"):
+    assertEquals(wb.evaluateFormula("=Sales!A1 + Sales!A2", "Summary"), Right(num(30)))
+    assertEquals(wb.evaluateFormula("=SUM(Sales!A1:A2) + A1", "Summary"), Right(num(35)))
+
+  test("SheetName variant behaves identically"):
+    assertEquals(
+      wb.evaluateFormula("=SUM(Sales!A1:A2)", SheetName.unsafe("Summary")),
+      Right(num(30))
+    )
+
+  test("missing sheet surfaces a structured error"):
+    wb.evaluateFormula("=A1", "Nope") match
+      case Left(err) => assert(err.message.contains("Nope"))
+      case Right(v) => fail(s"expected SheetNotFound, got $v")

--- a/xl/package.mill
+++ b/xl/package.mill
@@ -18,4 +18,12 @@ object `package` extends build.XLModule {
     build.`xl-cats-effect`,
     build.`xl-evaluator`
   )
+
+  object test extends ScalaTests with build.XLTestModule {
+    override def mvnDeps = Seq(
+      mvn"org.scalameta::munit:1.0.3",
+      mvn"org.scalameta::munit-scalacheck:1.2.0",
+      mvn"org.scalacheck::scalacheck:1.18.1"
+    )
+  }
 }

--- a/xl/src/com/tjclp/xl/scripting.scala
+++ b/xl/src/com/tjclp/xl/scripting.scala
@@ -41,6 +41,13 @@ object scripting:
   // The one sanctioned unwrap: .unsafe / .getOrElse on XLResult
   export com.tjclp.xl.unsafe.*
 
+  // Script-only sugar: total smart detection of currency/percent/date/number/boolean from raw
+  // strings ("$1,234.56".toFormatted → Currency). Kept out of the pure core import — heuristics
+  // are script/CLI territory; the underlying FormattedParsers.detect is available everywhere.
+  extension (s: String)
+    def toFormatted: com.tjclp.xl.formatted.Formatted =
+      com.tjclp.xl.formatted.FormattedParsers.detect(s)
+
   // Note: java.time types (LocalDate, LocalDateTime) cannot be re-exported — Scala's export
   // forwards only the type for Java classes, not the statics (LocalDate.of would not resolve).
   // Scripts import java.time directly when needed.

--- a/xl/src/com/tjclp/xl/scripting.scala
+++ b/xl/src/com/tjclp/xl/scripting.scala
@@ -27,12 +27,21 @@ object scripting:
   export com.tjclp.xl.api.*
 
   // DSL operators, codec/optics/patch/sheet syntax, style DSL, Easy Mode string extensions,
-  // rich text, display interpolator, compile-time literals (ref/col/fx/money/percent/date)
+  // rich text, display interpolator, compile-time literals (ref/col/fx/money/percent/date).
+  // The low-priority `default` FormulaDisplayStrategy (raw formula text) is excluded in favor
+  // of the evaluator-backed `evaluating` strategy below: the LowPriority inheritance trick does
+  // not survive export forwarding (both would sit at the same depth here and be ambiguous), so
+  // the prelude makes the choice explicitly — scripts display computed, NumFmt-formatted values.
   export com.tjclp.xl.syntax.*
-  export com.tjclp.xl.syntax.given
+  export com.tjclp.xl.syntax.{default as _, given}
 
-  // Formula system: FormulaParser, Sheet/Workbook evaluator extensions, DependencyGraph, Clock
+  // Formula system: FormulaParser, Sheet/Workbook evaluator extensions, DependencyGraph, Clock,
+  // plus the `evaluating` display given (wildcard exports skip givens, so it needs the explicit
+  // given selector — without it, excel"" interpolation prints raw formula text).
+  // (formulaExports.given also carries an inherited `default` forwarder — EvaluatingFormulaDisplay
+  // extends the LowPriority trait — so the exclusion is needed on this hop too.)
   export com.tjclp.xl.formulaExports.*
+  export com.tjclp.xl.formulaExports.{default as _, given}
 
   // Sync read/write/modify facade + streaming IO escape hatch
   export com.tjclp.xl.io.Excel

--- a/xl/src/com/tjclp/xl/scripting.scala
+++ b/xl/src/com/tjclp/xl/scripting.scala
@@ -37,6 +37,7 @@ object scripting:
   // Sync read/write/modify facade + streaming IO escape hatch
   export com.tjclp.xl.io.Excel
   export com.tjclp.xl.io.ExcelIO
+  export com.tjclp.xl.io.RowData // streaming row type (readStream/writeStream)
 
   // The one sanctioned unwrap: .unsafe / .getOrElse on XLResult
   export com.tjclp.xl.unsafe.*

--- a/xl/src/com/tjclp/xl/scripting.scala
+++ b/xl/src/com/tjclp/xl/scripting.scala
@@ -1,0 +1,46 @@
+package com.tjclp.xl
+
+/**
+ * Scripting prelude: everything a script needs in one import.
+ *
+ * {{{
+ * //> using dep com.tjclp::xl:0.11.0
+ * import com.tjclp.xl.scripting.{*, given}
+ *
+ * val wb = Excel.read("input.xlsx")
+ * val updated = wb.update("Sheet1", _.put(ref"A1", "Hello")).unsafe
+ * Excel.write(updated, "output.xlsx")
+ * }}}
+ *
+ * Bundles the core API, DSL operators, compile-time literals, formula evaluation, the sync `Excel`
+ * facade, streaming `ExcelIO`, and the `.unsafe` boundary. Importing this prelude is the explicit
+ * opt-in to script mode; `import com.tjclp.xl.{*, given}` remains the 100% pure alternative (no
+ * `.unsafe` in scope).
+ *
+ * Use EITHER this import OR `com.tjclp.xl.{*, given}` — never both in one file, as the overlapping
+ * forwarders become ambiguous.
+ */
+object scripting:
+  // Core domain model + String parsing helpers (asCell, asRange, asSheetName).
+  // Extension methods on opaque types (ARef.toA1/col/row/shift, Column.toLetter) resolve via
+  // the companion implicit scope and need no export — see the note in api.scala.
+  export com.tjclp.xl.api.*
+
+  // DSL operators, codec/optics/patch/sheet syntax, style DSL, Easy Mode string extensions,
+  // rich text, display interpolator, compile-time literals (ref/col/fx/money/percent/date)
+  export com.tjclp.xl.syntax.*
+  export com.tjclp.xl.syntax.given
+
+  // Formula system: FormulaParser, Sheet/Workbook evaluator extensions, DependencyGraph, Clock
+  export com.tjclp.xl.formulaExports.*
+
+  // Sync read/write/modify facade + streaming IO escape hatch
+  export com.tjclp.xl.io.Excel
+  export com.tjclp.xl.io.ExcelIO
+
+  // The one sanctioned unwrap: .unsafe / .getOrElse on XLResult
+  export com.tjclp.xl.unsafe.*
+
+  // Note: java.time types (LocalDate, LocalDateTime) cannot be re-exported — Scala's export
+  // forwards only the type for Java classes, not the statics (LocalDate.of would not resolve).
+  // Scripts import java.time directly when needed.

--- a/xl/test/src/xlprelude/BaseImportProbe.scala
+++ b/xl/test/src/xlprelude/BaseImportProbe.scala
@@ -1,0 +1,32 @@
+// Regression probe (issue #252): extension methods on opaque types must resolve and apply on
+// receivers typed via the package-level exported ALIASES (com.tjclp.xl.ARef etc.), from OUTSIDE
+// com.tjclp.xl — exactly how scripts see them. Compile success is the test.
+package xlprelude
+
+object BaseImportProbe:
+  import com.tjclp.xl.{*, given}
+
+  // Alias-typed receivers (the case that breaks with inline extensions)
+  val cell: ARef = ref"A1"
+  val a1: String = cell.toA1
+  val shifted: ARef = cell.shift(1, 1)
+  val shiftedA1: String = shifted.toA1
+  val column: Column = cell.col
+  val letter: String = column.toLetter
+  val colIdx: Int = column.index0
+  val colNext: Column = column + 1
+  val theRow: Row = cell.row
+  val rowIdx: Int = theRow.index1
+  val rowNext: Row = theRow + 1
+
+  // Companion factories through the package-level forwarders
+  val constructed: ARef = ARef(column, theRow)
+  val fromIdx: ARef = ARef.from0(2, 2)
+  val parsed: Either[String, ARef] = ARef.parse("C3")
+
+  // SheetName + style units through aliases
+  val sn: Either[String, SheetName] = SheetName("Data")
+  val snValue: Option[String] = sn.toOption.map(_.value)
+  val pt: Pt = Pt(12.0)
+  val px: Px = pt.toPx
+  val back: Double = px.value

--- a/xl/test/src/xlprelude/BaseImportProbe.scala
+++ b/xl/test/src/xlprelude/BaseImportProbe.scala
@@ -1,12 +1,12 @@
-// Regression probe (issue #252): extension methods on opaque types must resolve and apply on
-// receivers typed via the package-level exported ALIASES (com.tjclp.xl.ARef etc.), from OUTSIDE
-// com.tjclp.xl — exactly how scripts see them. Compile success is the test.
+// Regression probe (issue #252): the public API surface must work on receivers exactly as
+// scripts see them — package-level aliases, factory-result chains, and the prelude — from
+// OUTSIDE com.tjclp.xl. Compile success is the test.
 package xlprelude
 
 object BaseImportProbe:
   import com.tjclp.xl.{*, given}
 
-  // Alias-typed receivers (the case that breaks with inline extensions)
+  // Alias-typed receivers
   val cell: ARef = ref"A1"
   val a1: String = cell.toA1
   val shifted: ARef = cell.shift(1, 1)
@@ -19,14 +19,23 @@ object BaseImportProbe:
   val rowIdx: Int = theRow.index1
   val rowNext: Row = theRow + 1
 
-  // Companion factories through the package-level forwarders
+  // Companion factories through the package-level singleton vals
   val constructed: ARef = ARef(column, theRow)
   val fromIdx: ARef = ARef.from0(2, 2)
   val parsed: Either[String, ARef] = ARef.parse("C3")
 
-  // SheetName + style units through aliases
+  // Extension methods chained directly on factory results (demo.sc regression)
+  val chainedLetter: String = Column.from0(0).toLetter
+  val chainedA1: String = ARef.from0(2, 2).toA1
+  val chainedShift: String = ARef.from0(0, 0).shift(1, 1).toA1
+  val chainedIdx: Int = Row.from0(4).index1
+  val inferredFactory = Column.from0(0)
+  val inferredLetter: String = inferredFactory.toLetter
+
+  // SheetName + style units: aliases, factories, and chains
   val sn: Either[String, SheetName] = SheetName("Data")
   val snValue: Option[String] = sn.toOption.map(_.value)
   val pt: Pt = Pt(12.0)
   val px: Px = pt.toPx
   val back: Double = px.value
+  val chainedUnit: Double = Pt(12.0).toPx.value

--- a/xl/test/src/xlprelude/ScriptingPreludeTest.scala
+++ b/xl/test/src/xlprelude/ScriptingPreludeTest.scala
@@ -153,6 +153,13 @@ class ScriptingPreludeTest extends FunSuite:
       Some(3)
     )
 
+  test("smart detection: FormattedParsers.detect and String.toFormatted via the prelude"):
+    val detected = "$1,234.56".toFormatted
+    assertEquals(detected.numFmt, NumFmt.Currency)
+    assertEquals(FormattedParsers.detect("45.5%").numFmt, NumFmt.Percent)
+    val sheet = Sheet("Smart").put(ref"A1", detected)
+    assertEquals(sheet.cells.size, 1)
+
   test("ExcelIO escape hatch is reachable"):
     val io = ExcelIO
     assert(io != null || true)

--- a/xl/test/src/xlprelude/ScriptingPreludeTest.scala
+++ b/xl/test/src/xlprelude/ScriptingPreludeTest.scala
@@ -114,6 +114,13 @@ class ScriptingPreludeTest extends FunSuite:
     given Sheet = sheet
     assertEquals(excel"${ref"A1"}", "100")
 
+  test("display interpolator evaluates formulas (evaluating strategy wins in the prelude)"):
+    val sheet = Sheet("DispF")
+      .put(ref"A1", 100)
+      .put(ref"B1", fx"=A1*2")
+    given Sheet = sheet
+    assertEquals(excel"${ref"B1"}", "200")
+
   test("upsert, wb.evaluateFormula, and readTypedOr resolve through the prelude"):
     val wb = Workbook(Sheet("Sales").put(ref"A1", 10).put(ref"A2", 20))
       .upsert("Summary", _.put(ref"A1", 5))

--- a/xl/test/src/xlprelude/ScriptingPreludeTest.scala
+++ b/xl/test/src/xlprelude/ScriptingPreludeTest.scala
@@ -1,0 +1,129 @@
+// Deliberately OUTSIDE com.tjclp.xl: scripts import the prelude from a fresh namespace,
+// so this test must not see the package-level exports that files under com.tjclp.xl inherit.
+package xlprelude
+
+import java.time.{LocalDate, LocalDateTime}
+
+import munit.FunSuite
+
+import com.tjclp.xl.scripting.{*, given}
+
+/**
+ * Gate test for the scripting prelude: every public surface a script touches must resolve
+ * through `import com.tjclp.xl.scripting.{*, given}` alone — macros (transparent inline through
+ * an export hop), given instances, DSL operators, evaluator extensions, sync IO, and the unsafe
+ * boundary. Compile success is most of the test; runtime assertions confirm semantics.
+ */
+class ScriptingPreludeTest extends FunSuite:
+
+  test("compile-time ref macros resolve through the prelude"):
+    val cell: ARef = ref"A1"
+    val range: CellRange = ref"A1:B10"
+    assertEquals(cell.toA1, "A1")
+    assertEquals(range.start.toA1, "A1")
+    assertEquals(range.end.toA1, "B10")
+
+  test("formatted literal macros resolve through the prelude"):
+    val m: Formatted = money"$$1,234.56"
+    val p: Formatted = percent"12.5%"
+    val d: Formatted = date"2025-11-24"
+    val f: CellValue = fx"=SUM(A1:B10)"
+    assert(m.numFmt != NumFmt.General)
+    assert(p.numFmt != NumFmt.General)
+    assert(d.numFmt != NumFmt.General)
+    f match
+      case CellValue.Formula(expr, _) => assert(expr.nonEmpty)
+      case other => fail(s"fx literal should produce CellValue.Formula, got $other")
+
+  test("Sheet construction and literal-string puts are infallible"):
+    val sheet = Sheet("Demo")
+      .put("A1", "Title")
+      .put("B1", 42)
+    assertEquals(sheet.cells.size, 2)
+
+  test("CellCodec givens and conversions resolve: typed put and readTyped"):
+    val sheet = Sheet("Typed")
+      .put(ref"A1", "text")
+      .put(ref"B1", 42)
+      .put(ref"C1", BigDecimal("1000.50"))
+      .put(ref"D1", LocalDate.of(2025, 1, 15))
+      .put(ref"E1", LocalDateTime.of(2025, 1, 15, 10, 30))
+    assertEquals(sheet.readTyped[Int](ref"B1"), Right(Some(42)): Either[CodecError, Option[Int]])
+    assertEquals(
+      sheet.readTyped[String](ref"A1"),
+      Right(Some("text")): Either[CodecError, Option[String]]
+    )
+    assertEquals(
+      sheet.readTyped[BigDecimal](ref"C1"),
+      Right(Some(BigDecimal("1000.50"))): Either[CodecError, Option[BigDecimal]]
+    )
+
+  test("Patch DSL composes: :=, ++, styled, merge"):
+    val patch =
+      (ref"A1" := "Report") ++
+        ref"A1".styled(CellStyle.default.bold) ++
+        ref"A1:C1".merge ++
+        (ref"B2" := 19.99)
+    val sheet = Sheet("Patched").put(patch)
+    assertEquals(sheet.cells.size, 2)
+    assertEquals(sheet.mergedRanges.size, 1)
+
+  test("runtime ref interpolation returns Either and := works on RefType"):
+    val row = "5"
+    val patch = (for refType <- ref"A$row"
+    yield refType := "dynamic").getOrElse(Patch.empty)
+    val sheet = Sheet("Dyn").put(patch)
+    assertEquals(sheet.cells.size, 1)
+
+  test("rich text extensions resolve"):
+    val rich = "Status: ".bold + "ACTIVE".green
+    val sheet = Sheet("Rich").put(ref"A1", rich)
+    assertEquals(sheet.cells.size, 1)
+
+  test("unsafe boundary resolves: .unsafe unwraps XLResult"):
+    val runtimeRef = "A1"
+    val sheet = Sheet("Unsafe").put(runtimeRef, "value").unsafe
+    assertEquals(sheet.cells.size, 1)
+    // Literal invalid refs fail at compile time (verified: the macro rejects them through the
+    // prelude hop); a runtime string is needed to exercise the XLException path.
+    val invalidRef = "NOT A REF!!!"
+    intercept[XLException]:
+      Sheet("Unsafe").put(invalidRef, "boom").unsafe
+
+  test("formula evaluation extensions resolve through the prelude"):
+    val sheet = Sheet("Calc")
+      .put(ref"A1", 2)
+      .put(ref"A2", 3)
+    val result = sheet.evaluateFormula("=SUM(A1:A2)")
+    assert(result.exists {
+      case CellValue.Number(n) => n == BigDecimal(5)
+      case _ => false
+    })
+    assert(sheet.evaluateWithDependencyCheck().isRight)
+    assert(FormulaParser.parse("=SUM(A1:A10)").isRight)
+    val clock = Clock.system
+    assert(clock != null || true)
+
+  test("display interpolator resolves with given Sheet"):
+    val sheet = Sheet("Disp").put(ref"A1", 100)
+    given Sheet = sheet
+    assertEquals(excel"${ref"A1"}", "100")
+
+  test("workbook construction, withCachedFormulas, and sync Excel round-trip"):
+    val sheet = Sheet("Data")
+      .put(ref"A1", 10)
+      .put(ref"A2", 20)
+      .put(ref"A3", fx"=SUM(A1:A2)")
+    val wb = Workbook(sheet).withCachedFormulas()
+    val path = java.nio.file.Files.createTempDirectory("xl-prelude").resolve("roundtrip.xlsx")
+    Excel.write(wb, path.toString)
+    val loaded = Excel.read(path.toString)
+    assertEquals(loaded.sheets.size, 1)
+    assertEquals(
+      loaded.sheets.headOption.map(_.cells.size),
+      Some(3)
+    )
+
+  test("ExcelIO escape hatch is reachable"):
+    val io = ExcelIO
+    assert(io != null || true)

--- a/xl/test/src/xlprelude/ScriptingPreludeTest.scala
+++ b/xl/test/src/xlprelude/ScriptingPreludeTest.scala
@@ -68,6 +68,11 @@ class ScriptingPreludeTest extends FunSuite:
     assertEquals(sheet.cells.size, 2)
     assertEquals(sheet.mergedRanges.size, 1)
 
+  test("range fill := and ARef navigation resolve through the prelude"):
+    val sheet = Sheet("Fill").put(ref"A1:B2" := 0)
+    assertEquals(sheet.cells.size, 4)
+    assertEquals(ref"A1".down(2).right(1), ref"B3")
+
   test("runtime ref interpolation returns Either and := works on RefType"):
     val row = "5"
     val patch = (for refType <- ref"A$row"

--- a/xl/test/src/xlprelude/ScriptingPreludeTest.scala
+++ b/xl/test/src/xlprelude/ScriptingPreludeTest.scala
@@ -114,6 +114,17 @@ class ScriptingPreludeTest extends FunSuite:
     given Sheet = sheet
     assertEquals(excel"${ref"A1"}", "100")
 
+  test("upsert, wb.evaluateFormula, and readTypedOr resolve through the prelude"):
+    val wb = Workbook(Sheet("Sales").put(ref"A1", 10).put(ref"A2", 20))
+      .upsert("Summary", _.put(ref"A1", 5))
+    assertEquals(
+      wb.evaluateFormula("=SUM(Sales!A1:A2) + A1", "Summary"),
+      Right(CellValue.Number(BigDecimal(35))): XLResult[CellValue]
+    )
+    val sheet = wb.sheets.headOption.getOrElse(fail("missing sheet"))
+    assertEquals(sheet.readTypedOr[Int](ref"A1", 0), 10)
+    assertEquals(sheet.readTypedOpt[Int](ref"Z9"), None)
+
   test("workbook construction, withCachedFormulas, and sync Excel round-trip"):
     val sheet = Sheet("Data")
       .put(ref"A1", 10)

--- a/xl/test/src/xlprelude/ScriptingPreludeTest.scala
+++ b/xl/test/src/xlprelude/ScriptingPreludeTest.scala
@@ -125,6 +125,19 @@ class ScriptingPreludeTest extends FunSuite:
     assertEquals(sheet.readTypedOr[Int](ref"A1", 0), 10)
     assertEquals(sheet.readTypedOpt[Int](ref"Z9"), None)
 
+  test("recalculate with per-cell errors resolves through the prelude"):
+    val sheet = Sheet("Calc2")
+      .put(ref"A1", 10)
+      .put(ref"A2", fx"=A1*2")
+      .put(ref"A3", fx"=NOSUCHFN(A1)")
+    val result: RecalcResult = Workbook(sheet).recalculate()
+    assert(!result.isClean)
+    assertEquals(result.errors.map(_.ref.toA1), Vector("A3"))
+    assertEquals(
+      result.evaluated.values.headOption.flatMap(_.get(ref"A2")),
+      Some(CellValue.Number(BigDecimal(20)))
+    )
+
   test("workbook construction, withCachedFormulas, and sync Excel round-trip"):
     val sheet = Sheet("Data")
       .put(ref"A1", 10)


### PR DESCRIPTION
Closes #252. Targets 0.11.0 "Scripting".

## Library hardening

- **`com.tjclp.xl.scripting` prelude** — one import for scripts: core API, DSL, compile-time literals, evaluator, sync `Excel`, streaming `ExcelIO`/`RowData`, smart detection sugar, `.unsafe`. The plain `com.tjclp.xl.{*, given}` import stays 100% pure.
- **Total DSL**: `range := v` fills every cell (Excel Ctrl+Enter; the documented silent-no-op wart is fixed as a bug); `ARef.down/up/right/left` for Either-free loops.
- **`Workbook.upsert`** (total update-or-create), **`readTypedOr`/`readTypedOpt`**, **`wb.evaluateFormula(formula, onSheet)`** (cross-sheet context wired automatically).
- **`Workbook.recalculate`** → `RecalcResult`: total whole-workbook recalc, per-cell `CellEvalError`s, Tarjan cycle isolation (participants circular, dependents blocked, acyclic remainder evaluates).
- **`FormattedParsers.detect`** promoted from CLI-private code (CLI delegates; `String.toFormatted` in the prelude).

## Bugs found by the new gates (all shipped in ≤0.10.0)

1. **Opaque-type extensions were unusable outside `com.tjclp.xl`** — export forwarders produced proxy types that never unify; `Column.from0(0).toLetter` (examples/demo.sc) didn't compile against 0.10.0. Fixed with explicit alias + singleton-val pairs, de-inlined opaque extensions/factories, companion-scope resolution.
2. **`withCachedFormulas` uncached entire sheets** on one failing formula, and cross-sheet formulas always failed (no workbook context). Now per-cell + cross-sheet aware via `recalculate`.
3. **Scripts hung at exit after `toHtml`/`toSvg`** — non-headless AWT's non-daemon AWT-Shutdown thread. AWT now defaults to headless unless explicitly configured.

## xl-scripting skill + anti-rot

- `plugin/skills/xl-scripting/{SKILL.md, reference/API.md, reference/RECIPES.md}` — version-pinned (deliberate vs xl-cli's auto-detect: `//> using dep` needs an exact string; skill + library ship in the same tag), 7 complete runnable recipes, all 12 snippets compile-verified.
- CI: `examples` job (`scripts/test-examples.sh`: drift guard + compile all `examples/*.sc` + run curated subset with per-example timeout) and `skill-verify` workflow (`scripts/verify-skill-snippets.sh`).
- release.yml packages `xl-scripting-skill-<version>.zip` with a version-pin gate; release-prep checklist updated.
- 7 examples migrated to the prelude; external-consumer probes live in `xl/test/src/xlprelude/` (deliberately outside the package — files inside inherit package exports and mask these bugs).

## Verification

- 1028 tests green (incl. new RangeFillSpec, UpsertSpec, RecalcSpec, WorkbookEvaluateFormulaSpec, ScriptingPreludeTest, BaseImportProbe)
- All 20 `examples/*.sc` compile against the local build; 6 curated examples run
- All 12 skill snippets compile (`verify-skill-snippets.sh --local`)

Note for release-prep: STATUS.md doc-truth pass deferred to the release flow as usual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)