### PR TITLE
docs: post-0.11.0 full documentation overhaul (doc-truth pass)

### DIFF
--- a/.claude/commands/release-prep.md
+++ b/.claude/commands/release-prep.md
@@ -64,6 +64,9 @@ After updating all files:
    ```bash
    grep -r "SNAPSHOT" --include="*.scala" --include="*.mill" --include="*.md" . | grep -v RELEASING.md | grep -v ".scala-build" | grep -v "out/"
    ```
+6. Confirm new release features are documented in `plugin/skills/xl-scripting/reference/API.md`
+   and `docs/reference/scripting.md` — cross-check the release's CHANGELOG entries against both
+   files before tagging (doc drift here ships to every skill user).
 
 ### Commit
 
@@ -73,6 +76,11 @@ chore(release): Bump version to $ARGUMENTS
 ```
 
 ### Tagging
+
+**Step 0 — CHANGELOG heading**: Before tagging, add the new version heading to CHANGELOG.md —
+move the `## [Unreleased]` content under a new `## [$ARGUMENTS] - <YYYY-MM-DD>` entry (leaving an
+empty `## [Unreleased]` section) and include it in the release commit. The extraction below reads
+release notes from that heading, so a missing heading produces an empty tag message.
 
 After committing, create an **annotated tag** with release notes from CHANGELOG.md:
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,6 +16,8 @@
 - [ ] All tests pass: `./mill __.test`
 - [ ] Code formatted: `./mill __.reformat`
 - [ ] Zero WartRemover warnings
+- [ ] Skill snippets compile: `./scripts/verify-skill-snippets.sh --local` (if `plugin/skills` or `docs/reference/scripting.md` changed)
+- [ ] Examples pass: `./scripts/test-examples.sh` (if `examples/` or the prelude changed)
 
 ## Documentation Updates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,7 +112,7 @@ CI, adversarial reviews, property seeds) surfaced and fixed eight pre-existing b
 
 A correctness-and-authoring release: fix defects that silently corrupted data or
 falsified flagship guarantees, close the read↔write asymmetry, and broaden the
-formula library. See `docs/plan/v0.10.0-triage.md` for rationale.
+formula library. See `docs/archive/plan/v0.10.0-triage.md` for rationale.
 
 #### Added
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,14 +28,18 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Module Architecture
 
 ```
+xl/              → Aggregate module + scripting prelude (com.tjclp.xl.scripting) + prelude probes
 xl-core/         → Pure domain model (Cell, Sheet, Workbook, Patch, Style), macros, DSL
 xl-ooxml/        → Pure OOXML mapping (XlsxReader, XlsxWriter, SharedStrings, Styles)
 xl-cats-effect/  → IO interpreters and streaming (Excel[F], ExcelIO, SAX-based streaming)
-xl-benchmarks/   → JMH performance benchmarks
 xl-evaluator/    → Formula parser/evaluator (TExpr GADT, 104 functions, dependency graphs)
-xl-testkit/      → Test laws, generators, helpers [future]
+xl-cli/          → Stateless `xl` CLI (internal, native-image capable)
 xl-agent/        → AI agent benchmark runner (Anthropic API, skill comparison)
+xl-benchmarks/   → JMH performance benchmarks
+xl-testkit/      → Test laws, generators, helpers [placeholder — no sources yet]
 ```
+
+Published to Maven Central: `xl` (aggregate), `xl-core`, `xl-ooxml`, `xl-cats-effect`, `xl-evaluator`. Internal: `xl-cli`, `xl-agent`, `xl-benchmarks`, `xl-testkit`.
 
 ## Import Patterns
 
@@ -96,7 +100,7 @@ excel.read(path).flatMap(wb => excel.write(wb, outPath))
 
 ```bash
 ./mill __.compile          # Compile all
-./mill __.test             # Run all tests (1080+)
+./mill __.test             # Run all tests (3005+)
 ./mill xl-core.test        # Test specific module
 ./mill __.reformat         # Format (Scalafmt 3.10.1)
 ./mill __.checkFormat      # CI check
@@ -274,7 +278,7 @@ echo '[{"op":"add-sheet","name":"Summary","after":"Sheet1"}]' | xl ...
 echo '[{"op":"rename-sheet","from":"Old","to":"New"}]' | xl ...
 ```
 
-**All 20 batch operations**: `put`, `putf`, `style`, `merge`, `unmerge`, `colwidth`, `rowheight`, `comment`, `remove-comment`, `clear`, `col-hide`, `col-show`, `row-hide`, `row-show`, `autofit`, `add-sheet`, `rename-sheet`, `freeze`, `unfreeze`, `copy`
+**All 21 batch operations**: `put`, `putf`, `style`, `merge`, `unmerge`, `colwidth`, `rowheight`, `comment`, `remove-comment`, `hyperlink`, `clear`, `col-hide`, `col-show`, `row-hide`, `row-show`, `autofit`, `add-sheet`, `rename-sheet`, `freeze`, `unfreeze`, `copy`
 
 **Common mistake**: Using unqualified range without `--sheet`:
 ```bash
@@ -301,8 +305,8 @@ All code must pass `./mill __.checkFormat`. See `docs/design/style-guide.md`.
 **Rules**: opaque types for domain quantities | enums with `derives CanEqual` | `final case class` for data | total functions returning Either/Option | extension methods over implicit classes
 
 **WartRemover** (compile-time enforcement):
-- ❌ Error: `null`, `.head/.tail`, `.get` on Try/Either
-- ⚠️ Warning: `.get` on Option, `var`/`while`/`return` (acceptable in tests/macros)
+- ❌ Error: `null`, `.get` on Try/Either
+- ⚠️ Warning: `.head/.tail` on collections, `.get` on Option, `var`/`while`/`return` (acceptable in tests/macros)
 
 **Error Handling**: Always use `XLResult[A] = Either[XLError, A]`
 
@@ -391,12 +395,12 @@ Styles deduplicated by `CellStyle.canonicalKey`. Build style index before emitti
 
 **Framework**: MUnit + ScalaCheck | **Generators**: `xl-core/test/src/com/tjclp/xl/Generators.scala`
 
-**1080+ tests**: addressing (17), patch (21), style (60), datetime (8), codec (42), batch (46), syntax (18), optics (34), OOXML (24), streaming (18), RichText (5), formula (51+), v0.3.0 regressions (36), CLI (100+)
+**3005+ tests** by module: xl-evaluator (1198), xl-core (971), xl-ooxml (381), xl-cli (308), xl-cats-effect (76), xl-agent (54), xl prelude probes (17). See `docs/reference/testing-guide.md` for suite structure and patterns.
 
 ## Documentation
 
 - **Roadmap**: `docs/plan/roadmap.md` (single source of truth for work scheduling)
-- **Status**: `docs/STATUS.md` (current capabilities, 1080+ tests)
+- **Status**: `docs/STATUS.md` (current capabilities, 3005+ tests)
 - **Design**: `docs/design/*.md` (architecture, purity charter, domain model)
 - **Reference**: `docs/reference/*.md` (examples, scaffolds, performance guide)
 

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Install the xl plugin in [Claude Code](https://claude.ai/code) for AI-assisted E
 
 ```
 /plugin marketplace add TJC-LP/xl
-/plugin install xl-marketplace@xl
+/plugin install xl@xl-marketplace
 ```
 
 The plugin ships **two skills**:
@@ -191,7 +191,7 @@ The plugin ships **two skills**:
 - **xl-cli** — CLI operations: quick reads, single edits, search, visual exports (PNG/PDF/HTML)
 - **xl-scripting** — type-safe Scala scripts against the library (via scala-cli): bulk transformations, multi-file pipelines, typed extraction, formula models with recalculation, streaming 100k+ row files
 
-Rule of thumb: one-shot operations → CLI; anything with loops, intermediate computation, or many dependent edits → scripting.
+Rule of thumb: one-shot operations → CLI; anything with loops, intermediate computation, or many dependent edits → scripting (see the [scripting guide](docs/reference/scripting.md)).
 
 - "Read the data from sales.xlsx and show me the first 10 rows"
 - "Add a SUM formula to cell B10 that totals B2:B9"
@@ -204,6 +204,7 @@ Rule of thumb: one-shot operations → CLI; anything with loops, intermediate co
 |-----|---------|
 | **[docs/INDEX.md](docs/INDEX.md)** | Documentation navigation hub |
 | [docs/QUICK-START.md](docs/QUICK-START.md) | Get started in 5 minutes |
+| [docs/reference/scripting.md](docs/reference/scripting.md) | Scripting guide — scala-cli + one-import prelude |
 | [docs/STATUS.md](docs/STATUS.md) | Current capabilities |
 | [examples/](examples/) | Runnable scala-cli examples |
 | [CLAUDE.md](CLAUDE.md) | Complete API reference |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest minor release line (currently 0.11.x) receives security fixes. Older versions
+should upgrade — releases are API-stable within a minor line and artifacts are immutable on
+Maven Central.
+
+## Reporting a Vulnerability
+
+Report vulnerabilities **privately** via GitHub Security Advisories:
+<https://github.com/TJC-LP/xl/security/advisories/new>
+
+Please do **not** open a public issue or pull request for a suspected vulnerability. You should
+receive an acknowledgement within a few business days; coordinated disclosure is appreciated.
+
+## Built-in Hardening
+
+XLSX files are ZIP archives, and the reader treats them as untrusted input: decompression is
+capped at **100 MB uncompressed by default** and suspicious compression ratios are rejected with
+a structured `SecurityError` — a deliberate zip-bomb defense. The CLI exposes the cap as
+`--max-size <MB>` (`0` = unlimited); raise it only for files you trust, or prefer `--stream` for
+large files.

--- a/docs/FAQ-AND-GLOSSARY.md
+++ b/docs/FAQ-AND-GLOSSARY.md
@@ -1,6 +1,6 @@
 # FAQ & Glossary
 
-**Last Updated**: 2025-11-20
+**Last Updated**: 2026-06-10
 
 ---
 
@@ -8,6 +8,9 @@
 
 **Q: Why not reuse POI objects?**
 A: We want immutability, type safety, and compile-time guarantees; POI's design makes that difficult.
+
+**Q: What's the fastest way to use XL in a script?**
+A: One import — `import com.tjclp.xl.scripting.{*, given}` with scala-cli (since 0.11.0). See [reference/scripting.md](reference/scripting.md).
 
 **Q: Will charts look identical to Excel's?**
 A: Charts are not implemented yet; when added they will target ChartML with deterministic output.
@@ -25,4 +28,6 @@ A: Not initially. Focus is `.xlsx`/`.xlsm`. BIFF can be a separate module later.
 - **GADT** — Generalized Algebraic Data Type (typed formulas).
 - **Named tuple** — Scala 3.7 tuples with field names.
 - **Patch** — First-class edit value with a monoid, acting lawfully on a target.
+- **RecalcResult** — Result of `Workbook.recalculate` (0.11.0): recalculated workbook with cached formula values, plus per-sheet values and per-cell `CellEvalError`s.
+- **Scripting prelude** — `com.tjclp.xl.scripting.{*, given}` (0.11.0): one import bundling core API, DSL, compile-time literals, formula evaluation, sync `Excel`, and streaming `ExcelIO` for scripts.
 - **SST** — Shared Strings Table; deduplicates strings in OOXML.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -7,6 +7,7 @@ Welcome to the XL documentation. This index helps you find what you need quickly
 | I want to... | Go to |
 |--------------|-------|
 | Get started in 5 minutes | [QUICK-START.md](QUICK-START.md) |
+| Write Excel scripts with scala-cli | [reference/scripting.md](reference/scripting.md) |
 | See code examples | [reference/examples.md](reference/examples.md) |
 | Use the CLI tool | [reference/cli.md](reference/cli.md) |
 | Contribute code | [CONTRIBUTING.md](CONTRIBUTING.md) |
@@ -28,6 +29,8 @@ Welcome to the XL documentation. This index helps you find what you need quickly
 - **[FAQ-AND-GLOSSARY.md](FAQ-AND-GLOSSARY.md)** - Common questions and terminology
 
 ### Library Users
+- **[reference/scripting.md](reference/scripting.md)** - Scripting guide: scala-cli + the one-import prelude (`com.tjclp.xl.scripting`)
+- **[../examples/scripting_tour.sc](../examples/scripting_tour.sc)** - Canonical runnable tour of the scripting prelude
 - **[reference/examples.md](reference/examples.md)** - End-to-end code examples
 - **[reference/performance-guide.md](reference/performance-guide.md)** - In-memory vs streaming, optimization
 - **[reference/migration-from-poi.md](reference/migration-from-poi.md)** - Coming from Apache POI
@@ -35,10 +38,16 @@ Welcome to the XL documentation. This index helps you find what you need quickly
 ### CLI Users
 - **[reference/cli.md](reference/cli.md)** - Command reference, examples, LLM integration
 
+### Claude Code Users (Plugin Skills)
+- **[../plugin/skills/xl-cli/](../plugin/skills/xl-cli/)** - xl-cli skill: quick reads, single edits, search, visual exports
+- **[../plugin/skills/xl-scripting/](../plugin/skills/xl-scripting/)** - xl-scripting skill: type-safe Scala scripts (bulk transforms, pipelines, recalculation)
+
 ### Contributors
 - **[CONTRIBUTING.md](CONTRIBUTING.md)** - Code quality, pre-commit hooks
+- **[design/style-guide.md](design/style-guide.md)** - Code style rules (opaque types, totality, formatting)
 - **[reference/testing-guide.md](reference/testing-guide.md)** - MUnit, ScalaCheck, property tests
 - **[reference/implementation-scaffolds.md](reference/implementation-scaffolds.md)** - Code templates
+- **[reference/ai-contracts-guide.md](reference/ai-contracts-guide.md)** - Scaladoc contract format for parsers/serializers
 
 ---
 
@@ -50,6 +59,7 @@ Welcome to the XL documentation. This index helps you find what you need quickly
 - **[design/purity-charter.md](design/purity-charter.md)** - Pure FP principles
 - **[design/decisions.md](design/decisions.md)** - Architectural decision records (ADRs)
 - **[design/io-modes.md](design/io-modes.md)** - In-memory vs streaming comparison
+- **[design/query-api.md](design/query-api.md)** - Streaming query API (design-only, not implemented)
 
 ### Performance
 - **[reference/performance-guide.md](reference/performance-guide.md)** - Mode selection, benchmarks
@@ -68,3 +78,10 @@ Welcome to the XL documentation. This index helps you find what you need quickly
 
 - **[RELEASING.md](RELEASING.md)** - Maven Central publishing process
 - **[../CHANGELOG.md](../CHANGELOG.md)** - Version history
+
+---
+
+## Historical / Archive
+
+- **[archive/plan/](archive/plan/)** - Superseded plan documents (v0.10.0 execution & triage); current scheduling lives in [plan/roadmap.md](plan/roadmap.md)
+- **[reviews/](reviews/)** - Dated review artifacts ([gpt5-review-template.md](reviews/gpt5-review-template.md), [style-review.md](reviews/style-review.md)), kept for the record

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -1,9 +1,11 @@
 # XL Current Limitations and Future Roadmap
 
-**Last Updated**: 2026-06-07
-**Current Phase**: Core domain + OOXML + streaming I/O complete; formula system complete (**104 functions** + cross-sheet support + dynamic arrays); structural editing (insert/delete rows & columns with formula rewriting); named-range & hyperlink authoring; tables + benchmarks complete; row/column serialization complete; **security hardening complete** (ZIP bomb detection, XXE prevention, formula injection guards in both in-memory and streaming writes).
+**Last Updated**: 2026-06-10
+**Current Phase**: Core domain + OOXML + streaming I/O complete; formula system complete (**104 functions** + cross-sheet support + dynamic arrays); structural editing (insert/delete rows & columns with formula rewriting); named-range & hyperlink authoring; tables + benchmarks complete; row/column serialization complete; **security hardening complete** (ZIP bomb detection, XXE prevention, formula injection guards in both in-memory and streaming writes); scripting prelude + whole-workbook recalculation + print setup authoring (0.11.0).
 
-> **Note (0.10.0):** Sections below predate the 0.10.0 "Trust & Author" release and may understate current capabilities. Hyperlinks (#9) and named ranges (#15) are now **supported**; inline worksheet elements like data validation (#11) are now **preserved through edits** (authoring still pending). See [plan/v0.10.0-execution.md](plan/v0.10.0-execution.md).
+> **Note (0.11.0):** Sections below largely predate the 0.10.0 "Trust & Author" and 0.11.0 "Scripting" releases and may understate current capabilities. Hyperlinks (#9) and named ranges (#15) are **supported**; inline worksheet elements like data validation (#11) are **preserved through edits** (authoring still pending); print setup is **partially supported** as of 0.11.0 (#16). 0.11.0 also added the scripting prelude (`com.tjclp.xl.scripting`), whole-workbook `recalculate` with per-cell errors, per-side borders/outlines, and sheet view settings — see the [CHANGELOG](../CHANGELOG.md). For the 0.10.0 rationale, see [archive/plan/v0.10.0-execution.md](archive/plan/v0.10.0-execution.md).
+>
+> **Known open issues** (GitHub): leading `=+` formula prefix rejected (#271), trailing empty number-format sections (#262), quoting of cell-ref-shaped sheet names (#263), streaming StylePatcher indent (#264), SaxStax DirectSaxEmitter metadata gaps (#265), even/first page headers + fitToPage (#266), charts (#222), drawings (#221).
 
 This document provides a comprehensive overview of what XL can and cannot do today, with clear links to future implementation plans.
 
@@ -36,13 +38,13 @@ This document provides a comprehensive overview of what XL can and cannot do tod
 - ✅ **Mill build system**: Fast, reliable builds
 - ✅ **Scalafmt integration**: Consistent code formatting
 - ✅ **GitHub Actions CI**: Automated testing
-- ✅ **Comprehensive docs**: README, CLAUDE.md, 29 plan files
+- ✅ **Comprehensive docs**: README, CLAUDE.md, reference + design guides under `docs/`
 - ✅ **Property-based testing**: ScalaCheck generators for all core types
 - ✅ **Law verification**: Monoid laws, round-trip laws, invariants
 
 ---
 
-## Recently Completed ✅ (This Session)
+## Recently Completed ✅
 
 ### Style Application End-to-End
 **Completed**: 2025-11-10 (P4 Days 1-3)
@@ -118,10 +120,9 @@ This document provides a comprehensive overview of what XL can and cannot do tod
 #### 6. Formula System ✅ **PRODUCTION READY**
 **Status**: Complete (WI-07, WI-08, WI-09a-h + TJC-351 cross-sheet formulas)
 **Features**: Parser, evaluator, **104 functions** (including SUMIF, COUNTIF, SUMIFS, COUNTIFS, XLOOKUP, HLOOKUP, INDEX, MATCH, OFFSET, XIRR, XNPV, and dynamic arrays SEQUENCE/SORT/UNIQUE/FILTER), dependency graph, cycle detection, cross-sheet references
-**Plan**: [Formula System](plan/formula-system.md)
 **Phase**: WI-07, WI-08, WI-09a/b/c/d Complete + Financial Functions + Cross-Sheet Formulas
 
-**What Works** (Production Ready - 280+ tests):
+**What Works** (Production Ready — 1198 xl-evaluator tests):
 ```scala
 import com.tjclp.xl.formula.{FormulaParser, FormulaPrinter, Evaluator}
 import com.tjclp.xl.formula.SheetEvaluator.*
@@ -153,15 +154,17 @@ DependencyGraph.detectCrossSheetCycles(graph) match
 **Capabilities**:
 - ✅ **Parsing** (WI-07): Typed GADT AST (TExpr), FormulaParser, FormulaPrinter, round-trip laws (57 tests)
 - ✅ **Evaluation** (WI-08): Pure functional evaluator, total error handling, short-circuit semantics (58 tests)
-- ✅ **104 Built-in Functions** (the category breakdown below is representative and predates the 0.10.0 additions — IFS, SWITCH, CHOOSE, LARGE, SMALL, RANK, PERCENTILE, QUARTILE, HLOOKUP, MAXIFS, MINIFS, OFFSET, and dynamic arrays SEQUENCE/SORT/UNIQUE/FILTER):
+- ✅ **104 Built-in Functions** (complete current registry, verified against `xl functions`):
   - **Aggregate** (12): SUM, COUNT, COUNTA, COUNTBLANK, AVERAGE, MEDIAN, MIN, MAX, STDEV, STDEVP, VAR, VARP
-  - **Conditional** (7): SUMIF, COUNTIF, SUMIFS, COUNTIFS, AVERAGEIF, AVERAGEIFS, SUMPRODUCT
-  - **Logical** (9): IF, AND, OR, NOT, ISNUMBER, ISTEXT, ISBLANK, ISERR, ISERROR
-  - **Text** (11): CONCATENATE, LEFT, RIGHT, MID, LEN, UPPER, LOWER, TRIM, SUBSTITUTE, TEXT, VALUE
-  - **Date** (13): TODAY, NOW, DATE, YEAR, MONTH, DAY, HOUR, MINUTE, SECOND, EOMONTH, EDATE, DATEDIF, NETWORKDAYS, WORKDAY, YEARFRAC
+  - **Statistical** (5): LARGE, SMALL, RANK, PERCENTILE, QUARTILE
+  - **Conditional** (9): SUMIF, COUNTIF, SUMIFS, COUNTIFS, AVERAGEIF, AVERAGEIFS, MAXIFS, MINIFS, SUMPRODUCT
+  - **Logical / Selection** (13): IF, IFS, IFERROR, SWITCH, CHOOSE, AND, OR, NOT, ISNUMBER, ISTEXT, ISBLANK, ISERR, ISERROR
+  - **Text** (12): CONCATENATE, LEFT, RIGHT, MID, LEN, UPPER, LOWER, TRIM, FIND, SUBSTITUTE, TEXT, VALUE
+  - **Date** (12): TODAY, NOW, DATE, YEAR, MONTH, DAY, EOMONTH, EDATE, DATEDIF, NETWORKDAYS, WORKDAY, YEARFRAC
   - **Math** (16): ABS, ROUND, ROUNDUP, ROUNDDOWN, INT, MOD, POWER, SQRT, LOG, LN, EXP, FLOOR, CEILING, TRUNC, SIGN, PI
   - **Financial** (9): NPV, IRR, XNPV, XIRR, PMT, FV, PV, RATE, NPER
-  - **Lookup** (4): VLOOKUP, XLOOKUP, INDEX, MATCH
+  - **Lookup / Reference** (11): VLOOKUP, HLOOKUP, XLOOKUP, INDEX, MATCH, OFFSET, ROW, COLUMN, ROWS, COLUMNS, ADDRESS
+  - **Dynamic Arrays** (5): TRANSPOSE, SEQUENCE, SORT, UNIQUE, FILTER
 - ✅ **Dependency Graph** (WI-09d - 52 tests):
   - Tarjan's SCC algorithm: O(V+E) cycle detection
   - Kahn's algorithm: O(V+E) topological sort
@@ -182,7 +185,8 @@ DependencyGraph.detectCrossSheetCycles(graph) match
 - ⏳ Extended function library (300+ Excel functions) - WI-09e+
 - ⏳ Array formulas - Future work
 - ⏳ Structured references (Table[@Column]) - Requires WI-10 integration
-- ⏳ Quoted sheet names in formulas (`='Q1 Report'!A1`) - Parser support pending
+- ✅ Quoted sheet names in formulas (`='Q1 Report'!A1`) are parsed and printed; quoting of sheet names *shaped like cell refs* is tracked in #263
+- ⏳ Leading `=+` formula prefix (legacy Lotus style) is rejected by the parser - #271
 - 🛡️ **Formula depth cap (GH-56 totality guard):** nesting + operator-chain depth is capped at 256 levels so pathological input returns `ParseError.NestingTooDeep` instead of `StackOverflowError`. Excel allows 64 nesting levels and no operator-chain limit (within 8192 chars); xl additionally counts each operator in a *flat, paren-less* chain, so a chain of 256+ consecutive operators (e.g. `=A1+A2+…` ×256) is rejected — use `SUM`/ranges, or parenthesize to reset the budget. No real-world formula approaches this.
 
 **No workarounds needed** - formula system is complete and production-ready!
@@ -191,7 +195,6 @@ DependencyGraph.detectCrossSheetCycles(graph) match
 
 #### 7. Theme Colors ✅ **RESOLVED**
 **Status**: Implemented — theme color resolution works via `ThemePalette`
-**Plan**: [P5 - Styles](plan/05-styles-and-themes.md#theme-resolution)
 **Phase**: P5 (Complete)
 
 **Current State**:
@@ -208,8 +211,7 @@ Color.Theme(ThemeSlot.Accent1, tint = 0.5).toResolvedHex(theme)  // "#RRGGBB"
 #### 8. No Shared Strings Table (SST) in Streaming Write
 **Status**: Streaming write always uses inline strings
 **Impact**: Larger file sizes for repeated strings
-**Plan**: [P6 - SST Streaming Integration](plan/13-streaming-and-performance.md#sst-streaming)
-**Phase**: P6 (Future)
+**Plan**: see [plan/roadmap.md](plan/roadmap.md)
 
 **Current State**:
 - `writeStream` uses `type="inlineStr"` for all text cells
@@ -245,21 +247,19 @@ RowData(i, Map(0 -> CellValue.Text("ACME Corporation")))
 ---
 
 #### 10. Conditional Formatting Not Supported
-**Status**: Not implemented
-**Impact**: Cannot add color scales, data bars, icon sets
-**Plan**: [P10 - Conditional Formatting](plan/08-tables-and-pivots.md#conditional-formatting)
-**Phase**: P10 (Future)
+**Status**: Not implemented (preserved through edits since 0.10.0, like other unknown/inline parts)
+**Impact**: Cannot author color scales, data bars, icon sets
+**Plan**: see [plan/roadmap.md](plan/roadmap.md)
 
 **Effort**: 5-7 days
 **LOC**: ~300 (Rules model, XML serialization, testing)
 
 ---
 
-#### 11. Data Validation Not Supported
-**Status**: Not implemented
-**Impact**: Cannot add dropdown lists, input validation
-**Plan**: [P10 - Data Validation](plan/08-tables-and-pivots.md#data-validation)
-**Phase**: P10 (Future)
+#### 11. Data Validation Authoring Not Supported
+**Status**: Existing `dataValidations` are **preserved through edits** since 0.10.0 (C1); no authoring API yet
+**Impact**: Cannot add new dropdown lists or input validation
+**Plan**: see [plan/roadmap.md](plan/roadmap.md)
 
 **Effort**: 3-4 days
 **LOC**: ~200
@@ -267,10 +267,9 @@ RowData(i, Map(0 -> CellValue.Text("ACME Corporation")))
 ---
 
 #### 12. Charts Not Supported
-**Status**: Not implemented
+**Status**: Not implemented (existing charts are preserved through edits) — tracked in #222
 **Impact**: Cannot generate charts
-**Plan**: [P9 - Charts](plan/07-charts.md)
-**Phase**: P9 (Future - Very Complex)
+**Plan**: see [plan/roadmap.md](plan/roadmap.md)
 
 **Effort**: 20-30 days (massive scope)
 **LOC**: ~1500+
@@ -278,10 +277,9 @@ RowData(i, Map(0 -> CellValue.Text("ACME Corporation")))
 ---
 
 #### 13. Drawings (Images, Shapes) Not Supported
-**Status**: Not implemented
+**Status**: Not implemented (existing drawings are preserved through edits) — tracked in #221
 **Impact**: Cannot embed images or shapes
-**Plan**: [P8 - Drawings](plan/06-drawings.md)
-**Phase**: P8 (Future)
+**Plan**: see [plan/roadmap.md](plan/roadmap.md)
 
 **Effort**: 10-15 days
 **LOC**: ~800
@@ -291,8 +289,7 @@ RowData(i, Map(0 -> CellValue.Text("ACME Corporation")))
 #### 14. Pivot Tables Not Supported
 **Status**: Not implemented
 **Impact**: Cannot create Pivot Tables
-**Plan**: [P10 - Advanced Features](plan/advanced-features.md)
-**Phase**: P10 (Future)
+**Plan**: see [plan/roadmap.md](plan/roadmap.md)
 
 **Note**: Excel Tables (structured data ranges with headers, AutoFilter, styling) are ✅ **fully supported** as of WI-10.
 
@@ -307,22 +304,16 @@ RowData(i, Map(0 -> CellValue.Text("ACME Corporation")))
 
 ---
 
-#### 16. Print Settings and Page Setup Not Supported
-**Status**: Not implemented
-**Impact**: Default print settings used
-**Plan**: [P10 - Page Setup](plan/11-ooxml-mapping.md#page-setup)
-**Phase**: P10 (Future)
-
-**Effort**: 2-3 days
-**LOC**: ~150
+#### 16. Print Settings and Page Setup ⚠️ PARTIALLY SUPPORTED (0.11.0)
+**Status**: `PageSetup` authoring shipped in 0.11.0 (#259): odd header/footer (with `&P`/`&N` codes), page margins, print area, and repeat rows — emitted in schema order and round-tripped; print area/titles ride the defined-names pipeline as sheet-scoped `_xlnm` names. Reading now populates `Sheet.pageSetup` for any sheet with `<pageMargins>`.
+**Remaining**: even/first-page headers and the `fitToPage` flag — tracked in #266.
 
 ---
 
 #### 17. Document Properties Not Written
 **Status**: Not implemented
 **Impact**: Missing metadata (author, title, creation date)
-**Plan**: [P10 - Document Properties](plan/11-ooxml-mapping.md#document-properties)
-**Phase**: P10 (Future)
+**Plan**: see [plan/roadmap.md](plan/roadmap.md)
 
 **Current**:
 - No `docProps/core.xml` (core properties)
@@ -446,8 +437,7 @@ XlsxReader.read(path, strictConfig)
 #### 22. No Type-Class Derivation for Codecs
 **Status**: Not implemented
 **Impact**: Manual row/cell conversion required
-**Plan**: [P6 - Codecs](plan/09-codecs-and-named-tuples.md)
-**Phase**: P6 (High Priority)
+**Plan**: see [plan/roadmap.md](plan/roadmap.md)
 
 **What's Missing**:
 ```scala
@@ -470,10 +460,9 @@ people.through(Codec[Person].encode)
 ---
 
 #### 23. No Path Macro for Named Cell References
-**Status**: Not implemented
-**Impact**: Cannot use symbolic names for cells
-**Plan**: [P7 - Advanced Macros](plan/17-macros-and-syntax.md#path-macro)
-**Phase**: P7 (Future)
+**Status**: Not implemented (named ranges themselves are supported since 0.10.0 — see #15)
+**Impact**: Cannot use compile-time symbolic names for cells
+**Plan**: see [plan/roadmap.md](plan/roadmap.md)
 
 **Want**:
 ```scala
@@ -490,10 +479,9 @@ sheet.put(Paths.totalRevenue, formula"=SUM(${Paths.salesTable})")
 ---
 
 #### 24. No Style Literal for Inline Styling
-**Status**: Not implemented
-**Impact**: Verbose style definitions
-**Plan**: [P7 - Advanced Macros](plan/17-macros-and-syntax.md#style-literal)
-**Phase**: P7 (Future)
+**Status**: Not implemented (the builder DSL — `.bold`, plus 0.11.0's `.borderTop(...)`, `.indent(n)`, `range.outlined(...)` — covers most cases)
+**Impact**: No single-string style literal
+**Plan**: see [plan/roadmap.md](plan/roadmap.md)
 
 **Want**:
 ```scala
@@ -508,8 +496,7 @@ val headerStyle = style"font-weight: bold; background: #CCCCCC; border: all thin
 #### 25. XLSM Macros Not Preserved
 **Status**: Not implemented
 **Impact**: Opening XLSM files strips macros
-**Plan**: [P11 - Security](plan/23-security.md#macro-preservation)
-**Phase**: P11 (Future)
+**Plan**: see [plan/roadmap.md](plan/roadmap.md)
 
 **Current**: Reading `.xlsm` treats it as `.xlsx` (ignores `vbaProject.bin`)
 
@@ -586,14 +573,13 @@ excel.readStreamByIndex(path, 2)  // Sheet 2 (separate call)
 
 ## Roadmap to 100% Feature Parity
 
-### Phase 4 Continuation (Priority 1 - Next Sprint)
-**Effort**: 1-2 weeks
+### Phase 4 Continuation ✅ (Complete)
 **Focus**: Complete OOXML coverage for common use cases
 
-- [ ] Style application end-to-end (2-3 days) - **HIGH IMPACT**
-- [ ] DateTime serialization (1 day) - **HIGH IMPACT**
-- [ ] Merged cells XML (3 hours) - MEDIUM IMPACT
-- [ ] Column/row properties XML (4 hours) - MEDIUM IMPACT
+- [x] Style application end-to-end ✅
+- [x] DateTime serialization ✅
+- [x] Merged cells XML ✅
+- [x] Column/row properties XML ✅
 
 **Result**: Fully functional spreadsheet library with formatting
 
@@ -603,7 +589,7 @@ excel.readStreamByIndex(path, 2)  // Sheet 2 (separate call)
 **Effort**: 2-3 weeks
 **Focus**: Ergonomic data binding
 
-See: [plan/09-codecs-and-named-tuples.md](plan/09-codecs-and-named-tuples.md)
+See: [plan/roadmap.md](plan/roadmap.md)
 
 - [ ] Type-class derivation (7-10 days)
 - [ ] Header row binding (3-4 days)
@@ -617,7 +603,7 @@ See: [plan/09-codecs-and-named-tuples.md](plan/09-codecs-and-named-tuples.md)
 **Effort**: 1-2 weeks
 **Focus**: Enhanced compile-time DSL
 
-See: [plan/17-macros-and-syntax.md](plan/17-macros-and-syntax.md)
+See: [plan/roadmap.md](plan/roadmap.md)
 
 - [ ] Path macro for named references (3-4 days)
 - [ ] Style literal (2-3 days)
@@ -631,7 +617,7 @@ See: [plan/17-macros-and-syntax.md](plan/17-macros-and-syntax.md)
 **Effort**: 2-3 weeks
 **Focus**: Images and shapes
 
-See: [plan/06-drawings.md](plan/06-drawings.md)
+See: [plan/roadmap.md](plan/roadmap.md) (drawings tracked in #221)
 
 - [ ] Image embedding (5-7 days)
 - [ ] Shapes (3-4 days)
@@ -643,7 +629,7 @@ See: [plan/06-drawings.md](plan/06-drawings.md)
 **Effort**: 4-6 weeks
 **Focus**: Chart generation
 
-See: [plan/07-charts.md](plan/07-charts.md)
+See: [plan/roadmap.md](plan/roadmap.md) (charts tracked in #222)
 
 **Very complex**: 15+ chart types, each with custom XML structure
 
@@ -653,7 +639,7 @@ See: [plan/07-charts.md](plan/07-charts.md)
 **Effort**: 3-4 weeks
 **Focus**: Tables, pivots, conditional formatting
 
-See: [plan/08-tables-and-pivots.md](plan/08-tables-and-pivots.md)
+See: [plan/roadmap.md](plan/roadmap.md)
 
 ---
 
@@ -661,7 +647,7 @@ See: [plan/08-tables-and-pivots.md](plan/08-tables-and-pivots.md)
 **Status**: Production ready (2025-12-07)
 **Focus**: Security hardening
 
-See: [plan/23-security.md](plan/23-security.md)
+See: [plan/roadmap.md](plan/roadmap.md)
 
 **Completed** (WI-30):
 - ✅ ZIP bomb detection (`ReaderConfig` with compression ratio, size, entry count limits)
@@ -808,19 +794,18 @@ SAX parsing is inherently synchronous - the `parser.parse()` call blocks until t
 
 ### If you hit a limitation today:
 
-1. **Styles not working**: Wait for P4 completion (2-3 days) OR use external formatting tools
-2. **Need charts**: Use POI for now, plan to migrate when P9 complete
-3. **Formula evaluation**: Let Excel handle it (store formulas as strings)
-4. **Selective updates**: Use `read()` + `write()` for small files, wait for P6 for large files
+1. **Need charts or drawings**: Use POI for chart/drawing *authoring* (#222, #221); XL preserves existing charts/drawings through edits
+2. **Unsupported formula function**: Store the formula as a string and let Excel recalculate on open (XL evaluates the 104 built-ins)
+3. **Streaming update of one sheet in a huge workbook**: Use the in-memory read → modify → write path (surgical modification preserves untouched parts)
 
 ---
 
 ## Contributing
 
 Want to help implement these features? See:
-- [docs/plan/18-roadmap.md](plan/18-roadmap.md) - Full implementation plan
+- [docs/plan/roadmap.md](plan/roadmap.md) - Full implementation plan
 - [CLAUDE.md](../CLAUDE.md) - Contribution guidelines
-- Each feature links to detailed design doc in `docs/plan/`
+- [GitHub Issues](https://github.com/TJC-LP/xl/issues) - Per-feature tracking
 
 ---
 
@@ -834,4 +819,4 @@ Want to help implement these features? See:
 
 ---
 
-*Last updated by Claude Code session on 2025-12-18 (Week 1 Bug Fixes: TJC-352 VLOOKUP cross-sheet, TJC-339 streaming formula injection, TJC-354 SVG styling)*
+*Last updated 2026-06-10 (0.11.0 doc-truth pass, GH-272: refreshed fixed/open status against the 0.10.0 and 0.11.0 releases, corrected the function registry breakdown, repointed retired plan links).*

--- a/docs/QUICK-START.md
+++ b/docs/QUICK-START.md
@@ -38,6 +38,30 @@ For minimal dependencies, use individual modules:
 | `xl-cats-effect` | IO streaming with Cats Effect |
 | `xl-evaluator` | Formula parser and evaluator |
 
+## Scripting (one import)
+
+For scripts, skip the build setup entirely: a two-line `scala-cli` header and ONE import give you the whole library — core API, DSL, compile-time literals, formula evaluation, sync `Excel` I/O, and streaming.
+
+```scala
+//> using scala 3.8.3
+//> using dep com.tjclp::xl:0.11.0
+
+import com.tjclp.xl.scripting.{*, given}
+
+val sheet = Sheet("Model")
+  .put(ref"A1", 100)
+  .put(ref"A2", 200)
+  .put(ref"A3", fx"=SUM(A1:A2)")
+
+val recalc = Workbook(sheet).recalculate() // total: per-cell errors, never throws
+if !recalc.isClean then recalc.errors.foreach(e => println(e.render))
+Excel.write(recalc.workbook, "model.xlsx")
+```
+
+Save as `model.sc`, run with `scala-cli run model.sc`. Never combine this import with `com.tjclp.xl.{*, given}` in the same file (ambiguous forwarders).
+
+**More**: [reference/scripting.md](reference/scripting.md) (full guide) · [../examples/scripting_tour.sc](../examples/scripting_tour.sc) (runnable tour) · the **xl-scripting** Claude Code skill ([../plugin/skills/xl-scripting/](../plugin/skills/xl-scripting/))
+
 ## Your First Spreadsheet (30 seconds)
 
 ```scala
@@ -289,7 +313,7 @@ cyclicSheet.evaluateWithDependencyCheck() match
 - **Conditional**: SUMIF, COUNTIF, SUMIFS, COUNTIFS, AVERAGEIF, AVERAGEIFS, MAXIFS, MINIFS, SUMPRODUCT
 - **Logical / Selection**: IF, IFS, IFERROR, SWITCH, CHOOSE, AND, OR, NOT, ISNUMBER, ISTEXT, ISBLANK, ISERR, ISERROR
 - **Text**: CONCATENATE, LEFT, RIGHT, MID, LEN, UPPER, LOWER, TRIM, FIND, SUBSTITUTE, TEXT, VALUE
-- **Date**: TODAY, NOW, DATE, YEAR, MONTH, DAY, HOUR, MINUTE, SECOND, EOMONTH, EDATE, DATEDIF, NETWORKDAYS, WORKDAY, YEARFRAC
+- **Date**: TODAY, NOW, DATE, YEAR, MONTH, DAY, EOMONTH, EDATE, DATEDIF, NETWORKDAYS, WORKDAY, YEARFRAC
 - **Math**: ABS, ROUND, ROUNDUP, ROUNDDOWN, INT, MOD, POWER, SQRT, LOG, LN, EXP, FLOOR, CEILING, TRUNC, SIGN, PI
 - **Financial**: NPV, IRR, XNPV, XIRR, PMT, FV, PV, RATE, NPER
 - **Lookup / Reference**: VLOOKUP, HLOOKUP, XLOOKUP, INDEX, MATCH, OFFSET, ROW, COLUMN, ROWS, COLUMNS, ADDRESS
@@ -389,11 +413,11 @@ ref"XFE1"    // ❌ Invalid (column out of range)
 import com.tjclp.xl.addressing.SheetName
 
 SheetName("My Sheet!") match
-  case Right(name) => Workbook(name)
+  case Right(name) => Workbook(Sheet(name))
   case Left(err) => println(s"Invalid: $err")
 
 // Or use unsafe (throws on invalid):
-Workbook(SheetName.unsafe("ValidName"))
+Workbook(Sheet(SheetName.unsafe("ValidName")))
 ```
 
 ---

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,12 +1,26 @@
 # XL Project Status
 
-**Last Updated**: 2026-06-07
+**Last Updated**: 2026-06-10
 
 ## Current State
 
 > **For detailed phase completion status and roadmap, see [plan/roadmap.md](plan/roadmap.md)**
 
 ### What Works (Production-Ready)
+
+**New in 0.11.0 "Scripting"** (2026-06-10):
+- ✅ **Scripting prelude** `com.tjclp.xl.scripting.{*, given}` — ONE import for scripts: core API + DSL + compile-time literals + formula evaluation + sync `Excel` + streaming `ExcelIO` + smart detection (`String.toFormatted`) + `.unsafe` boundary
+- ✅ **Range fill**: `range := value` puts the value in every cell (Excel Ctrl+Enter semantics; previously a silent no-op)
+- ✅ **Total ARef navigation**: `down`/`up`/`right`/`left` (default 1) for Either-free loops
+- ✅ **`Workbook.upsert(name, f)`** — total update-or-create counterpart of `update`
+- ✅ **`Workbook.recalculate(clock)`** — total whole-workbook recalculation returning `RecalcResult` (cached workbook + per-sheet values + per-cell `CellEvalError`s; cycles isolated, acyclic remainder still evaluates)
+- ✅ **`FormattedParsers.detect`** — total smart value detection (currency/accounting/percent/ISO date/number/boolean/text), promoted from CLI-internal code
+- ✅ **Per-side borders + outlines**: `CellStyle.borderTop/borderBottom/borderLeft/borderRight` and `range.outlined(style[, color])` via the new `Patch.MergeBorder`
+- ✅ **Alignment indent**: `CellStyle.indent(n)`
+- ✅ **Sheet view settings**: `SheetView(showGridLines, zoomScale)` on `Sheet.viewSettings` (SVG renderer respects gridline suppression)
+- ✅ **Print setup extensions**: `PageSetup` gains `headerFooter`, `margins`, `printArea`, `repeatRows` (sheet-scoped `_xlnm` defined names; even/first headers + fitToPage tracked in #266)
+- ✅ **xl-scripting skill** (`plugin/skills/xl-scripting/`) — SKILL.md + API reference + runnable recipes, compile-verified on CI
+- ✅ **Anti-rot CI**: examples job (`scripts/test-examples.sh`) + skill-verify workflow (`scripts/verify-skill-snippets.sh`)
 
 **Core Features**:
 - ✅ Type-safe addressing (Column, Row, ARef with 64-bit packing)
@@ -81,48 +95,20 @@
 
 ### Test Coverage
 
-**1080+ tests across 6 modules** (includes P7+P8 string interpolation + WI-07/08/09/09d formula system + TJC-351 cross-sheet formulas + WI-10 table support + WI-15 benchmarks + WI-17 SAX streaming write + v0.3.0 regressions + TJC-1055 text functions):
-- **xl-core**: ~500+ tests
-  - 17 addressing (Column, Row, ARef, CellRange laws)
-  - 21 patch (Monoid laws, application semantics)
-  - 60 style (units, colors, builders, canonicalization, StylePatch, StyleRegistry)
-  - 8 datetime (Excel serial number conversions)
-  - 42 codec (CellCodec identity laws, type safety, auto-inference)
-  - 16 batch update (putMixed, readTyped, style deduplication)
-  - 18 elegant syntax (given conversions, batch put, formatted literals)
-  - 34 optics (Lens/Optional laws, focus DSL, real-world use cases)
-  - 5 RichText (composition, formatting, DSL)
-  - **+111 string interpolation Phase 1** (RefInterpolationSpec, FormattedInterpolationSpec, MacroUtilSpec)
-  - **+40 string interpolation Phase 2** (RefCompileTimeOptimizationSpec, FormattedCompileTimeOptimizationSpec)
-  - +200+ additional tests (range combinators, comprehensive property tests)
-- **xl-ooxml**: ~145+ tests
-  - Round-trip tests (text, numbers, booleans, mixed, multi-sheet, SST, styles, RichText)
-  - Compression tests (DEFLATED vs STORED, prettyPrint, defaults, debug mode)
-  - Security tests (XXE, DOCTYPE rejection)
-  - Error path tests (malformed XML, missing files)
-  - Whitespace preservation, alignment serialization
-  - **+45 table tests** (TableSpec: XML parsing, serialization, round-trips, domain conversions, edge cases)
-- **xl-cats-effect**: ~30+ tests
-  - True streaming I/O with fs2-data-xml (constant memory, 100k+ rows)
-  - Memory tests (O(1) verification, concurrent streams)
-- **xl-evaluator**: ~338 tests (parser, evaluator, function library, evaluation API, dependency graph, cross-sheet formulas, integration)
-  - **Parser (WI-07)**: 57 tests
-    - 7 property-based round-trip tests (parse ∘ print = id)
-    - 26 parser unit tests (literals, operators, functions, edge cases)
-    - 10 scientific notation tests (E notation, positive/negative exponents)
-    - 5 error handling tests (invalid syntax, unknown functions)
-    - 9 integration tests (complex expressions, nested formulas, operator precedence)
-  - **Evaluator (WI-08)**: 58 tests
-  - **Function library (WI-09a/b/c)**: 48 tests across aggregate/logical/text/date functions
-  - **Dependency graph (WI-09d)**: 44 graph tests + 8 integration/dependency tests
-    - 10 property-based law tests (literal identity, arithmetic correctness, short-circuit semantics)
-    - 28 unit tests (division by zero, boolean operations, comparisons, cell references, range references)
-    - 12 integration tests (IF, AND, OR, nested conditionals, SUM/COUNT, complex boolean logic)
-    - 8 error path tests (nested errors, codec failures, missing cells, propagation vs short-circuit)
-  - **Cross-sheet formulas (TJC-351)**: 26 tests + 8 ignored (future features)
-    - Parser tests: simple refs, ranges, round-trip property tests
-    - Evaluator tests: SheetPolyRef, cross-sheet range aggregates (SUM), error cases
-    - Cycle detection: `DependencyGraph.fromWorkbook`, `detectCrossSheetCycles`
+**3005+ tests** (verified via `./mill __.test`, 2026-06-10):
+
+| Module | Tests | Covers |
+|--------|-------|--------|
+| xl-evaluator | 1198 | parser, evaluator, 104-function library, dependency graph, cross-sheet formulas, recalculation, structural editing |
+| xl-core | 971 | addressing laws, Patch/StylePatch monoids, codecs, optics, RichText, interpolation, render (HTML/SVG), styles DSL |
+| xl-ooxml | 381 | round-trips (cells, styles, tables, comments, hyperlinks), compression, security (XXE, ZIP bomb), preservation |
+| xl-cli | 308 | command parsing, batch ops, view/eval/export, streaming mode |
+| xl-cats-effect | 76 | streaming I/O, O(1) memory verification, SAX/StAX write |
+| xl-agent | 54 | benchmark engine, skill abstraction |
+| xl (prelude) | 17 | external-consumer probes (`xl/test/src/xlprelude/`) |
+| xl-testkit | 0 | placeholder (no sources yet) |
+
+See [reference/testing-guide.md](reference/testing-guide.md) for suite structure and testing patterns.
 
 ---
 
@@ -133,17 +119,17 @@
 **Formula System** (WI-07, WI-08, WI-09a/b/c/d - Production Ready):
 - ✅ **Parsing** (WI-07): Typed AST (TExpr GADT), FormulaParser, FormulaPrinter, round-trip verification, 57 tests
 - ✅ **Evaluation** (WI-08): Pure functional evaluator, total error handling, short-circuit semantics, 58 tests
-- ✅ **Function Library** (WI-09a-h + TJC-1055 complete): **104 built-in functions**, extensible type class parser, evaluation API, 236 tests
+- ✅ **Function Library** (WI-09a-h + TJC-1055 complete): **104 built-in functions**, extensible type class parser, evaluation API
   - **Aggregate** (12): SUM, COUNT, COUNTA, COUNTBLANK, AVERAGE, MEDIAN, MIN, MAX, STDEV, STDEVP, VAR, VARP
-  - **Conditional** (7): SUMIF, COUNTIF, SUMIFS, COUNTIFS, AVERAGEIF, AVERAGEIFS, SUMPRODUCT
-  - **Logical** (9): IF, IFERROR, AND, OR, NOT, ISNUMBER, ISTEXT, ISBLANK, ISERR, ISERROR
+  - **Statistical** (5): LARGE, SMALL, RANK, PERCENTILE, QUARTILE
+  - **Conditional** (9): SUMIF, COUNTIF, SUMIFS, COUNTIFS, AVERAGEIF, AVERAGEIFS, MAXIFS, MINIFS, SUMPRODUCT
+  - **Logical / Selection** (13): IF, IFS, IFERROR, SWITCH, CHOOSE, AND, OR, NOT, ISNUMBER, ISTEXT, ISBLANK, ISERR, ISERROR
   - **Text** (12): CONCATENATE, LEFT, RIGHT, MID, LEN, UPPER, LOWER, TRIM, FIND, SUBSTITUTE, TEXT, VALUE
   - **Date** (12): TODAY, NOW, DATE, YEAR, MONTH, DAY, EOMONTH, EDATE, DATEDIF, NETWORKDAYS, WORKDAY, YEARFRAC
   - **Math** (16): ABS, ROUND, ROUNDUP, ROUNDDOWN, INT, MOD, POWER, SQRT, LOG, LN, EXP, FLOOR, CEILING, TRUNC, SIGN, PI
   - **Financial** (9): NPV, IRR, XNPV, XIRR, PMT, FV, PV, RATE, NPER
-  - **Lookup** (4): VLOOKUP, XLOOKUP, INDEX, MATCH
-  - **Info** (5): ROW, COLUMN, ROWS, COLUMNS, ADDRESS
-  - **Array** (1): TRANSPOSE
+  - **Lookup / Reference** (11): VLOOKUP, HLOOKUP, XLOOKUP, INDEX, MATCH, OFFSET, ROW, COLUMN, ROWS, COLUMNS, ADDRESS
+  - **Dynamic Arrays** (5): TRANSPOSE, SEQUENCE, SORT, UNIQUE, FILTER
   - FunctionSpec registry: macro-collected specs with extensible registry
   - APIs: sheet.evaluateFormula(), sheet.evaluateCell(), sheet.evaluateAllFormulas()
   - Clock trait for pure date/time functions (deterministic testing)
@@ -154,7 +140,7 @@
   - Safe evaluation: sheet.evaluateWithDependencyCheck() (production-ready)
   - Performance: Handles 10k formula cells in <10ms
 - ⚠️ Merged cells are supported by the in-memory OOXML path and `writeWorkbookStream`. Pure row-stream generation (`writeStream` / `writeStreamsSeq`) has no merge API.
-- ❌ Hyperlinks not serialized.
+- ✅ Hyperlinks serialized as of 0.10.0 (`Cell.hyperlink` → `<hyperlinks>` + worksheet relationships; populated on read).
 - ✅ Column/row properties (width, height, hidden, outlineLevel, collapsed) are fully serialized via DirectSaxEmitter.
 
 ### Style System
@@ -167,10 +153,10 @@
 
 **Missing Parts** (not critical for MVP):
 - ❌ docProps/core.xml, docProps/app.xml (metadata)
-- ❌ xl/theme/theme1.xml (theme palette)
+- ⚠️ xl/theme/theme1.xml (theme palette) — preserved from source on round-trip, not generated for new workbooks
 - ❌ xl/calcChain.xml (formula calculation order)
-- ❌ Worksheet relationships (_rels/sheet1.xml.rels)
-- ❌ Print settings, page setup
+- ✅ Worksheet relationships (`_rels/sheetN.xml.rels`) — written when a sheet has comments, tables, or hyperlinks
+- ⚠️ Print settings, page setup — partial as of 0.11.0: header/footer (odd), margins, print area, repeat rows (#259); even/first headers + fitToPage tracked in #266
 - ❌ Conditional formatting
 - ❌ Data validation (preserved through edits, but no authoring API yet)
 - ✅ Named ranges (authoring shipped in 0.10.0: `DefinedName` serialization + CLI `name add/rm`)
@@ -275,49 +261,44 @@
 
 ### Completed Modules
 ```
-xl-core/src/com/tjclp/xl/
-├── addressing.scala       ✅ Opaque types, ARef packing
-├── cell.scala             ✅ CellValue, CellError
-├── sheet.scala            ✅ Sheet, Workbook
-├── error.scala            ✅ XLError ADT
-├── patch.scala            ✅ Patch Monoid
-├── style.scala            ✅ CellStyle, Font, Fill, Border, Color, NumFmt, StylePatch, StyleRegistry
-├── datetime.scala         ✅ Excel serial number conversions
-├── codec/
-│   ├── CellCodec.scala    ✅ Bidirectional type-safe encoding (9 primitive types)
-│   └── BatchOps.scala     ✅ putMixed, readTyped APIs
-├── optics.scala           ✅ Lens, Optional, focus DSL
-├── richtext.scala         ✅ TextRun, RichText, DSL extensions
-├── html/
-│   └── HtmlExport.scala   ✅ sheet.toHtml with inline CSS
-├── conversions.scala      ✅ Given conversions
-├── formatted.scala        ✅ Formatted literals support
-└── dsl.scala              ✅ Ergonomic patch operators
+xl/src/com/tjclp/xl/
+└── scripting.scala        ✅ One-import scripting prelude (com.tjclp.xl.scripting)
 
-xl-macros/src/com/tjclp/xl/
-├── macros.scala           ✅ cell"", range"", batch put, money"", percent"", date"", accounting""
-└── MacroUtil.scala        ✅ Shared utilities for runtime interpolation (Phase 1)
+xl-core/src/com/tjclp/xl/
+├── addressing/            ✅ Opaque types (Column, Row, ARef packing), CellRange, SheetName
+├── cells/                 ✅ Cell, CellValue, CellError, Comment
+├── sheets/                ✅ Sheet, SheetView, PageSetup
+├── workbooks/             ✅ Workbook, WorkbookMetadata, DefinedName
+├── patch/                 ✅ Patch Monoid (incl. MergeBorder)
+├── styles/                ✅ CellStyle, Font, Fill, Border, Color, NumFmt, StylePatch, style DSL
+├── codec/                 ✅ CellCodec (9 primitive types), readTyped/readTypedOr/readTypedOpt
+├── macros/                ✅ ref"", fx"", money"" … compile-time literals (lives in xl-core; no separate xl-macros module)
+├── optics/                ✅ Lens, Optional, focus DSL
+├── richtext/              ✅ TextRun, RichText, DSL extensions
+├── formatted/             ✅ Formatted literals + FormattedParsers.detect
+├── render/                ✅ HTML/SVG renderers (sheet.toHtml / toSvg)
+└── dsl/                   ✅ Ergonomic patch operators (:=, ++, outlined)
 
 xl-ooxml/src/com/tjclp/xl/ooxml/
-├── xml.scala              ✅ XmlWritable/XmlReadable traits
 ├── ContentTypes.scala     ✅ [Content_Types].xml
 ├── Relationships.scala    ✅ .rels files
 ├── Workbook.scala         ✅ xl/workbook.xml
-├── Worksheet.scala        ✅ xl/worksheets/sheet#.xml (with RichText support)
+├── worksheet/             ✅ xl/worksheets/sheet#.xml (RichText, merges, hyperlinks, page setup)
 ├── SharedStrings.scala    ✅ xl/sharedStrings.xml (SST with RichText)
 ├── Styles.scala           ✅ xl/styles.xml
-├── XlsxWriter.scala       ✅ ZIP assembly
-└── XlsxReader.scala       ✅ ZIP parsing
+├── XlsxWriter.scala       ✅ ZIP assembly + surgical modification
+└── XlsxReader.scala       ✅ ZIP parsing + security limits
 
 xl-cats-effect/src/com/tjclp/xl/io/
 ├── Excel.scala            ✅ Algebra trait
 ├── ExcelIO.scala          ✅ Interpreter with true streaming
-├── StreamingXmlWriter.scala  ✅ Event-based write (fs2-data-xml)
-└── StreamingXmlReader.scala  ✅ Event-based read (fs2-data-xml)
+└── Sax/StAX + fs2 writers ✅ Event-based streaming read/write
 ```
 
 ### Completed Modules (Additional)
-- `xl-evaluator/` ✅ **Complete** (WI-07/08/09 - formula parsing, evaluation, 104 functions, dependency graph)
+- `xl-evaluator/` ✅ **Complete** (WI-07/08/09 - formula parsing, evaluation, 104 functions, dependency graph, structural editing, recalculation)
+- `xl-cli/` ✅ **Complete** (stateless `xl` CLI: 40 subcommands, 21 batch ops, rendering, streaming mode)
+- `xl-agent/` ✅ **Complete** (AI agent benchmark runner)
 - `xl-benchmarks/` ✅ **Complete** (WI-15 - JMH performance benchmarks)
 
 ### Not Started (Future Phases)
@@ -334,12 +315,12 @@ xl-cats-effect/src/com/tjclp/xl/io/
 2. ~~DateTime serialization~~ - ✅ Excel serial number conversion implemented
 3. ~~Cell → CellStyle linkage~~ - ✅ StyleRegistry provides sheet-level style management
 4. ~~Comments~~ - ✅ Full OOXML round-trip (xl/commentsN.xml + VML drawings), rich text support, 12+ tests
+5. ~~Merged cells~~ - ✅ `mergedRanges` serialized via `<mergeCells>` (in-memory + `writeWorkbookStream` paths)
+6. ~~Column/row properties~~ - ✅ width/height/hidden/outline serialized via DirectSaxEmitter
+7. ~~Hyperlinks~~ - ✅ serialized with worksheet relationships (0.10.0)
 
 ### Remaining
-1. **Merged cells** - Serialize mergedRanges to worksheet XML
-2. **Column/row properties** - Serialize width/height/hidden
-3. **Hyperlinks** - Add to worksheet relationships
-4. **Theme resolution** - Improve Theme color ARGB approximations (currently functional but not perfect)
+1. **Theme resolution** - Improve Theme color ARGB approximations (currently functional but not perfect)
 
 ---
 

--- a/docs/archive/plan/v0.10.0-execution.md
+++ b/docs/archive/plan/v0.10.0-execution.md
@@ -1,3 +1,5 @@
+> ✅ **Completed** — 0.10.0 shipped 2026-06-09. Archived 2026-06-10; kept as an execution record.
+
 # xl 0.10.0 "Trust & Author" — Execution Tracker
 
 > **This is the living checklist for the 0.10.0 release.** It is the single source of truth for *where we are*.

--- a/docs/archive/plan/v0.10.0-triage.md
+++ b/docs/archive/plan/v0.10.0-triage.md
@@ -1,3 +1,5 @@
+> ✅ **Completed** — 0.10.0 shipped 2026-06-09. Archived 2026-06-10; kept as an execution record.
+
 # xl 0.10.0 Release Triage — "Trust & Author"
 
 **Date**: 2026-06-07

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -6,39 +6,48 @@ This document describes the high‑level architecture of XL and how the main mod
 
 ```mermaid
 graph TD
-  subgraph Core
+  subgraph Published["Published libraries"]
     Core[xl-core<br/>Domain model]
-  end
-
-  subgraph OOXML
     Ooxml[xl-ooxml<br/>OOXML mapping]
-  end
-
-  subgraph IO
     Ce[xl-cats-effect<br/>Excel / ExcelIO]
-  end
-
-  subgraph Evaluator
     Eval[xl-evaluator<br/>Formula parser + evaluator]
+    Agg[xl<br/>aggregate bundle + scripting prelude]
   end
 
-  subgraph Test
-    Tk[xl-testkit<br/>(law & property tests)]
+  subgraph Internal["Internal (not published)"]
+    Cli[xl-cli<br/>CLI]
+    Agent[xl-agent<br/>AI agent benchmarks]
+    Bench[xl-benchmarks<br/>JMH]
+    Tk[xl-testkit<br/>placeholder]
   end
 
   Core --> Ooxml
   Core --> Ce
   Core --> Eval
-  Core --> Tk
   Ooxml --> Ce
-  Ooxml --> Tk
+  Ce --> Agg
+  Eval --> Agg
+  Ce --> Cli
+  Eval --> Cli
+  Ce --> Agent
+  Eval --> Agent
+  Ce --> Bench
 ```
+
+Published (Maven Central):
 
 - `xl-core`: Pure domain model (`Cell`, `Sheet`, `Workbook`, styles, codecs, optics, macros).
 - `xl-ooxml`: Pure OOXML mapping layer (`XlsxReader` / `XlsxWriter`, `OoxmlWorkbook`, `OoxmlWorksheet`, `SharedStrings`, `Styles`).
 - `xl-cats-effect`: Effectful interpreters (`Excel[F]` / `ExcelIO`) and true streaming I/O built on Cats Effect, fs2, and fs2-data-xml.
-- `xl-evaluator`: Formula parser, printer, evaluator, function registry, dependency graph, and cross-sheet formula support.
-- `xl-testkit`: Reusable generators and law test helpers for the other modules.
+- `xl-evaluator`: Formula parser, printer, evaluator, function registry, dependency graph, cross-sheet formula support, and whole-workbook recalculation.
+- `xl`: Aggregate bundle (`com.tjclp::xl`) depending on the four modules above, plus the `com.tjclp.xl.scripting` one-import prelude for scripts.
+
+Internal (not published):
+
+- `xl-cli`: Stateless command-line tool (`xl`); installed locally via `make install`.
+- `xl-agent`: AI agent benchmark runner (Anthropic API, skill comparison).
+- `xl-benchmarks`: JMH performance benchmarks (XL vs Apache POI).
+- `xl-testkit`: Placeholder — declared in the build but has no sources yet; reusable generators currently live in `xl-core/test` (`Generators.scala`).
 
 ## I/O Flow
 
@@ -52,7 +61,7 @@ flowchart LR
   end
 
   subgraph Streaming["Streaming I/O (xl-cats-effect)"]
-    SR[StreamingXmlReader<br/>ZIP entry → XML events → RowData]
+    SR[SaxStreamingReader<br/>ZIP entry → SAX events → RowData]
     SW[StreamingXmlWriter<br/>RowData → XML events → ZIP entry]
   end
 
@@ -70,7 +79,7 @@ flowchart LR
   - When a `Workbook` was created by `XlsxReader`, a `SourceContext` tracks the original file and a `ModificationTracker`, enabling *surgical modification* (copy unchanged parts verbatim, regenerate only what changed).
 
 - **Streaming path**:
-  - `ExcelIO.readStream` / `readSheetStream` open the ZIP and stream a worksheet’s XML through fs2‑data‑xml, yielding a `Stream[F, RowData]` with constant memory use (SST is still materialized once if present).
+  - `ExcelIO.readStream` / `readSheetStream` open the ZIP and stream a worksheet’s XML through a SAX parser (`SaxStreamingReader`, 3–4x faster than the original fs2‑data‑xml path), yielding a `Stream[F, RowData]` with constant memory use (SST is still materialized once if present).
   - `ExcelIO.writeStream` / `writeStreamsSeq` write static parts once, then stream worksheet XML events directly to a `ZipOutputStream` from a `Stream[F, RowData]` without ever materializing all rows.
   - `ExcelIO.writeWorkbookStream` is different: it accepts an already-materialized `Workbook`, then uses the SAX/StAX OOXML backend to reduce writer allocation while preserving the full metadata handled by `XlsxWriter`.
 
@@ -186,5 +195,6 @@ The evaluator implements: `Evaluator.eval: TExpr[A] => Sheet => Either[EvalError
 - Short-circuit evaluation for And/Or
 - Division by zero handling (returns `CellError.Div0`)
 - 104 Excel functions: SUM, AVERAGE, IF, VLOOKUP, XLOOKUP, OFFSET, SUMIF, COUNTIF, NPV, IRR, dynamic arrays (SEQUENCE/SORT/UNIQUE/FILTER), and more
+- Whole-workbook recalculation: `Workbook.recalculate(clock)` is total and returns `RecalcResult` (recached workbook + per-sheet values + per-cell `CellEvalError`s); cycle participants are isolated while the acyclic remainder still evaluates
 
 See `docs/STATUS.md` for the complete function list.

--- a/docs/design/decisions.md
+++ b/docs/design/decisions.md
@@ -50,11 +50,12 @@
 
 ## ADR-007: fs2-data-xml for streaming
 **Date**: 2025-01 (P5)
-**Status**: ✅ Implemented
+**Status**: ✅ Implemented (write path); read path superseded by SAX backend (P6.6)
 
 - **Decision**: Use fs2-data-xml for event-based XML parsing/writing instead of scala-xml
 - **Rationale**: Constant-memory streaming (O(1)), 4.5x faster than Apache POI
 - **Consequence**: More complex implementation, but enables 1M+ row files without OOM
+- **Update**: Streaming *reads* later moved to a plain SAX parser (`SaxStreamingReader`, 3–4x faster, still O(1) — see `performance-investigation.md`); fs2-data-xml remains the row-stream *write* backend (`StreamingXmlWriter`)
 
 ## ADR-008: CellCodec primitives over derivation
 **Date**: 2025-01 (P6)

--- a/docs/design/domain-model.md
+++ b/docs/design/domain-model.md
@@ -1,6 +1,6 @@
 # Domain Model (Scala 3.8, Deep Dive)
 
-This document mirrors the **current** xl-core data model. All types derive `CanEqual` and lean on opaque types for zero-overhead safety. Package references use `com.tjclp.xl` (macros and syntax live in the same module).
+This document mirrors the **current** xl-core data model. Core types lean on opaque types for zero-overhead safety; closed sums are enums with exhaustive matching. Package references use `com.tjclp.xl` (macros and syntax live in the same module).
 
 ## Addressing Primitives
 ```scala
@@ -8,41 +8,50 @@ package com.tjclp.xl.addressing
 
 opaque type Column = Int
 object Column:
-  val MaxIndex0 = 16383             // A..XFD
-  inline def from0(index: Int): Column = index
-  inline def from1(index: Int): Column = index - 1
+  val MaxIndex0: Int = 16383        // A..XFD
+  def from0(index: Int): Column = index
+  def from1(index: Int): Column = index - 1
   def fromLetter(input: String): Either[String, Column] = ...
   extension (c: Column)
-    inline def index0: Int = c
-    inline def index1: Int = c + 1
+    def index0: Int = c
+    def index1: Int = c + 1
     def toLetter: String = ...
 
 opaque type Row = Int
 object Row:
-  inline def from0(index: Int): Row = index
-  inline def from1(index: Int): Row = index - 1
+  val MaxIndex0: Int = 1048575      // 1..1048576
+  def from0(index: Int): Row = index
+  def from1(index: Int): Row = index - 1
   extension (r: Row)
-    inline def index0: Int = r
-    inline def index1: Int = r + 1
+    def index0: Int = r
+    def index1: Int = r + 1
 
 /** Absolute cell reference packed into a Long: high 32 bits = row, low 32 = col. */
 opaque type ARef = Long
 object ARef:
-  inline def apply(col: Column, row: Row): ARef = ((row.toLong) << 32) | (col.toLong & 0xffffffffL)
+  def apply(col: Column, row: Row): ARef = ((row.toLong) << 32) | (col.toLong & 0xffffffffL)
   def parse(a1: String): Either[String, ARef] = ...
   extension (ref: ARef)
-    inline def col: Column = (ref & 0xffffffffL).toInt
-    inline def row: Row    = (ref >>> 32).toInt
+    def col: Column = (ref & 0xffffffffL).toInt
+    def row: Row    = (ref >> 32).toInt
     def toA1: String = ...
 
-final case class CellRange(start: ARef, end: ARef) derives CanEqual
+/** Inclusive range; start/end carry anchoring for $-style absolute refs. */
+final case class CellRange(
+  start: ARef,
+  end: ARef,
+  startAnchor: Anchor = Anchor.Relative,
+  endAnchor: Anchor = Anchor.Relative
+)
 
 /** Validated sheet name */
 opaque type SheetName = String
 object SheetName:
   def apply(name: String): Either[String, SheetName] = ...
-  extension (n: SheetName) inline def value: String = n
+  extension (name: SheetName) def value: String = name
 ```
+
+> **Why no `inline`?** Members that touch an opaque type's underlying representation are deliberately non-`inline`: inline bodies fail to re-elaborate at call sites outside the defining package, breaking external consumers of the published jars (issue #252). See the NOTE in `xl-core/src/com/tjclp/xl/addressing/ARef.scala` and [style-guide.md](style-guide.md).
 
 ### Invariants
 - `CellRange` is normalized (start <= end by row, then col).
@@ -53,21 +62,21 @@ object SheetName:
 ```scala
 import java.time.LocalDateTime
 
-enum CellError derives CanEqual:
+enum CellError:
   case Div0, NA, Name, Null, Num, Ref, Value
 
-enum CellValue derives CanEqual:
+enum CellValue:
   case Text(value: String)
   case RichText(value: com.tjclp.xl.richtext.RichText)
   case Number(value: BigDecimal)
   case Bool(value: Boolean)
   case DateTime(value: LocalDateTime)
-  case Formula(expression: String)        // String stored; see TExpr in xl-evaluator for typed AST
+  case Formula(expression: String, cachedValue: Option[CellValue] = None)
   case Empty
   case Error(error: CellError)
 ```
 
-- Formula strings stored in `CellValue.Formula`; use `TExpr` in `xl-evaluator` for typed AST manipulation.
+- Formula strings stored in `CellValue.Formula` alongside an optional cached result (what Excel's `<v>` holds; populated by readers and by `Workbook.recalculate` in xl-evaluator); use `TExpr` in `xl-evaluator` for typed AST manipulation.
 - `CellValue.from` provides a best-effort conversion from common JVM types.
 
 ### Formula AST (xl-evaluator)
@@ -136,7 +145,7 @@ object TExpr:
 **Parser/Printer**:
 - `FormulaParser.parse(s: String): Either[ParseError, TExpr[?]]` — Parse formula strings
 - `FormulaPrinter.print(expr: TExpr[?]): String` — Print back to Excel syntax
-- Round-trip law: `parse(print(expr)) == Right(expr)` (verified by 51 property tests)
+- Round-trip law: `parse(print(expr)) == Right(expr)` (verified by property tests)
 
 **Evaluator**: `Evaluator.eval(expr: TExpr[A], sheet: Sheet): Either[EvalError, A]` (WI-08)
 
@@ -146,6 +155,8 @@ import com.tjclp.xl.styles.units.StyleId
 import com.tjclp.xl.styles.StyleRegistry
 import com.tjclp.xl.cells.Comment
 import com.tjclp.xl.context.SourceContext
+import com.tjclp.xl.sheets.{FreezePane, PageSetup, SheetView}
+import com.tjclp.xl.tables.TableSpec
 
 final case class Cell(
   ref: ARef,
@@ -164,7 +175,11 @@ final case class Sheet(
   defaultColumnWidth: Option[Double] = None,
   defaultRowHeight: Option[Double] = None,
   styleRegistry: StyleRegistry = StyleRegistry.default,
-  comments: Map[ARef, Comment] = Map.empty
+  comments: Map[ARef, Comment] = Map.empty,
+  tables: Map[String, TableSpec] = Map.empty,
+  pageSetup: Option[PageSetup] = None,
+  freezePane: Option[FreezePane] = None,
+  viewSettings: Option[SheetView] = None
 ):
   def apply(ref: ARef): Cell = cells.getOrElse(ref, Cell.empty(ref))
   def contains(ref: ARef): Boolean = cells.contains(ref)
@@ -184,6 +199,8 @@ final case class Workbook(
 - `styleId` indexes into the sheet-local `StyleRegistry` (style deduplication).
 - `SourceContext` attaches when reading from disk to enable surgical modification (copy unchanged ZIP parts verbatim).
 - Workbook has no global style/shared-strings fields; those are constructed ad hoc inside `xl-ooxml`.
+- Print/display settings live on the sheet: `pageSetup` (margins, header/footer, print area/titles — extended in 0.11.0), `freezePane`, and `viewSettings` (`SheetView(showGridLines, zoomScale)`, new in 0.11.0; serialized into the same `<sheetView>` element as freeze panes).
+- `tables` holds structured table definitions (`TableSpec`) keyed by table name.
 
 ## Style Model (summary)
 - Defined under `com.tjclp.xl.styles` with `CellStyle`, `Font`, `Fill`, `Border`, `Align`, `NumFmt`, and units (`Pt`, `Px`, `Emu`, `StyleId`).
@@ -195,29 +212,39 @@ package com.tjclp.xl.richtext
 
 final case class TextRun(
   text: String,
-  font: Option[com.tjclp.xl.styles.font.Font] = None,
-  color: Option[com.tjclp.xl.styles.color.Color] = None,
-  bold: Boolean = false,
-  italic: Boolean = false,
-  underline: Boolean = false
-) derives CanEqual
+  font: Option[Font] = None,          // All formatting (bold/italic/color/size) lives in Font
+  rawRPrXml: Option[String] = None    // Raw <rPr> XML preserved for lossless round-trip
+):
+  def bold: TextRun = ...             // Builder methods return updated TextRun
+  def italic: TextRun = ...
+  def underline: TextRun = ...
+  def withColor(c: Color): TextRun = ...
+  def size(pt: Double): TextRun = ...
+  def +(other: TextRun): RichText = ...   // also +(s: String), +(other: RichText)
 
-final case class RichText(runs: Vector[TextRun]) derives CanEqual:
-  def +(other: TextRun): RichText = copy(runs = runs :+ other)
-  def +(other: RichText): RichText = copy(runs = runs ++ other.runs)
+final case class RichText(runs: Vector[TextRun]):
+  def +(other: RichText): RichText = RichText(runs ++ other.runs)
+  def +(run: TextRun): RichText = RichText(runs :+ run)
+  def +(s: String): RichText = RichText(runs :+ TextRun(s))
   def toPlainText: String = runs.map(_.text).mkString
+  def isPlainText: Boolean = runs.forall(_.font.isEmpty)
 
-extension (s: String)
-  def bold: RichText = RichText(Vector(TextRun(s, bold = true)))
-  def italic: RichText = RichText(Vector(TextRun(s, italic = true)))
-  def underline: RichText = RichText(Vector(TextRun(s, underline = true)))
-  def red: RichText = RichText(Vector(TextRun(s, color = Some(com.tjclp.xl.styles.color.Color.rgb(255, 0, 0)))))
-  def green: RichText = RichText(Vector(TextRun(s, color = Some(com.tjclp.xl.styles.color.Color.rgb(0, 255, 0)))))
-  def blue: RichText = RichText(Vector(TextRun(s, color = Some(com.tjclp.xl.styles.color.Color.rgb(0, 0, 255)))))
-  def size(pt: Double): RichText = RichText(Vector(TextRun(s, font = Some(com.tjclp.xl.styles.font.Font("Calibri", pt, bold = false, italic = false)))))
+object RichText:
+  def plain(text: String): RichText = ...
+  given Conversion[String, TextRun] = TextRun(_)
+  given Conversion[TextRun, RichText] = r => RichText(Vector(r))
+
+  extension (s: String)   // DSL: "Bold".bold.red + " and " + "Italic".italic.blue
+    def bold: TextRun = TextRun(s).bold
+    def italic: TextRun = TextRun(s).italic
+    def underline: TextRun = TextRun(s).underline
+    def size(pt: Double): TextRun = TextRun(s).size(pt)
+    def fontFamily(name: String): TextRun = TextRun(s).fontFamily(name)
+    def withColor(c: Color): TextRun = TextRun(s).withColor(c)
+    def red: TextRun = TextRun(s).red   // also green, blue, black, white
 ```
 
-RichText is stored losslessly (including whitespace) via SharedStrings in `xl-ooxml` and supported in streaming write paths as inline strings.
+Run formatting is carried entirely by `Option[Font]` (the old per-run `bold`/`italic`/`color` flags were folded into `Font`); `rawRPrXml` preserves run properties the `Font` model doesn't represent (vertAlign, underline styles, …) so round-trips are lossless. RichText is stored losslessly (including whitespace) via SharedStrings in `xl-ooxml` and supported in streaming write paths as inline strings.
 
 ## Comments & Hyperlinks
 - Cells carry lightweight `comment: Option[String]` and `hyperlink: Option[String]`.

--- a/docs/design/io-modes.md
+++ b/docs/design/io-modes.md
@@ -32,21 +32,22 @@ XL has **two distinct I/O implementations** with fundamentally different archite
 ### Mode 2: Streaming (xl-cats-effect)
 
 **Implementation**: Event-based streaming with fs2
-- Stream ZIP bytes via fs2-data-xml
-- Emit XML events directly
+- Reads: SAX parser over ZIP entry streams (`SaxStreamingReader`)
+- Writes: fs2-data-xml events emitted directly (`StreamingXmlWriter`)
 - No intermediate trees
 - Constant memory
 
 **Modules**:
 - `xl-cats-effect`: Effect interpreters
 - `StreamingXmlWriter`: Domain model → XML events → ZIP
-- `StreamingXmlReader`: ZIP → XML events → Domain model
+- `SaxStreamingReader`: ZIP → SAX events → RowData
 
 **Key Files**:
 - `xl-cats-effect/src/com/tjclp/xl/io/Excel.scala`
 - `xl-cats-effect/src/com/tjclp/xl/io/ExcelIO.scala`
 - `xl-cats-effect/src/com/tjclp/xl/io/StreamingXmlWriter.scala`
-- `xl-cats-effect/src/com/tjclp/xl/io/StreamingXmlReader.scala`
+- `xl-cats-effect/src/com/tjclp/xl/io/SaxStreamingReader.scala`
+- `xl-cats-effect/src/com/tjclp/xl/io/streaming/` (SAX→StAX transforms: `ZipTransformer`, `StreamingTransform`, `StylePatcher`)
 
 ---
 
@@ -79,8 +80,8 @@ Write (`writeStream` / `writeStreamsSeq`):
 - Output is compact XML with `Compression.Deflated` by default; by design it uses inline strings (no SST) and a minimal style set.
 
 Read (`readStream` / `readSheetStream` / `readStreamByIndex`):
-- The ZIP is opened as a `ZipFile`, and the target worksheet entry is streamed through fs2‑data‑xml as a stream of XML events.
-- Those events are converted into `RowData` records on the fly.
+- The ZIP is opened as a `ZipFile`, and the target worksheet entry is streamed through a SAX parser (`SaxStreamingReader`; 3–4x faster than the original fs2‑data‑xml path).
+- SAX events are converted into `RowData` records (values plus raw style indices).
 - The `SharedStrings` table (if present) is parsed once up front and held in memory; worksheet data itself is streamed.
 
 Characteristics:
@@ -140,7 +141,9 @@ Features: Limited (reads values only, minimal style info)
 
 ---
 
-### ADR-012: Why Not Streaming-First?
+### Why Not Streaming-First?
+
+(Companion rationale to ADR-011; not a numbered ADR — see `decisions.md` for the canonical ADR list, where ADR-012 is compression defaults.)
 
 **Decision**: In-memory is the **default** API, streaming is opt-in
 
@@ -162,7 +165,7 @@ Features: Limited (reads values only, minimal style info)
 
 ### ADR-013: Streaming Read Bug - Why Not Fixed Yet?
 
-**Status**: Historical only – the original streaming reader used `readAllBytes()` and was O(n) in memory. As of P6.6 it has been rewritten on top of `fs2.io.readInputStream` and fs2‑data‑xml and now achieves the same constant‑memory characteristics as the streaming writer.
+**Status**: Historical only – the original streaming reader used `readAllBytes()` and was O(n) in memory. As of P6.6 it has been rewritten on top of `fs2.io.readInputStream` (and since moved to the SAX parser backend — see the status update under "Streaming: Why fs2-data-xml?" below) and now achieves the same constant‑memory characteristics as the streaming writer.
 
 Today:
 - `ExcelIO.readStream` / `readSheetStream` / `readStreamByIndex` are safe to use for large files.
@@ -175,11 +178,11 @@ Today:
 | Feature | In-Memory | Streaming Write | Streaming Read (Fixed) |
 |---------|-----------|-----------------|------------------------|
 | **SST** | ✅ Full | ❌ None (inline only) | ✅ Full |
-| **Styles** | ✅ Full | ⚠️ Default only | ⚠️ Minimal |
+| **Styles** | ✅ Full | ⚠️ Default only | ⚠️ Raw style indices on `RowData` |
 | **Formulas** | ✅ Store | ✅ Store | ✅ Read |
-| **Merged Cells** | ⚠️ Track (not serialized) | ❌ No | ❌ No |
+| **Merged Cells** | ✅ Full (serialized) | ❌ No | ❌ No |
 | **Rich Text** | ✅ Full | ✅ Full | ✅ Full |
-| **Column/Row Props** | ⚠️ Track (not serialized) | ❌ No | ❌ No |
+| **Column/Row Props** | ✅ Full (serialized) | ❌ No | ❌ No |
 | **Memory** | O(n) | O(1) | O(1) after P6.6 |
 | **Speed** | ~88k rows/sec | ~88k rows/sec | ~55k rows/sec |
 
@@ -216,6 +219,12 @@ Today:
 
 **Decision**: Use fs2-data-xml for event streaming
 
+**Status update**: this decision now applies to the row-stream *write* path only
+(`StreamingXmlWriter`). The streaming *read* path was later rebuilt on a plain SAX parser
+(`SaxStreamingReader`) for 3–4x throughput — see
+[performance-investigation.md](performance-investigation.md). The SAX→StAX transform writers
+(`ZipTransformer`/`StreamingTransform`) likewise use `javax.xml` wrapped in `Sync[F]`.
+
 **Pros**:
 - True streaming (no tree building)
 - Constant memory
@@ -228,7 +237,7 @@ Today:
 - Harder to debug (can't inspect tree)
 
 **Alternative Considered**: Use javax.xml.stream.XMLStreamWriter
-**Rejected Because**: Imperative, side-effecting, not fs2-compatible
+**Rejected Because**: Imperative, side-effecting, not fs2-compatible (later adopted, behind `Sync[F]`, where raw throughput won)
 
 ---
 
@@ -316,10 +325,11 @@ test("streaming read uses constant memory"):
 
 ## Migration Path
 
-### Current State (As of 2026-01)
+### Current State (As of 2026-06, v0.11.0)
 - In-memory: Production-ready for <100k rows
 - Streaming write: Production-ready for >100k rows (minimal styling)
 - Streaming read: Production-ready for >100k rows (O(1) memory)
+- Streaming transforms: targeted cell/style edits on existing files without full load (`ZipTransformer` + `StreamingTransform`; CLI `--stream` put/putf/style/batch)
 
 ### ✅ P6.6: Fix Streaming Read (Complete)
 - Replaced `readAllBytes()` with `fs2.io.readInputStream`
@@ -356,7 +366,7 @@ test("streaming read uses constant memory"):
 ## Related Documents
 
 - [performance-guide.md](../reference/performance-guide.md) - User guidance
-- [streaming-improvements.md](../plan/streaming-improvements.md) - Roadmap
+- [smart-streaming.md](smart-streaming.md) - Streaming roadmap (shipped vs future)
 - [purity-charter.md](purity-charter.md) - Why pure core matters
 - [STATUS.md](../STATUS.md) - Current limitations
 
@@ -364,4 +374,4 @@ test("streaming read uses constant memory"):
 
 ## Author
 
-Documented 2025-11-11
+Documented 2025-11-11. Last updated 2026-06-10 (SAX read backend, streaming transforms, feature-matrix corrections).

--- a/docs/design/performance-investigation.md
+++ b/docs/design/performance-investigation.md
@@ -4,6 +4,8 @@
 **Status**: Investigation Complete
 **Author**: Claude Code + Human Review
 
+> Investigation snapshot, 2025-12 — conclusions adopted (Option A); numbers reflect that benchmark run. For current user guidance see [performance-guide.md](../reference/performance-guide.md).
+
 ## Executive Summary
 
 XL outperforms Apache POI on typical workloads (<10k rows) for both reads and writes. At scale (100k+ rows), XL's functional abstractions introduce overhead for reads, while writes remain faster.

--- a/docs/design/purity-charter.md
+++ b/docs/design/purity-charter.md
@@ -5,6 +5,7 @@
 - `xl-core` and `xl-ooxml` expose **pure functions only**; no side‑effects, no clocks, no randomness.
 - `xl-cats-effect` contains **the only interpreters** for: ZIP I/O, file system, streams.
 - All IO return types are **`F[_]`** with typeclass constraints (`Sync`, `Async`) and **no hidden global state**.
+- One documented exception: the first render call (`toHtml`/`toSvg`) defaults `java.awt.headless=true` if the embedder left it unset — a deliberate, guarded, idempotent global property write (see `RenderUtils` in xl-core), not a hidden effect.
 
 ## 2) Totality & defensive programming
 - Abolish `null`; use `Option`.

--- a/docs/design/smart-streaming.md
+++ b/docs/design/smart-streaming.md
@@ -8,7 +8,7 @@ Make the XL CLI handle files of any size with optimal performance by automatical
 
 ---
 
-## Current State (v0.8.0)
+## Shipped (as of 0.11.0)
 
 ### Manual Mode Selection
 - `--stream` flag opts into O(1) streaming for compatible commands
@@ -21,20 +21,41 @@ Make the XL CLI handle files of any size with optimal performance by automatical
 |---------|-----------|-----------|-------|
 | `search` | ✅ O(1) | ✅ | Streaming stops early on limit |
 | `stats` | ✅ O(1) | ✅ | Streaming aggregation |
-| `bounds` | ✅ O(1) | ✅ | Track min/max during scan |
-| `view` (md/csv/json) | ✅ O(1) | ✅ | No styles needed |
+| `bounds` | ✅ O(1) | ✅ | `<dimension>` fast path; `--scan` forces full scan |
+| `view` (md/csv/json) | ✅ O(1) | ✅ | No styles needed; `--eval` not supported when streaming |
 | `view` (html/svg/pdf) | ❌ | ✅ | Requires style registry |
-| `cell` | ❌ | ✅ | Needs dependency graph |
+| `cell` | ✅ O(1) | ✅ | SAX single-cell reader (`SaxSingleCellReader`); dependents (reverse deps) need in-memory |
 | `eval` | ❌ | ✅ | Needs formula analysis |
 | `sheets` | ❌ | ✅ | Needs workbook metadata |
 | `names` | ❌ | ✅ | Needs workbook metadata |
-| All writes | ❌ | ✅ | Read-modify-write cycle |
+| `put` / `putf` / `style` / `batch` | ✅ O(1) | ✅ | SAX→StAX transform (`ZipTransformer`); copies untouched ZIP entries verbatim |
+| Other writes | ❌¹ | ✅ | Read-modify-write cycle |
+
+¹ For all other modifying commands, `--stream` still helps: the full workbook is loaded in
+memory, but the write goes through the lower-allocation SAX/StAX backend
+(`ExcelIO.writeWorkbookStream`).
 
 ---
 
-## Future Architecture
+## Architecture Phases: Status
+
+Each phase below was designed when streaming was read-only (v0.8.0 era). Status as of 0.11.0:
+
+| Phase | Status |
+|-------|--------|
+| 1. Lazy metadata loading | ⬜ Future — `sheets`/`names` still require full load; no `LazyWorkbook` |
+| 2. Style-aware streaming | ⚠️ Partial — `RowData`/`StyledRowData` carry style indices; styled HTML/SVG streaming not shipped |
+| 3a. Append-only writes | ⚠️ Partial — `import --stream` streams CSV→new sheet (O(1)); no append-to-existing-sheet API |
+| 3b. Range-based modifications | ✅ Shipped in 0.8.0 (#183) — `StreamingTransform` + `ZipTransformer`; CLI `--stream` `put`/`putf`/`style`/`batch` |
+| 4. Intelligent mode selection | ⬜ Future — mode selection is still manual via `--stream` |
+| 5. Parallel streaming | ⬜ Future |
+
+The original phase designs are kept below as rationale and as the target shape for the
+unshipped parts.
 
 ### Phase 1: Lazy Metadata Loading
+
+**Status**: ⬜ Future. `LazyWorkbook` does not exist; workbook-level commands still load fully.
 
 **Goal**: Load workbook structure without loading cell data.
 
@@ -61,6 +82,11 @@ trait LazyWorkbook:
 
 ### Phase 2: Style-Aware Streaming
 
+**Status**: ⚠️ Partial. Since #183, `RowData` carries `cellStyles: Map[Int, Int]` (raw style
+indices) and `StyledRowData` feeds style-preserving streaming writes (`StylePatcher` patches
+`styles.xml` during transforms). The rendering half — streaming HTML/SVG with resolved
+`CellStyle`s — has not shipped; `view --stream` remains md/csv/json only.
+
 **Goal**: Stream cells with style information for rich output formats.
 
 ```scala
@@ -83,6 +109,14 @@ def streamSheetStyled(name: SheetName): Stream[IO, StyledRowData]
 - PDF generation can stream pages
 
 ### Phase 3: Streaming Write Operations
+
+**Status**: ✅ Mostly shipped (0.8.0, #183; worksheet-metadata patches extended in 0.9.6, #219).
+The implementation matches the 3b design: `ZipTransformer` copies unchanged ZIP entries
+verbatim, `StreamingTransform` SAX→StAX-rewrites only the target worksheet (cell values,
+styles, plus `<cols>`, merges, and row attributes), and `StylePatcher` appends new styles to
+`styles.xml`. Exposed as CLI `--stream` on `put`/`putf`/`style`/`batch`. From 3a, only
+streaming CSV import shipped (`import --stream` to a new sheet via `writeStreamWithAutoDetect`);
+generic append-to-existing-sheet APIs remain future work.
 
 **Goal**: Enable streaming modifications without full workbook load.
 
@@ -116,6 +150,8 @@ def modifyRange(
 - `import` can stream CSV directly to new sheet
 
 ### Phase 4: Intelligent Mode Selection
+
+**Status**: ⬜ Future. No `FileProfile`/`SmartExecutor`; users choose with `--stream`.
 
 **Goal**: Automatically choose optimal mode based on operation and file.
 
@@ -156,6 +192,8 @@ def chooseMode(profile: FileProfile, command: CliCommand): ExecutionMode =
 - Graceful degradation for complex cases
 
 ### Phase 5: Parallel Streaming
+
+**Status**: ⬜ Future. No parallel multi-sheet streaming in xl-cats-effect or the CLI.
 
 **Goal**: Utilize multiple cores for large file operations.
 
@@ -216,24 +254,24 @@ ZIP File → Probe Metadata → Choose Mode → Execute Optimal Path → Output
 
 ## Migration Path
 
-### v0.8.0 (Current)
+(The original plan pinned phases to v0.9.0/v1.0.0/v1.1.0; delivery diverged — range
+modifications shipped first, lazy metadata has not shipped. Restated against reality:)
+
+### Shipped (0.8.0 – 0.11.0)
 - [x] `--stream` flag for opt-in streaming
 - [x] `--max-size` flag for large file override
-- [x] Streaming: search, stats, bounds, view (md/csv/json)
+- [x] Streaming reads: search, stats, bounds, view (md/csv/json), cell
+- [x] Streaming range modifications: `put`/`putf`/`style`/`batch` via SAX→StAX transform (0.8.0, #183)
+- [x] Streaming worksheet-metadata patches: col/row props, merges, visibility (0.9.6, #219)
+- [x] Streaming CSV import to new sheet (`import --stream`)
+- [x] SAX/StAX workbook writer for all other `--stream` writes (`writeWorkbookStream`)
 
-### v0.9.0
-- [ ] Lazy workbook metadata loading
-- [ ] `sheets` and `names` without full load
+### Future (unscheduled)
+- [ ] Lazy workbook metadata loading (`sheets` and `names` without full load)
 - [ ] Auto-streaming for search/stats (no flag needed)
-
-### v1.0.0
-- [ ] Style-aware streaming
-- [ ] HTML/SVG streaming for large ranges
+- [ ] Style-aware streaming HTML/SVG for large ranges
 - [ ] Intelligent mode selection
-
-### v1.1.0
-- [ ] Streaming range modifications
-- [ ] Append-only write operations
+- [ ] Append-to-existing-sheet write operations
 - [ ] Parallel multi-sheet operations
 
 ---
@@ -285,13 +323,16 @@ enum ExecutionMode:
 
 ## Performance Targets
 
-| Operation | File Size | Current | Target | Mode |
-|-----------|-----------|---------|--------|------|
-| `sheets` | 1M rows | 80s | <1s | Lazy metadata |
-| `search --limit 10` | 1M rows | 80s | <1s | Streaming + early stop |
-| `view A1:D100 --format html` | 1M rows | 80s | <2s | Lazy styled |
-| `put A1 "test"` | 1M rows | 80s | <5s | Streaming modify |
-| `search` (4 sheets) | 4x250k rows | 80s | 20s | Parallel streaming |
+("Baseline" is the v0.8.0-era in-memory load time the targets were set against. For current
+measured numbers on the shipped paths, see `docs/reference/performance-guide.md`.)
+
+| Operation | File Size | Baseline | Target | Mode | Status |
+|-----------|-----------|----------|--------|------|--------|
+| `sheets` | 1M rows | 80s | <1s | Lazy metadata | ⬜ Future |
+| `search --limit 10` | 1M rows | 80s | <1s | Streaming + early stop | ✅ Shipped |
+| `view A1:D100 --format html` | 1M rows | 80s | <2s | Lazy styled | ⬜ Future |
+| `put A1 "test"` | 1M rows | 80s | <5s | Streaming modify | ✅ Shipped |
+| `search` (4 sheets) | 4x250k rows | 80s | 20s | Parallel streaming | ⬜ Future |
 
 ---
 

--- a/docs/design/style-guide.md
+++ b/docs/design/style-guide.md
@@ -1,0 +1,134 @@
+# Code Style Guide
+
+House style for all XL modules. Two tools enforce it mechanically — Scalafmt (formatting) and
+WartRemover (purity warts) — and everything else here is convention that reviewers hold the line
+on. Philosophy lives in [purity-charter.md](purity-charter.md); this document is about how the
+code is written.
+
+All code must pass `./mill __.checkFormat` and compile clean under the Tier 1 warts before merge.
+
+## Formatting (Scalafmt)
+
+Configured in `.scalafmt.conf` at the repo root — **Scalafmt 3.10.1**, `runner.dialect = scala3`,
+`maxColumn = 100`, 2-space indentation everywhere (`indent.main/callSite/defnSite = 2`),
+`docstrings.style = Asterisk` with wrapping.
+
+```bash
+./mill __.reformat       # Format all modules
+./mill __.checkFormat    # CI / pre-commit check (fails on drift)
+```
+
+Never hand-format around the tool; if a construct formats badly, restructure the code.
+
+## Type Discipline
+
+- **Opaque types for domain quantities**: `Column`, `Row`, `ARef`, `SheetName`, and the style
+  units (`Pt`, `Px`, `Emu`, `StyleId`) are opaque wrappers over primitives — zero runtime
+  overhead, no accidental `Int`/`Long` mixing.
+
+  ```scala
+  opaque type Column = Int   // Cannot pass a raw Int where a Column is expected
+  opaque type ARef = Long    // Packed: (row << 32) | col
+  ```
+
+- **Enums for closed sums** (e.g. `Patch`, `StylePatch`, `CellValue`, `TExpr`) with exhaustive
+  `match` — no wildcard-default escape hatches on domain enums. Add `derives CanEqual` where
+  typed equality matters (e.g. `TExpr`, `Anchor`, `RefType`).
+- **`final case class` for data**; smart constructors on the companion when invariants exist
+  (`SheetName.apply` returns `Either`, `CellRange` normalizes on construction).
+
+## Totality & Error Handling
+
+- All fallible public APIs return `XLResult[A]`:
+
+  ```scala
+  type XLResult[A] = Either[XLError, A]   // xl-core/src/com/tjclp/xl/error/XLError.scala
+  ```
+
+- No `null` (use `Option`), no partial functions, no thrown exceptions as control flow in the
+  pure modules (`xl-core`, `xl-ooxml`, `xl-evaluator`). Effects live only behind `F[_]` in
+  `xl-cats-effect`.
+- Validation is first-class: return `Either`/`ValidatedNec`, never validate by throwing.
+
+## Extension Methods over Implicit Classes
+
+Use Scala 3 `extension` blocks, not Scala 2 implicit classes. Same-named extension methods on
+different receivers need distinct JVM names — disambiguate with `@annotation.targetName`:
+
+```scala
+// xl-core/src/com/tjclp/xl/unsafe.scala — `.unsafe` exists for several receiver types,
+// so each overload carries its own JVM name:
+extension (sheet: Sheet)
+  @annotation.targetName("unsafeSheet")
+  def unsafe: Sheet = sheet
+```
+
+(`xl-core/src/com/tjclp/xl/extensions.scala` uses the same pattern for the `style`/`put`
+overload families.)
+
+## Opaque-Type Members Must Stay Non-`inline`
+
+Companion factories and extension methods that touch an opaque type's underlying representation
+must **not** be declared `inline`. Inline bodies fail to re-elaborate at call sites outside the
+defining package, where the representation is hidden — external consumers of the published
+artifacts get compile errors (issue #252). The authoritative warning lives in
+`xl-core/src/com/tjclp/xl/addressing/ARef.scala`:
+
+> every member here (and in Column/Row/SheetName/style units) that touches the opaque
+> representation must stay NON-inline: inline bodies fail to re-elaborate at call sites outside
+> this package […] Do not "optimize" these back to `inline` — the JIT/AOT inlines trivial static
+> methods anyway.
+
+This is guarded by external-consumer probes in `xl/test/src/xlprelude/`; a "performance" PR that
+re-adds `inline` will break them.
+
+## Import Order
+
+Group imports top-down, separated by blank lines:
+
+1. Java / javax
+2. Scala stdlib
+3. Cats / Cats Effect / fs2
+4. Project (`com.tjclp.xl.*`)
+5. Test frameworks (test sources only)
+
+## WartRemover
+
+WartRemover **3.5.6** runs as a compiler plugin on every module (configured in `build.mill`,
+trait `XLModuleBase`). Two tiers:
+
+- **Tier 1 (errors, fail the build)**: `Null`, `TryPartial`, `EitherProjectionPartial`,
+  `TripleQuestionMark`, `ArrayEquals`, `JavaConversions`, `Option2Iterable`.
+- **Tier 2 (warnings, monitored)**: `IterableOps`, `OptionPartial`, `Var`, `Return`, `While`,
+  `AsInstanceOf`, `IsInstanceOf` — acceptable in tests, macros, and performance-critical
+  parser internals.
+
+Tier rationale, suppression rules, and the process for adding warts are in
+[wartremover-policy.md](wartremover-policy.md) — do not duplicate them here.
+
+## Known Gotchas
+
+- **Monoid syntax needs type ascription** on enum cases (the enum case's precise type is not the
+  enum type, so `Monoid[Patch]` is not found):
+
+  ```scala
+  val p = (Patch.Put(ref, value): Patch) |+| (Patch.SetStyle(ref, 1): Patch)
+  ```
+
+  The DSL's `++` on patches avoids this; prefer it in examples and scripts.
+- **`{*, given}` imports**: Scala 3's `*` does not pull in given instances — public API examples
+  must write `import com.tjclp.xl.{*, given}` (or `com.tjclp.xl.scripting.{*, given}` in
+  scripts, never both in one file).
+- **`var`/`while`/`return`** are tolerated (Tier 2 warnings) only in macros, zero-allocation
+  parsers, and tests — always with a comment saying why.
+
+## Enforcement Pipeline
+
+```bash
+./mill __.checkFormat    # Scalafmt drift → CI failure
+./mill __.compile        # WartRemover Tier 1 → compile error
+./mill __.test           # 3005+ tests
+```
+
+Pre-commit hooks (`.pre-commit-config.yaml`) run the same `checkFormat` and `compile` steps;
+GitHub Actions runs all three.

--- a/docs/design/wartremover-policy.md
+++ b/docs/design/wartremover-policy.md
@@ -4,9 +4,9 @@ XL uses [WartRemover](https://www.wartremover.org/) to enforce functional progra
 
 ## Overview
 
-**Version**: WartRemover 3.4.1
-**Integration**: Compiler plugin via Mill build system
-**Scope**: All modules (xl-core, xl-ooxml, xl-cats-effect, xl-evaluator, xl-testkit)
+**Version**: WartRemover 3.5.6
+**Integration**: Compiler plugin via Mill build system (`XLModuleBase` in `build.mill`)
+**Scope**: All modules (xl, xl-core, xl-ooxml, xl-cats-effect, xl-evaluator, xl-cli, xl-agent, xl-benchmarks, xl-testkit)
 
 ## Philosophy Alignment
 
@@ -27,11 +27,10 @@ These warts violate XL's fundamental principles and will **fail compilation**:
 | `Null` | Prevents use of `null` | Null violates totality; use Option instead |
 | `TryPartial` | Prevents `.get` on Try | Partial function; use `.fold` or `.getOrElse` |
 | `EitherProjectionPartial` | Prevents `.get` on Either projections | Deprecated API; use `.fold` or pattern matching |
-| `IterableOps` | Prevents `.head`/`.tail`/`.last` on collections | Partial functions; use `.headOption`/`.lastOption` |
 | `TripleQuestionMark` | Prevents `???` placeholders | Unimplemented code should not compile |
 | `ArrayEquals` | Prevents `==` on arrays | Reference equality; use `.sameElements` |
 | `JavaConversions` | Prevents automatic Java conversions | Implicit; use explicit conversions |
-| `Option2Iterable` | Prevents implicit Option to Iterable | Obscures intent; use `.toSeq` explicitly |
+| `Option2Iterable` | Prevents implicit Option to Iterable | Obscures intent; use `.toList` explicitly |
 
 #### Examples
 
@@ -41,12 +40,6 @@ val x: String = null  // Fails compilation
 
 // ✅ Correct: Use Option
 val x: Option[String] = None
-
-// ❌ Error: IterableOps
-val first = list.head  // Fails compilation
-
-// ✅ Correct: Use headOption
-val first = list.headOption.getOrElse(default)
 
 // ❌ Error: TryPartial
 val result = Try(operation).get  // Fails compilation
@@ -61,6 +54,7 @@ These warts highlight code quality issues but **only produce warnings**:
 
 | Wart | Description | Why Warning? |
 |------|-------------|-------------|
+| `IterableOps` | Warns on `.head`/`.tail`/`.last` on collections | Acceptable in tests; prefer `.headOption`/`.lastOption` in production |
 | `OptionPartial` | Warns on `.get` on Option | Acceptable in tests; prefer `.fold` in production |
 | `Var` | Warns on mutable variables | Intentional in performance-critical code (macros) |
 | `Return` | Warns on early returns | Intentional in parser optimizations |
@@ -70,7 +64,7 @@ These warts highlight code quality issues but **only produce warnings**:
 
 #### Why Warnings?
 
-- **OptionPartial**: Test code commonly uses `.get` for clearer assertions
+- **IterableOps/OptionPartial**: Test code commonly uses `.head`/`.get` for clearer assertions
 - **Var/While/Return**: Performance-critical code (macros, parsers) intentionally uses imperative patterns
 - **AsInstanceOf**: Opaque types require internal casts for zero-cost abstractions
 - **IsInstanceOf**: Runtime type inspection needed in certain scenarios (e.g., codec dispatch)
@@ -190,9 +184,9 @@ If a wart causes excessive false positives:
 WartRemover is configured in `build.mill`:
 
 ```scala
-trait XLModule extends ScalaModule {
+trait XLModuleBase extends ScalaModule with ScalafmtModule {
   def scalacPluginMvnDeps = Seq(
-    mvn"org.wartremover:::wartremover:3.4.1"
+    mvn"org.wartremover:::wartremover:3.5.6"
   )
 
   override def scalacOptions = Seq(
@@ -200,11 +194,11 @@ trait XLModule extends ScalaModule {
 
     // Tier 1 warts (errors)
     "-P:wartremover:traverser:org.wartremover.warts.Null",
-    // ... 8 more ...
+    // ... 6 more ...
 
     // Tier 2 warts (warnings)
-    "-P:wartremover:only-warn-traverser:org.wartremover.warts.OptionPartial",
-    // ... 5 more ...
+    "-P:wartremover:only-warn-traverser:org.wartremover.warts.IterableOps",
+    // ... 6 more ...
   )
 }
 ```
@@ -259,8 +253,10 @@ Violations will fail CI builds for Tier 1 warts.
 
 ## Version History
 
+- **2026-06-09** (0.10.0): WartRemover 3.4.1 → 3.5.6 (required for the Scala 3.8.3 compiler plugin)
+  - 3.5.6 newly caught `Option2Iterable` violations (`.toSeq` on `Option` replaced with `.toList`)
 - **2025-11-14**: Initial WartRemover integration (v3.4.1)
-  - 8 Tier 1 warts (errors)
-  - 6 Tier 2 warts (warnings)
+  - 7 Tier 1 warts (errors)
+  - 7 Tier 2 warts (warnings)
   - Mill 1.0.6 + Scala 3.7.3
   - All 467 tests passing

--- a/docs/plan/roadmap.md
+++ b/docs/plan/roadmap.md
@@ -2,15 +2,15 @@
 
 > **Track Progress**: [GitHub Issues](https://github.com/TJC-LP/xl/issues)
 
-**Last Updated**: 2026-06-07
+**Last Updated**: 2026-06-10
 
-> **Live trackers**: [v0.10.0-execution.md](v0.10.0-execution.md) (release tracker) and [v0.10.0-triage.md](v0.10.0-triage.md) (rationale + per-issue verdicts).
+> **Completed release records**: [archive/plan/v0.10.0-execution.md](../archive/plan/v0.10.0-execution.md) (0.10.0 tracker) and [archive/plan/v0.10.0-triage.md](../archive/plan/v0.10.0-triage.md) (rationale + per-issue verdicts).
 
 ---
 
 ## TL;DR
 
-**Current Status**: Production-ready with **104 formula functions** (incl. dynamic arrays SEQUENCE/SORT/UNIQUE/FILTER and OFFSET), **structural editing** (insert/delete rows & columns with formula rewriting), named-range & hyperlink authoring, SAX streaming (36% faster than POI), Excel tables, and full OOXML round-trip. 1100+ tests passing. **0.10.0 "Trust & Author"** is the active release — see [v0.10.0-execution.md](v0.10.0-execution.md).
+**Current Status**: Production-ready with **104 formula functions** (incl. dynamic arrays SEQUENCE/SORT/UNIQUE/FILTER and OFFSET), **structural editing** (insert/delete rows & columns with formula rewriting), the **scripting prelude** (`com.tjclp.xl.scripting`), whole-workbook `recalculate`, named-range & hyperlink authoring, SAX streaming (36% faster than POI), Excel tables, and full OOXML round-trip. 3005+ tests passing.
 
 **Current Version**: **0.11.0 "Scripting"** (released 2026-06-10)
 
@@ -18,7 +18,22 @@
 
 ## Release Roadmap
 
-### v0.11.0 "Scripting" (Current)
+### v0.12.0 candidates (not yet scheduled)
+
+This roadmap is the single source of truth for scheduling; entries below are **candidates, not commitments** — nothing is started until it is pulled into a release plan.
+
+| Candidate | Notes |
+|-----------|-------|
+| **"Visual" theme**: Chart model ([#222](https://github.com/TJC-LP/xl/issues/222)) on a DrawingML/image layer ([#221](https://github.com/TJC-LP/xl/issues/221)) | Deferred from 0.10.0/0.11.0; charts structurally depend on the drawing layer |
+| 0.11.x follow-up: leading `=+` unary plus rejected by parser ([#271](https://github.com/TJC-LP/xl/issues/271)) | Banker idiom (`=+A1`); flagged as the top 0.11.1 candidate |
+| 0.11.x follow-up: trailing empty format sections ([#262](https://github.com/TJC-LP/xl/issues/262)) | Number-format section selection edge case |
+| 0.11.x follow-up: quoting for cell-ref-shaped sheet names ([#263](https://github.com/TJC-LP/xl/issues/263)) | e.g. a sheet literally named `A1` |
+| 0.11.x follow-up: streaming StylePatcher indent + border-merge unification ([#264](https://github.com/TJC-LP/xl/issues/264)) | Parity between streaming and in-memory style edits |
+| 0.11.x follow-up: SaxStax DirectSaxEmitter metadata gaps ([#265](https://github.com/TJC-LP/xl/issues/265)) | Streaming writer metadata parity |
+| 0.11.x follow-up: even/first-page headers + `fitToPage` flag ([#266](https://github.com/TJC-LP/xl/issues/266)) | Completes the 0.11.0 `PageSetup` print extensions |
+| Display strategy: `excel""` interpolator re-evaluates formulas sheet-locally instead of using the `recalculate` cache | Cross-sheet formulas can display stale/erroring values in scripts; unify display on the recalc cache |
+
+### v0.11.0 "Scripting" (Released 2026-06-10)
 
 Make library scripting (scala-cli + `com.tjclp.xl.scripting` prelude) the turbo-charged agent path — goal: the best functional Excel scripting DSL. Tracked in [#252](https://github.com/TJC-LP/xl/issues/252).
 

--- a/docs/reference/ai-contracts-guide.md
+++ b/docs/reference/ai-contracts-guide.md
@@ -1,5 +1,7 @@
 # AI Contracts Guide
 
+> **Adoption status (2026-06-10)**: the contract format below is in active use, primarily in `xl-ooxml` (parsers/serializers: `SharedStrings`, `XlsxReader`, `StyleSerializer`, ...) and `xl-cats-effect` (`StreamingXmlWriter`) — about 20 functions today. Treat "always use for public APIs" as the aspiration, not the current state. Note that Scalafmt re-flows Scaladoc, so section keywords may not start a line in the source (e.g. `DETERMINISTIC: Yes (...) ERROR CASES: None` on one line); the keywords, not the line breaks, are the format.
+
 ## Purpose
 
 AI contracts are structured Scaladoc comments that make code behavior explicit and machine-readable. They help:

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -18,15 +18,17 @@ cd xl
 make install
 ```
 
-This builds a fat JAR and installs `xl` to `~/.local/bin/`. Ensure it's in your PATH:
+This builds a native binary (no JDK required, instant startup) and installs `xl` to `~/.local/bin/`. Ensure it's in your PATH:
 
 ```bash
 export PATH="$HOME/.local/bin:$PATH"
 ```
 
+**JAR install** (requires JDK 17+): `make install-jar`
+
 **Uninstall**: `make uninstall`
 
-**Update**: After `git pull`, run `make build` — the wrapper auto-picks up the new JAR.
+**Update**: After `git pull`, run `make install` (or `make install-jar`) again.
 
 ---
 
@@ -34,24 +36,36 @@ export PATH="$HOME/.local/bin:$PATH"
 
 ```bash
 # Global flags (used with all commands)
--f, --file <path>     # Input file (required)
--s, --sheet <name>    # Sheet to operate on (optional, defaults to first)
--o, --output <path>   # Output file for mutations (required for put/putf)
+-f, --file <path>     # Input file (required for most commands)
+-s, --sheet <name>    # Sheet to operate on (required for unqualified ranges)
+-o, --output <path>   # Output file for mutations
+-i, --in-place        # Edit file in place (same as -o matching -f)
+--stream              # O(1) memory streaming for large files (search/stats/bounds/view + writes)
+--max-size <MB>       # Max uncompressed size for in-memory load (default 100, 0 = unlimited)
+--backend <name>      # XML backend: scalaxml (default) or saxstax (faster)
 
 # Read-only operations
 xl -f model.xlsx sheets                    # List all sheets
-xl -f model.xlsx bounds                    # Show used range
+xl -f model.xlsx names                     # List defined names (named ranges)
+xl -f model.xlsx -s "P&L" bounds           # Show used range
 xl -f model.xlsx -s "P&L" view A1:D20      # View range as markdown
-xl -f model.xlsx cell B5                   # Get single cell details
-xl -f model.xlsx search "Revenue"          # Find cells by content
-xl -f model.xlsx eval "=SUM(B1:B10)"       # Evaluate formula (what-if)
+xl -f model.xlsx cell B5                   # Get single cell details (sheet auto-detected if unambiguous)
+xl -f model.xlsx search "Revenue"          # Find cells by content (all sheets)
+xl -f model.xlsx -s "P&L" stats B1:B100    # Numeric statistics for a range
+xl -f model.xlsx -s "P&L" eval "=SUM(B1:B10)"   # Evaluate formula (what-if)
+xl -f model.xlsx -s "P&L" evala "=TRANSPOSE(A1:C2)"  # Evaluate array formula (spill grid)
 
-# Mutations (require -o)
-xl -f model.xlsx -o output.xlsx put B5 1000000       # Write value
-xl -f model.xlsx -o output.xlsx putf C5 "=B5*1.1"    # Write formula
+# Mutations (require -o or -i)
+xl -f model.xlsx -s S1 -o output.xlsx put B5 1000000       # Write value
+xl -f model.xlsx -s S1 -o output.xlsx putf C5 "=B5*1.1"    # Write formula
 
 # What-if analysis with overrides
-xl -f model.xlsx eval "=B1*1.1" --with "B1=100"      # Evaluate with temporary values
+xl -f model.xlsx -s S1 eval "=B1*1.1" --with "B1=100"      # Evaluate with temporary values
+
+# No file needed
+xl new report.xlsx --sheet Data --sheet Summary   # Create a blank workbook
+xl functions                                       # List all 104 supported functions
+xl rasterizers                                     # List available PNG/PDF backends
 ```
 
 ---
@@ -62,39 +76,75 @@ xl -f model.xlsx eval "=B1*1.1" --with "B1=100"      # Evaluate with temporary v
 
 | Category | Commands | Purpose |
 |----------|----------|---------|
-| **Navigate** | `sheets`, `bounds` | Find your way around |
-| **Explore** | `view`, `cell`, `search` | Read data incrementally |
-| **Analyze** | `eval` | What-if formula evaluation |
-| **Mutate** | `put`, `putf`, `style`, `row`, `col`, `fill`, `clear` | Make changes (requires `-o`) |
+| **Info** (no `-f`) | `functions`, `rasterizers`, `new` | Capability listing, blank workbook |
+| **Navigate** | `sheets`, `bounds`, `names` | Find your way around |
+| **Explore** | `view`, `cell`, `search`, `stats` | Read data incrementally |
+| **Analyze** | `eval`, `evala` | What-if formula evaluation (scalar + array) |
+| **Mutate cells** | `put`, `putf`, `style`, `fill`, `clear`, `copy`, `sort`, `merge`, `unmerge`, `comment`, `remove-comment`, `batch`, `import` | Make changes (require `-o` or `-i`) |
+| **Rows/columns** | `row`, `col`, `autofit`, `insert-rows`, `delete-rows`, `insert-cols`, `delete-cols` | Sizing, visibility, structural editing |
+| **Sheets & view** | `add-sheet`, `remove-sheet`, `rename-sheet`, `move-sheet`, `copy-sheet`, `sheets hide/show`, `freeze`, `unfreeze`, `name` | Workbook structure |
 
 ### Command Summary
 
 | Command | Arguments | Description |
 |---------|-----------|-------------|
-| `sheets` | | List all sheets with stats |
-| `bounds` | | Show used range of current sheet |
-| `view` | `<range>` | Render range as markdown |
-| `cell` | `<ref>` | Get single cell details |
-| `search` | `<pattern>` | Find cells matching pattern |
+| `functions` | | List all 104 supported Excel functions (no `-f` needed) |
+| `rasterizers` | | List available SVG-to-raster backends (no `-f` needed) |
+| `new` | `<output> [--sheet <name>]...` | Create a blank xlsx file (no `-f` needed) |
+| `sheets` | `[list\|hide <name> [--very]\|show <name>]` | List sheets (default) or hide/show one |
+| `names` | | List defined names (named ranges) |
+| `name` | `add <name> <refers-to>` \| `rm <name>` | Manage named ranges (requires `-o`) |
+| `bounds` | `[--scan]` | Show used range of current sheet |
+| `view` | `<range> [flags]` | Render range (markdown/json/csv/html/svg/png/jpeg/webp/pdf) |
+| `cell` | `<ref> [--no-style]` | Get single cell details |
+| `search` | `<pattern> [--limit n] [--sheets a,b]` | Find cells matching pattern (regex, all sheets by default) |
+| `stats` | `<range>` | Statistics for numeric values in range |
 | `eval` | `<formula> [--with overrides]` | Evaluate formula without modifying |
-| `put` | `<ref> <value>` | Write value to cell (requires `-o`) |
-| `putf` | `<ref> <formula>` | Write formula to cell (requires `-o`) |
+| `evala` | `<formula> [--at <ref>] [--with overrides]` | Evaluate array formula; display or spill result grid |
+| `put` | `<ref\|range> <value...> [--csv]` | Write value(s) to cell or range (requires `-o`) |
+| `putf` | `<ref\|range> <formula...>` | Write formula(s); single formula + range drags with `$` anchors (requires `-o`) |
 | `style` | `<range> [options]` | Apply styling (requires `-o`) |
-| `row` | `<n> [options]` | Set row height, hide/show (requires `-o`) |
-| `col` | `<letter> [options]` | Set column width, hide/show, auto-fit (requires `-o`) |
+| `row` | `<n> [--height pt] [--hide\|--show]` | Set row properties (requires `-o`) |
+| `col` | `<letter\|A:F> [--width n] [--auto-fit] [--hide\|--show]` | Set column properties (requires `-o`) |
+| `autofit` | `[--columns A:F]` | Auto-fit column widths from content (requires `-o`) |
 | `fill` | `<source> <target> [--right]` | Fill cells with source value/formula (requires `-o`) |
 | `clear` | `<range> [--all\|--styles\|--comments]` | Clear cell contents/styles/comments (requires `-o`) |
-| `batch` | `<file\|->` | Apply multiple operations from JSON (requires `-o`) |
+| `copy` | `<source> <target> [--values-only]` | Copy range with formula adjustment (requires `-o`) |
+| `sort` | `<range> --by <col> [options]` | Sort rows by one or more columns (requires `-o`) |
+| `merge` | `<range>` | Merge cells (requires `-o`) |
+| `unmerge` | `<range>` | Unmerge cells (requires `-o`) |
+| `comment` | `<ref> <text> [--author name]` | Add cell comment (requires `-o`) |
+| `remove-comment` | `<ref>` | Remove cell comment (requires `-o`) |
+| `freeze` | `<ref>` | Freeze panes at cell (requires `-o`) |
+| `unfreeze` | | Remove freeze panes (requires `-o`) |
+| `import` | `<csv-file> [start-ref] [options]` | Import CSV with type detection (requires `-o`) |
+| `add-sheet` | `<name> [--after s] [--before s]` | Add new empty sheet (requires `-o`) |
+| `remove-sheet` | `<name>` | Remove sheet (requires `-o`) |
+| `rename-sheet` | `<name> <new-name>` | Rename sheet (requires `-o`) |
+| `move-sheet` | `<name> [--to idx] [--after s] [--before s]` | Move sheet to new position (requires `-o`) |
+| `copy-sheet` | `<name> <new-name>` | Copy sheet to new name (requires `-o`) |
+| `insert-rows` | `<at-row> [count]` | Insert rows; shifts cells, rewrites formulas (requires `-o`) |
+| `delete-rows` | `<at-row> [count]` | Delete rows; `#REF!` on lost references (requires `-o`) |
+| `insert-cols` | `<at-col> [count]` | Insert columns; shifts cells, rewrites formulas (requires `-o`) |
+| `delete-cols` | `<at-col> [count]` | Delete columns; `#REF!` on lost references (requires `-o`) |
+| `batch` | `<file\|-> [--dry-run]` | Apply multiple operations from JSON (requires `-o`; `--dry-run` validates without a file) |
 
 ---
 
 ## Command Details
 
-### `xl sheets`
+### `xl sheets [list|hide|show]`
 
-List all sheets as a markdown table.
+Sheet operations. With no subcommand, defaults to `list`.
 
-**Output**:
+**Subcommands**:
+| Subcommand | Arguments | Description |
+|------------|-----------|-------------|
+| `list` | `[--stats]` | List all sheets (`--stats` adds cell/formula counts; slower) |
+| `hide` | `<sheet-name> [--very]` | Hide a sheet (`--very` = very hidden, VBA-only; requires `-o`) |
+| `show` | `<sheet-name>` | Show a hidden sheet (requires `-o`) |
+
+**Output** (`list --stats`):
 ```markdown
 | # | Name        | Range    | Cells | Formulas |
 |---|-------------|----------|-------|----------|
@@ -105,14 +155,21 @@ List all sheets as a markdown table.
 
 ---
 
-### `xl bounds [sheet]`
+### `xl names` / `xl name add|rm`
 
-Show the used range (bounding box of non-empty cells).
+List and manage defined names (named ranges).
 
-**Arguments**:
-| Arg | Type | Required | Default | Description |
-|-----|------|----------|---------|-------------|
-| `sheet` | string | No | active | Sheet name |
+```bash
+xl -f model.xlsx names                                       # List all defined names
+xl -f model.xlsx -o out.xlsx name add Tax 'Sheet1!$A$1'      # Add or replace
+xl -f model.xlsx -o out.xlsx name rm Tax                     # Remove
+```
+
+---
+
+### `xl bounds [--scan]`
+
+Show the used range (bounding box of non-empty cells) for the sheet selected with `-s`. Instant by default (reads the worksheet's dimension element); `--scan` forces a full streaming scan for accurate bounds.
 
 **Output**:
 ```
@@ -127,15 +184,26 @@ Non-empty: 892 cells
 
 ### `xl view <range>`
 
-View a rectangular range as a markdown table with row/column headers.
+View a rectangular range — markdown table by default, or JSON/CSV/HTML/SVG/PNG/JPEG/WebP/PDF.
 
 **Arguments**:
 | Arg | Type | Required | Default | Description |
 |-----|------|----------|---------|-------------|
 | `range` | string | Yes | — | Cell range (e.g., "A1:D20") |
+| `--format` | string | No | markdown | Output format: markdown, json, csv, html, svg, png, jpeg, webp, pdf |
 | `--formulas` | flag | No | false | Show formulas instead of values |
 | `--eval` | flag | No | false | Evaluate formulas (compute live values) |
+| `--strict` | flag | No | false | Fail on formula evaluation errors (with `--eval`) |
 | `--limit` | int | No | 50 | Max rows to display |
+| `--skip-empty` | flag | No | false | Skip empty cells (JSON) or empty rows/columns (tabular) |
+| `--show-labels` | flag | No | false | Include column letters and row numbers |
+| `--header-row` | int | No | — | Use values from this row as keys in JSON output (1-based) |
+| `--raster-output` | path | For raster | — | Output file (required for png/jpeg/webp/pdf) |
+| `--dpi` | int | No | 144 | Resolution for raster output |
+| `--quality` | int | No | 90 | JPEG quality 1-100 |
+| `--rasterizer` | string | No | auto | Force backend: batik, cairosvg, rsvg-convert, resvg, imagemagick |
+| `--gridlines` | flag | No | false | Show cell gridlines in SVG output |
+| `--print-scale` | flag | No | false | Apply print scaling (for PDF-like output) |
 
 **Output**:
 ```markdown
@@ -177,14 +245,14 @@ Value: Revenue
 
 ### `xl search <pattern>`
 
-Find cells containing text matching pattern.
+Find cells containing text matching pattern. Searches all sheets by default (no `-s` needed).
 
 **Arguments**:
 | Arg | Type | Required | Default | Description |
 |-----|------|----------|---------|-------------|
 | `pattern` | string | Yes | — | Search pattern (supports regex) |
-| `--in` | string | No | entire sheet | Limit search to range |
-| `--limit` | int | No | 20 | Max results |
+| `--sheets` | string | No | all | Comma-separated list of sheets to search |
+| `--limit` | int | No | 50 | Max results |
 
 **Output**:
 ```markdown
@@ -200,31 +268,64 @@ Found 5 matches for "Revenue":
 
 ### `xl eval <formula> [--with overrides]`
 
-Evaluate a formula without modifying the file (what-if analysis).
+Evaluate a formula without modifying the file (what-if analysis). `-f` is optional for constant formulas (`xl eval "=PI()*2"`).
 
 **Arguments**:
 | Arg | Type | Required | Description |
 |-----|------|----------|-------------|
 | `formula` | string | Yes | Formula to evaluate |
-| `--with` | string | No | Temporary cell overrides (e.g., "B1=100") |
+| `--with`, `-w` | string | No | Temporary cell overrides (e.g., "B1=100,B2=200"; repeatable) |
 
 **Examples**:
 ```bash
-xl -f model.xlsx eval "=SUM(B1:B10)"
-xl -f model.xlsx eval "=B1*1.1" --with "B1=100"
+xl -f model.xlsx -s Sheet1 eval "=SUM(B1:B10)"
+xl -f model.xlsx -s Sheet1 eval "=B1*1.1" --with "B1=100"
 ```
 
 ---
 
-### `xl put <ref> <value>`
+### `xl evala <formula> [--at <ref>]`
 
-Write a value to a cell.
+Evaluate an **array formula** and display the result grid, or spill it into the sheet. Requires `-f` (array formulas need sheet context).
 
 **Arguments**:
 | Arg | Type | Required | Description |
 |-----|------|----------|-------------|
-| `ref` | string | Yes | Cell reference |
-| `value` | string | Yes | Value to write |
+| `formula` | string | Yes | Array formula to evaluate |
+| `--at` | string | No | Target cell for array spill (default: display only) |
+| `--with`, `-w` | string | No | Temporary cell overrides (repeatable) |
+
+**Examples**:
+```bash
+xl -f data.xlsx -s Sheet1 evala "=TRANSPOSE(A1:C2)"          # Display result grid
+xl -f data.xlsx -s Sheet1 evala "=SEQUENCE(5)" --at E1       # Spill starting at E1
+xl -f data.xlsx -s Sheet1 evala "=A1:B2*10"                  # Array arithmetic with broadcasting
+```
+
+---
+
+### `xl stats <range>`
+
+Calculate statistics (count, sum, min, max, average, ...) for numeric values in a range. Supports `--stream` for large files.
+
+```bash
+xl -f data.xlsx -s Sheet1 stats B2:B10000
+xl -f huge.xlsx --stream stats A1:E100000
+```
+
+---
+
+### `xl put <ref|range> <value...>`
+
+Write value(s) to a cell or range.
+
+**Modes**:
+| Mode | Example | Behavior |
+|------|---------|----------|
+| Single | `put A1 100` | Write 100 to A1 |
+| Fill | `put A1:A10 "TBD"` | Fill range with the same value |
+| Batch | `put A1:C1 "X" "Y" "Z"` | One value per cell (row-major) |
+| CSV split | `put A1:C1 "X,Y,Z" --csv` | Split one comma-separated value across the range |
 
 **Type Inference**:
 - Numbers: `1000`, `1,234.56`, `$100`, `50%`
@@ -232,29 +333,38 @@ Write a value to a cell.
 - Booleans: `true`, `false`
 - Text: Everything else
 
+**Negative numbers**: use the `--value` flag (a leading `-` is parsed as a flag):
+```bash
+xl -f input.xlsx -s S1 -o output.xlsx put A1 --value "-500"
+```
+
 **Example**:
 ```bash
-xl -f input.xlsx -o output.xlsx put B5 1000000
+xl -f input.xlsx -s S1 -o output.xlsx put B5 1000000
 ```
 
 ---
 
-### `xl putf <ref> <formula>`
+### `xl putf <ref|range> <formula...>`
 
-Write a formula to a cell.
+Write formula(s) to a cell or range with Excel-style dragging.
 
-**Arguments**:
-| Arg | Type | Required | Description |
-|-----|------|----------|-------------|
-| `ref` | string | Yes | Cell reference or range |
-| `formula` | string | Yes | Formula (with or without `=`) |
-| `--from` | string | No | Source cell for relative reference adjustment |
+**Modes**:
+| Mode | Example | Behavior |
+|------|---------|----------|
+| Single | `putf C1 "=A1+B1"` | One formula, one cell |
+| Drag | `putf B2:B10 "=A2*1.1"` | Single formula + range: references shift per cell (`$` anchors pin) |
+| Batch | `putf D1:D3 "=A1+B1" "=A2*B2" "=A3-B3"` | One formula per cell, applied as-is (no dragging) |
+
+**Anchor modes** (`$` controls shifting when dragging): `$A$1` absolute, `$A1` column-absolute, `A$1` row-absolute, `A1` fully relative.
 
 **Examples**:
 ```bash
-xl -f input.xlsx -o output.xlsx putf C5 "=B5*1.1"
-xl -f input.xlsx -o output.xlsx putf B2:B10 "=SUM(\$A\$1:A2)" --from B2
+xl -f input.xlsx -s S1 -o output.xlsx putf C5 "=B5*1.1"
+xl -f input.xlsx -s S1 -o output.xlsx putf C2:C10 "=SUM(\$B\$2:B2)"   # Running total
 ```
+
+(The batch JSON `putf` op additionally accepts a `"from"` field to drag from an explicit source cell.)
 
 ---
 
@@ -262,22 +372,31 @@ xl -f input.xlsx -o output.xlsx putf B2:B10 "=SUM(\$A\$1:A2)" --from B2
 
 Apply styling to cells.
 
+Styles **merge** with existing formatting by default; `--replace` overwrites.
+
 **Arguments**:
 | Arg | Type | Description |
 |-----|------|-------------|
 | `range` | string | Cell/range reference |
 | `--bold` | flag | Bold text |
 | `--italic` | flag | Italic text |
-| `--bg` | string | Background color (name or hex) |
+| `--underline` | flag | Underlined text |
+| `--font-size` | double | Font size in points |
+| `--font-name` | string | Font family (e.g., "Arial") |
+| `--bg` | string | Background color (name, #hex, or rgb(r,g,b)) |
 | `--fg` | string | Text color |
-| `--align` | string | Alignment: left, center, right |
-| `--format` | string | Number format: currency, percent, date |
-| `--border` | string | Border style: none, thin, medium, thick |
+| `--align` | string | Horizontal alignment: left, center, right |
+| `--valign` | string | Vertical alignment: top, middle, bottom |
+| `--wrap` | flag | Enable text wrapping |
+| `--format` | string | Number format: general, number, currency, percent, date, text |
+| `--border` | string | Border style for all sides: none, thin, medium, thick |
+| `--border-top` / `--border-right` / `--border-bottom` / `--border-left` | string | Per-side border style |
+| `--border-color` | string | Border color (applies to all specified borders) |
 | `--replace` | flag | Replace entire style instead of merging |
 
 **Example**:
 ```bash
-xl -f input.xlsx -o output.xlsx style A1:D1 --bold --bg yellow --align center
+xl -f input.xlsx -s S1 -o output.xlsx style A1:D1 --bold --bg yellow --align center
 ```
 
 ---
@@ -310,7 +429,7 @@ Set column properties (width, hide/show, auto-fit).
 **Arguments**:
 | Arg | Type | Required | Default | Description |
 |-----|------|----------|---------|-------------|
-| `letter` | string | Yes | — | Column letter (e.g., "A", "B", "AA") |
+| `letter` | string | Yes | — | Column letter or range (e.g., "A", "AA", "A:F") |
 | `--width` | double | No | — | Column width in character units (~8.43 default) |
 | `--auto-fit` | flag | No | false | Auto-fit width based on cell content |
 | `--hide` | flag | No | false | Hide the column |
@@ -419,6 +538,137 @@ xl -f input.xlsx -o output.xlsx fill B1 B1:B10
 
 ---
 
+### `xl autofit [--columns A:F]`
+
+Auto-fit column widths based on content (defaults to all used columns).
+
+```bash
+xl -f input.xlsx -s S1 -o output.xlsx autofit
+xl -f input.xlsx -s S1 -o output.xlsx autofit --columns A:F
+```
+
+---
+
+### `xl copy <source> <target> [--values-only]`
+
+Copy a range to another location with Excel-style formula adjustment (`$` anchors preserved). `--values-only` copies values without adjusting formulas.
+
+```bash
+xl -f input.xlsx -s S1 -o output.xlsx copy A1:C10 E1
+xl -f input.xlsx -s S1 -o output.xlsx copy A1:C10 E1 --values-only
+```
+
+---
+
+### `xl sort <range> --by <col> [options]`
+
+Sort rows in a range by one or more columns.
+
+**Arguments**:
+| Arg | Type | Required | Description |
+|-----|------|----------|-------------|
+| `range` | string | Yes | Range to sort |
+| `--by`, `-b` | string | Yes | Primary sort column |
+| `--then-by` | string | No | Secondary sort column(s) (repeatable) |
+| `--desc` | flag | No | Sort descending (default: ascending) |
+| `--numeric` | flag | No | Force numeric comparison ("10" > "9") |
+| `--header` | flag | No | First row is header (exclude from sort) |
+
+**Behavior**: empty cells sort last; formulas sort by cached value; rows move together.
+
+```bash
+xl -f f.xlsx -s S1 -o o.xlsx sort A1:D100 --by B --desc --numeric
+xl -f f.xlsx -s S1 -o o.xlsx sort A1:D100 --by B --then-by C --header
+```
+
+---
+
+### `xl merge <range>` / `xl unmerge <range>`
+
+Merge or unmerge cells in a range.
+
+```bash
+xl -f input.xlsx -s S1 -o output.xlsx merge A1:D1
+xl -f input.xlsx -s S1 -o output.xlsx unmerge A1:D1
+```
+
+---
+
+### `xl comment <ref> <text> [--author name]` / `xl remove-comment <ref>`
+
+Add or remove a cell comment.
+
+```bash
+xl -f input.xlsx -s S1 -o output.xlsx comment A1 "Verify this figure" --author "Analyst"
+xl -f input.xlsx -s S1 -o output.xlsx remove-comment A1
+```
+
+---
+
+### `xl freeze <ref>` / `xl unfreeze`
+
+Freeze panes at a cell reference (rows above and columns to the left are locked), or remove them.
+
+```bash
+xl -f input.xlsx -s S1 -o output.xlsx freeze B2    # Freeze row 1 + column A
+xl -f input.xlsx -s S1 -o output.xlsx unfreeze
+```
+
+---
+
+### `xl import <csv-file> [start-ref] [options]`
+
+Import CSV data with automatic type detection (numbers, booleans, ISO dates).
+
+**Arguments**:
+| Arg | Type | Required | Default | Description |
+|-----|------|----------|---------|-------------|
+| `csv-file` | string | Yes | — | CSV file path |
+| `start-ref` | string | No | A1 | Cell where import starts |
+| `--delimiter` | char | No | `,` | Field separator |
+| `--encoding` | string | No | UTF-8 | Input encoding |
+| `--skip-header` | flag | No | false | Skip first row (do not import) |
+| `--new-sheet` | string | No | — | Create new sheet for imported data |
+| `--no-type-inference` | flag | No | false | Treat all values as text |
+
+```bash
+xl -f f.xlsx -s S1 -o o.xlsx import data.csv A1 --delimiter ";" --skip-header
+xl -f f.xlsx -o o.xlsx import data.csv --new-sheet "Imported"
+```
+
+**Limitations**: entire CSV is loaded into memory (recommended <50k rows); dates must be ISO 8601 (`YYYY-MM-DD`).
+
+---
+
+### Sheet management: `add-sheet`, `remove-sheet`, `rename-sheet`, `move-sheet`, `copy-sheet`
+
+```bash
+xl -f f.xlsx -o o.xlsx add-sheet Summary --after Sheet1      # or --before <name>
+xl -f f.xlsx -o o.xlsx remove-sheet Scratch
+xl -f f.xlsx -o o.xlsx rename-sheet "Old Name" "New Name"
+xl -f f.xlsx -o o.xlsx move-sheet Summary --to 0             # or --after/--before <name>
+xl -f f.xlsx -o o.xlsx copy-sheet Template "Q2 Report"
+```
+
+---
+
+### Structural editing: `insert-rows`, `delete-rows`, `insert-cols`, `delete-cols`
+
+Insert or delete rows/columns with full formula-reference rewriting: references at or past the cut shift, straddling ranges shrink, and references to deleted cells become `#REF!`. Cross-sheet references to the edited sheet are rewritten too.
+
+**Arguments**: position (`<at-row>` 1-based, or `<at-col>` letter) and optional `<count>` (default 1). Column commands also accept an inclusive range (`C:E`), which overrides the count.
+
+```bash
+xl -f f.xlsx -s S1 -o o.xlsx insert-rows 5 2     # Insert 2 rows at row 5
+xl -f f.xlsx -s S1 -o o.xlsx delete-rows 5       # Delete row 5
+xl -f f.xlsx -s S1 -o o.xlsx insert-cols B 3     # Insert 3 columns at B
+xl -f f.xlsx -s S1 -o o.xlsx delete-cols C:E     # Delete columns C through E
+```
+
+Example formula rewriting: deleting row 2 turns `=A1+A3` into `=A1+A2`; `=SUM(A1:A4)` shrinks to `=SUM(A1:A3)`; a direct reference to a deleted cell becomes `#REF!`.
+
+---
+
 ### `xl batch <file|->`
 
 Apply multiple operations atomically from JSON input.
@@ -426,7 +676,8 @@ Apply multiple operations atomically from JSON input.
 **Arguments**:
 | Arg | Type | Required | Description |
 |-----|------|----------|-------------|
-| `file` | string | Yes | JSON file path or `-` for stdin |
+| `file` | string | No (default `-`) | JSON file path or `-` for stdin |
+| `--dry-run` | flag | No | Validate JSON and show a summary without writing (works without `-f`/`-o`) |
 
 **JSON Schema**:
 
@@ -457,6 +708,7 @@ Apply multiple operations atomically from JSON input.
 | `rowheight` | `row`, `height` | | Set row height |
 | `comment` | `ref`, `text` | `author` | Add cell comment |
 | `remove-comment` | `ref` | | Remove cell comment |
+| `hyperlink` | `ref` | `target` | Set cell hyperlink (omit `target` to clear) |
 | `clear` | `range` | `all`, `styles`, `comments` | Clear cell contents/styles/comments |
 | `col-hide` | `col` | | Hide column |
 | `col-show` | `col` | | Show column |
@@ -465,6 +717,9 @@ Apply multiple operations atomically from JSON input.
 | `autofit` | | `columns` | Auto-fit column widths |
 | `add-sheet` | `name` | `after` | Add new sheet |
 | `rename-sheet` | `from`, `to` | | Rename sheet |
+| `freeze` | `ref` | | Freeze panes at cell |
+| `unfreeze` | | | Remove freeze panes |
+| `copy` | `source`, `target` | `valuesOnly` | Copy range with formula adjustment |
 
 **Native JSON Types** (recommended):
 
@@ -643,5 +898,6 @@ Suggestion: Use a different cell reference to break the cycle
 ## See Also
 
 - [Quick Start Guide](../QUICK-START.md) — Library usage
+- [Scripting Guide](scripting.md) — When a task outgrows the CLI (loops, typed extraction, multi-file pipelines)
 - [Performance Guide](performance-guide.md) — Streaming for large files
 - [GitHub Issues](https://github.com/TJC-LP/xl/issues) — Feature requests and bug reports

--- a/docs/reference/examples.md
+++ b/docs/reference/examples.md
@@ -1,45 +1,48 @@
 
 # Examples — End‑to‑End Snippets
 
+> **Start here**: [`examples/scripting_tour.sc`](../../examples/scripting_tour.sc) is the canonical, runnable tour of the scripting prelude — one import, compile-time refs, patch folds, recalculation, typed reads, and the `.unsafe` boundary in ~80 lines. The full catalog of runnable scripts lives in [`examples/README.md`](../../examples/README.md), and the prose companion is the [Scripting Guide](scripting.md).
+
+Most snippets below use the **scripting prelude** (`import com.tjclp.xl.scripting.{*, given}`), the one-import path for scripts. Where an example deliberately demonstrates the **pure library import** (`com.tjclp.xl.{*, given}` — no `.unsafe`, no sync IO), it is labeled as such. Never combine the two imports in one file.
+
 ## 1) Export a simple table
+
 ```scala
-import com.tjclp.xl.{*, given}
-import com.tjclp.xl.unsafe.*
-import com.tjclp.xl.io.ExcelIO
-import cats.effect.IO
-import cats.effect.unsafe.implicits.global
-import java.nio.file.Path
+import com.tjclp.xl.scripting.{*, given}
 
 final case class Person(name: String, age: Int, email: String) derives CanEqual
 val people = Vector(Person("Ada", 34, "ada@ex.com"), Person("Linus", 55, "linus@ex.com"))
 
-// Build sheet with headers
-val sheet = Sheet("People").unsafe
-  .put(
-    ref"A1" -> "Name",
-    ref"B1" -> "Age",
-    ref"C1" -> "Email"
-  )
-  .unsafe
-
-// Add data rows
-val sheetWithData = people.zipWithIndex.foldLeft(sheet) { case (sh, (p, i)) =>
-  val row = i + 2  // Row 2, 3, ...
-  sh.put(
-    ref"A$row" -> p.name,
-    ref"B$row" -> p.age,
-    ref"C$row" -> p.email
-  ).unsafe
+// Headers + data rows: fold everything into one Patch, apply once
+val header = (ref"A1" := "Name") ++ (ref"B1" := "Age") ++ (ref"C1" := "Email")
+val rows = people.zipWithIndex.foldLeft(Patch.empty) { case (acc, (p, i)) =>
+  val r = ref"A2".down(i) // total navigation — no Either in the loop
+  acc ++ (r := p.name) ++ (r.right(1) := p.age) ++ (r.right(2) := p.email)
 }
 
-val workbook = Workbook(Vector(sheetWithData))
-ExcelIO.instance[IO].write(workbook, Path.of("people.xlsx")).unsafeRunSync()
+val sheet = Sheet("People").put(header ++ rows)
+Excel.write(Workbook(sheet), "people.xlsx")
+```
+
+For production code with Cats Effect (no sync facade), use the pure import + `ExcelIO`:
+
+```scala
+// Pure library import (deliberately NOT the scripting prelude)
+import com.tjclp.xl.{*, given}
+import com.tjclp.xl.io.ExcelIO
+import cats.effect.IO
+import java.nio.file.Path
+
+def write(wb: Workbook, path: Path): IO[Unit] =
+  ExcelIO.instance[IO].write(wb, path)
 ```
 
 ## 2) Formula Parsing & Typed AST
 
+This example uses the **pure library import** — the formula AST works identically under the prelude.
+
 ```scala
-import com.tjclp.xl.*
+import com.tjclp.xl.{*, given}
 import com.tjclp.xl.formula.{FormulaParser, FormulaPrinter, TExpr, ParseError}
 
 // ==================== Parsing Formula Strings ====================
@@ -116,37 +119,43 @@ parsedFormula.foreach { expr =>
 }
 ```
 
-**Note**: Formula evaluation is now **fully operational** (WI-07, WI-08, WI-09 complete). See runnable example scripts in `/examples/` directory.
+**Note**: Evaluation is fully operational — 104 functions, whole-workbook `recalculate()`, dependency graphs with cycle detection. See the runnable scripts below.
 
-## 3) Formula System Example Scripts
+## 3) Example Scripts Catalog
 
-The `/examples/` directory contains ready-to-run scripts demonstrating the complete formula system (parsing, evaluation, dependency analysis, and cycle detection).
+The `/examples/` directory contains ready-to-run scripts. Highlights (full catalog: [`examples/README.md`](../../examples/README.md)):
+
+### Scripting Tour (start here)
+
+**File**: `examples/scripting_tour.sc`
+
+Canonical tour of the scripting prelude — ONE import gives a script everything:
+- Compile-time literals (`ref"A1"`, `fx"..."`) and total navigation
+- Bulk generation by folding data into a `Patch`
+- Range fill (`ref"E2:E4" := 0`), smart detection (`"$1,234.56".toFormatted`)
+- `recalculate()` with per-cell errors, typed reads, the `excel""` display interpolator
+- Sync `Excel` IO and the one `.unsafe` boundary
 
 ### Quick Start (5 minutes)
 
-**File**: `examples/quick-start.sc`
+**File**: `examples/quick_start.sc`
 
-Get up and running with formula evaluation in 5 minutes. Demonstrates:
+Formula system in 5 minutes (pure import):
 - Parse Excel formulas to typed AST
 - Evaluate formulas against sheets
 - Handle errors gracefully (Either types, no exceptions)
 - Detect circular references automatically
 - Evaluate all formulas safely with dependency checking
 
-```bash
-scala-cli examples/quick-start.sc
-```
-
 **Key APIs shown**:
 - `FormulaParser.parse("=SUM(A1:A10)")`
-- `sheet.evaluateFormula(formula)`
 - `sheet.evaluateCell(ref)`
 - `sheet.evaluateWithDependencyCheck()`
 - `DependencyGraph.detectCycles(graph)`
 
-### Financial Modeling (~200 LOC)
+### Financial Modeling
 
-**File**: `examples/financial-model.sc`
+**File**: `examples/financial_model.sc`
 
 Complete 3-year income statement with:
 - Revenue projections with growth rates
@@ -154,110 +163,57 @@ Complete 3-year income statement with:
 - Financial ratios (gross margin, operating margin, net margin)
 - Dependency chain analysis (evaluation order)
 
-**Perfect for**: FP&A teams, finance applications, reporting automation
+### Dependency Analysis
 
-**Demonstrates**:
-- Complex formula chains (Revenue → COGS → Gross Profit → OpEx → Net Income)
-- Division operations (margin percentages)
-- Dependency analysis (impact of revenue changes)
-- Production-ready evaluation with cycle detection
-
-### Dependency Analysis (~100 LOC)
-
-**File**: `examples/dependency-analysis.sc`
+**File**: `examples/dependency_analysis.sc`
 
 Advanced dependency graph features:
 - Build dependency graphs from formula cells
 - Detect circular references with precise cycle paths (Tarjan's SCC)
 - Compute topological evaluation order (Kahn's algorithm)
-- Query precedents and dependents (O(1) lookups)
+- Query precedents and dependents
 - Perform impact analysis (transitive dependencies)
 
-**Perfect for**: Meta-programming, formula auditing, testing frameworks
+### Data Validation
 
-**Demonstrates**:
-- `DependencyGraph.fromSheet(sheet)`
-- `DependencyGraph.detectCycles(graph)` (with 4 cycle scenarios)
-- `DependencyGraph.topologicalSort(graph)`
-- `DependencyGraph.precedents/dependents(graph, ref)`
-- Transitive dependency calculation
-- What-if analysis (change propagation)
-
-### Data Validation (~120 LOC)
-
-**File**: `examples/data-validation.sc`
+**File**: `examples/data_validation.sc`
 
 Quality control and error detection:
 - Validate data ranges (MIN/MAX bounds checking)
 - Detect missing data (COUNT vs expected)
-- Normalize text (UPPER/LOWER for consistency)
-- Validate text length (LEN for field constraints)
+- Normalize text (UPPER/LOWER), validate lengths (LEN)
 - Handle division by zero gracefully
 
-**Perfect for**: ETL pipelines, data quality teams, validation frameworks
+### Sales Pipeline Analytics
 
-**Demonstrates**:
-- Validation formulas: `IF(AND(value>=0, value<=100), "Valid", "INVALID")`
-- Completeness checks: `COUNT(range) = expected`
-- Text operations: `UPPER`, `LEFT`, `RIGHT`, `LEN`
-- Error handling patterns
-
-### Sales Pipeline Analytics (~150 LOC)
-
-**File**: `examples/sales-pipeline.sc`
+**File**: `examples/sales_pipeline.sc`
 
 CRM and sales operations:
 - Pipeline funnel with stage-by-stage conversion rates
 - Tiered commission calculations (nested IF)
 - Quota attainment tracking
-- Average deal size metrics
 
-**Perfect for**: Sales teams, RevOps, CRM applications
+### Text Functions
 
-**Demonstrates**:
-- Conversion funnels: `current_stage / previous_stage`
-- Tiered logic: `IF(x<=t1, rate1, IF(x<=t2, rate2, rate3))`
-- Safe division (automatic zero handling)
-- Range aggregation across pipeline stages
-
-### Comprehensive Evaluator Demo
-
-**File**: `examples/evaluator-demo.sc`
-
-Complete formula system tour:
-- Low-level API (Evaluator.eval for programmatic use)
-- High-level API (Sheet extensions)
-- All 21 built-in functions
-- Error handling patterns
-- Dependency analysis
-- Integration with fx macro
-
-**Perfect for**: Learning all formula system capabilities systematically
+**File**: `examples/text_functions_demo.sc` — TRIM, MID, FIND, SUBSTITUTE, VALUE, TEXT.
 
 ### Running the Examples
 
-All example scripts use `scala-cli` with explicit dependencies:
+Examples resolve the library via the shared `examples/project.scala`, so publish locally first:
 
 ```bash
-# Option 1: Run directly (downloads dependencies)
-scala-cli examples/quick-start.sc
-
-# Option 2: Publish locally first (faster, uses local build)
-./mill xl-core.publishLocal && ./mill xl-evaluator.publishLocal
-scala-cli examples/quick-start.sc
-
-# Run specific examples
-scala-cli examples/financial-model.sc
-scala-cli examples/dependency-analysis.sc
-scala-cli examples/data-validation.sc
-scala-cli examples/sales-pipeline.sc
-scala-cli examples/evaluator-demo.sc
-scala-cli examples/text_functions_demo.sc   # TRIM, MID, FIND, SUBSTITUTE, VALUE, TEXT
+./mill __.publishLocal
+scala-cli run examples/scripting_tour.sc
+scala-cli run examples/quick_start.sc
+scala-cli run examples/financial_model.sc
 ```
 
-## 4) Chart spec (Future - WI-11)
+CI compiles every script via `scripts/test-examples.sh` (and runs a curated subset), so the catalog cannot silently rot.
+
+## 4) Chart spec (Future — #222)
 ```scala
-// Note: Chart support is planned for WI-11. This is a design preview.
+// Note: Chart support is a 0.12.0 candidate (GH #222, on the DrawingML layer #221).
+// This is a design preview only.
 import com.tjclp.xl.{*, given}
 // import com.tjclp.xl.chart.*  // Future module
 

--- a/docs/reference/implementation-scaffolds.md
+++ b/docs/reference/implementation-scaffolds.md
@@ -1,5 +1,7 @@
 # Implementation Scaffolds: Idiomatic Scala 3 Code Examples
 
+> **Status (2026-06-10)**: historical scaffold record — several targets have since shipped (hyperlinks & named ranges in 0.10.0, page setup in 0.11.0) and the test scaffolds use ScalaTest while the project standardized on MUnit. Useful as design sketches, not as current API documentation.
+
 **Purpose**: Complete, runnable code scaffolds for AI agents and developers
 **Last Updated**: 2026-01-23
 **Companion To**: [docs/plan/roadmap.md](../plan/roadmap.md)

--- a/docs/reference/migration-from-poi.md
+++ b/docs/reference/migration-from-poi.md
@@ -18,8 +18,8 @@ This guide helps Java developers migrate from Apache POI to XL. The two librarie
 
 | POI API | XL Equivalent | Notes |
 |---------|---------------|-------|
-| `new XSSFWorkbook()` | `Workbook.empty` | Returns `XLResult[Workbook]` |
-| `workbook.createSheet("Data")` | `Workbook("Data")` | Immutable, returns `Either` |
+| `new XSSFWorkbook()` | `Workbook.empty` | Returns `Workbook` (total) |
+| `workbook.createSheet("Data")` | `Workbook(Sheet("Data"))` | Immutable; literal sheet names are compile-time validated |
 | `sheet.createRow(0)` | N/A – XL is cell-oriented |
 | `row.createCell(0)` | `sheet.put(ref"A1", value)` | Pure and immutable |
 | `cell.setCellValue("Hello")` | `ref"A1" := "Hello"` | DSL syntax |
@@ -27,8 +27,8 @@ This guide helps Java developers migrate from Apache POI to XL. The two librarie
 | `cell.setCellValue(true)` | `ref"A1" := true` | Type-safe |
 | `cell.getCellValue()` | `sheet(ref"A1")` | Returns `Cell` (empty cells yield `CellValue.Empty`) |
 | `cell.getNumericCellValue()` | `sheet.readTyped[Int](ref"A1")` | Returns `Either[CodecError, Option[Int]]` |
-| `cell.setCellStyle(style)` | `sheet.withCellStyle(ref"A1", styleId)` | Register style first |
-| `workbook.write(out)` | `ExcelIO.instance[IO].write(wb, path)` | Effect-wrapped |
+| `cell.setCellStyle(style)` | `sheet.withCellStyle(ref"A1", style)` | Style auto-registered & deduplicated |
+| `workbook.write(out)` | `Excel.write(wb, "out.xlsx")` / `ExcelIO.instance[IO].write(wb, path)` | Sync facade or effect-wrapped |
 
 ## Common Patterns
 
@@ -54,28 +54,22 @@ out.close();
 
 **XL (Scala)**:
 ```scala
-import com.tjclp.xl.*
-import cats.effect.IO
-import cats.effect.unsafe.implicits.global
+import com.tjclp.xl.scripting.{*, given}
 
-val sheet =
-  Sheet("Sales").map(_.put(
-    ref"A1" -> "Product",
-    ref"B1" -> "Revenue",
-    ref"A2" -> "Widget",
-    ref"B2" -> 1000
-  )).unsafe
+val sheet = Sheet("Sales").put(
+  ref"A1" -> "Product",
+  ref"B1" -> "Revenue",
+  ref"A2" -> "Widget",
+  ref"B2" -> 1000
+)
 
-val workbook =
-  Workbook.empty.flatMap(_.put(sheet)).unsafe
-
-ExcelIO.instance[IO].write(workbook, Path.of("sales.xlsx")).unsafeRunSync()
+Excel.write(Workbook(sheet), "sales.xlsx")
 ```
 
 - **Key Differences**:
   - XL is **cell-oriented** (no explicit rows)
   - XL uses **immutable updates** (no setters)
-  - XL requires **effect handling** (`IO`)
+  - XL isolates **IO at the edge** (sync `Excel` facade for scripts, `ExcelIO.instance[IO]` for Cats Effect services)
   - XL uses **compile-time validated** references (`ref"A1"`)
 
 ---
@@ -98,19 +92,16 @@ cell.setCellStyle(style);
 
 **XL (Scala)**:
 ```scala
-import com.tjclp.xl.style.*
+import com.tjclp.xl.scripting.{*, given}
 
-val style = CellStyle.default
-  .withFont(Font("Arial", 12.0, bold = true, color = Color.fromHex("#FF0000")))
-  .withFill(Fill.Solid(Color.fromRgb(200, 200, 200)))
+// Style DSL: compile-time validated hex colors, fluent builders
+val style = CellStyle.default.bold.size(12.0).fontFamily("Arial")
+  .hex("#FF0000")          // font color
+  .bgRgb(200, 200, 200)    // fill
 
-val (registry, styleId) = sheet.styleRegistry.register(style)
-val updated = sheet
-  .copy(styleRegistry = registry)
-  .withCellStyle(ref"A1", styleId)
+val updated = sheet.withCellStyle(ref"A1", style) // auto-registered & deduplicated
 
-// Or use Patch DSL:
-import com.tjclp.xl.dsl.*
+// Or use the Patch DSL:
 val patch = ref"A1".styled(style)
 sheet.put(patch)
 ```
@@ -118,7 +109,7 @@ sheet.put(patch)
 **Key Differences**:
 - XL styles are **immutable** (builder pattern)
 - XL uses **RGB colors** (not indexed colors)
-- XL requires **style registration** (deduplication)
+- XL **auto-registers and deduplicates** styles (no manual registry bookkeeping)
 - XL supports **StylePatch Monoid** for composition
 
 ---
@@ -144,8 +135,7 @@ switch (cell.getCellType()) {
 
 **XL (Scala)**:
 ```scala
-import com.tjclp.xl.*
-import com.tjclp.xl.codec.syntax.*
+import com.tjclp.xl.scripting.{*, given}
 
 // Type-safe reading with Either
 sheet.readTyped[String](ref"A1") match
@@ -154,7 +144,7 @@ sheet.readTyped[String](ref"A1") match
   case Left(error) => println(s"Type error: $error")
 
 // Or pattern match on CellValue
-sheet.get(ref"A1") match
+sheet.cells.get(ref"A1") match
   case Some(cell) =>
     cell.value match
       case CellValue.Text(s) => println(s"String: $s")
@@ -193,7 +183,9 @@ workbook.dispose(); // Delete temp files
 
 **XL (Scala)**:
 ```scala
+import com.tjclp.xl.{*, given}
 import com.tjclp.xl.io.{Excel, RowData}
+import cats.effect.unsafe.implicits.global
 import fs2.Stream
 
 Stream.range(1, 1_000_001)
@@ -267,15 +259,15 @@ try {
 }
 ```
 
-**XL Philosophy**: Returns Either for errors (no exceptions)
+**XL Philosophy**: Returns Either for errors (no exceptions in the pure core)
 ```scala
-ExcelIO.instance.read[IO](path).map {
+ExcelIO.instance[IO].readR(path).map {
   case Right(wb) => // Success
   case Left(error: XLError) => // Explicit error handling
 }.unsafeRunSync()
 ```
 
-**Migration Tip**: XL errors are values, not exceptions. Use pattern matching or flatMap.
+**Migration Tip**: XL errors are values, not exceptions. Use pattern matching or flatMap. (`read` raises the error in `F` for monadic pipelines; `readR` surfaces it as `XLResult`. The sync `Excel.read` facade throws — only at the script IO edge.)
 
 ---
 
@@ -293,7 +285,7 @@ ExcelIO.instance.read[IO](path).map {
 ### Medium Files (10k-100k rows)
 
 **POI**: Use `XSSFWorkbook` or `SXSSFWorkbook` with window
-**XL**: Use in-memory API with batching (putAll, putMixed)
+**XL**: Use in-memory API with batching (varargs `Sheet.put` / Patch folds)
 
 **XL Advantage**: Simpler API, no temp files, faster
 
@@ -323,7 +315,7 @@ workbook.write(out);  // void
 
 **XL**:
 ```scala
-ExcelIO.instance.write[IO](wb, path)  // IO[Unit]
+ExcelIO.instance[IO].write(wb, path)  // IO[Unit]
   .unsafeRunSync()  // Must call to execute!
 ```
 
@@ -340,10 +332,10 @@ workbook.createSheet("My Sheet!");  // Works (POI allows most chars)
 
 **XL**:
 ```scala
-Workbook("My Sheet!")  // Error! Exclamation mark invalid
+Sheet("Sheet[1]")  // Compile error! Brackets are invalid in sheet names
 
-// Use SheetName.apply for validation:
-SheetName("My Sheet!") match
+// Runtime strings validate via SheetName.apply:
+SheetName(userInput) match
   case Right(name) => // Valid
   case Left(err) => // Invalid char
 ```
@@ -364,7 +356,7 @@ if (row == null) {
 
 **XL**:
 ```scala
-sheet.get(ref"A1") match
+sheet.cells.get(ref"A1") match
   case Some(cell) => // Exists
   case None => sheet.put(ref"A1", CellValue.Empty)  // Explicit creation
 ```
@@ -409,41 +401,31 @@ out.close();
 
 ### XL Version (Scala)
 ```scala
-import com.tjclp.xl.api.*
-import com.tjclp.xl.macros.*
-import com.tjclp.xl.codec.syntax.*
-import com.tjclp.xl.style.*
+import com.tjclp.xl.scripting.{*, given}
 import java.time.LocalDate
-import cats.effect.IO
-import cats.effect.unsafe.implicits.global
 
 // Header style
-val headerStyle = CellStyle.default
-  .withFont(Font("Arial", 12.0, bold = true))
+val headerStyle = CellStyle.default.bold.size(12.0).fontFamily("Arial")
 
-// Create sheet
-val sheet =
-  Sheet("Q1 Sales").map(_.put(
+// Header + style
+val header = Sheet("Q1 Sales")
+  .put(
     ref"A1" -> "Product",
     ref"B1" -> "Revenue",
     ref"C1" -> "Date"
-  )).get
-
-val styledHeader = sheet.withRangeStyle(ref"A1:C1", headerStyle)
-
-// Data rows (batched for performance)
-val dataRows = (1 to 1000).flatMap { i =>
-  Seq(
-    ref"A${i+1}" -> s"Product $i",
-    ref"B${i+1}" -> i * 100,
-    ref"C${i+1}" -> LocalDate.now()
   )
+  .withRangeStyle(ref"A1:C1", headerStyle)
+
+// Data rows: fold into a Patch, apply once (codecs auto-infer the date format)
+val dataRows = (1 to 1000).foldLeft(Patch.empty) { (p, i) =>
+  val r = ref"A2".down(i - 1)
+  p ++ (r := s"Product $i") ++ (r.right(1) := i * 100) ++
+    (r.right(2) := LocalDate.now().atStartOfDay)
 }
-val withData = sheet.put(dataRows*)
+val withData = header.put(dataRows)
 
 // Write
-val workbook = Workbook(Vector(withData))
-ExcelIO.instance.write[IO](workbook, Path.of("sales.xlsx")).unsafeRunSync()
+Excel.write(Workbook(withData), "sales.xlsx")
 ```
 
 **Differences**:
@@ -518,17 +500,18 @@ Memory: ~100MB (10x less)
 **A**: Not easily. They use different in-memory representations. You'd need to write to file and read back.
 
 ### Q: Does XL support all POI features?
-**A**: No. XL is ~55% feature complete. Missing: charts, drawings, pivot tables, formula evaluation. See roadmap.
+**A**: No. Still missing: charts, drawings, pivot tables, VBA. Formula **evaluation** is a point in XL's favor: 104 functions with whole-workbook recalculation (POI's evaluator exists but is partial and mutable). See [roadmap](../plan/roadmap.md) and [LIMITATIONS](../LIMITATIONS.md).
 
 ### Q: Is XL production-ready?
-**A**: Yes for core features (read/write, styling, streaming write). No for advanced features (charts, etc.).
+**A**: Yes for core features (read/write, styling, formulas, structural editing, streaming). No for visual features (charts, drawings).
 
 ### Q: How do I handle errors in XL?
 **A**: XL uses Either[XLError, A]. Pattern match or use flatMap/map:
 ```scala
+val excel = ExcelIO.instance[IO]
 for
-  workbook <- ExcelIO.instance.read[IO](path)
-  sheet <- IO.fromEither(workbook.flatMap(_.sheet("Data")))
+  workbook <- excel.read(path)              // errors raised in IO
+  sheet <- IO.fromEither(workbook("Data"))  // XLResult[Sheet] → IO
 yield sheet
 ```
 

--- a/docs/reference/ooxml-research.md
+++ b/docs/reference/ooxml-research.md
@@ -1,5 +1,7 @@
 # OOXML Research & Quick Reference
 
+> **Status (2026-06-10)**: pre-implementation research record, kept for OOXML spec reference. Its design *recommendations* are historical — several were deliberately superseded (e.g. "don't ship a full evaluator in v1.0": xl now ships a 104-function evaluator with whole-workbook recalculation). Trust [STATUS.md](../STATUS.md) and the code for what xl does today; trust this file for OOXML part/relationship details.
+
 Comprehensive research on OOXML (Office Open XML) SpreadsheetML specification with concrete API sketches and implementation guidance.
 
 ---

--- a/docs/reference/performance-guide.md
+++ b/docs/reference/performance-guide.md
@@ -142,22 +142,24 @@ excel.readStream(path)
 **Bad** (N intermediate sheets):
 ```scala
 (1 to 10000).foldLeft(sheet) { (s, i) =>
-  s.put(ref"A$i", CellValue.Number(i))
+  s.put(ref"A1".down(i - 1), i)
 }
 // Creates 10,000 intermediate Sheet instances
 ```
 
-**Good** (single putAll):
+**Good** (fold into a Patch, apply once):
 ```scala
-val cells = (1 to 10000).map(i => Cell(ref"A$i", CellValue.Number(i)))
-sheet.put(cells)
+val patch = (1 to 10000).foldLeft(Patch.empty) { (p, i) =>
+  p ++ (ref"A1".down(i - 1) := i)
+}
+sheet.put(patch)
 // Creates 1 Sheet instance
 ```
 
-**Best** (batch put with codecs):
+**Best** (batch varargs put with codecs):
 ```scala
 sheet.put(
-  (1 to 10000).map(i => ref"A$i" -> i)*
+  (1 to 10000).map(i => ARef.from0(0, i - 1) -> i)*
 )
 // Type-safe, auto-format inference, single allocation
 ```
@@ -170,16 +172,16 @@ sheet.put(
 ```scala
 var s = sheet
 for i <- 1 to 1000 do
-  s = s.put(ref"A$i", s"Row $i")  // 1000 Sheet instances
-  s = s.merge(ref"A$i:B$i")       // 1000 more Sheet instances
+  val r = ref"A1".down(i - 1)
+  s = s.put(r, s"Row $i")                  // 1000 Sheet instances
+  s = s.merge(CellRange(r, r.right(1)))    // 1000 more Sheet instances
 ```
 
 **Good** (deferred with Patch):
 ```scala
-import com.tjclp.xl.dsl.*
-
-val patch = (1 to 1000).foldLeft(Patch.empty: Patch) { (p, i) =>
-  p ++ (ref"A$i" := s"Row $i") ++ ref"A$i:B$i".merge
+val patch = (1 to 1000).foldLeft(Patch.empty) { (p, i) =>
+  val r = ref"A1".down(i - 1)
+  p ++ (r := s"Row $i") ++ CellRange(r, r.right(1)).merge
 }
 sheet.put(patch)  // Execute once at end
 ```
@@ -192,14 +194,15 @@ sheet.put(patch)  // Execute once at end
 
 **Manual** (verbose, error‑prone):
 ```scala
-import com.tjclp.xl.*
+import com.tjclp.xl.{*, given}
+import java.time.{LocalDate, LocalDateTime}
 
-val dateStyle = CellStyle.default.numFmt(NumFmt.Date)
-val decimalStyle = CellStyle.default.numFmt(NumFmt.Number)
+val dateStyle = CellStyle.default.withNumFmt(NumFmt.Date)
+val decimalStyle = CellStyle.default.withNumFmt(NumFmt.Decimal)
 
 sheet
   .put(ref"A1", CellValue.Text("Revenue"))
-  .put(ref"B1", CellValue.DateTime(LocalDate.of(2025, 11, 10)))
+  .put(ref"B1", CellValue.DateTime(LocalDate.of(2025, 11, 10).atStartOfDay))
   .withCellStyle(ref"B1", dateStyle)    // Must manually set format
   .put(ref"C1", CellValue.Number(BigDecimal("1000000.50")))
   .withCellStyle(ref"C1", decimalStyle) // Must manually set format
@@ -207,13 +210,13 @@ sheet
 
 **Batch `put` with codecs** (clean, automatic):
 ```scala
-import com.tjclp.xl.*
-import com.tjclp.xl.codec.syntax.*
+import com.tjclp.xl.{*, given}
+import java.time.LocalDate
 
 sheet.put(
   ref"A1" -> "Revenue",                         // String
   ref"B1" -> LocalDate.of(2025, 11, 10),        // Auto: date format
-  ref"C1" -> BigDecimal("1000000.50")           // Auto: number format
+  ref"C1" -> BigDecimal("1000000.50")           // Auto: decimal format
 )
 ```
 
@@ -252,7 +255,7 @@ database.stream()  // fs2.Stream[IO, Row]
 **Current** (after lazy optimizations):
 ```scala
 // Already optimized! range.cells returns Iterator
-sheet.fillBy(range"A1:Z100") { (col, row) =>
+sheet.fillBy(ref"A1:Z100") { (col, row) =>
   CellValue.Text(s"${col.toLetter}${row.index1}")
 }
 // No intermediate Vector allocation
@@ -292,16 +295,15 @@ sheet.put(newCells)
 
 ## Common Performance Pitfalls
 
-### Pitfall 1: Fold with Put Instead of PutAll
+### Pitfall 1: Fold with Put Instead of Batch Put
 ```scala
 // ❌ Bad: O(n) sheet copies
 val result = data.foldLeft(sheet) { (s, item) =>
-  s.put(ref"A${item.id}", item.name)
+  s.put(ARef.from0(0, item.id), item.name)
 }
 
 // ✅ Good: Single sheet copy
-val cells = data.map(item => Cell(ref"A${item.id}", CellValue.Text(item.name)))
-sheet.put(cells)
+sheet.put(data.map(item => ARef.from0(0, item.id) -> item.name)*)
 ```
 
 **Impact**: 10-20x faster for large datasets
@@ -341,7 +343,7 @@ excel.read(largeFile)
 - **Prototyping**: Optimize later
 
 ### Consider Optimizing
-- **10k-100k rows**: Use batching (putAll, putMixed)
+- **10k-100k rows**: Use batching (varargs `Sheet.put` / Patch folds)
 - **Complex styling**: Use Patch composition
 - **Repeated operations**: Cache usedRange, style registries
 
@@ -373,7 +375,7 @@ excel.read(largeFile)
 
 ## Performance Roadmap
 
-### Current (As of 2025-11-20)
+### Current (as of 0.11.0, 2026-06-10)
 - ✅ Streaming write: O(1) memory, ~88k rows/sec
 - ✅ Streaming read: O(1) memory via `fs2.io.readInputStream` (+ SST materialized once)
 - ✅ Lazy optimizations: 30-75% speedup (memoized canonicalKey, single-pass usedRange)
@@ -407,20 +409,18 @@ val sheet = Sheet("Data")
   .put(ref"A1", "Title")
   .put(ref"B1", 100)
 
-ExcelIO.instance.write[IO](Workbook(Vector(sheet)), path).unsafeRunSync()
+ExcelIO.instance[IO].write(Workbook(Vector(sheet)), path).unsafeRunSync()
 ```
 
 ### Medium Workbooks (10k-100k rows)
 ```scala
 // Use batching
-import com.tjclp.xl.codec.syntax.*
-
 val cells = (1 to 100_000).map(i =>
-  ref"A$i" -> s"Row $i"
+  ARef.from0(0, i - 1) -> s"Row $i"
 )
 val sheet = Sheet("Data").put(cells*)
 
-ExcelIO.instance.write[IO](Workbook(Vector(sheet)), path).unsafeRunSync()
+ExcelIO.instance[IO].write(Workbook(Vector(sheet)), path).unsafeRunSync()
 ```
 
 ### Large Workbooks (100k+ rows, minimal styling)

--- a/docs/reference/scripting.md
+++ b/docs/reference/scripting.md
@@ -1,0 +1,312 @@
+# Scripting Guide — `com.tjclp.xl.scripting`
+
+The scripting prelude is the fastest way to use XL from a script, a REPL, or any JVM project that
+just wants to get an `.xlsx` in and out without ceremony. One import gives you the core API, the
+patch DSL, compile-time literals, formula evaluation, sync IO, streaming IO, smart value
+detection, and the `.unsafe` boundary.
+
+This guide is for Maven/scala-cli users of the published library. If you are driving XL through
+Claude Code, the same material ships as the `xl-scripting` skill
+([`plugin/skills/xl-scripting/SKILL.md`](../../plugin/skills/xl-scripting/SKILL.md)).
+
+**Snippet convention** (same as the skill): every fenced block that starts with `//> using` is a
+complete, standalone script — these are compile-verified in CI by
+`scripts/verify-skill-snippets.sh`. Blocks without the directive header are fragments.
+
+---
+
+## One import
+
+```scala
+import com.tjclp.xl.scripting.{*, given}
+```
+
+- `{*, given}` is required — plain `*` misses the given instances (codecs, conversions, display).
+- The prelude and the pure library import are **mutually exclusive**: never combine
+  `com.tjclp.xl.scripting.{*, given}` with `com.tjclp.xl.{*, given}` in one file — the
+  overlapping forwarders become ambiguous. `import com.tjclp.xl.{*, given}` remains the 100%
+  pure alternative (no `.unsafe`, no sync `Excel` in scope) for library/production code.
+- `java.time` types are not re-exported; `import java.time.LocalDate` yourself when needed.
+
+The canonical script header (byte-identical across the skill, recipes, and this guide — a
+release bump is a mechanical substitution):
+
+```scala
+//> using scala 3.8.3
+//> using dep com.tjclp::xl:0.11.0
+import com.tjclp.xl.scripting.{*, given}
+
+val sheet = Sheet("Demo").put(ref"A1", "Hello").put(ref"B1", 42)
+Excel.write(Workbook(sheet), "/tmp/demo.xlsx")
+println(s"wrote ${sheet.cells.size} cells")
+```
+
+Run with `scala-cli run script.sc`. `.sc` files take top-level statements — no `@main`, no
+object wrapper.
+
+## Read → modify → write
+
+The sync `Excel` facade (`read`/`write`/`modify`) is the IO edge for scripts. Everything between
+read and write is pure values.
+
+```scala
+//> using scala 3.8.3
+//> using dep com.tjclp::xl:0.11.0
+import com.tjclp.xl.scripting.{*, given}
+
+val wb = Excel.read("input.xlsx")
+val updated = wb
+  .upsert("Audit", _.put(ref"A1", "reviewed")) // total: creates the sheet if missing
+  .update("Data", _.put(ref"B2", 99))          // XLResult: "Data" must exist
+  .unsafe                                      // ONE unwrap, at the edge
+Excel.write(updated, "output.xlsx")
+```
+
+- `Workbook.upsert(name, f)` is total update-or-create; `Workbook.update(name, f)` returns
+  `XLResult[Workbook]` and fails if the sheet is absent. Pick by intent.
+- `Excel.modify("file.xlsx")(f)` does read → transform → write in place with atomic file
+  replacement (no ZIP corruption on a crashed write).
+- `Excel.write` also accepts an `XLResult[Workbook]` directly.
+
+## Compile-time vs runtime refs (and the `fx` rule)
+
+Literal refs and formulas are validated **at compile time** — a typo fails the build, not the
+workbook:
+
+```scala
+val a = ref"A1"              // ARef
+val rng = ref"A1:B10"        // CellRange
+val f = fx"=SUM(A1:B10)"     // CellValue.Formula (syntax/parens checked at compile time)
+val m = money"$$1,234.56"    // Formatted(Number, Currency)
+```
+
+`$` is the interpolation character inside every interpolated literal, so Excel's absolute
+anchors need `$$`: write `fx"=SUM($$A$$1:B10)"` to get `=SUM($A$1:B10)`. Same for
+`money"$$1,234.56"`.
+
+With runtime interpolation, validation moves to runtime and the macros return `Either`:
+
+```scala
+val row = 5
+val cellE = ref"A$row"       // Either[XLError, RefType]
+val formE = fx"=B$row*C$row" // Either[XLError, CellValue]
+val cell2 = fx"=B$row*2".unsafe // explicit boundary when fail-fast is fine
+```
+
+Prefer **total navigation** over interpolated refs in loops — no `Either` at all:
+
+```scala
+val base = ref"A2"
+base.down(2)     // A4   (default step is 1: base.down() == A3)
+base.right(1)    // B2
+base.up(1)       // A1
+base.left(1)     // out of bounds! see below
+base.shift(1, 2) // B4   (colOffset, rowOffset)
+```
+
+Navigation is total but **unchecked at the sheet edges**: `ref"A1".up()` produces the
+non-existent "A0", which corrupts output if written. Keep loop bounds inside your data extent.
+
+## Range fill and the patch DSL
+
+Patches are pure values forming a monoid — build the whole change set with `++`, apply once with
+`sheet.put(patch)`:
+
+```scala
+val patch = (ref"A1" := "Report") ++ ref"A1:C1".merge ++ ref"A1".styled(CellStyle.default.bold)
+val sheet2 = sheet.put(patch)
+```
+
+`range := value` fills **every** cell in the range with the value — Excel Ctrl+Enter semantics:
+
+```scala
+ref"E2:E100" := 0          // 99 Puts, one per cell
+ref"A1" := "one cell"      // a 1x1 fill is a single Put
+```
+
+Fill cost is proportional to range size by design — `ref"A:A" := 0` really creates 1,048,576
+cells. Size fill ranges to your data.
+
+## Formulas: build, recalculate, inspect
+
+`wb.recalculate()` is a **total** whole-workbook recalculation: every formula on every sheet
+evaluates in dependency order, cross-sheet references resolve automatically, and failures never
+throw — they are collected per cell.
+
+```scala
+//> using scala 3.8.3
+//> using dep com.tjclp::xl:0.11.0
+import com.tjclp.xl.scripting.{*, given}
+
+val title = CellStyle.default.bold.size(14.0).center
+val label = CellStyle.default.bold.indent(1)
+val currencyStyle = CellStyle.default.currency
+val totalRow = CellStyle.default.currency.bold.borderTop(BorderStyle.Thin)
+
+val model = Sheet("Model").put(
+  (ref"B1" := "FY2026 Plan") ++ ref"B1:C1".merge ++ ref"B1".styled(title) ++
+    (ref"B3" := "Revenue") ++ (ref"C3" := 1200000) ++
+    (ref"B4" := "Costs") ++ (ref"C4" := fx"=C3*0.62") ++
+    (ref"B5" := "Profit") ++ (ref"C5" := fx"=C3-C4") ++
+    ref"B3:B5".styled(label) ++ ref"C3:C5".styled(currencyStyle) ++
+    ref"C5".styled(totalRow) ++ ref"B3:C5".outlined(BorderStyle.Medium)
+)
+
+Workbook(model).recalculate().toEither match
+  case Right(wb) =>
+    Excel.write(wb, "/tmp/plan.xlsx")
+    given Sheet = wb.sheets.headOption.getOrElse(sys.exit(1))
+    println(excel"Profit: ${ref"C5"}") // displays through NumFmt: $456,000.00
+  case Left(errors) =>
+    errors.foreach(e => println(s"✗ ${e.render}"))
+    sys.exit(1)
+```
+
+`recalculate(clock: Clock = Clock.system)` returns a `RecalcResult`:
+
+| Member | Meaning |
+|--------|---------|
+| `workbook` | The workbook with every successful formula cached (`Formula(expr, Some(value))`) |
+| `evaluated` | `Map[SheetName, Map[ARef, CellValue]]` — computed values for inspection |
+| `errors` | `Vector[CellEvalError]` — per-cell failures (parse/eval errors, cycle participants, cells blocked by a cycle) |
+| `isClean` | `true` when `errors.isEmpty` |
+| `toEither` | `Right(workbook)` when clean, `Left(errors)` otherwise — for fail-hard pipelines |
+
+Reference cycles are **isolated**: the participants and their downstream dependents are reported
+(e.g. `Model!A7: Formula error in '=B7': Circular reference` via `CellEvalError.render`) while
+the acyclic remainder still evaluates and caches.
+
+For one-off questions, `wb.evaluateFormula("=SUM(Data!A1:A9)", "Summary")` returns
+`XLResult[CellValue]` with cross-sheet context wired automatically (104 functions supported —
+see the [skill API reference](../../plugin/skills/xl-scripting/reference/API.md) for the full
+list).
+
+## Typed extraction
+
+```scala
+sheet.readTyped[BigDecimal](ref"C2")  // Either[CodecError, Option[BigDecimal]]
+sheet.readTypedOr[Int](ref"B2", 0)    // total, with default
+sheet.readTypedOpt[String](ref"A2")   // flat Option — mismatch and empty both None
+```
+
+Nine codec types: String, Int, Long, Double, BigDecimal, Boolean, LocalDate, LocalDateTime,
+RichText. Use `readTyped` when you must distinguish a type mismatch from an empty cell;
+`readTypedOr`/`readTypedOpt` when you just need a value.
+
+## Smart value detection
+
+`FormattedParsers.detect` (available everywhere) turns a raw string into a value + number
+format; the prelude adds `String.toFormatted` sugar:
+
+```scala
+sheet.put(ref"C1", "$1,234.56".toFormatted) // Number(1234.56) + Currency format
+"45.5%".toFormatted                          // Number(0.455) + Percent
+"2026-01-15".toFormatted                     // DateTime + Date format
+"plain text".toFormatted                     // Text (detection is total — never fails)
+```
+
+## Styling quick hits
+
+```scala
+CellStyle.default.bold.italic.underline.size(12.0).fontFamily("Arial")
+CellStyle.default.center.middle.wrap.indent(2)      // alignment (+ Align indent)
+CellStyle.default.red.bgGray                        // font / background color
+CellStyle.default.currency                          // named formats: .percent .decimal .dateFormat .dateTime
+CellStyle.default.withNumFmt(NumFmt.Custom("0.0x")) // any Excel format code
+CellStyle.default.bordered                          // thin border, all sides
+CellStyle.default.borderTop(BorderStyle.Thin)       // per-side: borderBottom/borderLeft/borderRight, color overloads
+ref"B3:F9".outlined(BorderStyle.Medium)             // outline the range edges only (banker box)
+```
+
+`range.outlined` is edge-correct (corners get both sides, interior cells untouched) and merges
+into existing borders at apply time, preserving each cell's font/fill/format.
+
+## Print and view setup
+
+`SheetView` (gridlines, zoom) and `PageSetup` (orientation, fit, margins, header/footer, print
+area, repeat rows) live in `com.tjclp.xl.sheets` and are not part of the prelude export — import
+them explicitly:
+
+```scala
+//> using scala 3.8.3
+//> using dep com.tjclp::xl:0.11.0
+import com.tjclp.xl.scripting.{*, given}
+import com.tjclp.xl.sheets.{HeaderFooter, PageMargins, PageSetup, SheetView}
+
+val report = Sheet("Report")
+  .put(ref"A1", "Quarterly Report")
+  .withViewSettings(SheetView(showGridLines = false, zoomScale = Some(90)))
+  .withPageSetup(
+    PageSetup(
+      orientation = Some("landscape"),
+      fitToWidth = Some(1),
+      headerFooter = Some(HeaderFooter(oddFooter = Some("&LACME Corp&RPage &P of &N"))),
+      margins = Some(PageMargins(left = 0.5, right = 0.5)),
+      printArea = Some(ref"A1:H40"),     // _xlnm.Print_Area defined name
+      repeatRows = Some((1, 2))          // rows 1-2 repeat on every printed page
+    )
+  )
+
+Excel.write(Workbook(report), "/tmp/report.xlsx")
+println("wrote print-ready report")
+```
+
+Header/footer strings use Excel's codes: `&P` page number, `&N` total pages, `&D` date, `&F`
+file name, `&A` sheet name, with `&L`/`&C`/`&R` section markers.
+
+## The `.unsafe` boundary
+
+Everything fallible returns `XLResult[A]` (= `Either[XLError, A]`). The prelude sanctions
+exactly one unwrap style — `.unsafe`, which throws a structured `XLException` wrapping the
+`XLError`:
+
+```scala
+val wb2 = wb.update("Sales", _.put(ref"A1", "x")).unsafe // fail-fast script style
+```
+
+Use it **once, at the edge** — compose with `for`-comprehensions in between, or lean on the
+total APIs (literal refs, `upsert`, range fill, `readTypedOr`, `recalculate`) so there is
+nothing to unwrap.
+
+## `Excel` vs `ExcelIO`
+
+| | `Excel` (sync facade) | `ExcelIO` (cats-effect) |
+|---|---|---|
+| Style | `Excel.read("in.xlsx")` returns `Workbook`, throws at the IO edge | `ExcelIO.instance[IO].read(path)` returns `IO[Workbook]` |
+| For | Scripts, REPL, quick tools | Production services, streaming, resource safety |
+| Streaming | — | `readStream`/`writeStream`: `fs2.Stream[F, RowData]`, O(1) memory |
+
+Both are in scope from the prelude. Switch to streaming above ~100k rows — `Excel.read` loads
+the whole workbook:
+
+```scala
+//> using scala 3.8.3
+//> using dep com.tjclp::xl:0.11.0
+import com.tjclp.xl.scripting.{*, given}
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import java.nio.file.Paths
+
+val excel = ExcelIO.instance[IO]
+val total = excel
+  .readStream(Paths.get("huge.xlsx")) // fs2.Stream[IO, RowData], O(1) memory
+  .map(_.cells.get(2))                // column C (0-based)
+  .collect { case Some(CellValue.Number(n)) => n }
+  .compile
+  .fold(BigDecimal(0))(_ + _)
+  .unsafeRunSync()
+println(s"column C total: $total")
+```
+
+Streaming writes: `Stream.emits(rows).through(excel.writeStream(path, "Sheet1"))` with
+`RowData(rowIndex, Map(colIdx -> CellValue))` (1-based rows, 0-based columns).
+
+## Going further
+
+- [`examples/scripting_tour.sc`](../../examples/scripting_tour.sc) — the canonical runnable tour
+  of everything above; [`examples/README.md`](../../examples/README.md) catalogs all example
+  scripts.
+- [`plugin/skills/xl-scripting/reference/RECIPES.md`](../../plugin/skills/xl-scripting/reference/RECIPES.md)
+  — seven complete scripts: bulk transform, typed extraction + validation, model build, workbook
+  merge, streaming filter, cell-level diff, CSV ingest.
+- [QUICK-START.md](../QUICK-START.md) — the pure-library path (`com.tjclp.xl.{*, given}`).

--- a/docs/reference/testing-guide.md
+++ b/docs/reference/testing-guide.md
@@ -1,6 +1,6 @@
 # Testing & Laws — Property Suites, Round-Trips, and Coverage
 
-**Current Status**: CI runs the full Mill test graph across the library, evaluator, CLI, and support modules. Use `./mill __.test` as the authoritative count.
+**Current Status**: CI runs the full Mill test graph across the library, evaluator, CLI, and support modules — **3005+ tests** as of 0.11.0. Use `./mill __.test` as the authoritative count.
 
 ## Test Infrastructure
 
@@ -16,14 +16,15 @@ xl-ooxml/test/src/com/tjclp/xl/ooxml/
 xl-cats-effect/test/src/com/tjclp/xl/io/
 xl-evaluator/test/src/com/tjclp/xl/formula/
 xl-cli/test/src/com/tjclp/xl/cli/
-xl-testkit/test/src/com/tjclp/xl/testkit/
+xl-agent/test/src/
+xl/test/src/xlprelude/          (external-consumer probes for the scripting prelude)
 ```
 
 ## Test Coverage by Module
 
 ### xl-core: domain, style, codec, optics, and law suites ✅
 
-#### Addressing Laws (17 tests)
+#### Addressing Laws
 - **Column/Row round-trips**: `from0` → `index0` identity
 - **ARef packing**: 64-bit (row, col) ↔ Long bijection
 - **A1 notation**: `parse` → `toA1` round-trip for all valid refs
@@ -31,7 +32,7 @@ xl-testkit/test/src/com/tjclp/xl/testkit/
 - **Range contains**: Point-in-rectangle tests
 - **Property-based**: Generated Column (0-16383), Row (0-1048575)
 
-#### Patch Laws (21 tests)
+#### Patch Laws
 - **Monoid associativity**: `(p1 |+| p2) |+| p3 == p1 |+| (p2 |+| p3)`
 - **Monoid identity**: `p |+| Patch.Empty == p`
 - **Idempotence**: `Put(ref, v1) |+| Put(ref, v2)` keeps v2
@@ -39,7 +40,7 @@ xl-testkit/test/src/com/tjclp/xl/testkit/
 - **Error handling**: Invalid patches return `Left[XLError]`
 - **Batch composition**: `Patch.Batch` flattens correctly
 
-#### Style System (60 tests)
+#### Style System
 - **Unit conversions**: `Pt ↔ Px ↔ Emu` bidirectional laws
 - **Color parsing**: Hex, RGB, ARGB, theme color parsing
 - **Style canonicalization**: `canonicalKey` idempotence
@@ -48,13 +49,13 @@ xl-testkit/test/src/com/tjclp/xl/testkit/
 - **Font/Fill/Border**: Builder patterns and deduplication
 - **NumFmt**: Pre-defined format IDs and custom formats
 
-#### DateTime (8 tests)
+#### DateTime
 - **Excel serial numbers**: LocalDate ↔ Double conversion
 - **1900 leap year bug**: Compatibility with Excel's quirk
 - **DateTime round-trips**: LocalDateTime ↔ serial + fraction
 - **Epoch correctness**: 1899-12-30 baseline
 
-#### CellCodec (42 tests)
+#### CellCodec
 - **Identity laws**: `read(write(v)) == Right(Some(v))` for all 9 types
 - **Type safety**: `readTyped[Wrong]` returns `Left[CodecError]`
 - **Auto-formatting**: LocalDate → NumFmt.Date, BigDecimal → NumFmt.Decimal
@@ -62,7 +63,7 @@ xl-testkit/test/src/com/tjclp/xl/testkit/
 - **Error cases**: Parse failures, type mismatches
 - **Round-trip precision**: BigDecimal maintains precision
 
-#### Batch Operations (16 tests)
+#### Batch Operations
 - **Batch `Sheet.put`**: Heterogeneous updates with type-safe codecs (replaces old `putMixed`)
 - **Style deduplication**: Multiple cells with same format share style
 - **Given conversions**: Implicit codec resolution
@@ -73,14 +74,14 @@ xl-testkit/test/src/com/tjclp/xl/testkit/
 - **Formatted literals**: `money"$1,234.56"`, `percent"45.5%"`, `date"2025-11-10"`, `accounting"-$500.00"`
 - **Macro expansion**: Compile-time parsing verified
 
-#### Optics (34 tests)
+#### Optics
 - **Lens laws**: `get ∘ set == id`, `set(get(s), s) == s`, `set(set(s, a), b) == set(s, b)`
 - **Optional laws**: Similar to Lens for partial updates
 - **Focus DSL**: `sheet.focus(ref).modify(f)` correctness
 - **Real-world scenarios**: Invoice updates, financial model edits
 - **Compose**: Lens/Optional composition verified
 
-#### RichText (5 tests)
+#### RichText
 - **Composition**: `run1 + run2` combines correctly
 - **DSL extensions**: `.bold`, `.italic`, `.red`, `.size()` work
 - **Whitespace**: Preserved correctly with `xml:space="preserve"`
@@ -199,7 +200,7 @@ property("get-set") {
 ```bash
 ./mill xl-core.test.testOnly com.tjclp.xl.AddressingSpec
 ./mill xl-core.test.testOnly com.tjclp.xl.PatchSpec
-./mill xl-ooxml.test.testOnly com.tjclp.xl.ooxml.RoundTripSpec
+./mill xl-ooxml.test.testOnly com.tjclp.xl.ooxml.OoxmlRoundTripSpec
 ```
 
 ### CI Integration
@@ -208,15 +209,20 @@ GitHub Actions runs:
 2. `./mill __.compile` (Compilation check)
 3. `./mill __.test` (All test modules)
 
-## Coverage Goals
+## Test Counts by Module
 
-| Module | Lines | Coverage | Status |
-|--------|-------|----------|--------|
-| xl-core | ~3500 | ~90% | ✅ Excellent |
-| xl-macros | ~400 | ~95% | ✅ Excellent |
-| xl-ooxml | ~1800 | ~85% | ✅ Good |
-| xl-cats-effect | ~500 | ~80% | ✅ Good |
-| **Total** | **~6200** | **~88%** | **✅ Excellent** |
+As of 0.11.0 (`./mill show __.test`; macros are part of xl-core — there is no separate xl-macros module):
+
+| Module | Tests |
+|--------|-------|
+| xl-evaluator | 1198 |
+| xl-core | 971 |
+| xl-ooxml | 381 |
+| xl-cli | 308 |
+| xl-cats-effect | 76 |
+| xl-agent | 54 |
+| xl (prelude probes, `xlprelude.ScriptingPreludeTest`) | 17 |
+| **Total** | **3005** (3004 passing + 1 ignored) |
 
 ## Test Quality Metrics
 

--- a/docs/reviews/gpt5-review-template.md
+++ b/docs/reviews/gpt5-review-template.md
@@ -1,3 +1,5 @@
+> 📜 **HISTORICAL** — dated review artifact (written when XL was at Scala 3.7 / 77 tests, pre-OOXML-MVP), kept for the record. Do not treat its status claims or API sketches as current; see [STATUS.md](../STATUS.md) and [plan/roadmap.md](../plan/roadmap.md).
+
 # GPT-5-Pro Review Prompt: XL Query API Design
 
 ## Context: About XL

--- a/docs/reviews/style-review.md
+++ b/docs/reviews/style-review.md
@@ -1,3 +1,5 @@
+> 📜 **HISTORICAL** — dated review artifact (2025-11-10), kept for the record. The issues it raised have long since been fixed or tracked; see [STATUS.md](../STATUS.md) for current behavior.
+
 # Style Review - Status: Documented ✓
 
 **Review Date**: Pre-implementation

--- a/examples/README.md
+++ b/examples/README.md
@@ -29,6 +29,12 @@ scala-cli run examples/<example-name>.sc
 
 ## Example Catalog
 
+### Start Here: Scripting Prelude
+
+| Example | Description |
+|---------|-------------|
+| `scripting_tour.sc` | **Canonical tour of the one-import scripting prelude** (`com.tjclp.xl.scripting.{*, given}`) — source of truth for the xl-scripting skill snippets |
+
 ### Core API
 
 | Example | Description |
@@ -42,6 +48,7 @@ scala-cli run examples/<example-name>.sc
 |---------|-------------|
 | `quick_start.sc` | Formula system in 5 minutes: parsing, evaluation, round-trip |
 | `dependency_analysis.sc` | Formula dependency graph analysis and visualization |
+| `text_functions_demo.sc` | Text functions (TRIM, MID, FIND, SUBSTITUTE, VALUE, TEXT) with expected-vs-actual output |
 
 ### Real-World Applications
 
@@ -52,6 +59,17 @@ scala-cli run examples/<example-name>.sc
 | `data_validation.sc` | Data quality validation patterns |
 | `table_demo.sc` | Excel tables with AutoFilter and styling |
 | `resize_demo.sc` | Row/column sizing and HTML/SVG export |
+
+### Streaming & Performance
+
+| Example | Description |
+|---------|-------------|
+| `big_demo.sc` | Streams 1,000,000 rows with a 256MB heap — O(1) memory write + read |
+| `verify_big.sc` | Verifies the million-row output via streaming reads (sample rows + total count) |
+| `streaming_benchmark.sc` | Streaming write benchmark: single-pass vs two-pass |
+| `streaming_pressure_test.sc` | O(1) memory pressure test for streaming reads over large datasets |
+| `calamine_comparison.sc` | Read-only streaming benchmark vs Rust's calamine (needs a local 1M-row NYC 311 sample) |
+| `nyc311_roundtrip.sc` | Round-trip benchmark: stream-read 1M rows, stream-write, verify (same NYC 311 sample) |
 
 ### Test Utilities
 
@@ -64,6 +82,17 @@ scala-cli run examples/<example-name>.sc
 ---
 
 ## Featured Examples
+
+### scripting_tour.sc
+
+```bash
+scala-cli run examples/scripting_tour.sc
+```
+
+The **canonical prelude tour** — one import (`com.tjclp.xl.scripting.{*, given}`) gives a script
+the core API, DSL operators, compile-time literals, formula evaluation, sync `Excel` IO, streaming
+`ExcelIO`, smart value detection, and the `.unsafe` boundary. Compile-verified by
+`scripts/test-examples.sh` and the source of truth for snippets in the xl-scripting skill.
 
 ### demo.sc
 

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,0 +1,46 @@
+# xl Claude Code Plugin
+
+LLM-friendly Excel tooling for [Claude Code](https://claude.ai/code): read, write, style, and
+analyze `.xlsx` files via the `xl` CLI, or script complex transformations against the xl Scala
+library. The plugin packages two complementary skills.
+
+## Skills
+
+### xl-cli — stateless CLI operations
+
+Drives the `xl` command-line binary: view ranges, read cells, search, evaluate formulas
+(104 supported functions), export to CSV/JSON/PNG/PDF, style cells, edit rows/columns, and apply
+atomic batch operations. Every invocation reads the file, applies one change set, and writes the
+result — no session state. The skill auto-detects the latest released binary from the GitHub API,
+so it never needs a version bump. See [`skills/xl-cli/SKILL.md`](skills/xl-cli/SKILL.md).
+
+### xl-scripting — type-safe Scala scripting
+
+Writes scala-cli scripts against the `com.tjclp::xl` library (one-import prelude,
+compile-time-validated cell references, total APIs, whole-workbook recalculation with per-cell
+error reporting). Suited to bulk or conditional transformations, multi-file pipelines, typed data
+extraction, formula-heavy model building, and streaming 100k+ row files in constant memory. Pins
+the library version; every documented snippet is compile-verified in CI. See
+[`skills/xl-scripting/SKILL.md`](skills/xl-scripting/SKILL.md).
+
+### Which one?
+
+One-shot operations (quick reads, single edits, search, visual exports) → **xl-cli**. Anything
+with loops, intermediate computation, or many dependent edits that would round-trip the file
+repeatedly → **xl-scripting**. They compose well: generate with a script, verify visually with
+the CLI.
+
+## Installation
+
+In Claude Code:
+
+```
+/plugin marketplace add TJC-LP/xl
+/plugin install xl@xl-marketplace
+```
+
+## Release artifacts
+
+Each [GitHub release](https://github.com/TJC-LP/xl/releases) also attaches the skills as
+standalone zips for non-marketplace installs: `xl-skill-<version>.zip` (xl-cli) and
+`xl-scripting-skill-<version>.zip` (xl-scripting), alongside the native `xl` binaries.

--- a/plugin/skills/xl-cli/SKILL.md
+++ b/plugin/skills/xl-cli/SKILL.md
@@ -60,7 +60,7 @@ Ensure `~/.local/bin` is in your PATH: `export PATH="$HOME/.local/bin:$PATH"`
 
 ### Info Commands (no file required)
 ```bash
-xl functions                           # List all 88 supported functions
+xl functions                           # List all 104 supported functions
 xl rasterizers                         # Check SVG-to-raster backends
 ```
 
@@ -107,6 +107,21 @@ xl -f <file> -s <sheet> -o <out> row <n> --height 30
 xl -f <file> -s <sheet> -o <out> col <letter> --width 20
 xl -f <file> -s <sheet> -o <out> col A:F --auto-fit
 xl -f <file> -s <sheet> -o <out> autofit              # All columns
+```
+
+### Structural Editing (require `-o`)
+
+Insert/delete rows and columns Excel-style: cells, merges, row/column properties, and freeze
+panes shift, and every affected formula (including cross-sheet references) is rewritten.
+References to deleted cells become `#REF!`.
+
+```bash
+xl -f <file> -s <sheet> -o <out> insert-rows 5        # Insert 1 row before row 5
+xl -f <file> -s <sheet> -o <out> insert-rows 5 3      # Insert 3 rows before row 5
+xl -f <file> -s <sheet> -o <out> delete-rows 5 2      # Delete rows 5-6
+xl -f <file> -s <sheet> -o <out> insert-cols C 2      # Insert 2 columns at C
+xl -f <file> -s <sheet> -o <out> delete-cols C        # Delete column C
+xl -f <file> -s <sheet> -o <out> delete-cols C:E      # Delete columns C through E
 ```
 
 ### Sheet Management (require `-o`)
@@ -273,7 +288,7 @@ Apply multiple operations atomically:
 ]
 ```
 
-**Operations**: put, putf, style, merge, unmerge, colwidth, rowheight
+**Operations**: put, putf, style, merge, unmerge, colwidth, rowheight, and more — all 21 listed under "All batch operations" below
 
 **Native JSON types** (recommended for numeric data):
 ```json
@@ -392,7 +407,7 @@ xl -f data.xlsx -s Sheet1 eval "=SUM(A1:A10)" --with "A1=500"  # What-if
 xl -f data.xlsx -s Sheet1 eval "=SUM(A1:A5)" --with "A1=0,A5=0"  # Multiple overrides (comma-separated)
 ```
 
-See [reference/FORMULAS.md](reference/FORMULAS.md) for 88 supported functions.
+See [reference/FORMULAS.md](reference/FORMULAS.md) for 104 supported functions.
 
 ### Create Formatted Report
 
@@ -431,15 +446,19 @@ echo '[{"op":"putf","ref":"A1","formula":"=SUM(B1:B10)"},{"op":"style","range":"
 echo '[{"op":"put","ref":"A1","value":"test"}]' | xl -f in.xlsx -o out.xlsx batch --dry-run -
 ```
 
-**All batch operations** (20): `put`, `putf`, `style`, `merge`, `unmerge`, `colwidth`, `rowheight`, `comment`, `remove-comment`, `clear`, `col-hide`, `col-show`, `row-hide`, `row-show`, `autofit`, `add-sheet`, `rename-sheet`, `freeze`, `unfreeze`, `copy`
+**All batch operations** (21): `put`, `putf`, `style`, `merge`, `unmerge`, `colwidth`, `rowheight`, `comment`, `remove-comment`, `hyperlink`, `clear`, `col-hide`, `col-show`, `row-hide`, `row-show`, `autofit`, `add-sheet`, `rename-sheet`, `freeze`, `unfreeze`, `copy`
 
-**Freeze/unfreeze/copy in batch:**
+**Freeze/unfreeze/copy/hyperlink in batch:**
 ```json
 {"op": "freeze", "ref": "B2"}
 {"op": "unfreeze"}
 {"op": "copy", "source": "A1:D10", "target": "F1"}
 {"op": "copy", "source": "A1:D10", "target": "F1", "valuesOnly": true}
+{"op": "hyperlink", "ref": "A1", "target": "https://example.com"}
+{"op": "hyperlink", "ref": "A1"}
 ```
+
+`hyperlink` sets a cell's hyperlink target; omit `target` to clear an existing hyperlink.
 
 ### CSV to Styled Table
 
@@ -534,7 +553,7 @@ xl -f huge.xlsx --max-size 500 cell A1    # Custom 500MB limit
 
 | Command | Description |
 |---------|-------------|
-| `functions` | List all 88 supported Excel functions |
+| `functions` | List all 104 supported Excel functions |
 | `rasterizers` | List SVG-to-raster backends with status |
 
 ### Workbook Commands
@@ -572,7 +591,7 @@ Run `xl view --help` for complete options.
 | `copy <source> <target>` | `--values-only` (no formula adjustment) |
 | `freeze <ref>` | Freeze panes (rows above + columns left of ref) |
 | `unfreeze` | Remove freeze panes |
-| `batch <json-file>` | 20 operations (see below) |
+| `batch <json-file>` | 21 operations (see below) |
 | `import <csv> [ref]` | `--new-sheet`, `--delimiter`, `--no-type-inference` |
 
 Run `xl <command> --help` for complete options.
@@ -614,11 +633,25 @@ Run `xl sort --help` for sorting details.
 | `col <letter(s)>` | `--width`, `--auto-fit`, `--hide`, `--show` |
 | `autofit` | `--columns` (range like A:Z) |
 
+### Structural Editing Commands
+
+| Command | Arguments |
+|---------|-----------|
+| `insert-rows <at-row> [count]` | Insert `count` rows (default 1) before 1-based row `at-row` |
+| `delete-rows <at-row> [count]` | Delete `count` rows (default 1) starting at row `at-row` |
+| `insert-cols <at-col> [count]` | Insert `count` columns (default 1) at column letter `at-col` |
+| `delete-cols <at-col> [count]` | Delete `count` columns (default 1) starting at `at-col` |
+
+Column commands also accept an inclusive range (`delete-cols C:E`), which derives the count and
+overrides the positional `count` argument. All four shift cells, merges, row/column properties,
+and freeze panes, then rewrite affected formulas across all sheets; formulas referencing deleted
+cells get `#REF!` and ranges shrink correctly.
+
 ---
 
 ## Links
 
 - `xl <command> --help` for detailed usage and examples
-- [reference/FORMULAS.md](reference/FORMULAS.md) for 88 supported functions
+- [reference/FORMULAS.md](reference/FORMULAS.md) for 104 supported functions
 - [reference/COLORS.md](reference/COLORS.md) for color names
 - [reference/OUTPUT-FORMATS.md](reference/OUTPUT-FORMATS.md) for format specs

--- a/plugin/skills/xl-cli/reference/FORMULAS.md
+++ b/plugin/skills/xl-cli/reference/FORMULAS.md
@@ -1,6 +1,6 @@
 # Supported Formula Functions
 
-The `eval` command supports 88 Excel functions.
+The `eval` command supports 104 Excel functions (run `xl functions` for the live list).
 
 ## Math Functions
 
@@ -39,6 +39,11 @@ The `eval` command supports 88 Excel functions.
 | STDEVP | `=STDEVP(range)` | `=STDEVP(A1:A10)` → population std dev (n) |
 | VAR | `=VAR(range)` | `=VAR(A1:A10)` → sample variance (n-1) |
 | VARP | `=VARP(range)` | `=VARP(A1:A10)` → population variance (n) |
+| LARGE | `=LARGE(range, k)` | `=LARGE(A1:A10, 2)` → 2nd largest (1-based k) |
+| SMALL | `=SMALL(range, k)` | `=SMALL(A1:A10, 2)` → 2nd smallest |
+| RANK | `=RANK(number, ref, [order])` | `=RANK(A1, A1:A10)` → rank; order 0/omitted = descending |
+| PERCENTILE | `=PERCENTILE(range, p)` | `=PERCENTILE(A1:A10, 0.9)` → p in [0,1], inclusive interpolation |
+| QUARTILE | `=QUARTILE(range, quart)` | `=QUARTILE(A1:A10, 3)` → quart 0-4 (0=min, 2=median, 4=max) |
 
 **Note**: STDEV/VAR use Welford's algorithm for numerical stability. Sample variants require at least 2 values; population variants require at least 1.
 
@@ -47,6 +52,9 @@ The `eval` command supports 88 Excel functions.
 | Function | Syntax | Example |
 |----------|--------|---------|
 | IF | `=IF(condition, true_val, false_val)` | `=IF(A1>100,"High","Low")` |
+| IFS | `=IFS(cond1, val1, cond2, val2, ...)` | `=IFS(A1>90,"A",A1>80,"B")` → first TRUE condition's value, else #N/A |
+| SWITCH | `=SWITCH(expr, case1, val1, ..., [default])` | `=SWITCH(A1,1,"One",2,"Two","Other")` → trailing default optional |
+| CHOOSE | `=CHOOSE(index, val1, val2, ...)` | `=CHOOSE(2,"a","b","c")` → "b" (1-based; out of range → #VALUE!) |
 | AND | `=AND(cond1, cond2, ...)` | `=AND(A1>0, B1>0)` |
 | OR | `=OR(cond1, cond2, ...)` | `=OR(A1="Yes", B1="Yes")` |
 | NOT | `=NOT(condition)` | `=NOT(A1=0)` |
@@ -121,9 +129,11 @@ The `eval` command supports 88 Excel functions.
 | Function | Syntax | Example |
 |----------|--------|---------|
 | VLOOKUP | `=VLOOKUP(value, range, col, [match])` | `=VLOOKUP(A1, B:D, 2, FALSE)` |
+| HLOOKUP | `=HLOOKUP(value, range, row, [match])` | `=HLOOKUP(A1, B1:F3, 2, FALSE)` → searches first row |
 | XLOOKUP | `=XLOOKUP(lookup, lookup_arr, return_arr)` | `=XLOOKUP(A1, B:B, C:C)` |
 | INDEX | `=INDEX(array, row, [col])` | `=INDEX(A1:C10, 2, 3)` |
 | MATCH | `=MATCH(value, range, [match_type])` | `=MATCH(A1, B:B, 0)` |
+| OFFSET | `=OFFSET(ref, rows, cols, [height], [width])` | `=SUM(OFFSET(A1, 1, 0, 5, 1))` → returns a range; composes with aggregates |
 
 ## Conditional Functions
 
@@ -135,6 +145,8 @@ The `eval` command supports 88 Excel functions.
 | SUMIFS | `=SUMIFS(sum_range, crit_range1, crit1, ...)` | `=SUMIFS(C:C, A:A, "Q1", B:B, ">0")` |
 | COUNTIFS | `=COUNTIFS(range1, crit1, range2, crit2, ...)` | `=COUNTIFS(A:A, "Active", B:B, ">100")` |
 | AVERAGEIFS | `=AVERAGEIFS(avg_range, crit_range1, crit1, ...)` | `=AVERAGEIFS(C:C, A:A, "Q1", B:B, ">0")` |
+| MAXIFS | `=MAXIFS(max_range, crit_range1, crit1, ...)` | `=MAXIFS(C:C, A:A, "Q1")` → 0 if nothing matches |
+| MINIFS | `=MINIFS(min_range, crit_range1, crit1, ...)` | `=MINIFS(C:C, A:A, "Q1")` → 0 if nothing matches |
 | SUMPRODUCT | `=SUMPRODUCT(array1, [array2], ...)` | `=SUMPRODUCT(A1:A10, B1:B10)` |
 
 ## Error Handling Functions
@@ -166,3 +178,16 @@ The `eval` command supports 88 Excel functions.
 | ADDRESS | `=ADDRESS(row, col, [abs], [a1], [sheet])` | `=ADDRESS(1, 1, 1, TRUE)` → "$A$1" |
 
 **ADDRESS abs_num**: 1=$A$1, 2=A$1, 3=$A1, 4=A1
+
+## Array Functions (Dynamic Arrays)
+
+These return a grid of values. Use `xl evala` to display the result grid or spill it into the
+sheet with `--at <ref>`; a 1×1 result collapses to a scalar.
+
+| Function | Syntax | Example |
+|----------|--------|---------|
+| TRANSPOSE | `=TRANSPOSE(array)` | `=TRANSPOSE(A1:C2)` → swaps rows and columns (2×3 → 3×2) |
+| SEQUENCE | `=SEQUENCE(rows, [cols], [start], [step])` | `=SEQUENCE(5)` → 1..5 column; defaults cols=1, start=1, step=1 |
+| SORT | `=SORT(array, [sort_index], [sort_order])` | `=SORT(A1:B10, 2, -1)` → rows by 1-based column; 1=asc (default), -1=desc |
+| UNIQUE | `=UNIQUE(array, [by_col], [exactly_once])` | `=UNIQUE(A1:A100)` → distinct rows, first-seen order |
+| FILTER | `=FILTER(array, include, [if_empty])` | `=FILTER(A1:B10, C1:C10)` → rows where include is truthy; if_empty/#N/A otherwise |

--- a/plugin/skills/xl-scripting/reference/API.md
+++ b/plugin/skills/xl-scripting/reference/API.md
@@ -14,8 +14,10 @@ Everything below is in scope after `import com.tjclp.xl.scripting.{*, given}`.
 | `CellValue` | enum: `Text`, `Number(BigDecimal)`, `Bool`, `DateTime`, `Formula(expr, cached)`, `RichText`, `Error`, `Empty` |
 | `Sheet` | Immutable sheet: `cells: Map[ARef, Cell]`, name, merges, comments, col/row properties |
 | `Workbook` | `sheets: Vector[Sheet]` + metadata |
-| `Patch` | Composable change set (monoid): `Put`, `SetCellStyle`, `SetRangeStyle`, `Merge`, `Remove`, `Batch`, ... |
+| `Patch` | Composable change set (monoid): `Put`, `SetCellStyle`, `SetRangeStyle`, `Merge`, `MergeBorder`, `Remove`, `Batch`, ... |
 | `CellStyle` | font, fill, border, numFmt, alignment |
+| `SheetView` | display settings: `(showGridLines, zoomScale)` — see Sheet View & Print Setup |
+| `PageSetup` | print settings: scale, orientation, fit, header/footer, margins, print area, repeat rows |
 | `NumFmt` | `General`, `Currency`, `Percent`, `Date`, `DateTime`, `Decimal`, custom |
 | `Formatted` | `(value: CellValue, numFmt: NumFmt)` — value + display format pair |
 | `XLResult[A]` | `Either[XLError, A]` — every fallible operation |
@@ -74,6 +76,8 @@ ARef.from0(colIdx, rowIdx)   // 0-based construction
 | `sheet.comment(ref, Comment.plainText("note", Some("author")))` | `Sheet` | |
 | `sheet.toHtml(ref"A1:B10")` | `String` | inline-CSS HTML table |
 | `sheet.usedRange` | `Option[CellRange]` | |
+| `sheet.withViewSettings(view)` | `Sheet` | gridlines/zoom — see Sheet View & Print Setup |
+| `sheet.withPageSetup(setup)` | `Sheet` | print settings — see Sheet View & Print Setup |
 
 Codec types for `put`/`readTyped*`: String, Int, Long, Double, BigDecimal, Boolean, LocalDate (→ Date format), LocalDateTime (→ DateTime format), RichText.
 
@@ -104,8 +108,15 @@ ref"A1:C1".styled(style)        // style a range
 ref"A1:C1".merge                // merge cells (also .unmerge)
 ref"A1:C10".remove              // clear cells
 ref"A1".clearStyle
+ref"B2:D6".outlined(BorderStyle.Medium)                       // box the range's outer edges
+ref"B2:D6".outlined(BorderStyle.Thin, Color.fromRgb(128, 128, 128))  // colored outline
 Patch.empty                     // identity — fold seed
 ```
+
+`outlined` is edge-correct (top row gets top, corners get both, interior untouched; 1×1 gets all
+four sides) and desugars to per-cell `Patch.MergeBorder(ref, border)` — an apply-time border
+overlay that preserves each cell's font, fill, numFmt, and untouched border sides. Cost is
+proportional to the perimeter; prefer bounded ranges over whole columns.
 
 Runtime `RefType` (from `ref"$s"`) supports the same `:=` / `.styled` / `.merge` / `.remove`; `:=` on a parsed range fills it.
 
@@ -120,14 +131,51 @@ CellStyle.default
   .center / .left / .right          // horizontal align
   .top / .middle / .bottom          // vertical align
   .wrap
+  .indent(2)                        // alignment indent level (~3 chars each); negatives clamp to 0
   .bordered / .borderedMedium / .borderedThick / .borderNone
+  .borderTop(BorderStyle.Thin)      // per-side: also borderBottom/borderLeft/borderRight
+  .borderBottom(BorderStyle.Medium, Color.fromRgb(0, 0, 128))  // color overloads on each side
   .currency / .percent / .decimal / .dateFormat / .dateTime   // numFmt shortcuts
   .withNumFmt(NumFmt.Percent)
 ```
 
+Per-side border builders merge into the existing border — only the named side is replaced, so
+they compose: `.borderTop(BorderStyle.Thin).borderBottom(BorderStyle.Medium)`. Indentation lives
+in the style (survives round-trips, keeps the stored value clean) — prefer it over leading spaces.
+
 Rich text: `"Bold ".bold + "red".red + " plain"` → `RichText`, put directly into a cell.
 
 Smart detection: `FormattedParsers.detect(s)` / `s.toFormatted` (prelude) — total: `"$1,234.56"` → Currency, `"45.5%"` → Percent (stored 0.455), `"2025-01-15"` → Date, `"123.4"`/`"true"` → Number/Bool (General), anything else → Text (General).
+
+## Sheet View & Print Setup
+
+The four settings types live one import deeper than the prelude:
+
+```scala
+import com.tjclp.xl.sheets.{HeaderFooter, PageMargins, PageSetup, SheetView}
+```
+
+```scala
+// Display: gridlines off (professional templates), zoom 10-400
+sheet.withViewSettings(SheetView(showGridLines = false, zoomScale = Some(90)))
+
+// Print/PDF setup — all fields optional with Excel defaults
+sheet.withPageSetup(
+  PageSetup(
+    scale = 100,                                              // 10-400
+    orientation = Some("landscape"),                          // or "portrait"
+    fitToWidth = Some(1),                                     // pages wide (also fitToHeight)
+    headerFooter = Some(HeaderFooter(oddFooter = Some("&CPage &P of &N"))),
+    margins = Some(PageMargins(left = 0.5, right = 0.5)),     // inches; defaults match Excel Normal
+    printArea = Some(ref"A1:F40"),                            // _xlnm.Print_Area defined name
+    repeatRows = Some((1, 2))                                 // 1-based rows repeated on every page
+  )
+)
+```
+
+Header/footer strings support Excel codes — `&P` page, `&N` total pages, `&D` date, `&T` time,
+`&F` file, `&A` sheet, with `&L`/`&C`/`&R` section markers. View settings share one
+`<sheetView>` element with freeze panes; print area/repeat rows ride the defined-names pipeline.
 
 ## Formula Evaluation
 

--- a/scripts/verify-skill-snippets.sh
+++ b/scripts/verify-skill-snippets.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Extract every fenced ```scala block that begins with `//> using` from the xl-scripting skill
-# and compile it with scala-cli. Blocks without the directive header are fragments and skipped.
+# and docs/reference/scripting.md, and compile it with scala-cli. Blocks without the directive
+# header are fragments and skipped.
 #
 # Usage:
 #   scripts/verify-skill-snippets.sh           # compile against the pinned Maven version
@@ -15,7 +16,8 @@ SKILL_DIR="plugin/skills/xl-scripting"
 TMP=$(mktemp -d)
 trap 'rm -rf "$TMP"' EXIT
 
-for md in "$SKILL_DIR/SKILL.md" "$SKILL_DIR/reference/RECIPES.md" "$SKILL_DIR/reference/API.md"; do
+for md in "$SKILL_DIR/SKILL.md" "$SKILL_DIR/reference/RECIPES.md" "$SKILL_DIR/reference/API.md" \
+  "docs/reference/scripting.md"; do
   [[ -f "$md" ]] || continue
   awk -v outdir="$TMP" -v src="$(basename "$md" .md)" '
     BEGIN { inblock = 0; n = 0 }
@@ -66,7 +68,7 @@ done
 
 if (( ${#FAILED[@]} > 0 )); then
   echo "" >&2
-  echo "✗ ${#FAILED[@]} skill snippet(s) failed to compile" >&2
+  echo "✗ ${#FAILED[@]} snippet(s) failed to compile" >&2
   exit 1
 fi
-echo "✓ All skill snippets compile"
+echo "✓ All skill/doc snippets compile"

--- a/xl-cats-effect/src/com/tjclp/xl/io/ExcelIO.scala
+++ b/xl-cats-effect/src/com/tjclp/xl/io/ExcelIO.scala
@@ -101,7 +101,7 @@ class ExcelIO[F[_]: Async](warningHandler: XlsxReader.Warning => F[Unit])
   /**
    * Stream rows from sheet by name with constant memory.
    *
-   * Uses fs2-data-xml pull parsing for the target sheet.
+   * Uses SAX parser (javax.xml.parsers.SAXParser) for 3-4x speedup vs fs2-data-xml.
    */
   def readSheetStream(path: Path, sheetName: String): Stream[F, RowData] =
     Stream

--- a/xl-cli/src/com/tjclp/xl/cli/helpers/BatchParser.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/helpers/BatchParser.scala
@@ -199,6 +199,8 @@ object BatchParser:
    *   - `rowheight`: {"op": "rowheight", "row": 1, "height": 30}
    *   - `comment`: {"op": "comment", "ref": "A1", "text": "Note", "author": "User"}
    *   - `remove-comment`: {"op": "remove-comment", "ref": "A1"}
+   *   - `hyperlink`: {"op": "hyperlink", "ref": "A1", "target": "https://example.com"} (omit target
+   *     to clear)
    *   - `clear`: {"op": "clear", "range": "A1:B10", "all": true}
    *   - `col-hide`: {"op": "col-hide", "col": "C"}
    *   - `col-show`: {"op": "col-show", "col": "C"}
@@ -207,6 +209,9 @@ object BatchParser:
    *   - `autofit`: {"op": "autofit", "columns": "A:F"}
    *   - `add-sheet`: {"op": "add-sheet", "name": "New Sheet", "after": "Sheet1"}
    *   - `rename-sheet`: {"op": "rename-sheet", "from": "Old", "to": "New"}
+   *   - `freeze`: {"op": "freeze", "ref": "B2"}
+   *   - `unfreeze`: {"op": "unfreeze"}
+   *   - `copy`: {"op": "copy", "source": "A1:B2", "target": "D1", "valuesOnly": false}
    */
   @SuppressWarnings(Array("org.wartremover.warts.Var"))
   def parseBatchJson(json: String): Either[Exception, ParseResult] =
@@ -378,8 +383,8 @@ object BatchParser:
             throw new Exception(
               s"Object ${idx + 1}: Unknown operation '$other'. " +
                 "Valid: put, putf, style, merge, unmerge, colwidth, rowheight, " +
-                "comment, remove-comment, clear, col-hide, col-show, row-hide, row-show, " +
-                "autofit, add-sheet, rename-sheet, freeze, unfreeze, copy"
+                "comment, remove-comment, hyperlink, clear, col-hide, col-show, " +
+                "row-hide, row-show, autofit, add-sheet, rename-sheet, freeze, unfreeze, copy"
             )
       }
 


### PR DESCRIPTION
## Summary

Full doc-truth pass over all 43 tracked `.md` files following the 0.11.0 "Scripting" release, executed as a 10-agent workflow (truth pack → 4 edit clusters → adversarial verifiers → consistency sweep). Every factual claim was re-derived from code before being written.

### Truth corrections (empirically verified)
- **Tests: `1080+` → `3005+`** — the old number was Mill's task ticker, not tests. Real count from `./mill show __.test`: 3004 passing + 1 ignored, per-module breakdown now in `docs/reference/testing-guide.md`
- **Functions: `88` → `104`** in the xl-cli skill (`xl functions` banner confirms; source/CLI name lists diff identical)
- **Batch ops: `20` → `21`** — a `hyperlink` op has existed in `BatchParser` (dispatch at line 312) but was documented nowhere; now listed in CLAUDE.md, skills, and `cli.md`

### New docs
- `docs/reference/scripting.md` — the prelude guide for Maven users (the skill only reaches Claude Code users); its snippets are now compile-gated by `verify-skill-snippets.sh` (17 snippets total, all green against Central 0.11.0)
- `docs/design/style-guide.md` — CLAUDE.md referenced this file but it **never existed**; now real
- `plugin/README.md`, `SECURITY.md`

### 0.11.0 coverage & housekeeping
- STATUS.md 0.11.0 headline section; LIMITATIONS.md swept (fixed items removed, open ones carry issue refs #262–#266, #271)
- xl-scripting `API.md` gains the missing 0.11.0 surface (SheetView, PageSetup/HeaderFooter, per-side borders, `outlined`, indent, `MergeBorder`, `upsert`); xl-cli `SKILL.md` gains structural editing (frontmatter untouched — xl-agent consumes it)
- v0.10.0 plan docs archived to `docs/archive/plan/` with completion banners per `docs-cleanup-xl` policy; HISTORICAL banners on `docs/reviews/*`; roadmap gains a 0.12.0 candidates section; INDEX.md now reaches every doc; examples catalog covers all 20 scripts; PR template lists the snippet/example gates
- One scaladoc fix in source: `ExcelIO.readSheetStream` claimed fs2-data-xml but routes through `SaxStreamingReader` (matches sibling method's wording)

## Verification
- [x] `./scripts/verify-skill-snippets.sh` — 17/17 snippets compile against Maven Central 0.11.0
- [x] `./mill __.test` — 3005 results, green (run by truth-pack agent on this branch)
- [x] Repo-wide relative-link check — zero broken links; `xl-cli` SKILL.md frontmatter byte-identical
- [x] Cross-doc fact consistency sweep — zero disagreements on version/function/test/batch-op counts outside dated historical records

Closes #272

🤖 Generated with [Claude Code](https://claude.com/claude-code)