### PR TITLE
chore(release): Bump version to 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0] "Scripting" - 2026-06-10
+
+The scripting release: one-import prelude, total-by-semantics APIs, whole-workbook
+recalculation with per-cell error reporting, the xl-scripting Claude Code skill with
+compile-verified snippets, and the render/style fidelity needed to reproduce professional
+(banker-grade) templates exactly. The new gate machinery (external-consumer probes, examples
+CI, adversarial reviews, property seeds) surfaced and fixed eight pre-existing bugs.
+
 ### Added (render & style fidelity, #254-#260)
 
 - **Per-side border DSL + range outlines** (#257): `CellStyle.borderTop/borderBottom/borderLeft/
@@ -36,6 +44,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   rules no longer declare fonts; every text path emits explicit, unquoted font attributes.
 - **SVG underline dropped** (#256): `Font.underline` now emits `text-decoration="underline"`
   on SVG text (HTML already had it), so underlined headers survive PNG/PDF export.
+- **Parser ate keyword-prefixed names** (#268): `=SUM(Notes1!A1:A2)` parsed as
+  `=SUM(NOT(es1!A1:A2))` — logical keywords (NOT/AND/OR) now require a word boundary; sheets
+  literally named `NOT`/`AND`/`OR` parse as references.
+- **Verbatim copy always failed** (#261): the read digest stopped at the ZIP central directory
+  while the copy check hashed the whole file, so writing an untouched workbook to a new path
+  errored loudly. Untouched copies are byte-identical again; tampering is still refused.
+- **excel"" printed raw formulas through the prelude**: the evaluator's `evaluating` display
+  strategy never survived wildcard export; the prelude now selects it explicitly, so scripts
+  display computed, NumFmt-formatted values.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ```scala 3 raw
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.10.0
+//> using dep com.tjclp::xl:0.11.0
 
 import com.tjclp.xl.{*, given}
 
@@ -55,13 +55,13 @@ import com.tjclp.xl.{*, given}
 
 ```scala 3 ignore
 // build.mill — single dependency for everything
-def ivyDeps = Agg(ivy"com.tjclp::xl:0.10.0")
+def ivyDeps = Agg(ivy"com.tjclp::xl:0.11.0")
 
 // Or individual modules for minimal footprint:
-// ivy"com.tjclp::xl-core:0.10.0"        — Pure domain model only
-// ivy"com.tjclp::xl-ooxml:0.10.0"       — Add OOXML read/write
-// ivy"com.tjclp::xl-cats-effect:0.10.0" — Add IO streaming
-// ivy"com.tjclp::xl-evaluator:0.10.0"   — Add formula evaluation
+// ivy"com.tjclp::xl-core:0.11.0"        — Pure domain model only
+// ivy"com.tjclp::xl-ooxml:0.11.0"       — Add OOXML read/write
+// ivy"com.tjclp::xl-cats-effect:0.11.0" — Add IO streaming
+// ivy"com.tjclp::xl-evaluator:0.11.0"   — Add formula evaluation
 ```
 
 ### Basic Usage

--- a/build.mill
+++ b/build.mill
@@ -14,7 +14,7 @@ val organization = "com.tjclp"
 /** Shared build configuration constants */
 object BuildConfig {
   /** Project version: CI sets PUBLISH_VERSION; local builds use this fallback */
-  val version: String = sys.env.getOrElse("PUBLISH_VERSION", "0.10.0")
+  val version: String = sys.env.getOrElse("PUBLISH_VERSION", "0.11.0")
 
   /** JVM options to silence Scala 3 LazyVals sun.misc.Unsafe deprecation warnings (JDK 21+) */
   val lazyValsJvmArgs: Seq[String] = Seq(

--- a/docs/QUICK-START.md
+++ b/docs/QUICK-START.md
@@ -12,19 +12,19 @@ import mill._, scalalib._
 
 object myproject extends ScalaModule {
   def scalaVersion = "3.8.3"
-  def ivyDeps = Agg(ivy"com.tjclp::xl:0.10.0")
+  def ivyDeps = Agg(ivy"com.tjclp::xl:0.11.0")
 }
 ```
 
 ### With sbt (build.sbt)
 ```scala
 scalaVersion := "3.8.3"
-libraryDependencies += "com.tjclp" %% "xl" % "0.10.0"
+libraryDependencies += "com.tjclp" %% "xl" % "0.11.0"
 ```
 
 ### With Scala CLI
 ```scala
-//> using dep com.tjclp::xl:0.10.0
+//> using dep com.tjclp::xl:0.11.0
 ```
 
 ### Individual Modules (Optional)

--- a/docs/plan/roadmap.md
+++ b/docs/plan/roadmap.md
@@ -12,13 +12,13 @@
 
 **Current Status**: Production-ready with **104 formula functions** (incl. dynamic arrays SEQUENCE/SORT/UNIQUE/FILTER and OFFSET), **structural editing** (insert/delete rows & columns with formula rewriting), named-range & hyperlink authoring, SAX streaming (36% faster than POI), Excel tables, and full OOXML round-trip. 1100+ tests passing. **0.10.0 "Trust & Author"** is the active release — see [v0.10.0-execution.md](v0.10.0-execution.md).
 
-**Current Version**: **0.10.0 "Trust & Author"** (released 2026-06-09)
+**Current Version**: **0.11.0 "Scripting"** (released 2026-06-10)
 
 ---
 
 ## Release Roadmap
 
-### v0.11.0 "Scripting" (Next)
+### v0.11.0 "Scripting" (Current)
 
 Make library scripting (scala-cli + `com.tjclp.xl.scripting` prelude) the turbo-charged agent path — goal: the best functional Excel scripting DSL. Tracked in [#252](https://github.com/TJC-LP/xl/issues/252).
 
@@ -35,7 +35,7 @@ Make library scripting (scala-cli + `com.tjclp.xl.scripting` prelude) the turbo-
 | Future: typed row/record extraction (RowCodec derivation) | 🔵 Proposed |
 | Future: bounds-checked `shift`/navigation variants | 🔵 Proposed |
 
-### v0.10.0 "Trust & Author" (Current)
+### v0.10.0 "Trust & Author" (Released)
 
 Build version **0.10.0**. Focus: trust (surgical-edit fidelity) and authoring (write the parts XL previously only read).
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -141,7 +141,7 @@ chmod +x examples/my_example.sc
 ./examples/my_example.sc
 ```
 
-The `project.scala` file centralizes dependencies (`com.tjclp::xl:0.10.0`) for all examples.
+The `project.scala` file centralizes dependencies (`com.tjclp::xl:0.11.0`) for all examples.
 
 ## Scripting Prelude & Skill
 

--- a/examples/project.scala
+++ b/examples/project.scala
@@ -2,4 +2,4 @@
 //> using repository ivy2Local
 
 // XL aggregate - includes all modules (core, ooxml, cats-effect, evaluator)
-//> using dep com.tjclp::xl:0.10.0
+//> using dep com.tjclp::xl:0.11.0

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "xl",
   "description": "LLM-friendly Excel tooling: the xl CLI for reading, writing, styling, and analyzing spreadsheets (xl-cli skill), plus type-safe Scala scripting against the xl library via scala-cli for bulk transformations, pipelines, and formula models (xl-scripting skill).",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "author": {
     "name": "TJC L.P.",
     "url": "https://github.com/TJC-LP"

--- a/xl-core/src/com/tjclp/xl/workbooks/WorkbookMetadata.scala
+++ b/xl-core/src/com/tjclp/xl/workbooks/WorkbookMetadata.scala
@@ -16,7 +16,7 @@ final case class WorkbookMetadata(
   modified: Option[java.time.LocalDateTime] = None,
   lastModifiedBy: Option[String] = None,
   application: Option[String] = Some("XL - Pure Scala 3.8 Excel Library"),
-  appVersion: Option[String] = Some("0.10.0"),
+  appVersion: Option[String] = Some("0.11.0"),
   theme: ThemePalette = ThemePalette.office,
   definedNames: Vector[DefinedName] = Vector.empty,
   sheetStates: Map[SheetName, Option[String]] = Map.empty


### PR DESCRIPTION
0.11.0 "Scripting" release prep: version bumps per release-prep checklist (build.mill, WorkbookMetadata, plugin.json, examples/project.scala, README, QUICK-START, examples/README — xl-scripting skill pins were already at 0.11.0 by design), CHANGELOG release section, roadmap current-release flip.

All gates green: compile 810, tests 1028/1028, examples harness (drift guard now 0.11.0==0.11.0), skill snippets against local 0.11.0 publish.

Tag v0.11.0 follows the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)