### PR TITLE
Render & style fidelity: fix #254-#256, implement #257-#260

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ results/
 ### Downloaded Binaries ###
 xl-*-linux-amd64
 xl-skill-*.zip
+.claude/worktrees/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added (render & style fidelity, #254-#260)
+
+- **Per-side border DSL + range outlines** (#257): `CellStyle.borderTop/borderBottom/borderLeft/
+  borderRight` builders (with color overloads) merging into the existing border, and
+  `range.outlined(style[, color])` — an edge-correct outline patch built on the new
+  `Patch.MergeBorder` case (apply-time border overlay preserving font/fill/numFmt; note for
+  exhaustive matchers: `Patch` gains a case).
+- **Alignment indent DSL** (#260): `CellStyle.indent(n)` shortcut (model + OOXML round-trip
+  already existed); style dedup and round-trip now covered by tests; styles parser hardened
+  against negative `indent` attributes in malformed files.
+- **Sheet view settings** (#258): `SheetView(showGridLines, zoomScale)` on
+  `Sheet.viewSettings`, serialized into the same `sheetView` element as freeze panes; SVG
+  renderer suppresses gridlines when a sheet disables them.
+- **Print setup** (#259): `PageSetup` gains `headerFooter` (odd header/footer with `&P`/`&N`
+  codes), `margins`, `printArea`, and `repeatRows` — emitted in schema order and round-tripped;
+  print area/titles ride the defined-names pipeline as sheet-scoped `_xlnm` names. Follow-ups
+  (even/first headers, `fitToPage` flag) tracked separately.
+
+### Fixed (render & style fidelity, #254-#260)
+
+- **Custom number formats: zero routed to the negative section** (#254): two-section codes
+  (`pos;neg`) now format zero through the positive section per Excel's rule — `$0.0`, not
+  `($0.0)`. One unified section-selection site covers display, HTML/SVG, CLI, and `TEXT()`.
+- **SVG cell fonts silently overridden** (#255): the embedded `.cell-text` CSS rule's
+  font-family/font-size outranked per-cell presentation attributes in every CSS-aware
+  rasterizer (and the attribute value carried CSS-style quotes fontconfig can't match). Class
+  rules no longer declare fonts; every text path emits explicit, unquoted font attributes.
+- **SVG underline dropped** (#256): `Font.underline` now emits `text-decoration="underline"`
+  on SVG text (HTML already had it), so underlined headers survive PNG/PDF export.
+
+### Changed
+
+- Reading a workbook now populates `Sheet.pageSetup` for any sheet with `<pageMargins>`
+  (virtually all real files) — previously only sheets with `<pageSetup>`; modelable
+  `_xlnm.Print_Area`/`_xlnm.Print_Titles` defined names are lifted into `pageSetup` instead of
+  surfacing in `metadata.definedNames`.
+
+
 ### Added (scripting hardening, #252)
 
 - **Scripting prelude** `com.tjclp.xl.scripting.{*, given}`: one import for scripts — core API,

--- a/xl-core/src/com/tjclp/xl/display/FormatCodeParser.scala
+++ b/xl-core/src/com/tjclp/xl/display/FormatCodeParser.scala
@@ -407,6 +407,11 @@ object FormatCodeParser:
   /**
    * Apply a parsed format code to a numeric value.
    *
+   * Section selection follows Excel's rules:
+   *   - 1 section: all numbers use it (negatives keep their default minus sign)
+   *   - 2 sections: positive and zero use the 1st, negative uses the 2nd
+   *   - 3+ sections: positive uses the 1st, negative the 2nd, zero the 3rd
+   *
    * @param value
    *   The number to format
    * @param format
@@ -425,7 +430,7 @@ object FormatCodeParser:
       else
         format.zero match
           case Some(z) => (z, value)
-          case None => format.negative.getOrElse(format.positive) -> value
+          case None => (format.positive, value) // Excel: zero uses positive section (GH-254)
 
     val color = section.condition.collect { case Condition.Color(c) => c }
     val formatted = applyPattern(effectiveValue, section.pattern)

--- a/xl-core/src/com/tjclp/xl/dsl/syntax.scala
+++ b/xl-core/src/com/tjclp/xl/dsl/syntax.scala
@@ -4,6 +4,8 @@ import com.tjclp.xl.addressing.{ARef, CellRange, RefType}
 import com.tjclp.xl.cells.CellValue
 import com.tjclp.xl.patch.Patch
 import com.tjclp.xl.styles.CellStyle
+import com.tjclp.xl.styles.border.{Border, BorderSide, BorderStyle}
+import com.tjclp.xl.styles.color.Color
 import com.tjclp.xl.styles.units.StyleId
 
 /**
@@ -150,6 +152,64 @@ object syntax:
 
     /** Create a SetRangeStyle patch to apply style to all cells in range */
     def styled(style: CellStyle): Patch = Patch.SetRangeStyle(range, style)
+
+    /**
+     * Outline the outer edges of the range (the boxed-figure pattern in banker templates).
+     *
+     * Edge-correct: cells on the top row get a top border, the bottom row a bottom border, the left
+     * column a left border, and the right column a right border — corners get both, interior cells
+     * are untouched. Degenerate shapes follow naturally: a 1x1 range gets all four sides, a single
+     * row gets top+bottom on every cell, a single column gets left+right.
+     *
+     * Desugars to a Batch of per-cell [[Patch.MergeBorder]] patches, so each cell's existing font,
+     * fill, number format, alignment, and untouched border sides are preserved at apply time (the
+     * CLI's additive border semantics).
+     *
+     * Cost is proportional to the perimeter, not the area — interior cells produce no patches.
+     * Outlining a full column (`A:A`) still touches 1,048,576 edge cells; prefer a bounded range.
+     */
+    def outlined(borderStyle: BorderStyle): Patch =
+      outlinePatch(range, BorderSide(borderStyle))
+
+    /** Outline the outer edges of the range with a colored border. See [[outlined]]. */
+    @annotation.targetName("outlinedColored")
+    def outlined(borderStyle: BorderStyle, color: Color): Patch =
+      outlinePatch(range, BorderSide(borderStyle, color))
+
+  /**
+   * Build the per-cell outline patch for a range: one [[Patch.MergeBorder]] per perimeter cell,
+   * carrying exactly the sides that cell contributes to the outline.
+   */
+  private def outlinePatch(range: CellRange, side: BorderSide): Patch =
+    val top = range.rowStart.index0
+    val bottom = range.rowEnd.index0
+    val left = range.colStart.index0
+    val right = range.colEnd.index0
+
+    def borderAt(col: Int, row: Int): Border =
+      Border(
+        left = if col == left then side else BorderSide.none,
+        right = if col == right then side else BorderSide.none,
+        top = if row == top then side else BorderSide.none,
+        bottom = if row == bottom then side else BorderSide.none
+      )
+
+    // Top and bottom rows span every column; left/right columns only the strictly interior rows
+    // (corners are covered once, by the row pass). A 1-row or 1-column range degenerates cleanly.
+    val edgeRows = if top == bottom then Vector(top) else Vector(top, bottom)
+    val edgeCols = if left == right then Vector(left) else Vector(left, right)
+    val rowPass =
+      for
+        row <- edgeRows
+        col <- left to right
+      yield Patch.MergeBorder(ARef.from0(col, row), borderAt(col, row)): Patch
+    val columnPass =
+      for
+        row <- (top + 1) until bottom
+        col <- edgeCols
+      yield Patch.MergeBorder(ARef.from0(col, row), borderAt(col, row)): Patch
+
+    Patch.Batch(rowPass.toVector ++ columnPass.toVector)
 
   // ========== RefType Extensions (Runtime Interpolation Support) ==========
 

--- a/xl-core/src/com/tjclp/xl/patch/Patch.scala
+++ b/xl-core/src/com/tjclp/xl/patch/Patch.scala
@@ -8,6 +8,7 @@ import com.tjclp.xl.error.XLResult
 import com.tjclp.xl.sheets.{ColumnProperties, RowProperties, Sheet}
 import com.tjclp.xl.sheets.syntax.*
 import com.tjclp.xl.styles.CellStyle
+import com.tjclp.xl.styles.border.Border
 import com.tjclp.xl.styles.units.StyleId
 
 /**
@@ -33,6 +34,16 @@ enum Patch:
 
   /** Set style for a range of cells (auto-registers in styleRegistry) */
   case SetRangeStyle(range: CellRange, style: CellStyle)
+
+  /**
+   * Merge border sides into a cell's existing style (auto-registers in styleRegistry).
+   *
+   * Unlike [[SetCellStyle]], which replaces the whole style, this preserves the cell's existing
+   * font, fill, number format, and alignment, and only overlays the border sides that are set
+   * (non-none) in `border` — the CLI's additive border semantics (`--border-top` etc.). Sides left
+   * as `BorderSide.none` keep the cell's existing sides.
+   */
+  case MergeBorder(ref: ARef, border: Border)
 
   /** Clear style for a cell */
   case ClearStyle(ref: ARef)
@@ -112,6 +123,11 @@ object Patch:
     case SetRangeStyle(range, style) =>
       // Register style and apply to all cells in range
       sheet.withRangeStyle(range, style)
+
+    case MergeBorder(ref, border) =>
+      // Overlay border sides onto the cell's existing style (font/fill/numFmt/align preserved)
+      val existing = sheet.getCellStyle(ref).getOrElse(CellStyle.default)
+      sheet.withCellStyle(ref, existing.withBorder(existing.border.merge(border)))
 
     case ClearStyle(ref) =>
       val cell = sheet(ref).clearStyle

--- a/xl-core/src/com/tjclp/xl/render/RenderUtils.scala
+++ b/xl-core/src/com/tjclp/xl/render/RenderUtils.scala
@@ -300,6 +300,17 @@ object RenderUtils:
       .replace("\r", "\\D ")
       .replace("\u0000", "")
 
+  /**
+   * Format a font family name for an SVG presentation attribute (`font-family="..."`).
+   *
+   * SVG presentation attributes accept multi-word family names unquoted; CSS-style single quotes
+   * would become part of the family name, so fontconfig-based rasterizers (rsvg-convert, resvg)
+   * fail to match the family and silently substitute sans-serif (GH-255). Only XML escaping is
+   * applied. Quotes are still required in CSS contexts (HTML `style=""` attributes and `<style>`
+   * blocks) — use `escapeCss` with explicit quotes there.
+   */
+  def svgFontFamily(name: String): String = escapeXml(name)
+
   // ========== Color Resolution ==========
 
   /** Convert Color to CSS/SVG-compatible RGB hex using theme for resolution. Returns #RRGGBB. */

--- a/xl-core/src/com/tjclp/xl/render/SvgRenderer.scala
+++ b/xl-core/src/com/tjclp/xl/render/SvgRenderer.scala
@@ -81,11 +81,14 @@ object SvgRenderer:
     sb.append(s"""width="$totalWidth" height="$totalHeight">\n""")
 
     // Embedded styles - note: 11pt = ~15px (11 * 4/3)
-    // Gridlines are now applied via inline stroke attributes for reliable cross-renderer support
+    // Gridlines are now applied via inline stroke attributes for reliable cross-renderer support.
+    // IMPORTANT: .cell-text must NOT declare font-family/font-size — CSS class rules outrank
+    // presentation attributes in the cascade, which silently overrode per-cell fonts in every
+    // CSS-aware rasterizer (GH-255). Cell text carries explicit font attributes on every path
+    // instead; the class remains for semantic grouping only.
     sb.append(s"""  <style>
     .header { fill: #E0E0E0; stroke: #999999; stroke-width: 1; }
     .header-text { font-family: 'Segoe UI', Arial, sans-serif; font-size: 15px; fill: #333333; }
-    .cell-text { font-family: 'Calibri', 'Segoe UI', Arial, sans-serif; font-size: 15px; }
   </style>
 """)
 
@@ -264,8 +267,9 @@ object SvgRenderer:
                       case "end" => textX - totalWidth
                       case _ => textX // "start"
 
+                    // Explicit base font attrs (was CSS .cell-text): tspan runs override per-run
                     textBuffer.append(
-                      s"""    <text y="$textY" class="cell-text"$clipAttr>"""
+                      s"""    <text y="$textY" class="cell-text" font-size="15px" font-family="Calibri"$clipAttr>"""
                     )
                     rt.runs.zipWithIndex.foldLeft(adjustedTextX) { case (currentX, (run, idx)) =>
                       val runStyle = runToSvgStyle(run, baseFont, theme)
@@ -279,8 +283,11 @@ object SvgRenderer:
                   case other =>
                     val text = cellValueToText(other, numFmt)
                     if text.nonEmpty then
+                      // includeStyles=false still needs explicit font attrs now that the
+                      // .cell-text CSS rule no longer declares them (GH-255 cascade fix)
                       val textStyle =
-                        if includeStyles then cellTextStyle(cell, sheet, theme) else ""
+                        if includeStyles then cellTextStyle(cell, sheet, theme)
+                        else """ fill="#000000" font-size="15px" font-family="Calibri""""
                       val style = cell.styleId.flatMap(sheet.styleRegistry.get)
                       val shouldWrap = style.exists(_.align.wrapText)
 

--- a/xl-core/src/com/tjclp/xl/render/SvgRenderer.scala
+++ b/xl-core/src/com/tjclp/xl/render/SvgRenderer.scala
@@ -489,18 +489,21 @@ object SvgRenderer:
         // Font style
         if style.font.italic then attrs += """font-style="italic""""
 
+        // Underline (SVG uses text-decoration, GH-256)
+        if style.font.underline then attrs += """text-decoration="underline""""
+
         // ALWAYS include font size (don't rely on CSS defaults) - convert pt to px (pt * 4/3)
         val fontSizePx = (style.font.sizePt * 4.0 / 3.0).toInt
         attrs += s"""font-size="${fontSizePx}px""""
 
-        // ALWAYS include font family (even if default) - quote font names for SVG
-        attrs += s"""font-family="'${escapeCss(style.font.name)}'""""
+        // ALWAYS include font family (even if default) - unquoted in SVG attributes (GH-255)
+        attrs += s"""font-family="${svgFontFamily(style.font.name)}""""
 
         " " + attrs.mkString(" ")
       }
       .getOrElse {
         // No style - use explicit defaults for exact fidelity
-        """ fill="#000000" font-size="15px" font-family="'Calibri'""""
+        """ fill="#000000" font-size="15px" font-family="Calibri""""
       }
 
   /**
@@ -535,8 +538,8 @@ object SvgRenderer:
         val fontSizePx = (f.sizePt * 4.0 / 3.0).toInt
         attrs += s"""font-size="${fontSizePx}px""""
 
-        // Font family - always include for exact fidelity - quote font names for SVG
-        attrs += s"""font-family="'${escapeCss(f.name)}'""""
+        // Font family - always include for exact fidelity - unquoted in SVG attributes (GH-255)
+        attrs += s"""font-family="${svgFontFamily(f.name)}""""
 
         if attrs.nonEmpty then " " + attrs.mkString(" ") else ""
 

--- a/xl-core/src/com/tjclp/xl/render/SvgRenderer.scala
+++ b/xl-core/src/com/tjclp/xl/render/SvgRenderer.scala
@@ -34,7 +34,9 @@ object SvgRenderer:
    * @param showLabels
    *   Whether to show column letters (A, B, C...) and row numbers (1, 2, 3...) (default: false)
    * @param showGridlines
-   *   Whether to show cell gridlines (default: false, matches HTML behavior)
+   *   Whether to show cell gridlines (default: false, matches HTML behavior). A sheet-level
+   *   `SheetView(showGridLines = false)` suppresses gridlines even when this flag is set, matching
+   *   how Excel renders such sheets (GH-258).
    * @return
    *   SVG string
    */
@@ -46,6 +48,9 @@ object SvgRenderer:
     showLabels: Boolean = false,
     showGridlines: Boolean = false
   ): String =
+    // GH-258: the sheet's own view settings win when they disable gridlines (templates that are
+    // gridline-free in Excel must stay gridline-free in exports).
+    val gridlinesEnabled = showGridlines && sheet.viewSettings.forall(_.showGridLines)
     val startCol = range.start.col.index0
     val endCol = range.end.col.index0
     val startRow = range.start.row.index0
@@ -207,7 +212,7 @@ object SvgRenderer:
 
             // Gridlines: add explicit stroke attributes (CSS-only approach unreliable across renderers)
             val strokeAttr =
-              if showGridlines then """ stroke="#D0D0D0" stroke-width="0.5""""
+              if gridlinesEnabled then """ stroke="#D0D0D0" stroke-width="0.5""""
               else ""
 
             sb.append(

--- a/xl-core/src/com/tjclp/xl/sheets/PageSetup.scala
+++ b/xl-core/src/com/tjclp/xl/sheets/PageSetup.scala
@@ -1,7 +1,67 @@
 package com.tjclp.xl.sheets
 
+import com.tjclp.xl.addressing.{CellRange, Row}
+
+/**
+ * Print header/footer text for a sheet, serialized to the worksheet's `<headerFooter>` element.
+ *
+ * Strings support Excel's formatting codes: `&P` (page number), `&N` (total pages), `&D` (date),
+ * `&T` (time), `&F` (file name), `&A` (sheet name), plus the `&L`/`&C`/`&R` section markers for
+ * left/center/right placement (e.g. `"&LTHE JORDAN COMPANY&RPage &P of &N"`).
+ *
+ * Only odd-page headers/footers are modeled for now; even/first-page variants present in a source
+ * file are preserved verbatim on rewrite.
+ *
+ * @param oddHeader
+ *   Header text for odd pages (all pages unless differentOddEven is set in the source file)
+ * @param oddFooter
+ *   Footer text for odd pages
+ */
+final case class HeaderFooter(
+  oddHeader: Option[String] = None,
+  oddFooter: Option[String] = None
+)
+
+/**
+ * Page margins in inches, serialized to the worksheet's `<pageMargins>` element.
+ *
+ * Defaults match Excel's "Normal" margin preset.
+ *
+ * @param left
+ *   Left margin (default 0.7")
+ * @param right
+ *   Right margin (default 0.7")
+ * @param top
+ *   Top margin (default 0.75")
+ * @param bottom
+ *   Bottom margin (default 0.75")
+ * @param header
+ *   Distance from page top to header (default 0.3")
+ * @param footer
+ *   Distance from page bottom to footer (default 0.3")
+ */
+final case class PageMargins(
+  left: Double = 0.7,
+  right: Double = 0.7,
+  top: Double = 0.75,
+  bottom: Double = 0.75,
+  header: Double = 0.3,
+  footer: Double = 0.3
+):
+  require(
+    left >= 0 && right >= 0 && top >= 0 && bottom >= 0 && header >= 0 && footer >= 0,
+    s"Margins must be non-negative, got: left=$left right=$right top=$top bottom=$bottom header=$header footer=$footer"
+  )
+
+object PageMargins:
+  val default: PageMargins = PageMargins()
+
 /**
  * Page setup settings for printing/PDF export.
+ *
+ * Scale/orientation/fit map to the worksheet's `<pageSetup>` element, margins to `<pageMargins>`,
+ * header/footer to `<headerFooter>`. Print area and repeat rows are serialized as sheet-scoped
+ * workbook defined names (`_xlnm.Print_Area` / `_xlnm.Print_Titles`).
  *
  * @param scale
  *   Print scale percentage (10-400, default 100)
@@ -11,17 +71,34 @@ package com.tjclp.xl.sheets
  *   Fit to N pages wide (None = no fit)
  * @param fitToHeight
  *   Fit to N pages tall (None = no fit)
+ * @param headerFooter
+ *   Print header/footer text with Excel codes (None = no header/footer)
+ * @param margins
+ *   Page margins in inches (None = Excel defaults / preserve existing)
+ * @param printArea
+ *   Range to print (`_xlnm.Print_Area`); None prints the used range
+ * @param repeatRows
+ *   1-based inclusive row span repeated at the top of every printed page (`_xlnm.Print_Titles`),
+ *   e.g. `Some((1, 2))` repeats rows 1-2
  */
 final case class PageSetup(
   scale: Int = 100,
   orientation: Option[String] = None,
   fitToWidth: Option[Int] = None,
-  fitToHeight: Option[Int] = None
+  fitToHeight: Option[Int] = None,
+  headerFooter: Option[HeaderFooter] = None,
+  margins: Option[PageMargins] = None,
+  printArea: Option[CellRange] = None,
+  repeatRows: Option[(Int, Int)] = None
 ):
   require(scale >= 10 && scale <= 400, s"Scale must be 10-400, got: $scale")
   require(
     orientation.forall(o => o == "portrait" || o == "landscape"),
     s"Orientation must be 'portrait' or 'landscape', got: ${orientation.getOrElse("None")}"
+  )
+  require(
+    repeatRows.forall((start, end) => start >= 1 && start <= end && end <= Row.MaxIndex0 + 1),
+    s"Repeat rows must be a 1-based span within 1-${Row.MaxIndex0 + 1}, got: ${repeatRows.fold("None")(_.toString)}"
   )
 
 object PageSetup:

--- a/xl-core/src/com/tjclp/xl/sheets/Sheet.scala
+++ b/xl-core/src/com/tjclp/xl/sheets/Sheet.scala
@@ -25,6 +25,11 @@ import scala.util.boundary, boundary.break
  * The distinction between `None` and `Some(Remove)` matters: `None` is the passive default
  * (round-trip preserves the original); `Some(Remove)` is the active intent to remove freeze panes
  * even when the source XML had them.
+ *
+ * @param viewSettings
+ *   Sheet view settings (gridline visibility, zoom). `None` preserves any existing `<sheetView>`
+ *   attributes on write; `Some(view)` sets them. Freeze panes and view settings share a single
+ *   `<sheetView>` element in the serialized XML.
  */
 final case class Sheet(
   name: SheetName,
@@ -38,7 +43,8 @@ final case class Sheet(
   comments: Map[ARef, Comment] = Map.empty,
   tables: Map[String, TableSpec] = Map.empty,
   pageSetup: Option[PageSetup] = None,
-  freezePane: Option[FreezePane] = None
+  freezePane: Option[FreezePane] = None,
+  viewSettings: Option[SheetView] = None
 ):
 
   /** Get cell at reference (returns empty cell if not present) */
@@ -577,6 +583,29 @@ final case class Sheet(
 
   /** Remove freeze panes. */
   def unfreeze: Sheet = copy(freezePane = Some(FreezePane.Remove))
+
+  /**
+   * Set sheet view settings (gridline visibility, zoom).
+   *
+   * Example:
+   * {{{
+   * sheet.withViewSettings(SheetView(showGridLines = false, zoomScale = Some(85)))
+   * }}}
+   */
+  def withViewSettings(view: SheetView): Sheet = copy(viewSettings = Some(view))
+
+  /**
+   * Set page setup (print scale/orientation, margins, header/footer, print area, repeat rows).
+   *
+   * Example:
+   * {{{
+   * sheet.withPageSetup(PageSetup(
+   *   orientation = Some("landscape"),
+   *   headerFooter = Some(HeaderFooter(oddFooter = Some("Page &P of &N")))
+   * ))
+   * }}}
+   */
+  def withPageSetup(setup: PageSetup): Sheet = copy(pageSetup = Some(setup))
 
   /** Count of non-empty cells */
   def cellCount: Int = cells.size

--- a/xl-core/src/com/tjclp/xl/sheets/SheetView.scala
+++ b/xl-core/src/com/tjclp/xl/sheets/SheetView.scala
@@ -1,0 +1,28 @@
+package com.tjclp.xl.sheets
+
+/**
+ * Sheet view settings, serialized into the worksheet's `<sheetViews><sheetView .../>` element.
+ *
+ * These control how Excel displays the sheet (not how it prints — see [[PageSetup]] for print
+ * settings). Professional templates are typically gridline-free: structure comes from cell borders,
+ * and the default gridlines visibly cheapen the artifact in Excel and in HTML/SVG/PNG exports.
+ *
+ * On write, view settings share a single `<sheetView>` element with freeze panes
+ * ([[Sheet.freezePane]]), so setting both never produces duplicate view elements.
+ *
+ * @param showGridLines
+ *   Whether Excel draws the default cell gridlines (default: true, Excel's default)
+ * @param zoomScale
+ *   Zoom percentage (10-400), or None for Excel's default (100)
+ */
+final case class SheetView(
+  showGridLines: Boolean = true,
+  zoomScale: Option[Int] = None
+):
+  require(
+    zoomScale.forall(z => z >= 10 && z <= 400),
+    s"Zoom scale must be 10-400, got: ${zoomScale.fold("None")(_.toString)}"
+  )
+
+object SheetView:
+  val default: SheetView = SheetView()

--- a/xl-core/src/com/tjclp/xl/styles/alignment/Align.scala
+++ b/xl-core/src/com/tjclp/xl/styles/alignment/Align.scala
@@ -1,6 +1,18 @@
 package com.tjclp.xl.styles.alignment
 
-/** Cell alignment settings */
+/**
+ * Cell alignment settings.
+ *
+ * @param horizontal
+ *   Horizontal alignment (Excel default: General, content-aware)
+ * @param vertical
+ *   Vertical alignment (Excel default: Bottom)
+ * @param wrapText
+ *   Whether text wraps within the cell
+ * @param indent
+ *   Excel's alignment indent level (~3 characters per level); 0 means no indent and is omitted from
+ *   OOXML output. Indentation travels with the style rather than the value, unlike leading spaces.
+ */
 final case class Align(
   horizontal: HAlign = HAlign.General,
   vertical: VAlign = VAlign.Bottom,

--- a/xl-core/src/com/tjclp/xl/styles/border/Border.scala
+++ b/xl-core/src/com/tjclp/xl/styles/border/Border.scala
@@ -14,6 +14,23 @@ final case class Border(
   def withTop(side: BorderSide): Border = copy(top = side)
   def withBottom(side: BorderSide): Border = copy(bottom = side)
 
+  /**
+   * Merge another border into this one, side by side (additive overlay).
+   *
+   * Sides that are set (non-none) in `overlay` replace the corresponding side of this border; sides
+   * that are `BorderSide.none` in `overlay` leave the existing side untouched. This mirrors the
+   * CLI's additive border semantics (`--border-top` only touches the top side).
+   *
+   * Laws: associative, idempotent, with `Border.none` as identity.
+   */
+  def merge(overlay: Border): Border =
+    Border(
+      left = if overlay.left == BorderSide.none then left else overlay.left,
+      right = if overlay.right == BorderSide.none then right else overlay.right,
+      top = if overlay.top == BorderSide.none then top else overlay.top,
+      bottom = if overlay.bottom == BorderSide.none then bottom else overlay.bottom
+    )
+
 object Border:
   val none: Border = Border()
 

--- a/xl-core/src/com/tjclp/xl/styles/dsl.scala
+++ b/xl-core/src/com/tjclp/xl/styles/dsl.scala
@@ -1,7 +1,7 @@
 package com.tjclp.xl.styles
 
 import com.tjclp.xl.styles.alignment.{Align, HAlign, VAlign}
-import com.tjclp.xl.styles.border.{Border, BorderStyle}
+import com.tjclp.xl.styles.border.{Border, BorderSide, BorderStyle}
 import com.tjclp.xl.styles.color.Color
 import com.tjclp.xl.styles.fill.Fill
 import com.tjclp.xl.styles.font.Font
@@ -189,6 +189,16 @@ object dsl:
     inline def wrap: CellStyle =
       style.withAlign(style.align.withWrap(true))
 
+    /**
+     * Set the alignment indent level (Excel's `indent` attribute, ~3 characters per level).
+     *
+     * Indentation travels with the style, not the value — unlike leading spaces, it survives
+     * round-trips, keeps the stored value clean for downstream parsing, and matches how house
+     * templates indent line items. Negative values are clamped to 0 (no indent).
+     */
+    inline def indent(n: Int): CellStyle =
+      style.withAlign(style.align.withIndent(math.max(0, n)))
+
     // ========== Borders ==========
 
     /** Set all borders to thin */
@@ -206,6 +216,49 @@ object dsl:
     /** Remove all borders */
     inline def borderNone: CellStyle =
       style.withBorder(Border.none)
+
+    // ========== Per-Side Borders ==========
+    // Each builder merges into the existing border: only the named side is replaced, the other
+    // three sides are preserved, so per-side builders compose (e.g. `.borderTop(Thin).borderBottom
+    // (Medium)`). Color-taking variants are explicit overloads, NOT default parameters: extension
+    // methods with default parameters break when merged through wildcard exports (see
+    // xl-evaluator exports.scala note on the Scala 3 compiler bug).
+
+    /** Set the top border side, preserving the other sides (typical column-header bottom rule). */
+    inline def borderTop(borderStyle: BorderStyle): CellStyle =
+      style.withBorder(style.border.withTop(BorderSide(borderStyle)))
+
+    /** Set the top border side with a color, preserving the other sides. */
+    @annotation.targetName("borderTopColored")
+    inline def borderTop(borderStyle: BorderStyle, color: Color): CellStyle =
+      style.withBorder(style.border.withTop(BorderSide(borderStyle, color)))
+
+    /** Set the bottom border side, preserving the other sides. */
+    inline def borderBottom(borderStyle: BorderStyle): CellStyle =
+      style.withBorder(style.border.withBottom(BorderSide(borderStyle)))
+
+    /** Set the bottom border side with a color, preserving the other sides. */
+    @annotation.targetName("borderBottomColored")
+    inline def borderBottom(borderStyle: BorderStyle, color: Color): CellStyle =
+      style.withBorder(style.border.withBottom(BorderSide(borderStyle, color)))
+
+    /** Set the left border side, preserving the other sides. */
+    inline def borderLeft(borderStyle: BorderStyle): CellStyle =
+      style.withBorder(style.border.withLeft(BorderSide(borderStyle)))
+
+    /** Set the left border side with a color, preserving the other sides. */
+    @annotation.targetName("borderLeftColored")
+    inline def borderLeft(borderStyle: BorderStyle, color: Color): CellStyle =
+      style.withBorder(style.border.withLeft(BorderSide(borderStyle, color)))
+
+    /** Set the right border side, preserving the other sides. */
+    inline def borderRight(borderStyle: BorderStyle): CellStyle =
+      style.withBorder(style.border.withRight(BorderSide(borderStyle)))
+
+    /** Set the right border side with a color, preserving the other sides. */
+    @annotation.targetName("borderRightColored")
+    inline def borderRight(borderStyle: BorderStyle, color: Color): CellStyle =
+      style.withBorder(style.border.withRight(BorderSide(borderStyle, color)))
 
     // ========== Number Formats ==========
 

--- a/xl-core/test/src/com/tjclp/xl/ElegantSyntaxSpec.scala
+++ b/xl-core/test/src/com/tjclp/xl/ElegantSyntaxSpec.scala
@@ -281,3 +281,26 @@ class ElegantSyntaxSpec extends FunSuite:
     assert(sheet.getCellStyle(ref"B2").exists(_.numFmt == NumFmt.Currency))
     assert(sheet.getCellStyle(ref"C2").exists(_.numFmt == NumFmt.Percent))
   }
+
+  test("Top-level import: per-side borders, indent, and outlined resolve (GH-257/GH-260)") {
+    // Smoke test that the new style DSL and outline patch survive the wildcard-export merge
+    // (com.tjclp.xl.* re-exports styles.dsl and dsl.syntax through the syntax facade).
+    import com.tjclp.xl.macros.ref
+    import com.tjclp.xl.styles.border.{BorderSide, BorderStyle}
+    import com.tjclp.xl.styles.color.Color
+
+    val ruled = CellStyle.default.bold
+      .borderBottom(BorderStyle.Thin)
+      .borderTop(BorderStyle.Double, Color.fromRgb(0, 0, 0))
+      .indent(1)
+    assertEquals(ruled.border.bottom, BorderSide(BorderStyle.Thin))
+    assertEquals(ruled.border.top, BorderSide(BorderStyle.Double, Color.fromRgb(0, 0, 0)))
+    assertEquals(ruled.align.indent, 1)
+    assert(ruled.font.bold)
+
+    val sheet = Patch.applyPatch(emptySheet, ref"A1:B2".outlined(BorderStyle.Medium))
+    val corner = sheet.getCellStyle(ref"A1").map(_.border)
+    assertEquals(corner.map(_.top), Some(BorderSide(BorderStyle.Medium)))
+    assertEquals(corner.map(_.left), Some(BorderSide(BorderStyle.Medium)))
+    assertEquals(corner.map(_.right), Some(BorderSide.none))
+  }

--- a/xl-core/test/src/com/tjclp/xl/OutlinedPatchSpec.scala
+++ b/xl-core/test/src/com/tjclp/xl/OutlinedPatchSpec.scala
@@ -1,0 +1,193 @@
+package com.tjclp.xl
+
+import munit.FunSuite
+import com.tjclp.xl.addressing.{ARef, CellRange, SheetName}
+import com.tjclp.xl.api.*
+import com.tjclp.xl.dsl.syntax.*
+import com.tjclp.xl.macros.ref
+import com.tjclp.xl.patch.Patch
+import com.tjclp.xl.sheets.syntax.*
+import com.tjclp.xl.styles.CellStyle
+import com.tjclp.xl.styles.border.{Border, BorderSide, BorderStyle}
+import com.tjclp.xl.styles.color.Color
+import com.tjclp.xl.styles.dsl.*
+
+/**
+ * Tests for `range.outlined(style[, color])` (GH-257): edge-correct outline around a range built
+ * from per-cell [[Patch.MergeBorder]] patches that preserve existing cell styles.
+ */
+class OutlinedPatchSpec extends FunSuite:
+
+  def emptySheet: Sheet = Sheet(SheetName.unsafe("Test"))
+
+  private val thin = BorderSide(BorderStyle.Thin)
+
+  /** Border of the cell at `ref`, or Border.none when the cell is unstyled. */
+  private def borderAt(sheet: Sheet, cellRef: ARef): Border =
+    sheet.getCellStyle(cellRef).map(_.border).getOrElse(Border.none)
+
+  // ========== Geometry: 3x3 ==========
+
+  test("outlined 3x3: corners get two sides, edges one, interior none") {
+    val sheet = Patch.applyPatch(emptySheet, ref"B2:D4".outlined(BorderStyle.Thin))
+
+    // Corners
+    assertEquals(borderAt(sheet, ref"B2"), Border(left = thin, top = thin))
+    assertEquals(borderAt(sheet, ref"D2"), Border(right = thin, top = thin))
+    assertEquals(borderAt(sheet, ref"B4"), Border(left = thin, bottom = thin))
+    assertEquals(borderAt(sheet, ref"D4"), Border(right = thin, bottom = thin))
+
+    // Edge midpoints
+    assertEquals(borderAt(sheet, ref"C2"), Border(top = thin))
+    assertEquals(borderAt(sheet, ref"C4"), Border(bottom = thin))
+    assertEquals(borderAt(sheet, ref"B3"), Border(left = thin))
+    assertEquals(borderAt(sheet, ref"D3"), Border(right = thin))
+
+    // Interior cell is untouched (no cell materialized at all)
+    assertEquals(sheet.cells.get(ref"C3"), None)
+  }
+
+  test("outlined 3x3: exactly the 8 perimeter cells are patched") {
+    val patch = ref"B2:D4".outlined(BorderStyle.Thin)
+    patch match
+      case Patch.Batch(patches) =>
+        assertEquals(patches.size, 8)
+        val refs = patches.collect { case Patch.MergeBorder(r, _) => r }
+        assertEquals(refs.size, 8, "every patch should be a MergeBorder")
+        assertEquals(refs.distinct.size, 8, "one patch per perimeter cell")
+        assert(!refs.contains(ref"C3"), "interior cell must not be patched")
+      case other => fail(s"Expected Batch, got: $other")
+  }
+
+  // ========== Geometry: degenerate shapes ==========
+
+  test("outlined 1x3 row: every cell top+bottom, ends add left/right") {
+    val sheet = Patch.applyPatch(emptySheet, ref"A1:C1".outlined(BorderStyle.Thin))
+
+    assertEquals(borderAt(sheet, ref"A1"), Border(left = thin, top = thin, bottom = thin))
+    assertEquals(borderAt(sheet, ref"B1"), Border(top = thin, bottom = thin))
+    assertEquals(borderAt(sheet, ref"C1"), Border(right = thin, top = thin, bottom = thin))
+  }
+
+  test("outlined 3x1 column: every cell left+right, caps add top/bottom") {
+    val sheet = Patch.applyPatch(emptySheet, ref"A1:A3".outlined(BorderStyle.Thin))
+
+    assertEquals(borderAt(sheet, ref"A1"), Border(left = thin, right = thin, top = thin))
+    assertEquals(borderAt(sheet, ref"A2"), Border(left = thin, right = thin))
+    assertEquals(borderAt(sheet, ref"A3"), Border(left = thin, right = thin, bottom = thin))
+  }
+
+  test("outlined 1x1: all four sides (full box)") {
+    val sheet = Patch.applyPatch(emptySheet, ref"B2:B2".outlined(BorderStyle.Medium))
+    assertEquals(borderAt(sheet, ref"B2"), Border.all(BorderStyle.Medium))
+  }
+
+  test("outlined 2x2: every cell is a corner with exactly two sides") {
+    val sheet = Patch.applyPatch(emptySheet, ref"A1:B2".outlined(BorderStyle.Thin))
+
+    assertEquals(borderAt(sheet, ref"A1"), Border(left = thin, top = thin))
+    assertEquals(borderAt(sheet, ref"B1"), Border(right = thin, top = thin))
+    assertEquals(borderAt(sheet, ref"A2"), Border(left = thin, bottom = thin))
+    assertEquals(borderAt(sheet, ref"B2"), Border(right = thin, bottom = thin))
+  }
+
+  // ========== Color overload ==========
+
+  test("outlined with color applies the color to every emitted side") {
+    val gray = Color.fromRgb(128, 128, 128)
+    val side = BorderSide(BorderStyle.MediumDashed, gray)
+    val sheet = Patch.applyPatch(emptySheet, ref"A1:B1".outlined(BorderStyle.MediumDashed, gray))
+
+    assertEquals(borderAt(sheet, ref"A1"), Border(left = side, top = side, bottom = side))
+    assertEquals(borderAt(sheet, ref"B1"), Border(right = side, top = side, bottom = side))
+  }
+
+  // ========== Existing style preservation ==========
+
+  test("outlined preserves existing font, fill, and numFmt on edge cells") {
+    val keyFigure = CellStyle.default.bold.bgYellow.currency
+    val base = emptySheet
+      .put(ref"B2", CellValue.Number(BigDecimal(42)))
+      .withCellStyle(ref"B2", keyFigure)
+
+    val sheet = Patch.applyPatch(base, ref"B2:D4".outlined(BorderStyle.Thin))
+    val style = sheet.getCellStyle(ref"B2").getOrElse(fail("B2 should have a style"))
+
+    assert(style.font.bold, "bold preserved")
+    assertEquals(style.fill, keyFigure.fill, "fill preserved")
+    assertEquals(style.numFmt, keyFigure.numFmt, "numFmt preserved")
+    assertEquals(style.border, Border(left = thin, top = thin), "outline sides applied")
+    assertEquals(
+      sheet.cells.get(ref"B2").map(_.value),
+      Some(CellValue.Number(BigDecimal(42))),
+      "cell value untouched"
+    )
+  }
+
+  test("outlined preserves existing border sides it does not set") {
+    // B2 sits on the top-left corner of the outline: outline sets top+left only,
+    // so a pre-existing bottom rule must survive.
+    val ruled = CellStyle.default.borderBottom(BorderStyle.Double)
+    val base = emptySheet.withCellStyle(ref"B2", ruled)
+
+    val sheet = Patch.applyPatch(base, ref"B2:D4".outlined(BorderStyle.Thin))
+
+    assertEquals(
+      borderAt(sheet, ref"B2"),
+      Border(left = thin, top = thin, bottom = BorderSide(BorderStyle.Double))
+    )
+  }
+
+  test("outlined overrides the sides it does set") {
+    val boxed = CellStyle.default.bordered // thin on all four sides
+    val base = emptySheet.withCellStyle(ref"A1", boxed)
+
+    val sheet = Patch.applyPatch(base, ref"A1:B2".outlined(BorderStyle.Thick))
+
+    // A1 is the top-left corner: top+left become thick, right+bottom keep the existing thin
+    assertEquals(
+      borderAt(sheet, ref"A1"),
+      Border(
+        left = BorderSide(BorderStyle.Thick),
+        right = thin,
+        top = BorderSide(BorderStyle.Thick),
+        bottom = thin
+      )
+    )
+  }
+
+  // ========== Composition and idempotence ==========
+
+  test("outlined composes with other patches via ++") {
+    val patch = (ref"A1" := "Total") ++ ref"A1:C1".outlined(BorderStyle.Thin)
+    val sheet = Patch.applyPatch(emptySheet, patch)
+
+    assertEquals(sheet.cells.get(ref"A1").map(_.value), Some(CellValue.Text("Total")))
+    assertEquals(borderAt(sheet, ref"A1"), Border(left = thin, top = thin, bottom = thin))
+  }
+
+  test("outlined is idempotent (applying twice equals applying once)") {
+    val patch = ref"B2:D4".outlined(BorderStyle.Thin)
+    val once = Patch.applyPatch(emptySheet, patch)
+    val twice = Patch.applyPatch(once, patch)
+
+    assertEquals(twice.cells, once.cells)
+    ref"B2:D4".cells.foreach { r =>
+      assertEquals(twice.getCellStyle(r), once.getCellStyle(r))
+    }
+  }
+
+  // ========== MergeBorder patch semantics ==========
+
+  test("MergeBorder on an unstyled cell creates a border-only style") {
+    val patch = Patch.MergeBorder(ref"A1", Border(top = thin))
+    val sheet = Patch.applyPatch(emptySheet, patch)
+    val style = sheet.getCellStyle(ref"A1").getOrElse(fail("A1 should have a style"))
+    assertEquals(style, CellStyle.default.withBorder(Border(top = thin)))
+  }
+
+  test("MergeBorder with Border.none leaves the existing style intact") {
+    val base = emptySheet.withCellStyle(ref"A1", CellStyle.default.bold.bordered)
+    val sheet = Patch.applyPatch(base, Patch.MergeBorder(ref"A1", Border.none))
+    assertEquals(sheet.getCellStyle(ref"A1"), base.getCellStyle(ref"A1"))
+  }

--- a/xl-core/test/src/com/tjclp/xl/SheetViewPageSetupSpec.scala
+++ b/xl-core/test/src/com/tjclp/xl/SheetViewPageSetupSpec.scala
@@ -1,0 +1,86 @@
+package com.tjclp.xl
+
+import com.tjclp.xl.{*, given}
+import com.tjclp.xl.render.SvgRenderer
+import com.tjclp.xl.sheets.{HeaderFooter, PageMargins, PageSetup, SheetView}
+import munit.FunSuite
+
+/**
+ * GH-258/GH-259 model tests: SheetView (gridlines, zoom), PageSetup print extensions
+ * (header/footer, margins, print area, repeat rows), and renderer gridline suppression.
+ */
+class SheetViewPageSetupSpec extends FunSuite:
+
+  // ===== SheetView (GH-258) =====
+
+  test("SheetView defaults match Excel (gridlines on, no explicit zoom)") {
+    assertEquals(SheetView.default, SheetView(showGridLines = true, zoomScale = None))
+  }
+
+  test("SheetView accepts zoom bounds 10 and 400") {
+    assertEquals(SheetView(zoomScale = Some(10)).zoomScale, Some(10))
+    assertEquals(SheetView(zoomScale = Some(400)).zoomScale, Some(400))
+  }
+
+  test("SheetView rejects zoom outside 10-400") {
+    intercept[IllegalArgumentException](SheetView(zoomScale = Some(9)))
+    intercept[IllegalArgumentException](SheetView(zoomScale = Some(401)))
+  }
+
+  test("Sheet.withViewSettings sets viewSettings") {
+    val view = SheetView(showGridLines = false, zoomScale = Some(85))
+    val sheet = Sheet("S").withViewSettings(view)
+    assertEquals(sheet.viewSettings, Some(view))
+  }
+
+  // ===== PageSetup extensions (GH-259) =====
+
+  test("PageMargins defaults match Excel's Normal preset") {
+    val m = PageMargins.default
+    assertEquals((m.left, m.right, m.top, m.bottom, m.header, m.footer), (0.7, 0.7, 0.75, 0.75, 0.3, 0.3))
+  }
+
+  test("PageMargins rejects negative margins") {
+    intercept[IllegalArgumentException](PageMargins(left = -0.1))
+    intercept[IllegalArgumentException](PageMargins(footer = -1.0))
+  }
+
+  test("PageSetup accepts a valid repeat-rows span") {
+    assertEquals(PageSetup(repeatRows = Some((1, 3))).repeatRows, Some((1, 3)))
+    assertEquals(PageSetup(repeatRows = Some((5, 5))).repeatRows, Some((5, 5)))
+  }
+
+  test("PageSetup rejects invalid repeat-rows spans") {
+    intercept[IllegalArgumentException](PageSetup(repeatRows = Some((0, 3)))) // 1-based
+    intercept[IllegalArgumentException](PageSetup(repeatRows = Some((4, 2)))) // start > end
+    intercept[IllegalArgumentException](PageSetup(repeatRows = Some((1, 1_048_577)))) // > max row
+  }
+
+  test("Sheet.withPageSetup sets pageSetup with all print extensions") {
+    val setup = PageSetup(
+      scale = 85,
+      orientation = Some("landscape"),
+      headerFooter = Some(HeaderFooter(oddFooter = Some("Page &P of &N"))),
+      margins = Some(PageMargins(left = 1.0)),
+      printArea = Some(ref"A1:D20"),
+      repeatRows = Some((1, 2))
+    )
+    val sheet = Sheet("S").withPageSetup(setup)
+    assertEquals(sheet.pageSetup, Some(setup))
+  }
+
+  // ===== Renderer integration (GH-258) =====
+
+  test("SvgRenderer suppresses gridlines when sheet view disables them") {
+    val sheet = Sheet("S")
+      .put("A1" -> "X")
+      .withViewSettings(SheetView(showGridLines = false))
+    val svg = SvgRenderer.toSvg(sheet, ref"A1:B2", showGridlines = true)
+    assert(!svg.contains("stroke=\"#D0D0D0\""), "sheet-level showGridLines=false must win")
+  }
+
+  test("SvgRenderer keeps caller-requested gridlines when sheet has no view settings") {
+    val sheet = Sheet("S").put("A1" -> "X")
+    val svg = SvgRenderer.toSvg(sheet, ref"A1:B2", showGridlines = true)
+    assert(svg.contains("stroke=\"#D0D0D0\""), "caller-controlled gridlines unchanged by default")
+  }

--- a/xl-core/test/src/com/tjclp/xl/StyleSpec.scala
+++ b/xl-core/test/src/com/tjclp/xl/StyleSpec.scala
@@ -379,6 +379,18 @@ class StyleSpec extends ScalaCheckSuite:
     assertNotEquals(key1, key2)
   }
 
+  test("CellStyle.canonicalKey distinguishes styles differing only by indent (GH-260)") {
+    // Style dedup must account for indent: two styles that differ only by indent level
+    // would otherwise collapse to one xf in styles.xml, losing the indentation.
+    val indent0 = CellStyle.default.withAlign(Align(horizontal = HAlign.Left))
+    val indent1 = CellStyle.default.withAlign(Align(horizontal = HAlign.Left, indent = 1))
+    val indent2 = CellStyle.default.withAlign(Align(horizontal = HAlign.Left, indent = 2))
+
+    assertNotEquals(indent0.canonicalKey, indent1.canonicalKey)
+    assertNotEquals(indent1.canonicalKey, indent2.canonicalKey)
+    assertNotEquals(indent0.canonicalKey, indent2.canonicalKey)
+  }
+
   property("CellStyle.canonicalKey: equal styles have equal keys") {
     forAll { (style: CellStyle) =>
       val copy = style.copy()

--- a/xl-core/test/src/com/tjclp/xl/display/DisplaySpec.scala
+++ b/xl-core/test/src/com/tjclp/xl/display/DisplaySpec.scala
@@ -301,6 +301,22 @@ class DisplaySpec extends FunSuite:
     assertEquals(result, "Product: 5 units @ $1,000.00 each")
   }
 
+  test("excel interpolator routes zero through positive section of 2-section custom code (GH-254)") {
+    import ExcelInterpolator.*
+    import DisplayConversions.given
+
+    given Sheet = Sheet(name = SheetName.unsafe("Test"))
+      .put(ref"A1", BigDecimal("0"))
+      .style(ref"A1", CellStyle.default.withNumFmt(NumFmt.Custom("0.0%_);(0.0%)")))
+      .unsafe
+
+    given FormulaDisplayStrategy = FormulaDisplayStrategy.default
+
+    val result = excel"Rate: ${ref"A1"}"
+    assertEquals(result.trim, "Rate: 0.0%") // trailing space from _) spacer
+    assert(!result.contains("("), s"Zero must not use the negative section: $result")
+  }
+
   // ========== Syntax Extension Tests ==========
 
   test("sheet.display() returns formatted value") {
@@ -316,6 +332,23 @@ class DisplaySpec extends FunSuite:
 
     val result = mySheet.displayCell(ref"A1")
     assertEquals(result.formatted, "85%")
+  }
+
+  test("displayCell routes zero through positive section of 2-section custom code (GH-254)") {
+    import com.tjclp.xl.display.syntax.*
+    import DisplayConversions.given
+
+    val houseCode = "\"$\"#,##0.0_);(\"$\"#,##0.0)"
+    val mySheet = Sheet(name = SheetName.unsafe("Test"))
+      .put(ref"A1", BigDecimal("0"))
+      .style(ref"A1", CellStyle.default.withNumFmt(NumFmt.Custom(houseCode)))
+      .unsafe
+
+    given FormulaDisplayStrategy = FormulaDisplayStrategy.default
+
+    val result = mySheet.displayCell(ref"A1")
+    assertEquals(result.formatted.trim, "$0.0") // trailing space from _) spacer
+    assert(!result.formatted.contains("("), s"Zero must not use the negative section: $result")
   }
 
   test("sheet.displayFormula() shows raw formula") {

--- a/xl-core/test/src/com/tjclp/xl/display/FormatCodeParserSpec.scala
+++ b/xl-core/test/src/com/tjclp/xl/display/FormatCodeParserSpec.scala
@@ -276,6 +276,70 @@ class FormatCodeParserSpec extends FunSuite:
     assertEquals(zero, "—")
   }
 
+  // ========== Section Selection (Excel semantics, GH-254) ==========
+  // Excel routes values to sections as follows:
+  //   1 section:  all numbers use it
+  //   2 sections: positive + zero use 1st, negative uses 2nd
+  //   3 sections: positive → 1st, negative → 2nd, zero → 3rd
+  //   4 sections: positive / negative / zero / text
+
+  test("section selection: 1 section formats positive, negative, and zero") {
+    val code = FormatCodeParser.parse("0.0").toOption.get
+    assertEquals(FormatCodeParser.applyFormat(BigDecimal("1.5"), code)._1, "1.5")
+    assertEquals(FormatCodeParser.applyFormat(BigDecimal("-1.5"), code)._1, "-1.5")
+    assertEquals(FormatCodeParser.applyFormat(BigDecimal("0"), code)._1, "0.0")
+  }
+
+  test("section selection: 2 sections route zero to positive section") {
+    val code = FormatCodeParser.parse("0.0;(0.0)").toOption.get
+    assertEquals(FormatCodeParser.applyFormat(BigDecimal("1.5"), code)._1, "1.5")
+    assertEquals(FormatCodeParser.applyFormat(BigDecimal("-1.5"), code)._1, "(1.5)")
+    assertEquals(FormatCodeParser.applyFormat(BigDecimal("0"), code)._1, "0.0")
+  }
+
+  test("section selection: 3 sections route zero to explicit zero section") {
+    val code = FormatCodeParser.parse("0.0;(0.0);\"-\"").toOption.get
+    assertEquals(FormatCodeParser.applyFormat(BigDecimal("1.5"), code)._1, "1.5")
+    assertEquals(FormatCodeParser.applyFormat(BigDecimal("-1.5"), code)._1, "(1.5)")
+    assertEquals(FormatCodeParser.applyFormat(BigDecimal("0"), code)._1, "-")
+  }
+
+  test("section selection: 4 sections route pos/neg/zero/text independently") {
+    val code = FormatCodeParser.parse("0.0;(0.0);\"zero\";@").toOption.get
+    assertEquals(FormatCodeParser.applyFormat(BigDecimal("1.5"), code)._1, "1.5")
+    assertEquals(FormatCodeParser.applyFormat(BigDecimal("-1.5"), code)._1, "(1.5)")
+    assertEquals(FormatCodeParser.applyFormat(BigDecimal("0"), code)._1, "zero")
+    assertEquals(FormatCodeParser.applyTextFormat("abc", code), "abc")
+  }
+
+  test("TJC house code: \"$\"#,##0.0_);(\"$\"#,##0.0) routes zero to positive (GH-254)") {
+    val code = FormatCodeParser.parse("\"$\"#,##0.0_);(\"$\"#,##0.0)").toOption.get
+
+    val (zero, _) = FormatCodeParser.applyFormat(BigDecimal("0"), code)
+    assert(!zero.contains("("), s"Zero must not use the negative section: $zero")
+    assertEquals(zero.trim, "$0.0") // trailing space from _) spacer
+
+    val (pos, _) = FormatCodeParser.applyFormat(BigDecimal("1234.56"), code)
+    assertEquals(pos.trim, "$1,234.6")
+
+    val (neg, _) = FormatCodeParser.applyFormat(BigDecimal("-1234.56"), code)
+    assertEquals(neg, "($1,234.6)")
+  }
+
+  test("TJC house code: 0.0%_);(0.0%) routes zero to positive (GH-254)") {
+    val code = FormatCodeParser.parse("0.0%_);(0.0%)").toOption.get
+
+    val (zero, _) = FormatCodeParser.applyFormat(BigDecimal("0"), code)
+    assert(!zero.contains("("), s"Zero must not use the negative section: $zero")
+    assertEquals(zero.trim, "0.0%") // trailing space from _) spacer
+
+    val (pos, _) = FormatCodeParser.applyFormat(BigDecimal("0.125"), code)
+    assertEquals(pos.trim, "12.5%")
+
+    val (neg, _) = FormatCodeParser.applyFormat(BigDecimal("-0.125"), code)
+    assertEquals(neg, "(12.5%)")
+  }
+
   // ========== Date/Time Formatting Tests ==========
 
   test("applyDateFormat: simple date m/d/yy") {

--- a/xl-core/test/src/com/tjclp/xl/styles/StyleDslSpec.scala
+++ b/xl-core/test/src/com/tjclp/xl/styles/StyleDslSpec.scala
@@ -1,7 +1,7 @@
 package com.tjclp.xl.styles
 
 import com.tjclp.xl.styles.alignment.{Align, HAlign, VAlign}
-import com.tjclp.xl.styles.border.{Border, BorderStyle}
+import com.tjclp.xl.styles.border.{Border, BorderSide, BorderStyle}
 import com.tjclp.xl.styles.color.Color
 import com.tjclp.xl.styles.fill.Fill
 import com.tjclp.xl.styles.font.Font
@@ -189,6 +189,31 @@ class StyleDslSpec extends ScalaCheckSuite:
     assert(style.align.wrapText)
   }
 
+  // ========== Indent Tests ==========
+
+  test("indent sets alignment indent level") {
+    val style = CellStyle.default.indent(2)
+    assertEquals(style.align.indent, 2)
+  }
+
+  test("indent preserves other alignment properties") {
+    val style = CellStyle.default.left.wrap.indent(3)
+    assertEquals(style.align.horizontal, HAlign.Left)
+    assert(style.align.wrapText)
+    assertEquals(style.align.indent, 3)
+  }
+
+  test("indent clamps negative values to 0 (total, never throws)") {
+    val style = CellStyle.default.indent(5).indent(-1)
+    assertEquals(style.align.indent, 0)
+  }
+
+  test("indent(0) clears an existing indent") {
+    val style = CellStyle.default.indent(4).indent(0)
+    assertEquals(style.align.indent, 0)
+    assertEquals(style.align, Align.default)
+  }
+
   // ========== Border Tests ==========
 
   test("bordered sets all borders to thin") {
@@ -204,6 +229,86 @@ class StyleDslSpec extends ScalaCheckSuite:
   test("borderedThick sets all borders to thick") {
     val style = CellStyle.default.borderedThick
     assertEquals(style.border, Border.all(BorderStyle.Thick))
+  }
+
+  // ========== Per-Side Border Tests ==========
+
+  test("borderTop sets only the top side") {
+    val style = CellStyle.default.borderTop(BorderStyle.Thin)
+    assertEquals(style.border.top, BorderSide(BorderStyle.Thin))
+    assertEquals(style.border.bottom, BorderSide.none)
+    assertEquals(style.border.left, BorderSide.none)
+    assertEquals(style.border.right, BorderSide.none)
+  }
+
+  test("borderBottom sets only the bottom side") {
+    val style = CellStyle.default.borderBottom(BorderStyle.Medium)
+    assertEquals(style.border.bottom, BorderSide(BorderStyle.Medium))
+    assertEquals(style.border.top, BorderSide.none)
+  }
+
+  test("borderLeft sets only the left side") {
+    val style = CellStyle.default.borderLeft(BorderStyle.Dashed)
+    assertEquals(style.border.left, BorderSide(BorderStyle.Dashed))
+    assertEquals(style.border.right, BorderSide.none)
+  }
+
+  test("borderRight sets only the right side") {
+    val style = CellStyle.default.borderRight(BorderStyle.Double)
+    assertEquals(style.border.right, BorderSide(BorderStyle.Double))
+    assertEquals(style.border.left, BorderSide.none)
+  }
+
+  test("per-side border builders compose (each side independent)") {
+    val style = CellStyle.default
+      .borderTop(BorderStyle.Thin)
+      .borderBottom(BorderStyle.Double)
+      .borderLeft(BorderStyle.Medium)
+      .borderRight(BorderStyle.Thick)
+    assertEquals(
+      style.border,
+      Border(
+        left = BorderSide(BorderStyle.Medium),
+        right = BorderSide(BorderStyle.Thick),
+        top = BorderSide(BorderStyle.Thin),
+        bottom = BorderSide(BorderStyle.Double)
+      )
+    )
+  }
+
+  test("per-side builders merge into an existing all-side border") {
+    val style = CellStyle.default.bordered.borderBottom(BorderStyle.Medium)
+    assertEquals(style.border.bottom, BorderSide(BorderStyle.Medium))
+    assertEquals(style.border.top, BorderSide(BorderStyle.Thin))
+    assertEquals(style.border.left, BorderSide(BorderStyle.Thin))
+    assertEquals(style.border.right, BorderSide(BorderStyle.Thin))
+  }
+
+  test("per-side builders preserve non-border style content") {
+    val style = CellStyle.default.bold.bgYellow.currency.borderTop(BorderStyle.Thin)
+    assert(style.font.bold)
+    assertEquals(style.fill, Fill.Solid(Color.fromRgb(255, 255, 0)))
+    assertEquals(style.numFmt, NumFmt.Currency)
+    assertEquals(style.border.top, BorderSide(BorderStyle.Thin))
+  }
+
+  test("color-taking overloads set side color") {
+    val red = Color.fromRgb(255, 0, 0)
+    val blue = Color.fromRgb(0, 0, 255)
+    val style = CellStyle.default
+      .borderTop(BorderStyle.Thin, red)
+      .borderBottom(BorderStyle.Thin, blue)
+      .borderLeft(BorderStyle.Medium, red)
+      .borderRight(BorderStyle.Medium, blue)
+    assertEquals(style.border.top, BorderSide(BorderStyle.Thin, red))
+    assertEquals(style.border.bottom, BorderSide(BorderStyle.Thin, blue))
+    assertEquals(style.border.left, BorderSide(BorderStyle.Medium, red))
+    assertEquals(style.border.right, BorderSide(BorderStyle.Medium, blue))
+  }
+
+  test("setting the same side twice keeps the last write") {
+    val style = CellStyle.default.borderTop(BorderStyle.Thin).borderTop(BorderStyle.Thick)
+    assertEquals(style.border.top, BorderSide(BorderStyle.Thick))
   }
 
   // ========== Number Format Tests ==========

--- a/xl-core/test/src/com/tjclp/xl/svg/SvgRendererSpec.scala
+++ b/xl-core/test/src/com/tjclp/xl/svg/SvgRendererSpec.scala
@@ -1081,3 +1081,15 @@ class SvgRendererSpec extends FunSuite:
     assert(svg.contains("2/3/25"), s"SVG should contain formatted date '2/3/25', got: $svg")
     assert(!svg.contains("2025-02-03T"), s"SVG should NOT contain ISO format")
   }
+
+  test("GH-255 cascade: .cell-text CSS rule declares no font, so per-cell attrs win"):
+    // CSS class rules outrank presentation attributes; a font-family/font-size declaration on
+    // .cell-text silently overrode every per-cell font in CSS-aware rasterizers.
+    val sheet = Sheet(SheetName.unsafe("S")).put(
+      ARef.from0(0, 0),
+      CellValue.Text("serif")
+    )
+    val svg = SvgRenderer.toSvg(sheet, CellRange(ARef.from0(0, 0), ARef.from0(0, 0)))
+    val styleBlock = svg.substring(svg.indexOf("<style>"), svg.indexOf("</style>"))
+    assert(!styleBlock.contains(".cell-text"), "cell-text must not have a CSS rule")
+    assert(styleBlock.contains(".header-text"), "header styling stays CSS-driven")

--- a/xl-core/test/src/com/tjclp/xl/svg/SvgRendererSpec.scala
+++ b/xl-core/test/src/com/tjclp/xl/svg/SvgRendererSpec.scala
@@ -566,7 +566,7 @@ class SvgRendererSpec extends FunSuite:
     assert(svg.contains("""font-size="12px""""), s"9pt should be 12px, got: $svg")
   }
 
-  test("toSvg: font-family with spaces is quoted") {
+  test("toSvg: multi-word font-family is unquoted in SVG attributes, quoted in HTML CSS (GH-255)") {
     import com.tjclp.xl.styles.font.Font
     val timesFont = CellStyle.default.withFont(Font(name = "Times New Roman"))
     val sheet = Sheet("Test")
@@ -576,14 +576,26 @@ class SvgRendererSpec extends FunSuite:
 
     val svg = sheet.toSvg(ref"A1:A1")
 
-    // Font name should be quoted to handle spaces
+    // Quotes are CSS syntax; in an SVG presentation attribute they become part of the family
+    // name, so fontconfig rasterizers (rsvg-convert, resvg) silently substitute sans-serif
     assert(
-      svg.contains("""font-family="'Times New Roman'""""),
-      s"Font with spaces should be quoted, got: $svg"
+      svg.contains("""font-family="Times New Roman""""),
+      s"Multi-word font should be unquoted in SVG attribute, got: $svg"
+    )
+    assert(
+      !svg.contains("'Times New Roman'"),
+      s"SVG attribute must not contain CSS-style quotes, got: $svg"
+    )
+
+    // HTML inline styles are CSS context, where multi-word families keep their quotes
+    val html = sheet.toHtml(ref"A1:A1")
+    assert(
+      html.contains("font-family: 'Times New Roman'"),
+      s"HTML CSS should keep quoted family, got: $html"
     )
   }
 
-  test("toSvg: simple font-family is also quoted") {
+  test("toSvg: simple font-family is also unquoted") {
     import com.tjclp.xl.styles.font.Font
     val arialFont = CellStyle.default.withFont(Font(name = "Arial"))
     val sheet = Sheet("Test")
@@ -593,8 +605,9 @@ class SvgRendererSpec extends FunSuite:
 
     val svg = sheet.toSvg(ref"A1:A1")
 
-    // Even simple font names should be quoted for consistency
-    assert(svg.contains("""font-family="'Arial'""""), s"Font should be quoted, got: $svg")
+    // Simple font names are unquoted for consistency with multi-word names
+    assert(svg.contains("""font-family="Arial""""), s"Font should be unquoted, got: $svg")
+    assert(!svg.contains("""font-family="'Arial'""""), s"Font must not be quoted, got: $svg")
   }
 
   test("toSvg: rich text font size converts pt to px") {
@@ -610,7 +623,7 @@ class SvgRendererSpec extends FunSuite:
     assert(svg.contains("""font-size="21px""""), s"Rich text 16pt should be 21px, got: $svg")
   }
 
-  test("toSvg: rich text font-family is quoted") {
+  test("toSvg: rich text font-family is unquoted in SVG attributes") {
     import com.tjclp.xl.richtext.{RichText, TextRun}
     import com.tjclp.xl.styles.font.Font
     val richText = RichText(TextRun("Styled", Some(Font(name = "Comic Sans MS"))))
@@ -619,8 +632,60 @@ class SvgRendererSpec extends FunSuite:
     val svg = sheet.toSvg(ref"A1:A1")
 
     assert(
-      svg.contains("""font-family="'Comic Sans MS'""""),
-      s"Rich text font should be quoted, got: $svg"
+      svg.contains("""font-family="Comic Sans MS""""),
+      s"Rich text font should be unquoted in SVG attribute, got: $svg"
+    )
+    assert(
+      !svg.contains("'Comic Sans MS'"),
+      s"SVG attribute must not contain CSS-style quotes, got: $svg"
+    )
+  }
+
+  // ========== Underline Tests (GH-256) ==========
+
+  test("toSvg: underlined cell emits text-decoration on text element (GH-256)") {
+    import com.tjclp.xl.styles.font.Font
+    val underlined = CellStyle.default.withFont(Font(bold = true, underline = true))
+    val sheet = Sheet("Test")
+      .put(ref"A1" -> "I. Valuation Analysis")
+      .unsafe
+      .withCellStyle(ref"A1", underlined)
+
+    val svg = sheet.toSvg(ref"A1:A1")
+
+    assert(
+      svg.contains("""text-decoration="underline""""),
+      s"Underlined cell should emit text-decoration on <text>, got: $svg"
+    )
+  }
+
+  test("toSvg: cell without underline has no text-decoration") {
+    import com.tjclp.xl.styles.font.Font
+    val plain = CellStyle.default.withFont(Font(bold = true))
+    val sheet = Sheet("Test")
+      .put(ref"A1" -> "Plain")
+      .unsafe
+      .withCellStyle(ref"A1", plain)
+
+    val svg = sheet.toSvg(ref"A1:A1")
+
+    assert(
+      !svg.contains("text-decoration"),
+      s"Cell without underline should not emit text-decoration, got: $svg"
+    )
+  }
+
+  test("toSvg: underlined rich text run emits text-decoration") {
+    import com.tjclp.xl.richtext.{RichText, TextRun}
+    import com.tjclp.xl.styles.font.Font
+    val richText = RichText(TextRun("Key", Some(Font(underline = true))))
+    val sheet = Sheet("Test").put(ref"A1", CellValue.RichText(richText))
+
+    val svg = sheet.toSvg(ref"A1:A1")
+
+    assert(
+      svg.contains("""text-decoration="underline""""),
+      s"Underlined rich text run should emit text-decoration, got: $svg"
     )
   }
 

--- a/xl-evaluator/src/com/tjclp/xl/formula/parser/FormulaParser.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/parser/FormulaParser.scala
@@ -169,13 +169,29 @@ object FormulaParser:
     }
 
   /**
+   * Match a logical keyword (NOT/AND/OR) at the current position with a word boundary: the keyword
+   * must be followed by whitespace, '(', or end of input. Without the boundary, sheet and defined
+   * names starting with a keyword were consumed as the operator — `Notes1!A1` parsed as
+   * `NOT(es1!A1)` (found by the cross-sheet round-trip property, GH-268).
+   */
+  private def isKeywordAt(s: ParserState, keyword: String): Boolean =
+    val rem = s.remaining
+    rem.length >= keyword.length &&
+    rem.substring(0, keyword.length).equalsIgnoreCase(keyword) && {
+      rem.length == keyword.length || {
+        val next = rem.charAt(keyword.length)
+        next.isWhitespace || next == '('
+      }
+    }
+
+  /**
    * Parse logical OR (lowest precedence).
    */
   @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
   private def parseLogicalOr(state: ParserState): ParseResult[TExpr[?]] =
     parseLogicalAnd(state).flatMap { case (left, s1) =>
       val s2 = skipWhitespace(s1)
-      if s2.remaining.toUpperCase.startsWith("OR") then
+      if isKeywordAt(s2, "OR") then
         val s3 = skipWhitespace(s2.advance(2))
         descend(s3).flatMap { sd =>
           parseLogicalOr(sd).map { case (right, s4) =>
@@ -198,7 +214,7 @@ object FormulaParser:
   private def parseLogicalAnd(state: ParserState): ParseResult[TExpr[?]] =
     parseComparison(state).flatMap { case (left, s1) =>
       val s2 = skipWhitespace(s1)
-      if s2.remaining.toUpperCase.startsWith("AND") then
+      if isKeywordAt(s2, "AND") then
         val s3 = skipWhitespace(s2.advance(3))
         descend(s3).flatMap { sd =>
           parseLogicalAnd(sd).map { case (right, s4) =>
@@ -493,7 +509,7 @@ object FormulaParser:
             )
           }
         }
-      case Some('N') | Some('n') if s.remaining.toUpperCase.startsWith("NOT") =>
+      case Some('N') | Some('n') if isKeywordAt(s, "NOT") =>
         descend(s).flatMap { sd =>
           val s2 = skipWhitespace(sd.advance(3))
           parseUnary(s2).map { case (expr, s3) =>

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/CrossSheetFormulaSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/CrossSheetFormulaSpec.scala
@@ -136,6 +136,24 @@ class CrossSheetFormulaSpec extends ScalaCheckSuite:
     }
   }
 
+
+  // ===== GH-268: keyword-prefixed sheet names must parse as references =====
+
+  test("GH-268: sheet names starting with NOT/AND/OR round-trip as references") {
+    for name <- List("Notes1", "NoTuq0", "Andrea", "Orders", "NOT", "AND", "OR") do
+      val formula = s"=SUM($name!A47:A48)"
+      val reprinted = FormulaParser.parse(formula).map(FormulaPrinter.print(_))
+      assertEquals(reprinted, Right(formula), s"sheet name: $name")
+  }
+
+  test("GH-268: logical keywords still parse with proper boundaries") {
+    assert(FormulaParser.parse("=NOT(A1)").isRight)
+    assert(FormulaParser.parse("=NOT A1").isRight)
+    assert(FormulaParser.parse("=A1>0 AND B1<5").isRight)
+    assert(FormulaParser.parse("=A1>0 OR B1<5").isRight)
+    assert(FormulaParser.parse("=not(TRUE)").isRight)
+  }
+
   // ===== Evaluator Tests =====
 
   test("SheetPolyRef: evaluates number from target sheet") {

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/PrintNames.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/PrintNames.scala
@@ -1,0 +1,164 @@
+package com.tjclp.xl.ooxml
+
+import com.tjclp.xl.addressing.{CellRange, SheetName}
+import com.tjclp.xl.api.{Sheet, Workbook}
+import com.tjclp.xl.sheets.PageSetup
+import com.tjclp.xl.workbooks.DefinedName
+
+/**
+ * Print area / print titles defined-name mapping (GH-259).
+ *
+ * Excel stores a sheet's print area and repeated title rows as sheet-scoped workbook defined names
+ * (`_xlnm.Print_Area` / `_xlnm.Print_Titles` with `localSheetId`). The typed home for both is
+ * `PageSetup.printArea` / `PageSetup.repeatRows`; this object converts between that model and the
+ * defined-name formulas.
+ *
+ * Only modelable formula shapes are lifted into the model on read: a single absolute range for
+ * Print_Area (`Sheet1!$A$1:$D$20`) and a pure row span for Print_Titles (`Sheet1!$1:$3`).
+ * Multi-range areas, column-only titles, and hidden/commented names stay in
+ * `WorkbookMetadata.definedNames` verbatim, so nothing is lost on rewrite.
+ */
+private[ooxml] object PrintNames:
+
+  /** Defined name Excel uses for a sheet's print area. */
+  val PrintArea = "_xlnm.Print_Area"
+
+  /** Defined name Excel uses for a sheet's repeated print titles (rows and/or columns). */
+  val PrintTitles = "_xlnm.Print_Titles"
+
+  private val AbsRangeRe = """^\$([A-Za-z]{1,3})\$([0-9]+):\$([A-Za-z]{1,3})\$([0-9]+)$""".r
+  private val AbsCellRe = """^\$([A-Za-z]{1,3})\$([0-9]+)$""".r
+  private val RowSpanRe = """^\$([0-9]+):\$([0-9]+)$""".r
+
+  /**
+   * Quote a sheet name for use in a defined-name formula, matching Excel's convention: simple names
+   * (letters/digits/underscore, not starting with a digit) stay bare, everything else is wrapped in
+   * single quotes with embedded quotes doubled.
+   */
+  def quoteSheetName(name: String): String =
+    val simple = name.nonEmpty && !name.charAt(0).isDigit &&
+      name.forall(c => c.isLetterOrDigit || c == '_')
+    if simple then name else s"'${name.replace("'", "''")}'"
+
+  /** Format a Print_Area formula, e.g. `Sheet1!$A$1:$D$20` or `'Q1 Report'!$A$1:$D$20`. */
+  def printAreaFormula(sheet: SheetName, area: CellRange): String =
+    val s = area.start
+    val e = area.end
+    s"${quoteSheetName(sheet.value)}!$$${s.col.toLetter}$$${s.row.index1}:$$${e.col.toLetter}$$${e.row.index1}"
+
+  /** Format a row-span Print_Titles formula, e.g. `Sheet1!$1:$3`. */
+  def printTitlesFormula(sheet: SheetName, rows: (Int, Int)): String =
+    s"${quoteSheetName(sheet.value)}!$$${rows._1}:$$${rows._2}"
+
+  /**
+   * Split a `Sheet!rest` or `'Quoted Sheet'!rest` formula prefix, unescaping `''` to `'`. Returns
+   * None when the formula has no (single) sheet qualifier.
+   */
+  private def splitSheetPrefix(formula: String): Option[(String, String)] =
+    if formula.startsWith("'") then
+      @annotation.tailrec
+      def findClose(i: Int): Option[Int] =
+        if i >= formula.length then None
+        else if formula.charAt(i) == '\'' then
+          if i + 1 < formula.length && formula.charAt(i + 1) == '\'' then findClose(i + 2)
+          else Some(i)
+        else findClose(i + 1)
+      findClose(1).flatMap { close =>
+        val name = formula.substring(1, close).replace("''", "'")
+        val rest = formula.substring(close + 1)
+        if rest.startsWith("!") then Some((name, rest.drop(1))) else None
+      }
+    else
+      val bang = formula.indexOf('!')
+      if bang <= 0 then None
+      else Some((formula.substring(0, bang), formula.substring(bang + 1)))
+
+  /**
+   * Parse a Print_Area formula into a CellRange when it is a single absolute range (or cell) scoped
+   * to the given sheet. Multi-range areas (comma-separated) are not modeled.
+   */
+  def parsePrintArea(formula: String, sheet: SheetName): Option[CellRange] =
+    splitSheetPrefix(formula.trim).filter((name, _) => name == sheet.value).flatMap { (_, rest) =>
+      rest match
+        case AbsRangeRe(c1, r1, c2, r2) => CellRange.parse(s"$c1$r1:$c2$r2").toOption
+        case AbsCellRe(c, r) => CellRange.parse(s"$c$r:$c$r").toOption
+        case _ => None
+    }
+
+  /**
+   * Parse a Print_Titles formula into a 1-based row span when it is a pure row span scoped to the
+   * given sheet. Column titles (`$A:$B`) and mixed forms are not modeled.
+   */
+  def parsePrintTitles(formula: String, sheet: SheetName): Option[(Int, Int)] =
+    splitSheetPrefix(formula.trim).filter((name, _) => name == sheet.value).flatMap { (_, rest) =>
+      rest match
+        case RowSpanRe(a, b) =>
+          for
+            start <- a.toIntOption
+            end <- b.toIntOption
+            // Bounds mirror PageSetup's repeatRows invariant (total parse: never throw on read)
+            if start >= 1 && start <= end && end <= com.tjclp.xl.addressing.Row.MaxIndex0 + 1
+          yield (start, end)
+        case _ => None
+    }
+
+  /** Defined names derived from each sheet's PageSetup (write side), in sheet order. */
+  def fromSheets(sheets: Vector[Sheet]): Vector[DefinedName] =
+    sheets.zipWithIndex.flatMap { case (sheet, idx) =>
+      val area = sheet.pageSetup.flatMap(_.printArea).map { range =>
+        DefinedName(PrintArea, printAreaFormula(sheet.name, range), localSheetId = Some(idx))
+      }
+      val titles = sheet.pageSetup.flatMap(_.repeatRows).map { rows =>
+        DefinedName(PrintTitles, printTitlesFormula(sheet.name, rows), localSheetId = Some(idx))
+      }
+      area.toList ++ titles.toList
+    }
+
+  /**
+   * Defined names to serialize for a workbook: the metadata names (with any print name shadowed by
+   * a PageSetup-derived one removed) followed by the derived print names.
+   */
+  def effective(wb: Workbook): Vector[DefinedName] =
+    val derived = fromSheets(wb.sheets)
+    val derivedKeys = derived.map(dn => (dn.name, dn.localSheetId)).toSet
+    wb.metadata.definedNames.filterNot(dn =>
+      derivedKeys.contains((dn.name, dn.localSheetId))
+    ) ++ derived
+
+  /**
+   * Read side: lift modelable sheet-scoped print names into each Sheet's PageSetup and drop them
+   * from the metadata list (the writer re-derives them from the model). Unmodelable names are left
+   * in the metadata verbatim and the corresponding PageSetup fields stay None.
+   *
+   * @return
+   *   (sheets with printArea/repeatRows populated, defined names minus the lifted ones)
+   */
+  def extract(
+    sheets: Vector[Sheet],
+    names: Vector[DefinedName]
+  ): (Vector[Sheet], Vector[DefinedName]) =
+    if names.isEmpty then (sheets, names)
+    else
+      def candidate(name: String, idx: Int): Option[DefinedName] =
+        names.find(dn =>
+          dn.name == name && dn.localSheetId.contains(idx) && !dn.hidden && dn.comment.isEmpty
+        )
+
+      val parsed = sheets.zipWithIndex.map { case (sheet, idx) =>
+        val area = candidate(PrintArea, idx)
+          .flatMap(dn => parsePrintArea(dn.formula, sheet.name).map(dn -> _))
+        val titles = candidate(PrintTitles, idx)
+          .flatMap(dn => parsePrintTitles(dn.formula, sheet.name).map(dn -> _))
+        (area, titles)
+      }
+
+      val updatedSheets = sheets.zip(parsed).map { case (sheet, (area, titles)) =>
+        if area.isEmpty && titles.isEmpty then sheet
+        else
+          val base = sheet.pageSetup.getOrElse(PageSetup())
+          sheet.copy(pageSetup =
+            Some(base.copy(printArea = area.map(_._2), repeatRows = titles.map(_._2)))
+          )
+      }
+      val lifted = parsed.flatMap((a, t) => a.map(_._1).toList ++ t.map(_._1).toList).toSet
+      (updatedSheets, names.filterNot(lifted.contains))

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/Workbook.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/Workbook.scala
@@ -208,8 +208,10 @@ object OoxmlWorkbook extends XmlReadable[OoxmlWorkbook]:
       val state = wb.metadata.sheetStates.get(sheet.name).flatten
       SheetRef(sheet.name, idx + 1, s"rId${idx + 1}", state)
     }
-    // GH-236: serialize named ranges from the typed model (previously dropped on write)
-    OoxmlWorkbook(sheetRefs, definedNames = buildDefinedNames(wb.metadata.definedNames))
+    // GH-236: serialize named ranges from the typed model (previously dropped on write).
+    // GH-259: print area / repeat rows live on Sheet.pageSetup and are appended here as
+    // sheet-scoped _xlnm.Print_Area / _xlnm.Print_Titles names.
+    OoxmlWorkbook(sheetRefs, definedNames = buildDefinedNames(PrintNames.effective(wb)))
 
   /**
    * Build a `<definedNames>` element from the typed model (GH-236), or None when empty. Order

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/XlsxReader.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/XlsxReader.scala
@@ -3,7 +3,14 @@ package com.tjclp.xl.ooxml
 import com.tjclp.xl.addressing.{ARef, Column, Row, SheetName}
 import com.tjclp.xl.cells.{Cell, CellError, CellValue}
 import com.tjclp.xl.api.{Sheet, Workbook}
-import com.tjclp.xl.sheets.{ColumnProperties, PageSetup, RowProperties}
+import com.tjclp.xl.sheets.{
+  ColumnProperties,
+  HeaderFooter,
+  PageMargins,
+  PageSetup,
+  RowProperties,
+  SheetView
+}
 import com.tjclp.xl.error.{XLError, XLResult}
 import com.tjclp.xl.context.{ModificationTracker, SourceContext, SourceFingerprint}
 import com.tjclp.xl.tables.TableSpec
@@ -774,8 +781,12 @@ object XlsxReader:
     // Extract row properties from OoxmlRow data
     val rowProperties = extractRowProperties(ooxmlSheet.rows)
 
-    // Parse page setup (print scale, orientation, etc.)
-    val pageSetup = parsePageSetup(ooxmlSheet.pageSetup)
+    // Parse print setup (scale/orientation/fit, margins, header/footer) — GH-259
+    val pageSetup =
+      parsePageSetup(ooxmlSheet.pageSetup, ooxmlSheet.pageMargins, ooxmlSheet.headerFooter)
+
+    // Parse view settings (gridlines, zoom) from <sheetViews> — GH-258
+    val viewSettings = parseSheetView(ooxmlSheet.sheetViews)
 
     Right(
       Sheet(
@@ -787,7 +798,8 @@ object XlsxReader:
         tables = tables,
         columnProperties = columnProperties,
         rowProperties = rowProperties,
-        pageSetup = pageSetup
+        pageSetup = pageSetup,
+        viewSettings = viewSettings
       )
     )
 
@@ -851,20 +863,80 @@ object XlsxReader:
     builder.result()
 
   /**
-   * Parse page setup from <pageSetup> XML element.
+   * Parse print setup from the <pageSetup>, <pageMargins>, and <headerFooter> XML elements
+   * (GH-259). Any one of the three is enough to produce a PageSetup; printArea/repeatRows are
+   * lifted from workbook defined names later (PrintNames.extract).
    *
-   * Extracts print settings like scale, orientation, fitToWidth, fitToHeight.
+   * The parse is total: out-of-range or unmodeled attribute values (scale outside 10-400,
+   * orientation="default", negative margins) fall back to defaults instead of violating the model
+   * invariants — a malformed file must never throw.
    */
-  private def parsePageSetup(pageSetupElem: Option[Elem]): Option[PageSetup] =
-    pageSetupElem.map { elem =>
+  private def parsePageSetup(
+    pageSetupElem: Option[Elem],
+    pageMarginsElem: Option[Elem],
+    headerFooterElem: Option[Elem]
+  ): Option[PageSetup] =
+    val margins = pageMarginsElem.flatMap(parsePageMargins)
+    val headerFooter = headerFooterElem.flatMap(parseHeaderFooter)
+    val base = pageSetupElem.map { elem =>
       val attrs = elem.attributes.asAttrMap
       PageSetup(
-        scale = attrs.get("scale").flatMap(_.toIntOption).getOrElse(100),
-        orientation = attrs.get("orientation"),
-        fitToWidth = attrs.get("fitToWidth").flatMap(_.toIntOption),
-        fitToHeight = attrs.get("fitToHeight").flatMap(_.toIntOption)
+        scale = attrs
+          .get("scale")
+          .flatMap(_.toIntOption)
+          .filter(s => s >= 10 && s <= 400)
+          .getOrElse(100),
+        orientation = attrs.get("orientation").filter(o => o == "portrait" || o == "landscape"),
+        fitToWidth = attrs.get("fitToWidth").flatMap(_.toIntOption).filter(_ >= 0),
+        fitToHeight = attrs.get("fitToHeight").flatMap(_.toIntOption).filter(_ >= 0)
       )
     }
+    if base.isEmpty && margins.isEmpty && headerFooter.isEmpty then None
+    else Some(base.getOrElse(PageSetup()).copy(margins = margins, headerFooter = headerFooter))
+
+  /**
+   * Parse <pageMargins>; all six attributes are required by the schema (total: None if invalid).
+   */
+  private def parsePageMargins(elem: Elem): Option[PageMargins] =
+    val attrs = elem.attributes.asAttrMap
+    def attr(name: String): Option[Double] =
+      attrs.get(name).flatMap(_.toDoubleOption).filter(_ >= 0)
+    for
+      left <- attr("left")
+      right <- attr("right")
+      top <- attr("top")
+      bottom <- attr("bottom")
+      header <- attr("header")
+      footer <- attr("footer")
+    yield PageMargins(left, right, top, bottom, header, footer)
+
+  /**
+   * Parse the modeled odd header/footer from <headerFooter>. Returns Some only when an odd part is
+   * present; even/first-page variants are preserved as raw XML, not modeled.
+   */
+  private def parseHeaderFooter(elem: Elem): Option[HeaderFooter] =
+    val oddHeader = (elem \ "oddHeader").headOption.map(_.text).filter(_.nonEmpty)
+    val oddFooter = (elem \ "oddFooter").headOption.map(_.text).filter(_.nonEmpty)
+    if oddHeader.isEmpty && oddFooter.isEmpty then None
+    else Some(HeaderFooter(oddHeader, oddFooter))
+
+  /**
+   * Parse sheet view settings (GH-258) from the first <sheetView>.
+   *
+   * Returns Some only when a modeled attribute (showGridLines, zoomScale) is present, so typical
+   * files keep viewSettings = None and the raw sheetViews XML rides through unchanged on rewrite
+   * (passive preserve, mirroring freezePane semantics). Out-of-range zoom values are dropped rather
+   * than violating the SheetView invariant.
+   */
+  private def parseSheetView(sheetViewsElem: Option[Elem]): Option[SheetView] =
+    for
+      views <- sheetViewsElem
+      view <- (views \ "sheetView").collectFirst { case e: Elem => e }
+      attrs = view.attributes.asAttrMap
+      showGridLines = attrs.get("showGridLines").map(v => v != "0" && v != "false")
+      zoomScale = attrs.get("zoomScale").flatMap(_.toIntOption).filter(z => z >= 10 && z <= 400)
+      if showGridLines.isDefined || zoomScale.isDefined
+    yield SheetView(showGridLines = showGridLines.getOrElse(true), zoomScale = zoomScale)
 
   /**
    * Assemble final workbook with optional SourceContext for surgical modification.
@@ -911,10 +983,14 @@ object XlsxReader:
           case (None, Some(_)) =>
             Left(XLError.IOError("Unexpected source fingerprint without source handle"))
 
+      // GH-259: lift modelable sheet-scoped print names (_xlnm.Print_Area/_xlnm.Print_Titles)
+      // into Sheet.pageSetup; unmodelable forms stay in metadata.definedNames verbatim.
+      val (sheetsWithPrint, remainingNames) = PrintNames.extract(sheets, definedNames)
+
       val metadata =
-        WorkbookMetadata(theme = theme, definedNames = definedNames, sheetStates = sheetStates)
+        WorkbookMetadata(theme = theme, definedNames = remainingNames, sheetStates = sheetStates)
       sourceContextEither.map(ctx =>
-        Workbook(sheets = sheets, metadata = metadata, sourceContext = ctx)
+        Workbook(sheets = sheetsWithPrint, metadata = metadata, sourceContext = ctx)
       )
 
   /**

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/XlsxWriter.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/XlsxWriter.scala
@@ -1355,10 +1355,18 @@ object XlsxWriter:
         // Update sheets in preserved structure (names/order/visibility may have changed).
         // Named ranges (definedNames) ride through verbatim here (byte-identical). Authoring a
         // name marks metadata modified, which routes to the fromDomain branch below (GH-236).
-        preserved.updateSheets(workbook.sheets, workbook.metadata.sheetStates)
+        val updated = preserved.updateSheets(workbook.sheets, workbook.metadata.sheetStates)
+        // GH-259: print names (_xlnm.Print_Area/_xlnm.Print_Titles) are modeled on Sheet.pageSetup,
+        // so a sheet edit can change them WITHOUT marking metadata modified. Reconcile: keep the
+        // preserved definedNames bytes when the model agrees, otherwise regenerate the element.
+        val expected = PrintNames.effective(workbook)
+        if OoxmlWorkbook.parseDefinedNames(updated.definedNames).toSet == expected.toSet then
+          updated
+        else updated.copy(definedNames = OoxmlWorkbook.buildDefinedNames(expected))
       case None =>
         // Fallback for programmatically created workbooks OR when metadata was modified — fresh
-        // workbook structure; fromDomain now serializes wb.metadata.definedNames (GH-236).
+        // workbook structure; fromDomain serializes wb.metadata.definedNames (GH-236) plus the
+        // PageSetup-derived print names (GH-259).
         OoxmlWorkbook.fromDomain(workbook)
 
     // Content types: preserve from source when available, otherwise generate minimal.

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/style/StyleParser.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/style/StyleParser.scala
@@ -231,9 +231,12 @@ object WorkbookStyles:
           .attribute("wrapText")
           .flatMap(attr => parseBool(attr.text))
           .getOrElse(Align.default.wrapText)
+        // OOXML indent is an unsigned int; ignore negative values from malformed files so the
+        // parser stays total (Align requires indent >= 0)
         val indent = alignElem
           .attribute("indent")
           .flatMap(attr => attr.text.toIntOption)
+          .filter(_ >= 0)
           .getOrElse(Align.default.indent)
         Some(
           Align(

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/OoxmlWorksheet.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/OoxmlWorksheet.scala
@@ -5,7 +5,7 @@ import scala.xml.*
 import com.tjclp.xl.addressing.{ARef, CellRange, Row}
 import com.tjclp.xl.ooxml.XmlUtil.{elem, nsRelationships}
 import com.tjclp.xl.ooxml.{SaxSerializable, SaxWriter, SharedStrings, XmlWritable}
-import com.tjclp.xl.sheets.{FreezePane, Sheet}
+import com.tjclp.xl.sheets.{FreezePane, Sheet, SheetView}
 
 /**
  * Worksheet for xl/worksheets/sheet#.xml
@@ -477,7 +477,7 @@ object OoxmlWorksheet extends com.tjclp.xl.ooxml.XmlReadable[OoxmlWorksheet]:
           calculatedDimension.orElse(
             preserved.dimension
           ), // Use calculated dimension, fallback to preserved
-          applyFreezePaneOverride(preserved.sheetViews, sheet.freezePane),
+          applySheetViewOverrides(preserved.sheetViews, sheet.freezePane, sheet.viewSettings),
           preserved.sheetFormatPr,
           generatedCols.orElse(preserved.cols), // Prefer domain props over preserved XML
           preserved.conditionalFormatting,
@@ -485,9 +485,10 @@ object OoxmlWorksheet extends com.tjclp.xl.ooxml.XmlReadable[OoxmlWorksheet]:
           preserved.rowBreaks,
           preserved.colBreaks,
           preserved.customPropertiesWs,
-          preserved.pageMargins,
-          preserved.pageSetup,
-          preserved.headerFooter,
+          // GH-259: overlay modeled print setup on the preserved XML (unmodeled bits survive)
+          buildPageMarginsElem(sheet.pageSetup).orElse(preserved.pageMargins),
+          mergePageSetupElem(preserved.pageSetup, sheet.pageSetup),
+          mergeHeaderFooterElem(preserved.headerFooter, sheet.pageSetup),
           preserved.drawing,
           legacyDrawingElem, // Use computed element (preserved or generated)
           preserved.picture,
@@ -507,12 +508,73 @@ object OoxmlWorksheet extends com.tjclp.xl.ooxml.XmlReadable[OoxmlWorksheet]:
           rowsWithCells,
           sheet.mergedRanges,
           dimension = calculatedDimension,
-          sheetViews = applyFreezePaneOverride(None, sheet.freezePane),
+          sheetViews = applySheetViewOverrides(None, sheet.freezePane, sheet.viewSettings),
           cols = generatedCols,
+          pageMargins = buildPageMarginsElem(sheet.pageSetup),
+          pageSetup = mergePageSetupElem(None, sheet.pageSetup),
+          headerFooter = mergeHeaderFooterElem(None, sheet.pageSetup),
           legacyDrawing = legacyDrawingElem,
           tableParts = tableParts,
           preservedKnown = hyperlinksMap
         )
+
+  /**
+   * Apply freeze pane and view-settings overrides to sheetViews XML (GH-258).
+   *
+   * The freeze pane override runs first (creating a minimal `<sheetViews><sheetView/></sheetViews>`
+   * when needed), then view settings are merged onto the same `<sheetView>` element, so freeze
+   * panes and view settings always share ONE sheetView.
+   */
+  private def applySheetViewOverrides(
+    existing: Option[Elem],
+    freezeOverride: Option[FreezePane],
+    viewSettings: Option[SheetView]
+  ): Option[Elem] =
+    applyViewSettingsOverride(applyFreezePaneOverride(existing, freezeOverride), viewSettings)
+
+  /**
+   * Apply sheet view settings to sheetViews XML.
+   *
+   * When `None`, preserves existing sheetViews unchanged (passive default, mirroring freezePane).
+   * When `Some(view)`, sets `showGridLines` ("1"/"0", always written so the setting round-trips)
+   * and `zoomScale` (written when defined, removed when None) on every `<sheetView>` element,
+   * creating a minimal `<sheetViews><sheetView workbookViewId="0"/></sheetViews>` when absent.
+   * Unmodeled attributes (tabSelected, topLeftCell, view, ...) are preserved.
+   */
+  private def applyViewSettingsOverride(
+    existing: Option[Elem],
+    viewSettings: Option[SheetView]
+  ): Option[Elem] =
+    viewSettings match
+      case None => existing
+      case Some(view) =>
+        val base = existing.getOrElse(
+          elem("sheetViews")(elem("sheetView", "workbookViewId" -> "0")())
+        )
+        // Degenerate guard: a <sheetViews> without any <sheetView> child gets one appended
+        val hasSheetView = base.child.exists {
+          case e: Elem => e.label == "sheetView"
+          case _ => false
+        }
+        val withView =
+          if hasSheetView then base
+          else base.copy(child = base.child :+ elem("sheetView", "workbookViewId" -> "0")())
+        val newChildren = withView.child.map {
+          case e: Elem if e.label == "sheetView" => applyViewAttrs(e, view)
+          case other => other
+        }
+        Some(withView.copy(child = newChildren))
+
+  /** Set the modeled view attributes on a single `<sheetView>` element. */
+  private def applyViewAttrs(sheetView: Elem, view: SheetView): Elem =
+    val withGrid = sheetView % new UnprefixedAttribute(
+      "showGridLines",
+      if view.showGridLines then "1" else "0",
+      Null
+    )
+    view.zoomScale match
+      case Some(zoom) => withGrid % new UnprefixedAttribute("zoomScale", zoom.toString, Null)
+      case None => withGrid.copy(attributes = withGrid.attributes.remove("zoomScale"))
 
   /**
    * Apply freeze pane override to sheetViews XML.

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/WorksheetHelpers.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/WorksheetHelpers.scala
@@ -5,7 +5,7 @@ import scala.xml.*
 import com.tjclp.xl.addressing.{ARef, Column}
 import com.tjclp.xl.ooxml.XmlUtil
 import com.tjclp.xl.ooxml.XmlUtil.nsSpreadsheetML
-import com.tjclp.xl.sheets.{ColumnProperties, RowProperties, Sheet}
+import com.tjclp.xl.sheets.{ColumnProperties, PageSetup, RowProperties, Sheet}
 
 // Default namespaces for generated worksheets. Real files capture the original scope/attributes to
 // avoid redundant declarations and preserve mc/x14/xr bindings from the source sheet.
@@ -213,6 +213,88 @@ private[ooxml] def buildColsElement(sheet: Sheet): Option[Elem] =
       XmlUtil.elemOrdered("col", attrs.result()*)( /* no children */ )
     }
     Some(XmlUtil.elem("cols")(colElems*))
+
+// ===== Print setup authoring (GH-259) =====
+// PageSetup is the typed model for <pageMargins>, <pageSetup>, and <headerFooter>. The merge
+// helpers below overlay the modeled fields onto any preserved source XML so unmodeled attributes
+// (paperSize, printer r:id, even/first-page headers, differentOddEven, ...) survive a rewrite.
+
+/** Replace or remove an unprefixed attribute on an element (deterministic for a given input). */
+private def setOrRemoveAttr(e: Elem, key: String, value: Option[String]): Elem =
+  value match
+    case Some(v) => e % new UnprefixedAttribute(key, v, Null)
+    case None => e.copy(attributes = e.attributes.remove(key))
+
+/**
+ * Build a `<pageMargins>` element from the domain margins, or None when not set.
+ *
+ * All six attributes are required by the schema (CT_PageMargins), so the element is fully modeled
+ * and regenerated rather than merged.
+ */
+private[ooxml] def buildPageMarginsElem(pageSetup: Option[PageSetup]): Option[Elem] =
+  pageSetup.flatMap(_.margins).map { m =>
+    XmlUtil.elem(
+      "pageMargins",
+      "left" -> m.left.toString,
+      "right" -> m.right.toString,
+      "top" -> m.top.toString,
+      "bottom" -> m.bottom.toString,
+      "header" -> m.header.toString,
+      "footer" -> m.footer.toString
+    )()
+  }
+
+/**
+ * Merge the modeled `<pageSetup>` attributes (scale, orientation, fitToWidth, fitToHeight) into the
+ * preserved element, keeping unmodeled attributes (paperSize, r:id, dpi, ...) intact.
+ *
+ * Default-valued fields remove their attribute (the OOXML defaults match), so parse-then-merge of
+ * an untouched sheet is an identity. When nothing is preserved and every modeled field is at its
+ * default, no element is emitted.
+ */
+private[ooxml] def mergePageSetupElem(
+  existing: Option[Elem],
+  pageSetup: Option[PageSetup]
+): Option[Elem] =
+  pageSetup match
+    case None => existing
+    case Some(ps) =>
+      val base = existing.getOrElse(XmlUtil.elem("pageSetup")())
+      val overrides: Seq[(String, Option[String])] = Seq(
+        "scale" -> Some(ps.scale.toString).filter(_ => ps.scale != 100),
+        "orientation" -> ps.orientation,
+        "fitToWidth" -> ps.fitToWidth.map(_.toString),
+        "fitToHeight" -> ps.fitToHeight.map(_.toString)
+      )
+      val updated = overrides.foldLeft(base) { case (e, (key, value)) =>
+        setOrRemoveAttr(e, key, value)
+      }
+      if existing.isEmpty && updated.attributes == Null then None else Some(updated)
+
+/**
+ * Merge the modeled odd header/footer into the preserved `<headerFooter>` element, keeping
+ * unmodeled children (evenHeader/evenFooter/firstHeader/firstFooter) and attributes
+ * (differentOddEven, ...) intact. `headerFooter = None` preserves the source element verbatim;
+ * `Some(HeaderFooter(None, None))` actively clears the odd header/footer.
+ */
+private[ooxml] def mergeHeaderFooterElem(
+  existing: Option[Elem],
+  pageSetup: Option[PageSetup]
+): Option[Elem] =
+  pageSetup.flatMap(_.headerFooter) match
+    case None => existing
+    case Some(hf) =>
+      val base = existing.getOrElse(XmlUtil.elem("headerFooter")())
+      val withoutOdd = base.child.filterNot {
+        case e: Elem => e.label == "oddHeader" || e.label == "oddFooter"
+        case _ => false
+      }
+      // CT_HeaderFooter sequence starts with oddHeader, oddFooter — prepend in schema order
+      val oddElems: Seq[Node] =
+        hf.oddHeader.map(t => XmlUtil.elem("oddHeader")(Text(t))).toList ++
+          hf.oddFooter.map(t => XmlUtil.elem("oddFooter")(Text(t))).toList
+      val updated = base.copy(child = oddElems ++ withoutOdd)
+      if updated.child.isEmpty && updated.attributes == Null then None else Some(updated)
 
 /**
  * Apply domain RowProperties to an OoxmlRow.

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/AlignmentSerializationSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/AlignmentSerializationSpec.scala
@@ -1,7 +1,14 @@
 package com.tjclp.xl.ooxml
 
 import munit.FunSuite
+import com.tjclp.xl.addressing.ARef
+import com.tjclp.xl.cells.CellValue
+import com.tjclp.xl.macros.ref
+import com.tjclp.xl.sheets.Sheet
+import com.tjclp.xl.sheets.styleSyntax.*
 import com.tjclp.xl.styles.{CellStyle, Align, HAlign, VAlign}
+import com.tjclp.xl.styles.dsl.*
+import com.tjclp.xl.workbooks.Workbook
 
 /** Tests for alignment serialization to styles.xml */
 @SuppressWarnings(Array("org.wartremover.warts.IterableOps"))
@@ -144,6 +151,66 @@ class AlignmentSerializationSpec extends FunSuite:
         )
       case Left(error) =>
         fail(s"Failed to parse styles: $error")
+  }
+
+  test("workbook with indented styles round-trips indent through write/read (GH-260)") {
+    // House templates indent line items via the alignment indent attribute, not leading
+    // spaces — the indent must survive a full workbook write → read cycle.
+    val item = CellStyle.default.left
+    val sub = CellStyle.default.left.indent(1)
+    val subsub = CellStyle.default.left.indent(2)
+
+    val sheet = Sheet("Indent")
+      .put(ref"A1", CellValue.Text("Revenue"))
+      .put(ref"A2", CellValue.Text("Product"))
+      .put(ref"A3", CellValue.Text("Hardware"))
+      .withCellStyle(ref"A1", item)
+      .withCellStyle(ref"A2", sub)
+      .withCellStyle(ref"A3", subsub)
+    val wb = Workbook(Vector(sheet))
+
+    val bytes = XlsxWriter.writeToBytes(wb) match
+      case Right(b) => b
+      case Left(err) => fail(s"Write failed: $err")
+    val readWb = XlsxReader.readFromBytes(bytes) match
+      case Right(w) => w
+      case Left(err) => fail(s"Read failed: $err")
+
+    val readSheet = readWb.sheets(0)
+    def indentOf(r: ARef): Int =
+      readSheet.getCellStyle(r).map(_.align.indent).getOrElse(-1)
+
+    assertEquals(indentOf(ref"A1"), 0, "A1 should have no indent")
+    assertEquals(indentOf(ref"A2"), 1, "A2 indent should round-trip")
+    assertEquals(indentOf(ref"A3"), 2, "A3 indent should round-trip")
+  }
+
+  test("style dedup keeps styles differing only by indent distinct after round-trip (GH-260)") {
+    // canonicalKey accounts for indent: two styles identical except for indent must map to
+    // distinct xf entries in styles.xml, not collapse into one.
+    val indented1 = CellStyle.default.left.indent(1)
+    val indented2 = CellStyle.default.left.indent(2)
+
+    val sheet = Sheet("Dedup")
+      .put(ref"A1", CellValue.Text("one"))
+      .put(ref"A2", CellValue.Text("two"))
+      .withCellStyle(ref"A1", indented1)
+      .withCellStyle(ref"A2", indented2)
+    val wb = Workbook(Vector(sheet))
+
+    val bytes = XlsxWriter.writeToBytes(wb) match
+      case Right(b) => b
+      case Left(err) => fail(s"Write failed: $err")
+    val readWb = XlsxReader.readFromBytes(bytes) match
+      case Right(w) => w
+      case Left(err) => fail(s"Read failed: $err")
+
+    val readSheet = readWb.sheets(0)
+    val ids = Vector(ref"A1", ref"A2").flatMap(r => readSheet.cells.get(r).flatMap(_.styleId))
+    assertEquals(ids.size, 2, "both cells should carry a style after round-trip")
+    assertEquals(ids.distinct.size, 2, "indent-only style variants must not collapse")
+    assertEquals(readSheet.getCellStyle(ref"A1").map(_.align.indent), Some(1))
+    assertEquals(readSheet.getCellStyle(ref"A2").map(_.align.indent), Some(2))
   }
 
   test("all HAlign enum values serialize correctly") {

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/PageSetupRoundTripSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/PageSetupRoundTripSpec.scala
@@ -1,0 +1,264 @@
+package com.tjclp.xl.ooxml
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path}
+import java.util.zip.ZipFile
+
+import com.tjclp.xl.api.*
+import com.tjclp.xl.codec.CellCodec.given
+import com.tjclp.xl.macros.ref
+import com.tjclp.xl.sheets.{HeaderFooter, PageMargins, PageSetup, SheetView}
+import com.tjclp.xl.workbooks.DefinedName
+import munit.FunSuite
+
+/**
+ * GH-259: PageSetup print extensions round-trip — scale/orientation/fit via `<pageSetup>`, margins
+ * via `<pageMargins>`, header/footer via `<headerFooter>`, and print area / repeat title rows via
+ * sheet-scoped workbook defined names (`_xlnm.Print_Area` / `_xlnm.Print_Titles`).
+ */
+class PageSetupRoundTripSpec extends FunSuite:
+
+  private def zipEntryString(path: Path, entry: String): String =
+    val zf = new ZipFile(path.toFile)
+    try
+      val is = zf.getInputStream(zf.getEntry(entry))
+      try new String(is.readAllBytes(), StandardCharsets.UTF_8)
+      finally is.close()
+    finally zf.close()
+
+  private def writeRead(wb: Workbook): (Workbook, Path) =
+    val out = Files.createTempFile("pagesetup", ".xlsx")
+    XlsxWriter.write(wb, out).fold(e => fail(s"write failed: $e"), identity)
+    val reread = XlsxReader.read(out).fold(e => fail(s"read failed: $e"), identity)
+    (reread, out)
+
+  private def sheetSetup(wb: Workbook): PageSetup =
+    wb("Sheet1")
+      .fold(e => fail(s"sheet missing: $e"), identity)
+      .pageSetup
+      .getOrElse(fail("pageSetup missing after round-trip"))
+
+  test("GH-259: scale/orientation/fitTo round-trip (previously never serialized)") {
+    val setup =
+      PageSetup(scale = 85, orientation = Some("landscape"), fitToWidth = Some(1), fitToHeight = Some(2))
+    val wb = Workbook(Sheet("Sheet1").put(ref"A1" -> 1).withPageSetup(setup))
+    val (reread, out) = writeRead(wb)
+    assertEquals(sheetSetup(reread), setup)
+    Files.deleteIfExists(out)
+  }
+
+  test("GH-259: page margins round-trip") {
+    val setup = PageSetup(margins =
+      Some(PageMargins(left = 1.0, right = 0.5, top = 0.75, bottom = 0.75, header = 0.25, footer = 0.4))
+    )
+    val wb = Workbook(Sheet("Sheet1").put(ref"A1" -> 1).withPageSetup(setup))
+    val (reread, out) = writeRead(wb)
+    assertEquals(sheetSetup(reread), setup)
+
+    val xml = zipEntryString(out, "xl/worksheets/sheet1.xml")
+    assert(xml.contains("<pageMargins"), s"pageMargins element missing: $xml")
+    assert(xml.contains("left=\"1.0\""), s"left margin missing: $xml")
+    Files.deleteIfExists(out)
+  }
+
+  test("GH-259: header/footer with Excel codes round-trip") {
+    val setup = PageSetup(headerFooter =
+      Some(
+        HeaderFooter(
+          oddHeader = Some("&LTHE JORDAN COMPANY&RConfidential"),
+          oddFooter = Some("&CPage &P of &N — &D")
+        )
+      )
+    )
+    val wb = Workbook(Sheet("Sheet1").put(ref"A1" -> 1).withPageSetup(setup))
+    val (reread, out) = writeRead(wb)
+    assertEquals(sheetSetup(reread), setup)
+
+    val xml = zipEntryString(out, "xl/worksheets/sheet1.xml")
+    assert(xml.contains("<oddHeader>"), s"oddHeader missing: $xml")
+    assert(xml.contains("<oddFooter>"), s"oddFooter missing: $xml")
+    assert(xml.contains("&amp;P"), s"footer codes must be XML-escaped: $xml")
+    Files.deleteIfExists(out)
+  }
+
+  test("GH-259: print area round-trips via _xlnm.Print_Area defined name") {
+    val setup = PageSetup(printArea = Some(ref"A1:D20"))
+    val wb = Workbook(Sheet("Sheet1").put(ref"A1" -> 1).withPageSetup(setup))
+    val (reread, out) = writeRead(wb)
+
+    assertEquals(sheetSetup(reread).printArea, Some(ref"A1:D20"))
+    // Lifted into PageSetup, not duplicated in metadata
+    assertEquals(reread.metadata.definedNames, Vector.empty)
+
+    val workbookXml = zipEntryString(out, "xl/workbook.xml")
+    assert(workbookXml.contains("_xlnm.Print_Area"), s"Print_Area name missing: $workbookXml")
+    assert(workbookXml.contains("localSheetId=\"0\""), s"sheet scope missing: $workbookXml")
+    assert(workbookXml.contains("Sheet1!$A$1:$D$20"), s"area formula wrong: $workbookXml")
+    Files.deleteIfExists(out)
+  }
+
+  test("GH-259: repeat rows round-trip via _xlnm.Print_Titles defined name") {
+    val setup = PageSetup(repeatRows = Some((1, 3)))
+    val wb = Workbook(Sheet("Sheet1").put(ref"A1" -> 1).withPageSetup(setup))
+    val (reread, out) = writeRead(wb)
+
+    assertEquals(sheetSetup(reread).repeatRows, Some((1, 3)))
+    assertEquals(reread.metadata.definedNames, Vector.empty)
+
+    val workbookXml = zipEntryString(out, "xl/workbook.xml")
+    assert(workbookXml.contains("_xlnm.Print_Titles"), s"Print_Titles missing: $workbookXml")
+    assert(workbookXml.contains("Sheet1!$1:$3"), s"titles formula wrong: $workbookXml")
+    Files.deleteIfExists(out)
+  }
+
+  test("GH-259: sheet names needing quotes produce quoted print formulas") {
+    val setup = PageSetup(printArea = Some(ref"A1:B2"), repeatRows = Some((1, 1)))
+    val sheet = Sheet(SheetName.unsafe("Q1 Report")).put(ref"A1", 1).withPageSetup(setup)
+    val wb = Workbook(sheet)
+    val out = Files.createTempFile("pagesetup-quoted", ".xlsx")
+    XlsxWriter.write(wb, out).fold(e => fail(s"write failed: $e"), identity)
+
+    val workbookXml = zipEntryString(out, "xl/workbook.xml")
+    assert(
+      workbookXml.contains("'Q1 Report'!$A$1:$B$2"),
+      s"quoted area formula missing: $workbookXml"
+    )
+    assert(workbookXml.contains("'Q1 Report'!$1:$1"), s"quoted titles formula: $workbookXml")
+
+    val reread = XlsxReader.read(out).fold(e => fail(s"read failed: $e"), identity)
+    val rereadSheet = reread(SheetName.unsafe("Q1 Report")).fold(e => fail(s"$e"), identity)
+    assertEquals(rereadSheet.pageSetup, Some(setup))
+    Files.deleteIfExists(out)
+  }
+
+  test("GH-259: every print field round-trips together (full PageSetup equality)") {
+    val setup = PageSetup(
+      scale = 90,
+      orientation = Some("landscape"),
+      fitToWidth = Some(1),
+      fitToHeight = Some(0),
+      headerFooter = Some(HeaderFooter(oddHeader = Some("&A"), oddFooter = Some("Page &P of &N"))),
+      margins = Some(PageMargins(left = 0.25, right = 0.25, top = 0.5, bottom = 0.5, header = 0.2, footer = 0.2)),
+      printArea = Some(ref"A1:H44"),
+      repeatRows = Some((1, 2))
+    )
+    val wb = Workbook(Sheet("Sheet1").put(ref"A1" -> 1).withPageSetup(setup))
+    val (reread, out) = writeRead(wb)
+    assertEquals(sheetSetup(reread), setup)
+    Files.deleteIfExists(out)
+  }
+
+  test("GH-259: worksheet elements appear in schema order (pageMargins, pageSetup, headerFooter)") {
+    val setup = PageSetup(
+      scale = 80,
+      margins = Some(PageMargins.default),
+      headerFooter = Some(HeaderFooter(oddFooter = Some("&P")))
+    )
+    val wb = Workbook(Sheet("Sheet1").put(ref"A1" -> 1).withPageSetup(setup))
+    val out = Files.createTempFile("pagesetup-order", ".xlsx")
+    XlsxWriter.write(wb, out).fold(e => fail(s"write failed: $e"), identity)
+
+    val xml = zipEntryString(out, "xl/worksheets/sheet1.xml")
+    val margins = xml.indexOf("<pageMargins")
+    val pageSetup = xml.indexOf("<pageSetup")
+    val headerFooter = xml.indexOf("<headerFooter")
+    assert(margins >= 0 && pageSetup >= 0 && headerFooter >= 0, s"elements missing: $xml")
+    assert(margins < pageSetup, "pageMargins must precede pageSetup")
+    assert(pageSetup < headerFooter, "headerFooter must follow pageSetup")
+    assert(xml.indexOf("<sheetData>") < margins, "print elements follow sheetData")
+    Files.deleteIfExists(out)
+  }
+
+  test("GH-259: surgical write (cell edit) preserves print setup from the source file") {
+    val setup = PageSetup(
+      orientation = Some("portrait"),
+      margins = Some(PageMargins(left = 1.0)),
+      headerFooter = Some(HeaderFooter(oddFooter = Some("Page &P"))),
+      printArea = Some(ref"A1:C10"),
+      repeatRows = Some((1, 1))
+    )
+    val wb0 = Workbook(Sheet("Sheet1").put(ref"A1" -> 1).withPageSetup(setup))
+    val src = Files.createTempFile("pagesetup-src", ".xlsx")
+    XlsxWriter.write(wb0, src).fold(e => fail(s"seed write failed: $e"), identity)
+
+    val edited = for
+      wb <- XlsxReader.read(src)
+      sheet <- wb("Sheet1")
+    yield wb.put(sheet.put(ref"B1" -> 2))
+    val wb1 = edited.fold(e => fail(s"edit failed: $e"), identity)
+
+    val out = Files.createTempFile("pagesetup-out", ".xlsx")
+    XlsxWriter.write(wb1, out).fold(e => fail(s"write failed: $e"), identity)
+
+    val reread = XlsxReader.read(out).fold(e => fail(s"reread failed: $e"), identity)
+    assertEquals(sheetSetup(reread), setup)
+    Files.deleteIfExists(src)
+    Files.deleteIfExists(out)
+  }
+
+  test("GH-259: changing the print area on a read workbook regenerates the defined name") {
+    val wb0 = Workbook(
+      Sheet("Sheet1").put(ref"A1" -> 1).withPageSetup(PageSetup(printArea = Some(ref"A1:B2")))
+    )
+    val src = Files.createTempFile("pagesetup-edit-src", ".xlsx")
+    XlsxWriter.write(wb0, src).fold(e => fail(s"seed write failed: $e"), identity)
+
+    val edited = for
+      wb <- XlsxReader.read(src)
+      updated <- wb.updateAt(0, _.withPageSetup(PageSetup(printArea = Some(ref"C1:D2"))))
+    yield updated
+    val wb1 = edited.fold(e => fail(s"edit failed: $e"), identity)
+
+    val out = Files.createTempFile("pagesetup-edit-out", ".xlsx")
+    XlsxWriter.write(wb1, out).fold(e => fail(s"write failed: $e"), identity)
+
+    val workbookXml = zipEntryString(out, "xl/workbook.xml")
+    assert(workbookXml.contains("Sheet1!$C$1:$D$2"), s"updated area missing: $workbookXml")
+    assert(!workbookXml.contains("Sheet1!$A$1:$B$2"), s"stale area lingering: $workbookXml")
+
+    val reread = XlsxReader.read(out).fold(e => fail(s"reread failed: $e"), identity)
+    assertEquals(sheetSetup(reread).printArea, Some(ref"C1:D2"))
+    Files.deleteIfExists(src)
+    Files.deleteIfExists(out)
+  }
+
+  test("GH-259: unmodelable Print_Titles (column span) stays in metadata.definedNames verbatim") {
+    val colTitles =
+      DefinedName("_xlnm.Print_Titles", "Sheet1!$A:$B", localSheetId = Some(0))
+    val base = Workbook(Sheet("Sheet1").put(ref"A1" -> 1))
+    val wb = base.copy(metadata = base.metadata.copy(definedNames = Vector(colTitles)))
+    val (reread, out) = writeRead(wb)
+
+    val sheet = reread("Sheet1").fold(e => fail(s"sheet missing: $e"), identity)
+    assertEquals(sheet.pageSetup.flatMap(_.repeatRows), None)
+    assertEquals(reread.metadata.definedNames, Vector(colTitles))
+    Files.deleteIfExists(out)
+  }
+
+  test("GH-258/GH-259: freeze panes + view settings + print setup round-trip together") {
+    val view = SheetView(showGridLines = false, zoomScale = Some(90))
+    val setup = PageSetup(
+      orientation = Some("landscape"),
+      margins = Some(PageMargins.default),
+      headerFooter = Some(HeaderFooter(oddFooter = Some("&CPage &P of &N"))),
+      printArea = Some(ref"A1:F30"),
+      repeatRows = Some((1, 2))
+    )
+    val wb = Workbook(
+      Sheet("Sheet1")
+        .put(ref"A1" -> "Title", ref"A2" -> 1)
+        .freezeAt(ref"A3")
+        .withViewSettings(view)
+        .withPageSetup(setup)
+    )
+    val (reread, out) = writeRead(wb)
+
+    val sheet = reread("Sheet1").fold(e => fail(s"sheet missing: $e"), identity)
+    assertEquals(sheet.viewSettings, Some(view))
+    assertEquals(sheet.pageSetup, Some(setup))
+
+    val xml = zipEntryString(out, "xl/worksheets/sheet1.xml")
+    assert(xml.contains("<pane "), s"freeze pane missing: $xml")
+    assert(xml.contains("showGridLines=\"0\""), s"view settings missing: $xml")
+    Files.deleteIfExists(out)
+  }

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/SheetViewRoundTripSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/SheetViewRoundTripSpec.scala
@@ -1,0 +1,138 @@
+package com.tjclp.xl.ooxml
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path}
+import java.util.zip.ZipFile
+
+import com.tjclp.xl.api.*
+import com.tjclp.xl.codec.CellCodec.given
+import com.tjclp.xl.macros.ref
+import com.tjclp.xl.sheets.SheetView
+import com.tjclp.xl.unsafe.*
+import munit.FunSuite
+
+/**
+ * GH-258: sheet view settings (showGridLines, zoomScale) serialize into
+ * `<sheetViews><sheetView .../>` and parse back. Freeze panes and view settings must share ONE
+ * sheetView element.
+ */
+class SheetViewRoundTripSpec extends FunSuite:
+
+  private def zipEntryString(path: Path, entry: String): String =
+    val zf = new ZipFile(path.toFile)
+    try
+      val is = zf.getInputStream(zf.getEntry(entry))
+      try new String(is.readAllBytes(), StandardCharsets.UTF_8)
+      finally is.close()
+    finally zf.close()
+
+  private def writeRead(wb: Workbook): (Workbook, Path) =
+    val out = Files.createTempFile("sheetview", ".xlsx")
+    XlsxWriter.write(wb, out).fold(e => fail(s"write failed: $e"), identity)
+    val reread = XlsxReader.read(out).fold(e => fail(s"read failed: $e"), identity)
+    (reread, out)
+
+  test("GH-258: gridlines-off + zoom round-trips (write → read → equality)") {
+    val view = SheetView(showGridLines = false, zoomScale = Some(85))
+    val wb = Workbook(Sheet("Sheet1").put(ref"A1" -> 1).withViewSettings(view))
+    val (reread, out) = writeRead(wb)
+
+    val sheet = reread("Sheet1").fold(e => fail(s"sheet missing: $e"), identity)
+    assertEquals(sheet.viewSettings, Some(view))
+
+    val xml = zipEntryString(out, "xl/worksheets/sheet1.xml")
+    assert(xml.contains("showGridLines=\"0\""), s"showGridLines attr missing: $xml")
+    assert(xml.contains("zoomScale=\"85\""), s"zoomScale attr missing: $xml")
+    Files.deleteIfExists(out)
+  }
+
+  test("GH-258: default view settings (gridlines on, no zoom) round-trip when explicitly set") {
+    val view = SheetView(showGridLines = true, zoomScale = None)
+    val wb = Workbook(Sheet("Sheet1").put(ref"A1" -> 1).withViewSettings(view))
+    val (reread, out) = writeRead(wb)
+
+    val sheet = reread("Sheet1").fold(e => fail(s"sheet missing: $e"), identity)
+    assertEquals(sheet.viewSettings, Some(view))
+    Files.deleteIfExists(out)
+  }
+
+  test("GH-258: workbook without view settings reads back as None (passive default)") {
+    val wb = Workbook(Sheet("Sheet1").put(ref"A1" -> 1))
+    val (reread, out) = writeRead(wb)
+    val sheet = reread("Sheet1").fold(e => fail(s"sheet missing: $e"), identity)
+    assertEquals(sheet.viewSettings, None)
+    Files.deleteIfExists(out)
+  }
+
+  test("GH-258: freeze panes + view settings share ONE sheetView element and round-trip") {
+    val view = SheetView(showGridLines = false, zoomScale = Some(120))
+    val wb = Workbook(
+      Sheet("Sheet1").put(ref"A1" -> "Header", ref"A2" -> 1).freezeAt(ref"B2").withViewSettings(view)
+    )
+    val (reread, out) = writeRead(wb)
+
+    // Domain: view settings round-trip
+    val sheet = reread("Sheet1").fold(e => fail(s"sheet missing: $e"), identity)
+    assertEquals(sheet.viewSettings, Some(view))
+
+    // XML: exactly one <sheetView ...> element carrying BOTH the pane and the view attributes,
+    // in spec order (sheetViews before sheetData)
+    val xml = zipEntryString(out, "xl/worksheets/sheet1.xml")
+    val sheetViewCount = xml.sliding("<sheetView ".length).count(_ == "<sheetView ")
+    assertEquals(sheetViewCount, 1, s"expected one sheetView element: $xml")
+    assert(xml.contains("showGridLines=\"0\""), s"view attrs missing: $xml")
+    assert(xml.contains("zoomScale=\"120\""), s"zoom attr missing: $xml")
+    assert(xml.contains("<pane "), s"freeze pane missing: $xml")
+    assert(xml.contains("topLeftCell=\"B2\""), s"freeze anchor missing: $xml")
+    assert(
+      xml.indexOf("<sheetViews>") < xml.indexOf("<sheetData>"),
+      s"sheetViews must precede sheetData: $xml"
+    )
+    Files.deleteIfExists(out)
+  }
+
+  test("GH-258: surgical write (cell edit) preserves view settings from the source file") {
+    val view = SheetView(showGridLines = false, zoomScale = Some(75))
+    val wb0 = Workbook(Sheet("Sheet1").put(ref"A1" -> 1).withViewSettings(view))
+    val src = Files.createTempFile("sheetview-src", ".xlsx")
+    XlsxWriter.write(wb0, src).fold(e => fail(s"seed write failed: $e"), identity)
+
+    val edited = for
+      wb <- XlsxReader.read(src)
+      sheet <- wb("Sheet1")
+    yield wb.put(sheet.put(ref"B1" -> 2))
+    val wb1 = edited.fold(e => fail(s"edit failed: $e"), identity)
+
+    val out = Files.createTempFile("sheetview-out", ".xlsx")
+    XlsxWriter.write(wb1, out).fold(e => fail(s"write failed: $e"), identity)
+
+    val reread = XlsxReader.read(out).fold(e => fail(s"reread failed: $e"), identity)
+    val sheet = reread("Sheet1").fold(e => fail(s"sheet missing: $e"), identity)
+    assertEquals(sheet.viewSettings, Some(view))
+    Files.deleteIfExists(src)
+    Files.deleteIfExists(out)
+  }
+
+  test("GH-258: view settings can be changed on a read workbook (sheet-level edit)") {
+    val wb0 = Workbook(
+      Sheet("Sheet1").put(ref"A1" -> 1).withViewSettings(SheetView(showGridLines = true))
+    )
+    val src = Files.createTempFile("sheetview-edit-src", ".xlsx")
+    XlsxWriter.write(wb0, src).fold(e => fail(s"seed write failed: $e"), identity)
+
+    val newView = SheetView(showGridLines = false, zoomScale = Some(60))
+    val edited = for
+      wb <- XlsxReader.read(src)
+      updated <- wb.updateAt(0, _.withViewSettings(newView))
+    yield updated
+    val wb1 = edited.fold(e => fail(s"edit failed: $e"), identity)
+
+    val out = Files.createTempFile("sheetview-edit-out", ".xlsx")
+    XlsxWriter.write(wb1, out).fold(e => fail(s"write failed: $e"), identity)
+
+    val reread = XlsxReader.read(out).fold(e => fail(s"reread failed: $e"), identity)
+    val sheet = reread("Sheet1").fold(e => fail(s"sheet missing: $e"), identity)
+    assertEquals(sheet.viewSettings, Some(newView))
+    Files.deleteIfExists(src)
+    Files.deleteIfExists(out)
+  }


### PR DESCRIPTION
Closes #254, #255, #256, #257, #258, #259, #260.

Built via a 4-cluster multi-agent workflow (worktree-isolated implementations, each adversarially reviewed), integrated by cherry-pick with one review blocker fixed on top.

## Fixed
- **#254** — custom numfmt codes route zero through the **positive** section per Excel's rule (`$0.0`, not `($0.0)`); section selection verified unified across display/HTML/SVG/CLI/`TEXT()`.
- **#255** — SVG cell fonts were silently overridden twice over: CSS-quoted `font-family` attributes fontconfig can't match, **and** (found by the adversarial reviewer via real A/B rasterization) the embedded `.cell-text` CSS rule outranking presentation attributes in the cascade. Class rules no longer declare fonts; all text paths emit explicit unquoted font attributes. Verified end-to-end with rsvg: TJC valuation renders true Times New Roman with no SVG post-processing.
- **#256** — `Font.underline` now emits `text-decoration="underline"` on SVG text (survives PNG/PDF export).

## Added
- **#257** — `borderTop/Bottom/Left/Right` style builders (+ color overloads) and `range.outlined(style[, color])` via a new `Patch.MergeBorder` case (apply-time border overlay preserving font/fill/numFmt). Note for exhaustive matchers: `Patch` gains a case.
- **#260** — `CellStyle.indent(n)` DSL + round-trip/dedup tests (model + serde pre-existed); styles parser hardened against negative indent.
- **#258** — `SheetView(showGridLines, zoomScale)` on `Sheet.viewSettings`, sharing one `sheetView` element with freeze panes; SVG honors gridline suppression.
- **#259** — `PageSetup` headers/footers (odd), margins, print area + repeat rows via sheet-scoped `_xlnm` defined names; schema-ordered emission, full round-trip, surgical-write reconciliation.

## Behavior changes
- Reading any real-world file now yields `Sheet.pageSetup = Some(...)` (pageMargins parse into the model); modelable `_xlnm.Print_Area`/`Print_Titles` lift into `pageSetup` rather than `metadata.definedNames`.
- 73 new tests across the clusters; full suite 1028 green; examples + skill snippets verified.

## Follow-ups filed from the adversarial reviews
#261 (verbatim-copy digest mismatch — serious pre-existing, reproduced at `cddd752`), #262 (trailing empty format sections), #263 (cell-ref-shaped sheet name quoting), #264 (streaming StylePatcher indent totality + border-merge unification), #265 (SaxStax DirectSaxEmitter metadata gaps), #266 (even/first headers + fitToPage flag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)