### PR TITLE
Fix verbatim-copy digest mismatch: untouched file→file writes work again (#261)

### DIFF
--- a/xl-ooxml/src/com/tjclp/xl/ooxml/XlsxReader.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/XlsxReader.scala
@@ -283,6 +283,14 @@ object XlsxReader:
           // Build final manifest
           val manifest = builder.build()
 
+          // Drain the remaining container bytes through the digest before fingerprinting:
+          // ZipInputStream stops consuming at the central directory, but copyVerbatim hashes
+          // the whole file — without this drain the fingerprints could never match and every
+          // clean file→file write failed loudly (GH-261).
+          if source.isDefined then
+            val drainBuf = new Array[Byte](8192)
+            while is.read(drainBuf) != -1 do ()
+
           // Compute fingerprint if reading from a file
           val fingerprint = source.map(_.finalizeFingerprint())
 

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/VerbatimCopySpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/VerbatimCopySpec.scala
@@ -1,0 +1,56 @@
+package com.tjclp.xl.ooxml
+
+import java.nio.file.Files
+
+import com.tjclp.xl.addressing.SheetName
+import com.tjclp.xl.cells.CellValue
+import com.tjclp.xl.sheets.Sheet
+import com.tjclp.xl.workbooks.Workbook
+import com.tjclp.xl.addressing.ARef
+import munit.FunSuite
+
+/**
+ * GH-261: an untouched workbook read from a file and written to a new path must take the
+ * verbatim-copy fast path and produce byte-identical output. The read-side digest previously
+ * stopped at the ZIP central directory (ZipInputStream never consumes it) while copyVerbatim
+ * hashed the whole file, so the fingerprints could never match and every clean copy failed.
+ */
+class VerbatimCopySpec extends FunSuite:
+
+  private def freshFile(): java.nio.file.Path =
+    val dir = Files.createTempDirectory("xl-verbatim")
+    val src = dir.resolve("src.xlsx")
+    val wb = Workbook(
+      Sheet(SheetName.unsafe("Data"))
+        .put(ARef.from0(0, 0), CellValue.Text("hello"))
+        .put(ARef.from0(1, 0), CellValue.Number(BigDecimal(42)))
+    )
+    XlsxWriter.write(wb, src).fold(e => fail(s"setup write failed: $e"), identity)
+    src
+
+  test("GH-261: clean read -> write to new path succeeds and is byte-identical"):
+    val src = freshFile()
+    val dest = src.getParent.resolve("copy.xlsx")
+    val read = XlsxReader.read(src).fold(e => fail(s"read failed: $e"), identity)
+    assert(read.sourceContext.exists(_.isClean), "freshly read workbook must be clean")
+    XlsxWriter.write(read, dest) match
+      case Left(err) => fail(s"verbatim copy failed: $err")
+      case Right(_) =>
+        assert(
+          java.util.Arrays.equals(Files.readAllBytes(src), Files.readAllBytes(dest)),
+          "verbatim copy must be byte-identical"
+        )
+
+  test("GH-261: fingerprint covers the whole file (mutating trailing bytes is detected)"):
+    val src = freshFile()
+    val dest = src.getParent.resolve("copy2.xlsx")
+    val read = XlsxReader.read(src).fold(e => fail(s"read failed: $e"), identity)
+    // Append a byte after reading: size check catches it — then mutate the LAST byte in place
+    // (same size, inside the central directory) which only a whole-file digest detects.
+    val bytes = Files.readAllBytes(src)
+    bytes(bytes.length - 1) = (bytes(bytes.length - 1) ^ 0xff).toByte
+    Files.write(src, bytes)
+    XlsxWriter.write(read, dest) match
+      case Left(_) => () // refusing is acceptable
+      case Right(_) =>
+        fail("write must not verbatim-copy a file whose trailing bytes changed since read")


### PR DESCRIPTION
Closes #261. Read-side digest stopped at the ZIP central directory (ZipInputStream never consumes it); copyVerbatim hashes the whole file → fingerprints could never match → every clean file→file write failed loudly. Fix: drain the stream to EOF through the DigestInputStream before fingerprinting.

Verified untouched read→write of a real 13-sheet valuation workbook is byte-identical; new VerbatimCopySpec pins the clean path and that trailing-byte mutations are still refused. Full suite 1028 green.

Pre-release hardening for 0.11.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)