### PR TITLE
Wave 1 "Totality": all open bugs — #271 #263 #262 #264 #265 #266 #275 #48 #17 (0.11.1)

### DIFF
--- a/.claude/workflows/issue-wave.js
+++ b/.claude/workflows/issue-wave.js
@@ -1,0 +1,196 @@
+export const meta = {
+  name: 'issue-wave',
+  description: 'Parameterized backlog wave: baseline gate, optional design panel, worktree-isolated TDD implementers, pipelined adversarial review with one rework round',
+  whenToUse: 'Run a wave of GitHub issues as parallel worktree clusters. Pass {wave, branch, clusters:[{key, issues, modules, brief, serialNote?}], designFirst:[{issue, question}]} as args. Integration/PR/merge stays in the main loop.',
+  phases: [
+    { title: 'Baseline', detail: 'compile+test green on the wave branch, capture ground truth' },
+    { title: 'Design', detail: 'judge panel for designFirst issues (skipped when none)' },
+    { title: 'Implement', detail: 'one TDD agent per cluster in an isolated worktree' },
+    { title: 'Review', detail: 'adversarial reviewer per cluster, one rework round' },
+  ],
+}
+
+const ARGS = typeof args === 'string' ? JSON.parse(args) : (args || {})
+const REPO = ARGS.repo || '/Users/rcaputo3/git/xl'
+const WAVE = ARGS.wave || 0
+const BRANCH = ARGS.branch || `wave-${WAVE}`
+const CLUSTERS = ARGS.clusters || []
+const DESIGN_FIRST = ARGS.designFirst || []
+if (!CLUSTERS.length) throw new Error('issue-wave requires args.clusters')
+
+const BASELINE_SCHEMA = {
+  type: 'object',
+  required: ['green', 'testCount', 'preExisting', 'notes'],
+  properties: {
+    green: { type: 'boolean' },
+    testCount: { type: 'integer' },
+    preExisting: { type: 'array', items: { type: 'string' } },
+    notes: { type: 'string' },
+  },
+}
+
+const DESIGN_SCHEMA = {
+  type: 'object',
+  required: ['design', 'tradeoffs'],
+  properties: { design: { type: 'string' }, tradeoffs: { type: 'string' } },
+}
+
+const JUDGE_SCHEMA = {
+  type: 'object',
+  required: ['brief', 'rationale'],
+  properties: { brief: { type: 'string' }, rationale: { type: 'string' } },
+}
+
+const IMPL_SCHEMA = {
+  type: 'object',
+  required: ['outcome', 'sha', 'branch', 'worktreePath', 'summary', 'filesChanged', 'testsAdded', 'gateEvidence', 'gaps'],
+  properties: {
+    outcome: { type: 'string', enum: ['fixed', 'not-reproducible', 'partial', 'blocked'] },
+    sha: { type: 'string' },
+    branch: { type: 'string' },
+    worktreePath: { type: 'string' },
+    summary: { type: 'string' },
+    filesChanged: { type: 'array', items: { type: 'string' } },
+    testsAdded: { type: 'array', items: { type: 'string' } },
+    gateEvidence: { type: 'string' },
+    gaps: { type: 'array', items: { type: 'string' } },
+  },
+}
+
+const REVIEW_SCHEMA = {
+  type: 'object',
+  required: ['verdict', 'findings', 'empiricalEvidence'],
+  properties: {
+    verdict: { type: 'string', enum: ['approve', 'rework', 'reject'] },
+    findings: { type: 'array', items: { type: 'string' } },
+    empiricalEvidence: { type: 'string' },
+    reworkInstructions: { type: 'string' },
+  },
+}
+
+const HOUSE_RULES = `HOUSE RULES (xl repo, ${REPO}):
+- Purity charter: no null, no thrown exceptions in pure code, total functions returning Either/Option (XLResult), opaque types, enums with derives CanEqual. WartRemover enforces; .head/.tail and Option.get are warnings, var/while acceptable only in tests/macros.
+- NEVER re-inline extension methods or factories on opaque types (compiler landmines — see NOTE in xl-core addressing/ARef.scala). No default params on exported extension methods (use @targetName overloads).
+- Do NOT edit CHANGELOG.md or docs/plan/roadmap.md (the integrator owns them — avoids 6-way conflicts).
+- Style: ./mill <module>.reformat before committing; match surrounding code idiom; comments only for constraints code cannot express.
+- Commit with --no-verify (you run the format/test gates explicitly instead of the slow pre-commit hook), conventional message ending with "Refs #<issue>" per issue (NOT "Closes" — the wave PR owns closing).`
+
+phase('Baseline')
+log(`Wave ${WAVE}: baseline gate on branch ${BRANCH}...`)
+const baseline = await agent(`You are the baseline agent for wave ${WAVE} in ${REPO} (branch ${BRANCH} checked out). READ-ONLY plus build commands; no file edits, no commits.
+1. Confirm git branch --show-current prints ${BRANCH} and git status is clean.
+2. Run ./mill __.compile (timeout 600000 ms). Then ./mill __.test (timeout 600000 ms).
+3. Report: green (both succeeded), testCount (total test results from the run output), preExisting (any failures/warnings that exist BEFORE this wave touches anything — exact test names), notes (anything implementers should know, e.g. flaky tests, long-running suites).
+If the suite is red, report green=false with the failing names — the wave will abort rather than build on a broken base.`, { label: 'baseline', phase: 'Baseline', schema: BASELINE_SCHEMA })
+
+if (!baseline || !baseline.green) {
+  return { aborted: 'baseline-red', baseline }
+}
+log(`Baseline green: ${baseline.testCount} tests. ${baseline.preExisting.length} pre-existing notes.`)
+
+const designBriefs = {}
+if (DESIGN_FIRST.length) {
+  phase('Design')
+  log(`Design panel for ${DESIGN_FIRST.length} issue(s)...`)
+  const LENSES = ['Excel-parity-first: match Excel observable behavior exactly, cite real Excel semantics', 'purity-first: totality, determinism, law-governed — the design must not weaken the purity charter', 'minimal-diff-first: smallest change that ships, defer everything deferrable, name what is deferred']
+  for (const df of DESIGN_FIRST) {
+    const designs = await parallel(LENSES.map((lens, i) => () =>
+      agent(`You are design panelist ${i + 1} for xl issue #${df.issue} in ${REPO} (read-only — explore code, read the issue with gh issue view ${df.issue}, but edit nothing).
+Your lens: ${lens}.
+Design question: ${df.question}
+Produce a concrete design: API signatures, file-level change list, semantics decisions, test strategy, what is explicitly out of scope. Ground every claim in the actual code (cite paths).`, { label: `design:${df.issue}:${i + 1}`, phase: 'Design', schema: DESIGN_SCHEMA })))
+    const valid = designs.filter(Boolean)
+    const judged = await agent(`You are the adversarial design judge for xl issue #${df.issue}. Three panelists designed independently under different lenses. Score each for correctness against the actual codebase (verify claims — read the code), Excel parity, purity-charter fit, and implementability. Then synthesize THE brief the implementer will follow: take the winning skeleton, graft superior ideas from the others, list explicit decisions (no open questions), file-level change list, and test plan.
+PANELIST DESIGNS:
+${valid.map((d, i) => `--- Design ${i + 1} ---\n${d.design}\nTradeoffs: ${d.tradeoffs}`).join('\n')}`, { label: `judge:${df.issue}`, phase: 'Design', schema: JUDGE_SCHEMA })
+    if (judged) designBriefs[df.issue] = judged.brief
+  }
+}
+
+phase('Implement')
+log(`Fanning out ${CLUSTERS.length} worktree implementers...`)
+
+const implPrompt = (c) => {
+  const briefExtras = (c.issues || []).filter(n => designBriefs[n]).map(n => `\nDESIGN BRIEF for #${n} (binding — follow it):\n${designBriefs[n]}`).join('')
+  return `You are the implementation agent for cluster "${c.key}" of wave ${WAVE} in the xl repo. You are running in an ISOLATED GIT WORKTREE — confirm with pwd and git rev-parse --show-toplevel (it will NOT be ${REPO}; that is correct). Base branch: ${BRANCH}. Modules in scope: ${c.modules}.
+
+ISSUES TO RESOLVE (read each fully first: gh issue view <n> --json title,body,comments): ${(c.issues || []).map(n => '#' + n).join(', ')}
+${c.serialNote ? `SERIALIZATION ORDER (mandatory): ${c.serialNote}` : ''}
+
+CLUSTER BRIEF (exploration-verified seeds — re-verify line numbers before editing, code may have drifted):
+${c.brief}${briefExtras}
+
+${HOUSE_RULES}
+
+METHOD (mandatory):
+1. TDD: for each issue, FIRST write the failing test that pins the bug/feature from the issue's repro, run it, SEE IT FAIL, then implement until green. Tests live in the module's existing spec files where the brief names them.
+2. Touch only files within this cluster's footprint. If a fix genuinely requires a file another cluster owns, STOP that part and report it as a gap instead.
+3. Local gates before declaring done: ./mill <module>.test for every module you touched (timeout 600000), ./mill __.checkFormat after ./mill <module>.reformat. All green.
+4. Commit (git commit --no-verify) with a conventional message; one commit per issue is ideal, a single clean cluster commit acceptable. Message body: "Refs #<n>" lines.
+5. Report: outcome (fixed | not-reproducible [only if the brief says verify-first and you proved it] | partial | blocked), sha (git rev-parse HEAD), branch (git branch --show-current), worktreePath (pwd), summary, filesChanged, testsAdded (test names), gateEvidence (the actual gate commands + tail of their output), gaps (anything discovered worth filing as a new issue — be specific).
+Your final structured output is consumed by an adversarial reviewer who will try to refute your work — include enough evidence that an honest reviewer can retrace every claim.`
+}
+
+const reviewPrompt = (c, impl, isReReview) => `You are the ADVERSARIAL reviewer for cluster "${c.key}" of wave ${WAVE} (xl repo). ${isReReview ? 'This is a RE-REVIEW after one rework round — previous findings should now be addressed.' : ''}Default stance: the implementation is wrong until you fail to refute it. Empirical evidence only — claims you did not execute do not count.
+
+THE IMPLEMENTER REPORTED: ${JSON.stringify(impl, null, 2)}
+
+ISSUES: ${(c.issues || []).map(n => '#' + n).join(', ')} (read them: gh issue view <n>)
+CLUSTER BRIEF (what was supposed to happen):
+${c.brief}
+
+PROTOCOL:
+1. Get the code: work in the implementer's worktree if it still exists (cd ${impl.worktreePath}); otherwise create your own: git -C ${REPO} worktree add /tmp/review-${c.key}-w${WAVE} ${impl.sha} and work there (remove it when done).
+2. Refutation pass: run the issue's ORIGINAL repro — it must now behave correctly. Then prove the new tests pin the bug: temporarily restore the pre-fix source (git checkout ${BRANCH} -- <changed src files>, NOT the test files), run the new tests, they MUST FAIL; then restore (git checkout ${impl.sha} -- <files>). A test that passes without the fix is a rubber stamp — that is a rework finding.
+3. Break it: probe edge cases the issue implies but the tests skip (empty/boundary/unicode/negative/huge inputs; for parser work, round-trip law parse-print-parse; for OOXML work, write-read round-trip AND streaming-vs-in-memory parity where both paths exist; for refactors, behavioral equivalence on the old test suite).
+4. Run the module test suite yourself (./mill <module>.test) — do not trust gateEvidence.
+5. Scope check: git show --stat ${impl.sha} — flag files outside the cluster footprint, CHANGELOG/roadmap edits (forbidden), or unrelated drive-by changes.
+VERDICT: approve (everything held) | rework (fixable findings — give precise reworkInstructions: file, what is wrong, what correct looks like) | reject (fundamentally wrong approach; explain). Report empiricalEvidence: the commands you ran and their actual outcomes. Do NOT edit the implementation yourself.`
+
+const reworkPrompt = (c, impl, review) => `You are the rework agent for cluster "${c.key}" of wave ${WAVE} (xl repo). An adversarial reviewer found concrete problems in the implementation. Fix exactly these findings — no scope creep.
+
+WORKTREE: cd ${impl.worktreePath} — if it no longer exists, recreate it: git -C ${REPO} worktree add /tmp/rework-${c.key}-w${WAVE} ${impl.branch} && cd there.
+PRIOR IMPLEMENTATION REPORT: ${JSON.stringify(impl, null, 2)}
+REVIEWER FINDINGS (fix all of these):
+${(review.findings || []).map(f => '- ' + f).join('\n')}
+REWORK INSTRUCTIONS: ${review.reworkInstructions || '(see findings)'}
+
+${HOUSE_RULES}
+
+Fix, keep TDD discipline (failing test first for any finding that lacks one), rerun local gates (./mill <module>.test + ./mill __.checkFormat after reformat), commit on top (--no-verify), and report the same structured output as an implementer (outcome/sha/branch/worktreePath/summary/filesChanged/testsAdded/gateEvidence/gaps). The reviewer re-reviews after you.`
+
+const results = await pipeline(
+  CLUSTERS,
+  c => agent(implPrompt(c), { label: `impl:${c.key}`, phase: 'Implement', isolation: 'worktree', schema: IMPL_SCHEMA }),
+  async (impl, c) => {
+    if (!impl) return { cluster: c.key, status: 'impl-failed' }
+    if (impl.outcome === 'blocked') return { cluster: c.key, status: 'blocked', impl }
+    let review = await agent(reviewPrompt(c, impl, false), { label: `review:${c.key}`, phase: 'Review', schema: REVIEW_SCHEMA })
+    let finalImpl = impl
+    let reworked = false
+    if (review && review.verdict === 'rework') {
+      log(`Cluster ${c.key}: rework round (${review.findings.length} findings)`)
+      const fixed = await agent(reworkPrompt(c, impl, review), { label: `rework:${c.key}`, phase: 'Review', schema: IMPL_SCHEMA })
+      if (fixed) {
+        finalImpl = fixed
+        reworked = true
+        review = await agent(reviewPrompt(c, fixed, true), { label: `re-review:${c.key}`, phase: 'Review', schema: REVIEW_SCHEMA })
+      }
+    }
+    return { cluster: c.key, status: review ? review.verdict : 'review-failed', impl: finalImpl, review, reworked }
+  }
+)
+
+const summary = results.filter(Boolean)
+const approved = summary.filter(r => r.status === 'approve')
+const problems = summary.filter(r => r.status !== 'approve')
+log(`Wave ${WAVE} agents done: ${approved.length}/${CLUSTERS.length} clusters approved${problems.length ? `; needs integrator attention: ${problems.map(p => p.cluster + ':' + p.status).join(', ')}` : ''}`)
+
+return {
+  wave: WAVE,
+  baseline: { testCount: baseline.testCount, preExisting: baseline.preExisting },
+  designBriefs: Object.keys(designBriefs),
+  clusters: summary,
+  integrationOrder: summary.filter(r => r.impl && r.impl.sha).map(r => ({ cluster: r.cluster, sha: r.impl.sha, branch: r.impl.branch, status: r.status, outcome: r.impl.outcome })),
+  gaps: summary.flatMap(r => (r.impl && r.impl.gaps) || []),
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Leading unary plus in formulas** (#271): `=+A1`, `=+SUM(A1:B2)`, chained `=++A1`, and
+  exponent positions (`=2^+2`) now parse — the ubiquitous banker idiom from real bank-built
+  models. Unary plus is identity: it parses to the same AST as the bare expression, so the
+  printer normalizes (`=+A1` prints `=A1`) and the parse∘print round-trip law is untouched.
+  Deeply chained `+` counts against the recursion budget (`NestingTooDeep`, never overflow).
+- **Even/first-page headers & footers + fitToPage** (#266): `HeaderFooter` gains
+  `evenHeader/evenFooter/firstHeader/firstFooter` and `differentOddEven/differentFirst`;
+  setting `fitToWidth`/`fitToHeight` now also emits `<sheetPr><pageSetUpPr fitToPage="1"/>`
+  (without which Excel ignores fit-to-page). Full write→read round-trip.
+
+### Fixed
+
+- **Sheet names that look like cell refs are now quoted** (#263): a sheet named `Q1`, `A1`,
+  or `R1C1` previously produced unquoted, ambiguous formulas (`Q1!$A$1:$B$2`) in printed
+  formulas, `toA1`, and `_xlnm` print names. One shared predicate (`SheetName.needsQuoting` /
+  `SheetName.quoteForFormula`) now drives `RefType`, `FormulaPrinter`, and `PrintNames` —
+  including `TRUE`/`FALSE` as sheet names, which the parser would otherwise re-read as booleans.
+- **Trailing empty format sections preserved** (#262): `"0.0;;"` (the hide-zero idiom) now
+  splits into three sections and empty sections render as empty string instead of falling
+  back to General. `";;;"` (hide-everything) works.
+- **Evaluating display strategy prefers cached formula values** (#275): after
+  `wb.recalculate()`, cross-sheet formulas display their cached values in `excel""` /
+  `displayCell` output instead of raw formula text.
+- **Streaming `StylePatcher` totality** (#264): malformed `indent="-2"` (and other invalid
+  numeric attributes) in styles.xml no longer throw through `Align`'s domain guard during
+  streaming style patches — hardened to match the DOM-side parser exactly.
+- **Streaming writer emits sheet metadata for fresh sheets** (#265): `DirectSaxEmitter` now
+  writes `sheetPr`, `sheetViews` (freeze panes, gridline settings), `pageMargins`,
+  `pageSetup`, `headerFooter`, and `hyperlinks` in schema order — previously all silently
+  dropped on the SaxStax path; also fixes orphaned hyperlink relationships.
+
+### Changed
+
+- **`SheetEvaluator` is now var-free** (#48): the two mutable accumulation blocks were
+  refactored to `foldLeft`, removing the last `@SuppressWarnings(Var)` exemptions in the
+  evaluator's hot path. Behavior is identical (locked by the existing suite + new
+  equivalence pins).
+- **SST whitespace preservation through surgical writes pinned by regression spec** (#17):
+  investigated with a falsifiability protocol (three hypothesized bug classes injected, each
+  caught) — the 2025-11 report is not reproducible on the current write path; a permanent
+  regression spec now guards it.
+
 ## [0.11.0] "Scripting" - 2026-06-10
 
 The scripting release: one-import prelude, total-by-semantics APIs, whole-workbook

--- a/docs/plan/roadmap.md
+++ b/docs/plan/roadmap.md
@@ -18,20 +18,44 @@
 
 ## Release Roadmap
 
-### v0.12.0 candidates (not yet scheduled)
+The full open backlog (triaged 2026-06-10) is scheduled as **six waves → four releases**, each wave
+executed as a parallel multi-agent run via `.claude/workflows/issue-wave.js` (baseline gate →
+worktree-isolated TDD clusters → adversarial review → integration). This roadmap is the single
+source of truth for scheduling.
 
-This roadmap is the single source of truth for scheduling; entries below are **candidates, not commitments** — nothing is started until it is pulled into a release plan.
+### v0.11.1 "Totality" — wave 1 (in flight)
 
-| Candidate | Notes |
-|-----------|-------|
-| **"Visual" theme**: Chart model ([#222](https://github.com/TJC-LP/xl/issues/222)) on a DrawingML/image layer ([#221](https://github.com/TJC-LP/xl/issues/221)) | Deferred from 0.10.0/0.11.0; charts structurally depend on the drawing layer |
-| 0.11.x follow-up: leading `=+` unary plus rejected by parser ([#271](https://github.com/TJC-LP/xl/issues/271)) | Banker idiom (`=+A1`); flagged as the top 0.11.1 candidate |
-| 0.11.x follow-up: trailing empty format sections ([#262](https://github.com/TJC-LP/xl/issues/262)) | Number-format section selection edge case |
-| 0.11.x follow-up: quoting for cell-ref-shaped sheet names ([#263](https://github.com/TJC-LP/xl/issues/263)) | e.g. a sheet literally named `A1` |
-| 0.11.x follow-up: streaming StylePatcher indent + border-merge unification ([#264](https://github.com/TJC-LP/xl/issues/264)) | Parity between streaming and in-memory style edits |
-| 0.11.x follow-up: SaxStax DirectSaxEmitter metadata gaps ([#265](https://github.com/TJC-LP/xl/issues/265)) | Streaming writer metadata parity |
-| 0.11.x follow-up: even/first-page headers + `fitToPage` flag ([#266](https://github.com/TJC-LP/xl/issues/266)) | Completes the 0.11.0 `PageSetup` print extensions |
-| Display strategy: `excel""` interpolator re-evaluates formulas sheet-locally instead of using the `recalculate` cache | Cross-sheet formulas can display stale/erroring values in scripts; unify display on the recalc cache |
+All open bugs, one patch release.
+
+| Issue | Fix |
+|-------|-----|
+| [#271](https://github.com/TJC-LP/xl/issues/271) | Leading unary plus (`=+A1`) parses as identity; printer normalizes |
+| [#263](https://github.com/TJC-LP/xl/issues/263) | Cell-ref-shaped sheet names quoted via shared `SheetName.needsQuoting` |
+| [#262](https://github.com/TJC-LP/xl/issues/262) | Trailing empty format sections preserved (`"0.0;;"` hide-zero idiom) |
+| [#264](https://github.com/TJC-LP/xl/issues/264) | Streaming `StylePatcher` totality (malformed attribute hardening) |
+| [#266](https://github.com/TJC-LP/xl/issues/266) | Even/first-page headers+footers, `fitToPage` flag |
+| [#265](https://github.com/TJC-LP/xl/issues/265) | `DirectSaxEmitter` emits sheet metadata (+ hyperlinks) for fresh sheets |
+| [#275](https://github.com/TJC-LP/xl/issues/275) | Evaluating display prefers `recalculate`'s cached values |
+| [#48](https://github.com/TJC-LP/xl/issues/48) | `SheetEvaluator` var-free refactor |
+| [#17](https://github.com/TJC-LP/xl/issues/17) | SST surgical whitespace: not reproducible; regression spec added |
+
+### v0.11.2 "Laws & Functions" — waves 2 + 3
+
+| Wave | Issues |
+|------|--------|
+| 2 — test infrastructure | [#240](https://github.com/TJC-LP/xl/issues/240) real-fixture corpus + generative round-trip law + streaming/in-memory parity; [#40](https://github.com/TJC-LP/xl/issues/40) `Sheet.put` benchmark; [#47](https://github.com/TJC-LP/xl/issues/47) renderer edge tests |
+| 3 — evaluator breadth | [#193](https://github.com/TJC-LP/xl/issues/193) LET; [#274](https://github.com/TJC-LP/xl/issues/274) INDIRECT (design-first); [#93](https://github.com/TJC-LP/xl/issues/93) YEARFRAC parity; [#115](https://github.com/TJC-LP/xl/issues/115) RAND/RANDBETWEEN (seeded-RNG capability); [#184](https://github.com/TJC-LP/xl/issues/184) formula numFmt inheritance |
+
+### v0.11.3 "Robustness" — waves 4 + 5
+
+| Wave | Issues |
+|------|--------|
+| 4 — streaming/OOXML | [#223](https://github.com/TJC-LP/xl/issues/223) two-pass streaming SST + style registry; [#242](https://github.com/TJC-LP/xl/issues/242) docProps emission; [#243](https://github.com/TJC-LP/xl/issues/243) 1904 dates + `NumFmt.Fraction` + autofilter authoring |
+| 5 — CLI/UX | [#134](https://github.com/TJC-LP/xl/issues/134) `filter --where` (row predicates); [#137](https://github.com/TJC-LP/xl/issues/137) `diff`; [#159](https://github.com/TJC-LP/xl/issues/159) markdown import; [#156](https://github.com/TJC-LP/xl/issues/156) AWT-metric autofit; [#86](https://github.com/TJC-LP/xl/issues/86) Batik-first rasterization |
+
+### v0.12.0 "Visual" — wave 6 (design-first)
+
+Phased: (a) verbatim chart/drawing preservation proven by the wave-2 fixture corpus; (b) `Drawing`/`Image`/anchor domain model + image authoring ([#221](https://github.com/TJC-LP/xl/issues/221)); (c) typed chart AST (bar/line/pie) + authoring + `xl chart` CLI ([#222](https://github.com/TJC-LP/xl/issues/222)). Re-scoped by its own design panel when reached.
 
 ### v0.11.0 "Scripting" (Released 2026-06-10)
 

--- a/xl-cats-effect/src/com/tjclp/xl/io/streaming/StylePatcher.scala
+++ b/xl-cats-effect/src/com/tjclp/xl/io/streaming/StylePatcher.scala
@@ -501,7 +501,9 @@ object StylePatcher:
         val bold = (f \ "b").nonEmpty
         val italic = (f \ "i").nonEmpty
         val underline = (f \ "u").nonEmpty
-        val size = (f \ "sz" \ "@val").text.toDoubleOption.getOrElse(11.0)
+        // Font requires sizePt > 0; treat non-positive (or NaN) sizes from malformed files
+        // as absent so the streaming path stays total
+        val size = (f \ "sz" \ "@val").text.toDoubleOption.filter(_ > 0).getOrElse(11.0)
         val name = (f \ "name" \ "@val").text match
           case "" => "Calibri"
           case n => n
@@ -600,7 +602,9 @@ object StylePatcher:
         case "distributed" => VAlign.Distributed
         case _ => VAlign.Bottom
       val wrap = (alignment \ "@wrapText").text == "1"
-      val indent = (alignment \ "@indent").text.toIntOption.getOrElse(0)
+      // OOXML indent is an unsigned int; ignore negative values from malformed files so the
+      // streaming path stays total (Align requires indent >= 0), matching the DOM StyleParser
+      val indent = (alignment \ "@indent").text.toIntOption.filter(_ >= 0).getOrElse(0)
       Align(h, v, wrap, indent)
 
   private def extractColor(nodes: NodeSeq): Option[Color] =

--- a/xl-cats-effect/test/src/com/tjclp/xl/io/streaming/StreamingErrorSpec.scala
+++ b/xl-cats-effect/test/src/com/tjclp/xl/io/streaming/StreamingErrorSpec.scala
@@ -1,7 +1,10 @@
 package com.tjclp.xl.io.streaming
 
 import munit.FunSuite
+import com.tjclp.xl.ooxml.XmlSecurity
+import com.tjclp.xl.ooxml.style.WorkbookStyles
 import com.tjclp.xl.styles.CellStyle
+import com.tjclp.xl.styles.alignment.HAlign
 import com.tjclp.xl.styles.font.Font
 import com.tjclp.xl.styles.fill.Fill
 import com.tjclp.xl.styles.color.Color
@@ -12,6 +15,7 @@ import com.tjclp.xl.error.XLError
  *
  * Covers:
  *   - Malformed XML handling in StylePatcher
+ *   - Malformed attribute values in StylePatcher (totality, DOM-parser parity)
  *   - Error recovery in streaming transforms
  */
 @SuppressWarnings(Array("org.wartremover.warts.OptionPartial"))
@@ -112,6 +116,68 @@ class StreamingErrorSpec extends FunSuite:
     assertEquals(merged.font.italic, true)
   }
 
+  // ========== StylePatcher Attribute Totality (#264) ==========
+
+  test("StylePatcher.getStyle: negative indent attribute is ignored, not thrown") {
+    val xml = stylesXmlWith(
+      defaultFontsXml,
+      """<xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0" applyAlignment="1"><alignment horizontal="left" wrapText="1" indent="-2"/></xf>"""
+    )
+
+    val result = StylePatcher.getStyle(xml, 1)
+    result match
+      case Right(Some(style)) =>
+        assertEquals(style.align.indent, 0) // negative treated as absent, like DOM parser
+        assertEquals(style.align.horizontal, HAlign.Left)
+        assertEquals(style.align.wrapText, true)
+      case other => fail(s"Expected Right(Some(style)), got: $other")
+  }
+
+  test("StylePatcher.getStyle: negative indent behaves identically to DOM StyleParser") {
+    val xml = stylesXmlWith(
+      defaultFontsXml,
+      """<xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0" applyAlignment="1"><alignment horizontal="left" wrapText="1" indent="-2"/></xf>"""
+    )
+
+    val streamingAlign = StylePatcher.getStyle(xml, 1).toOption.flatten.map(_.align)
+    val domAlign = XmlSecurity
+      .parseSafe(xml, "styles.xml")
+      .toOption
+      .flatMap(elem => WorkbookStyles.fromXml(elem).toOption)
+      .flatMap(_.styleAt(1))
+      .map(_.align)
+
+    assert(streamingAlign.isDefined, "streaming path should produce an alignment")
+    assert(domAlign.isDefined, "DOM path should produce an alignment")
+    assertEquals(streamingAlign, domAlign)
+  }
+
+  test("StylePatcher.getStyle: valid positive indent is preserved") {
+    val xml = stylesXmlWith(
+      defaultFontsXml,
+      """<xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0" applyAlignment="1"><alignment horizontal="left" indent="3"/></xf>"""
+    )
+
+    val result = StylePatcher.getStyle(xml, 1)
+    result match
+      case Right(Some(style)) => assertEquals(style.align.indent, 3)
+      case other => fail(s"Expected Right(Some(style)), got: $other")
+  }
+
+  test("StylePatcher.getStyle: non-positive font size falls back to default, not thrown") {
+    for badSize <- List("-5", "0", "NaN") do
+      val xml = stylesXmlWith(
+        s"""<fonts count="2"><font><sz val="11"/><name val="Calibri"/></font><font><sz val="$badSize"/><name val="Calibri"/></font></fonts>""",
+        """<xf numFmtId="0" fontId="1" fillId="0" borderId="0" xfId="0" applyFont="1"/>"""
+      )
+
+      val result = StylePatcher.getStyle(xml, 1)
+      result match
+        case Right(Some(style)) =>
+          assertEquals(style.font.sizePt, Font.default.sizePt, s"for sz val=$badSize")
+        case other => fail(s"Expected Right(Some(style)) for sz val=$badSize, got: $other")
+  }
+
   // ========== StreamingTransform Edge Cases ==========
 
   test("StreamingTransform.analyzePatches: empty patches returns None") {
@@ -150,6 +216,20 @@ class StreamingErrorSpec extends FunSuite:
   }
 
   // ========== Helpers ==========
+
+  private val defaultFontsXml: String =
+    """<fonts count="1"><font><sz val="11"/><name val="Calibri"/></font></fonts>"""
+
+  /** styles.xml with the given fonts block and a second cellXf (style id 1). */
+  private def stylesXmlWith(fontsXml: String, secondXf: String): String =
+    s"""<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+       |<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+       |$fontsXml
+       |<fills count="2"><fill><patternFill patternType="none"/></fill><fill><patternFill patternType="gray125"/></fill></fills>
+       |<borders count="1"><border><left/><right/><top/><bottom/><diagonal/></border></borders>
+       |<cellStyleXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0"/></cellStyleXfs>
+       |<cellXfs count="2"><xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0"/>$secondXf</cellXfs>
+       |</styleSheet>""".stripMargin.replaceAll("\n", "")
 
   private val minimalStylesXml: String =
     """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>

--- a/xl-core/src/com/tjclp/xl/addressing/RefType.scala
+++ b/xl-core/src/com/tjclp/xl/addressing/RefType.scala
@@ -59,30 +59,17 @@ enum RefType derives CanEqual:
   /**
    * Convert to A1 notation.
    *
-   * For qualified refs, includes sheet name (with quotes if needed). Escapes single quotes as ''
-   * (Excel convention).
+   * For qualified refs, includes sheet name, quoted when required (special characters, leading
+   * digits, or cell-ref-shaped names like `Q1` — see SheetName.needsQuoting). Escapes single quotes
+   * as '' (Excel convention).
    */
   def toA1: String = this match
     case Cell(ref) => ref.toA1
     case Range(range) => range.toA1
     case QualifiedCell(sheet, ref) =>
-      val sheetStr = formatSheetName(sheet.value)
-      s"$sheetStr!${ref.toA1}"
+      s"${SheetName.quoteForFormula(sheet.value)}!${ref.toA1}"
     case QualifiedRange(sheet, range) =>
-      val sheetStr = formatSheetName(sheet.value)
-      s"$sheetStr!${range.toA1}"
-
-  /** Format sheet name with proper quoting and escaping */
-  private def formatSheetName(name: String): String =
-    if needsQuoting(name) then
-      // Escape ' → '' and wrap in quotes
-      val escaped = name.replace("'", "''")
-      s"'$escaped'"
-    else name
-
-  /** Check if sheet name needs quoting (has spaces or special chars) */
-  private def needsQuoting(name: String): Boolean =
-    name.exists(c => c == ' ' || c == '\'' || !c.isLetterOrDigit && c != '_')
+      s"${SheetName.quoteForFormula(sheet.value)}!${range.toA1}"
 
 end RefType
 

--- a/xl-core/src/com/tjclp/xl/addressing/SheetName.scala
+++ b/xl-core/src/com/tjclp/xl/addressing/SheetName.scala
@@ -8,6 +8,8 @@ object SheetName:
   private val MaxLength = 31
   // Excel reserved names (case-insensitive)
   private val ReservedNames = Set("history")
+  // R1C1-style reference shapes (R1C1, RC, r2c, ...) that Excel reads as references, not names
+  private val R1C1Shaped = "(?i)^R\\d*C\\d*$".r
 
   /** Create a validated sheet name */
   def apply(name: String): Either[String, SheetName] =
@@ -21,6 +23,34 @@ object SheetName:
 
   /** Create an unsafe sheet name (use only when validation is guaranteed) */
   def unsafe(name: String): SheetName = name
+
+  /**
+   * True when this name must be single-quoted in A1-style formulas and references (GH-263).
+   *
+   * Shared by every formatter that emits sheet-qualified references (RefType.toA1, FormulaPrinter,
+   * defined-name print formulas). Quoting is required for names that:
+   *   - are empty or start with a digit,
+   *   - contain any character outside letters/digits/underscore (spaces, quotes, `-`, ...),
+   *   - parse as an A1 cell reference (`A1` through `XFD1048576`, case-insensitive) — bare `Q1!B2`
+   *     would be read as something else entirely by Excel,
+   *   - look like an R1C1 reference (`R1C1`, `RC`, `r2c`, ...),
+   *   - spell a boolean literal (formula parsers read bare TRUE/FALSE as literals).
+   */
+  def needsQuoting(name: String): Boolean =
+    name.isEmpty
+      || name.headOption.exists(_.isDigit)
+      || name.exists(c => !c.isLetterOrDigit && c != '_')
+      || ARef.parse(name).isRight
+      || R1C1Shaped.matches(name)
+      || name.equalsIgnoreCase("TRUE")
+      || name.equalsIgnoreCase("FALSE")
+
+  /**
+   * Render a sheet name for use in a formula or A1 reference: bare when safe, otherwise
+   * single-quoted with embedded quotes doubled (Excel escape convention).
+   */
+  def quoteForFormula(name: String): String =
+    if needsQuoting(name) then s"'${name.replace("'", "''")}'" else name
 
   extension (name: SheetName) def value: String = name
 

--- a/xl-core/src/com/tjclp/xl/display/DisplayConversions.scala
+++ b/xl-core/src/com/tjclp/xl/display/DisplayConversions.scala
@@ -88,9 +88,10 @@ object DisplayConversions:
 
     // Format based on value type
     val formatted = cell.value match
-      case CellValue.Formula(expr, _) =>
-        // Use formula display strategy (raw text or evaluation)
-        fds.format(expr, sheet)
+      case CellValue.Formula(expr, cached) =>
+        // Use formula display strategy (raw text or evaluation), passing the cached
+        // value and cell numFmt so strategies can prefer the cache (GH-275)
+        fds.formatCached(expr, cached, numFmt, sheet)
 
       case other =>
         // Use NumFmt formatter for non-formula values

--- a/xl-core/src/com/tjclp/xl/display/FormatCodeParser.scala
+++ b/xl-core/src/com/tjclp/xl/display/FormatCodeParser.scala
@@ -171,6 +171,9 @@ object FormatCodeParser:
 
   /**
    * Split format code into sections by semicolon. Respects quoted strings and brackets.
+   *
+   * Empty sections are preserved — including trailing ones — because an empty section means
+   * "display nothing" for that value class (e.g. `0.0;;` hides negative and zero, GH-262).
    */
   private def splitSections(code: String): Vector[String] =
     val sections = ArrayBuffer[String]()
@@ -198,7 +201,9 @@ object FormatCodeParser:
           current += c
       i += 1
 
-    if current.nonEmpty then sections += current.toString
+    // Keep the final segment whenever a separator created it (sections.nonEmpty),
+    // so trailing empty sections survive: "0.0;;" splits into three sections.
+    if sections.nonEmpty || current.nonEmpty then sections += current.toString
     sections.toVector
 
   /**

--- a/xl-core/src/com/tjclp/xl/display/FormulaDisplayStrategy.scala
+++ b/xl-core/src/com/tjclp/xl/display/FormulaDisplayStrategy.scala
@@ -1,6 +1,8 @@
 package com.tjclp.xl.display
 
+import com.tjclp.xl.cells.CellValue
 import com.tjclp.xl.sheets.Sheet
+import com.tjclp.xl.styles.numfmt.NumFmt
 
 /**
  * Type class for displaying formula cells.
@@ -25,6 +27,32 @@ trait FormulaDisplayStrategy:
    *   Formatted display string
    */
   def format(formula: String, sheet: Sheet): String
+
+  /**
+   * Format a formula cell for display, with access to its cached value and number format.
+   *
+   * Called by the display layer with the full formula-cell context: the cached value (populated by
+   * `Workbook.recalculate()` / read from disk) and the cell's number format. The default
+   * implementation ignores both and delegates to [[format]]; strategies may override to prefer the
+   * cached value (see EvaluatingFormulaDisplay in xl-evaluator, GH-275).
+   *
+   * @param formula
+   *   The formula expression
+   * @param cached
+   *   The cached computed value carried by the formula cell, if any
+   * @param numFmt
+   *   The cell's number format (from its style; General when unstyled)
+   * @param sheet
+   *   The sheet context for evaluation (if evaluating)
+   * @return
+   *   Formatted display string
+   */
+  def formatCached(
+    formula: String,
+    cached: Option[CellValue],
+    numFmt: NumFmt,
+    sheet: Sheet
+  ): String = format(formula, sheet)
 
 /**
  * Low-priority given instances for FormulaDisplayStrategy.

--- a/xl-core/src/com/tjclp/xl/sheets/PageSetup.scala
+++ b/xl-core/src/com/tjclp/xl/sheets/PageSetup.scala
@@ -9,17 +9,36 @@ import com.tjclp.xl.addressing.{CellRange, Row}
  * `&T` (time), `&F` (file name), `&A` (sheet name), plus the `&L`/`&C`/`&R` section markers for
  * left/center/right placement (e.g. `"&LTHE JORDAN COMPANY&RPage &P of &N"`).
  *
- * Only odd-page headers/footers are modeled for now; even/first-page variants present in a source
- * file are preserved verbatim on rewrite.
+ * Even-page text only takes effect when `differentOddEven` is set, and first-page text only when
+ * `differentFirst` is set — mirroring Excel, which keeps the text but ignores it while the
+ * corresponding flag is off.
  *
  * @param oddHeader
- *   Header text for odd pages (all pages unless differentOddEven is set in the source file)
+ *   Header text for odd pages (all pages unless differentOddEven is set)
  * @param oddFooter
  *   Footer text for odd pages
+ * @param evenHeader
+ *   Header text for even pages (used when differentOddEven is set)
+ * @param evenFooter
+ *   Footer text for even pages (used when differentOddEven is set)
+ * @param firstHeader
+ *   Header text for the first page (used when differentFirst is set)
+ * @param firstFooter
+ *   Footer text for the first page (used when differentFirst is set)
+ * @param differentOddEven
+ *   Whether even pages use evenHeader/evenFooter instead of the odd text
+ * @param differentFirst
+ *   Whether the first page uses firstHeader/firstFooter instead of the odd text
  */
 final case class HeaderFooter(
   oddHeader: Option[String] = None,
-  oddFooter: Option[String] = None
+  oddFooter: Option[String] = None,
+  evenHeader: Option[String] = None,
+  evenFooter: Option[String] = None,
+  firstHeader: Option[String] = None,
+  firstFooter: Option[String] = None,
+  differentOddEven: Boolean = false,
+  differentFirst: Boolean = false
 )
 
 /**

--- a/xl-core/test/src/com/tjclp/xl/addressing/RefTypeSpec.scala
+++ b/xl-core/test/src/com/tjclp/xl/addressing/RefTypeSpec.scala
@@ -309,6 +309,102 @@ class RefTypeSpec extends ScalaCheckSuite:
     assert(ref.toA1.contains("'"), "Should quote sheet name with apostrophe")
   }
 
+  // ========== GH-263: cell-ref-shaped sheet names must be quoted ==========
+
+  test("GH-263: toA1 quotes sheet names that parse as cell references") {
+    val b2 = ARef.from1(2, 2)
+    assertEquals(RefType.QualifiedCell(SheetName.unsafe("A1"), b2).toA1, "'A1'!B2")
+    assertEquals(RefType.QualifiedCell(SheetName.unsafe("Q1"), b2).toA1, "'Q1'!B2")
+    assertEquals(RefType.QualifiedCell(SheetName.unsafe("XFD1048576"), b2).toA1, "'XFD1048576'!B2")
+    assertEquals(RefType.QualifiedCell(SheetName.unsafe("q4"), b2).toA1, "'q4'!B2")
+  }
+
+  test("GH-263: toA1 quotes R1C1-shaped and leading-digit sheet names") {
+    val b2 = ARef.from1(2, 2)
+    assertEquals(RefType.QualifiedCell(SheetName.unsafe("R1C1"), b2).toA1, "'R1C1'!B2")
+    assertEquals(RefType.QualifiedCell(SheetName.unsafe("RC"), b2).toA1, "'RC'!B2")
+    assertEquals(RefType.QualifiedCell(SheetName.unsafe("r2c3"), b2).toA1, "'r2c3'!B2")
+    assertEquals(RefType.QualifiedCell(SheetName.unsafe("2024Q1"), b2).toA1, "'2024Q1'!B2")
+  }
+
+  test("GH-263: 'A1' as a sheet name round-trips through toA1/parse") {
+    val original = RefType.QualifiedCell(SheetName.unsafe("A1"), ARef.from1(2, 2))
+    assertEquals(RefType.parse(original.toA1), Right(original))
+    val qrange = RefType.QualifiedRange(
+      SheetName.unsafe("Q1"),
+      CellRange(ARef.from1(1, 1), ARef.from1(2, 2))
+    )
+    assertEquals(RefType.parse(qrange.toA1), Right(qrange))
+  }
+
+  test("GH-263: names beyond cell-ref bounds or plain identifiers stay bare") {
+    val b2 = ARef.from1(2, 2)
+    assertEquals(RefType.QualifiedCell(SheetName.unsafe("XFE1"), b2).toA1, "XFE1!B2")
+    assertEquals(RefType.QualifiedCell(SheetName.unsafe("A1048577"), b2).toA1, "A1048577!B2")
+    assertEquals(RefType.QualifiedCell(SheetName.unsafe("Sales"), b2).toA1, "Sales!B2")
+    assertEquals(RefType.QualifiedCell(SheetName.unsafe("Sheet1"), b2).toA1, "Sheet1!B2")
+  }
+
+  test("GH-263: SheetName.needsQuoting truth table") {
+    // cell-ref shaped (A1 through XFD1048576, case-insensitive)
+    assert(SheetName.needsQuoting("A1"), "A1")
+    assert(SheetName.needsQuoting("Q1"), "Q1")
+    assert(SheetName.needsQuoting("ab12"), "ab12")
+    assert(SheetName.needsQuoting("xfd1048576"), "xfd1048576")
+    // R1C1 shaped (case-insensitive, digits optional)
+    assert(SheetName.needsQuoting("R1C1"), "R1C1")
+    assert(SheetName.needsQuoting("rc"), "rc")
+    assert(SheetName.needsQuoting("R1C"), "R1C")
+    assert(SheetName.needsQuoting("RC2"), "RC2")
+    // leading digit / empty / special chars / quotes / spaces (existing rules)
+    assert(SheetName.needsQuoting("2024Q1"), "2024Q1")
+    assert(SheetName.needsQuoting(""), "empty")
+    assert(SheetName.needsQuoting("Q1 Report"), "Q1 Report")
+    assert(SheetName.needsQuoting("P&L"), "P&L")
+    assert(SheetName.needsQuoting("It's"), "It's")
+    // bare TRUE/FALSE parse as boolean literals in formulas, not sheet names
+    assert(SheetName.needsQuoting("TRUE"), "TRUE")
+    assert(SheetName.needsQuoting("false"), "false")
+    // safe names stay bare
+    assert(!SheetName.needsQuoting("Sales"), "Sales")
+    assert(!SheetName.needsQuoting("Sheet1"), "Sheet1")
+    assert(!SheetName.needsQuoting("XFE1"), "XFE1 is beyond max column")
+    assert(!SheetName.needsQuoting("A1048577"), "A1048577 is beyond max row")
+    assert(!SheetName.needsQuoting("Revenue_2024"), "Revenue_2024")
+    assert(!SheetName.needsQuoting("R"), "bare R is a valid name")
+    assert(!SheetName.needsQuoting("C"), "bare C is a valid name")
+  }
+
+  property("GH-263: hostile sheet names round-trip through toA1/parse") {
+    val genHostileName = Gen.oneOf(
+      "A1",
+      "a1",
+      "Q1",
+      "q4",
+      "AB12",
+      "XFD1048576",
+      "R1C1",
+      "RC",
+      "r1c1",
+      "2024Q1",
+      "TRUE",
+      "FALSE",
+      "Sales",
+      "Sheet1",
+      "My Sheet",
+      "It's Q1",
+      "P&L",
+      "XFE1"
+    )
+    forAll(genHostileName, genARef) { (name: String, ref: ARef) =>
+      val original = RefType.QualifiedCell(SheetName.unsafe(name), ref)
+      RefType.parse(original.toA1) match
+        case Right(parsed) => assertEquals(parsed, original)
+        case Left(err) => fail(s"Failed to parse ${original.toA1}: $err")
+      true
+    }
+  }
+
   // ========== Pattern Matching ==========
 
   test("Pattern match on RefType variants") {

--- a/xl-core/test/src/com/tjclp/xl/display/FormatCodeParserSpec.scala
+++ b/xl-core/test/src/com/tjclp/xl/display/FormatCodeParserSpec.scala
@@ -2,6 +2,7 @@ package com.tjclp.xl.display
 
 import munit.FunSuite
 import FormatCodeParser.*
+import com.tjclp.xl.styles.numfmt.NumFmt
 
 /**
  * Tests for Excel custom number format code parser.
@@ -338,6 +339,58 @@ class FormatCodeParserSpec extends FunSuite:
 
     val (neg, _) = FormatCodeParser.applyFormat(BigDecimal("-0.125"), code)
     assertEquals(neg, "(12.5%)")
+  }
+
+  // ========== Empty Sections (hide-value idiom, GH-262) ==========
+  // An EMPTY section means "display nothing" for that value class:
+  //   "0.0;;" → positive shown, negative hidden, zero hidden
+  //   "0.0;"  → negative hidden, zero routes to positive (2-section rule)
+
+  test("parse: trailing empty sections preserved — 0.0;; yields 3 sections (GH-262)") {
+    val code = FormatCodeParser.parse("0.0;;").toOption.get
+    assert(code.negative.isDefined, "negative (2nd) section must exist")
+    assert(code.zero.isDefined, "zero (3rd) section must exist")
+    assertEquals(code.negative.get.pattern.tokens, Vector.empty[FormatToken])
+    assertEquals(code.zero.get.pattern.tokens, Vector.empty[FormatToken])
+    assertEquals(code.text, None)
+  }
+
+  test("hide-zero idiom: zero with 0.0;; renders empty string (GH-262)") {
+    val code = FormatCodeParser.parse("0.0;;").toOption.get
+    assertEquals(FormatCodeParser.applyFormat(BigDecimal("0"), code)._1, "")
+    assertEquals(FormatCodeParser.applyFormat(BigDecimal("1.5"), code)._1, "1.5")
+  }
+
+  test("hide-negative idiom: negative with 0.0;; renders empty string (GH-262)") {
+    val code = FormatCodeParser.parse("0.0;;").toOption.get
+    assertEquals(FormatCodeParser.applyFormat(BigDecimal("-1.5"), code)._1, "")
+  }
+
+  test("trailing empty 2nd section: 0.0; hides negatives, zero routes to positive (GH-262)") {
+    val code = FormatCodeParser.parse("0.0;").toOption.get
+    assert(code.negative.isDefined, "negative (2nd) section must exist")
+    assertEquals(code.negative.get.pattern.tokens, Vector.empty[FormatToken])
+    assertEquals(FormatCodeParser.applyFormat(BigDecimal("1.5"), code)._1, "1.5")
+    assertEquals(FormatCodeParser.applyFormat(BigDecimal("-1.5"), code)._1, "")
+    // GH-254 zero routing must be intact: 2 sections → zero uses positive section
+    assertEquals(FormatCodeParser.applyFormat(BigDecimal("0"), code)._1, "0.0")
+  }
+
+  test("interior empty zero section: 0;-0;;@ hides zero only (GH-262)") {
+    val code = FormatCodeParser.parse("0;-0;;@").toOption.get
+    assert(code.zero.isDefined, "zero (3rd) section must exist")
+    assert(code.text.isDefined, "text (4th) section must exist")
+    assertEquals(FormatCodeParser.applyFormat(BigDecimal("5"), code)._1, "5")
+    assertEquals(FormatCodeParser.applyFormat(BigDecimal("-5"), code)._1, "-5")
+    assertEquals(FormatCodeParser.applyFormat(BigDecimal("0"), code)._1, "")
+    assertEquals(FormatCodeParser.applyTextFormat("abc", code), "abc")
+  }
+
+  test("NumFmtFormatter: Custom 0.0;; hides zero and negative, no General fallback (GH-262)") {
+    val fmt = NumFmt.Custom("0.0;;")
+    assertEquals(NumFmtFormatter.formatNumber(BigDecimal("0"), fmt), "")
+    assertEquals(NumFmtFormatter.formatNumber(BigDecimal("-2.5"), fmt), "")
+    assertEquals(NumFmtFormatter.formatNumber(BigDecimal("2.5"), fmt), "2.5")
   }
 
   // ========== Date/Time Formatting Tests ==========

--- a/xl-core/test/src/com/tjclp/xl/macros/FormulaInterpolationSpec.scala
+++ b/xl-core/test/src/com/tjclp/xl/macros/FormulaInterpolationSpec.scala
@@ -15,6 +15,13 @@ class FormulaInterpolationSpec extends FunSuite:
       case other => fail(s"Expected Formula, got $other")
   }
 
+  test("GH-271: compile-time literal accepts leading unary plus (=+SUM(A1:B2))") {
+    // The macro accepted '=+' before the full parser did; this pins the two staying in agreement
+    fx"=+SUM(A1:B2)" match
+      case CellValue.Formula(expr, _) => assertEquals(expr, "=+SUM(A1:B2)")
+      case other => fail(s"Expected Formula, got $other")
+  }
+
   // ===== Runtime Interpolation (New Functionality) =====
 
   test("Runtime interpolation: simple SUM formula") {

--- a/xl-evaluator/src/com/tjclp/xl/formula/display/EvaluatingFormulaDisplay.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/display/EvaluatingFormulaDisplay.scala
@@ -1,5 +1,6 @@
 package com.tjclp.xl.formula.display
 
+import com.tjclp.xl.cells.CellValue
 import com.tjclp.xl.display.{FormulaDisplayStrategy, LowPriorityFormulaDisplay, NumFmtFormatter}
 import com.tjclp.xl.formula.Clock
 import com.tjclp.xl.formula.eval.SheetEvaluator
@@ -68,6 +69,24 @@ object EvaluatingFormulaDisplay extends LowPriorityFormulaDisplay:
         case Left(error) =>
           // Evaluation failed - show raw formula as fallback
           formulaWithEquals
+
+    override def formatCached(
+      formula: String,
+      cached: Option[CellValue],
+      numFmt: NumFmt,
+      sheet: Sheet
+    ): String =
+      // Prefer the cached value (populated by Workbook.recalculate() or read from
+      // disk): sheet-local re-evaluation has no workbook context, so cross-sheet
+      // formulas would degrade to raw text despite a correct cached value (GH-275).
+      // Only uncached formulas fall back to local evaluation.
+      cached match
+        case Some(value) =>
+          val effectiveFmt = numFmt match
+            case NumFmt.General => inferFormatFromValue(value)
+            case explicit => explicit
+          NumFmtFormatter.formatValue(value, effectiveFmt)
+        case None => format(formula, sheet)
 
   /**
    * Infer appropriate NumFmt from a computed value.

--- a/xl-evaluator/src/com/tjclp/xl/formula/eval/SheetEvaluator.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/eval/SheetEvaluator.scala
@@ -161,13 +161,10 @@ object SheetEvaluator:
      * sheet.evaluateWithDependencyCheck() // Left(XLError.FormulaError(..., CircularRef))
      * }}}
      */
-    @SuppressWarnings(Array("org.wartremover.warts.Var"))
     def evaluateWithDependencyCheck(
       clock: Clock = Clock.system,
       workbook: Option[Workbook] = None
     ): XLResult[Map[ARef, CellValue]] =
-      // Suppression rationale: Mutable accumulator for building results map during iteration.
-      // Functional fold alternative less clear for this use case.
       // Build dependency graph
       val graph = DependencyGraph.fromSheet(sheet)
 
@@ -183,27 +180,21 @@ object SheetEvaluator:
               // Topological sort found cycle (shouldn't happen after detectCycles passed)
               scala.util.Left(evalErrorToXLError(circularRef, None))
             case scala.util.Right(evalOrder) =>
-              // Evaluate in dependency order
-              // Create a mutable temp sheet to accumulate evaluated values
-              var tempSheet = sheet
-              var results = Map.empty[ARef, CellValue]
-
-              val evalResult = evalOrder.foldLeft[XLResult[Unit]](scala.util.Right(())) {
-                case (scala.util.Right(_), ref) =>
-                  // Evaluate this cell against the temp sheet (which has previously evaluated values)
+              // Evaluate in dependency order, threading the partially evaluated sheet so
+              // dependent formulas see previously computed values. Fail-fast on first error.
+              val evalResult = evalOrder.foldLeft[XLResult[(Sheet, Map[ARef, CellValue])]](
+                scala.util.Right((sheet, Map.empty))
+              ) {
+                case (scala.util.Right((tempSheet, results)), ref) =>
                   tempSheet.evaluateCell(ref, clock, workbook) match
                     case scala.util.Right(value) =>
-                      // Update temp sheet with evaluated value (for dependent formulas to use)
-                      // put(ref, CellValue) returns Sheet directly - it cannot fail
-                      tempSheet = tempSheet.put(ref, value)
-                      results = results + (ref -> value)
-                      scala.util.Right(())
+                      scala.util.Right((tempSheet.put(ref, value), results + (ref -> value)))
                     case scala.util.Left(error) =>
                       scala.util.Left(error)
                 case (left, _) => left
               }
 
-              evalResult.map(_ => results)
+              evalResult.map(_._2)
 
     /**
      * Evaluate all formula cells in sheet (unsafe, no cycle detection).
@@ -261,15 +252,11 @@ object SheetEvaluator:
      * // Only evaluates formulas in A1:C10 + their dependencies
      * }}}
      */
-    @SuppressWarnings(Array("org.wartremover.warts.Var"))
     def evaluateForRange(
       range: CellRange,
       clock: Clock = Clock.system,
       workbook: Option[Workbook] = None
     ): XLResult[Map[ARef, CellValue]] =
-      // Suppression rationale: Mutable accumulator for building results map during iteration.
-      // Same pattern as evaluateWithDependencyCheck.
-
       // 1. Find formula cells within the range (using pattern match, not isInstanceOf)
       val rangeFormulaCells = sheet.cells
         .collect {
@@ -308,24 +295,24 @@ object SheetEvaluator:
                 // Filter to only include cells we need to evaluate
                 val evalOrder = fullEvalOrder.filter(targetCells.contains)
 
-                // 7. Evaluate in dependency order
-                var tempSheet = sheet
-                var results = Map.empty[ARef, CellValue]
-
-                val evalResult = evalOrder.foldLeft[XLResult[Unit]](scala.util.Right(())) {
-                  case (scala.util.Right(_), ref) =>
+                // 7. Evaluate in dependency order, threading the partially evaluated sheet.
+                // Fail-fast on first error; only cells in the original range are reported.
+                val evalResult = evalOrder.foldLeft[XLResult[(Sheet, Map[ARef, CellValue])]](
+                  scala.util.Right((sheet, Map.empty))
+                ) {
+                  case (scala.util.Right((tempSheet, results)), ref) =>
                     tempSheet.evaluateCell(ref, clock, workbook) match
                       case scala.util.Right(value) =>
-                        tempSheet = tempSheet.put(ref, value)
-                        // Only include results for cells in the original range
-                        if rangeFormulaCells.contains(ref) then results = results + (ref -> value)
-                        scala.util.Right(())
+                        val nextResults =
+                          if rangeFormulaCells.contains(ref) then results + (ref -> value)
+                          else results
+                        scala.util.Right((tempSheet.put(ref, value), nextResults))
                       case scala.util.Left(error) =>
                         scala.util.Left(error)
                   case (left, _) => left
                 }
 
-                evalResult.map(_ => results)
+                evalResult.map(_._2)
 
     /**
      * Evaluate an array formula and spill results into adjacent cells.

--- a/xl-evaluator/src/com/tjclp/xl/formula/parser/FormulaParser.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/parser/FormulaParser.scala
@@ -471,8 +471,8 @@ object FormulaParser:
     }
 
   /**
-   * Parse the exponent of a power expression, allowing unary minus. This handles cases like 2^-1 =
-   * 0.5 while keeping -2^2 = -(2^2) = -4
+   * Parse the exponent of a power expression, allowing unary minus and plus. This handles cases
+   * like 2^-1 = 0.5 while keeping -2^2 = -(2^2) = -4. Unary plus is identity (GH-271).
    */
   private def parsePowExponent(state: ParserState): ParseResult[TExpr[?]] =
     val s = skipWhitespace(state)
@@ -487,12 +487,22 @@ object FormulaParser:
             )
           }
         }
+      case Some('+') =>
+        descend(s).flatMap { sd =>
+          val s2 = skipWhitespace(sd.advance())
+          parsePowExponent(s2).map { case (expr, s3) =>
+            (expr, s3.copy(depth = s.depth))
+          }
+        }
       case _ => parsePow(s)
 
   /**
-   * Parse unary operators: -, NOT
+   * Parse unary operators: -, +, NOT
    *
    * Excel precedence: unary minus has lower precedence than ^, so -2^2 = -(2^2) = -4
+   *
+   * Unary plus (GH-271: =+A1, the pervasive banker idiom) is identity: it parses to the same AST as
+   * the operand alone, so the printer normalizes it away while parse∘print=id holds on the AST.
    */
   @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
   private def parseUnary(state: ParserState): ParseResult[TExpr[?]] =
@@ -507,6 +517,14 @@ object FormulaParser:
               TExpr.Sub(TExpr.Lit(BigDecimal(0)), TExpr.asNumericExpr(expr)), // Convert PolyRef
               s3.copy(depth = s.depth)
             )
+          }
+        }
+      case Some('+') =>
+        // descend: each chained '+' counts against the depth budget (GH-56 recursion guard)
+        descend(s).flatMap { sd =>
+          val s2 = skipWhitespace(sd.advance())
+          parseUnary(s2).map { case (expr, s3) =>
+            (expr, s3.copy(depth = s.depth))
           }
         }
       case Some('N') | Some('n') if isKeywordAt(s, "NOT") =>

--- a/xl-evaluator/src/com/tjclp/xl/formula/printer/FormulaPrinter.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/printer/FormulaPrinter.scala
@@ -265,23 +265,12 @@ object FormulaPrinter:
   /**
    * Format sheet name for Excel formula.
    *
-   * Sheet names with spaces or special characters need to be quoted with single quotes. Any single
-   * quotes within the name are doubled (Excel escape convention).
+   * Delegates to the shared SheetName predicate (GH-263): quoting covers spaces, special
+   * characters, leading digits, and names that would parse as cell references (Q1, A1, R1C1).
+   * Single quotes within the name are doubled (Excel escape convention).
    */
   private def formatSheetName(sheet: SheetName): String =
-    val name = sheet.value
-    // Sheet names need quoting if they contain spaces, special chars, or look like cell refs
-    val needsQuoting = name.contains(' ') ||
-      name.contains('\'') ||
-      name.contains('-') ||
-      name.exists(c => !c.isLetterOrDigit && c != '_') ||
-      name.headOption.exists(_.isDigit) // Names starting with digit need quoting
-
-    if needsQuoting then
-      // Escape single quotes by doubling them
-      val escaped = name.replace("'", "''")
-      s"'$escaped'"
-    else name
+    SheetName.quoteForFormula(sheet.value)
 
   /**
    * Print with minimal whitespace (compact format).

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/CrossSheetFormulaSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/CrossSheetFormulaSpec.scala
@@ -99,11 +99,13 @@ class CrossSheetFormulaSpec extends ScalaCheckSuite:
 
   // ===== Round-Trip Property Tests =====
 
-  // Generator for valid unquoted sheet names
-  val genSimpleSheetName: Gen[String] = for
+  // Generator for valid unquoted sheet names — must exclude names the printer quotes
+  // (cell-ref/R1C1 shapes like "ab1234", per GH-263); quoted-name round-trips are
+  // covered by genQuotedSheetName below and the hostile-name property in RefTypeSpec
+  val genSimpleSheetName: Gen[String] = (for
     first <- Gen.alphaChar
     rest <- Gen.listOfN(5, Gen.alphaNumChar)
-  yield (first :: rest).mkString
+  yield (first :: rest).mkString).suchThat(n => !SheetName.needsQuoting(n))
 
   // Generator for sheet names requiring quotes (spaces, special chars)
   val genQuotedSheetName: Gen[String] = for

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/FormulaParserSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/FormulaParserSpec.scala
@@ -272,6 +272,51 @@ class FormulaParserSpec extends ScalaCheckSuite:
     assertEquals(result, Right(BigDecimal(3)))
   }
 
+  // ==================== GH-263: cell-ref-shaped sheet names ====================
+  // A sheet named Q1/A1/R1C1 must be single-quoted by the printer or the generated
+  // formula is spec-invalid (Excel would read Q1!A1 as something else entirely).
+
+  test("GH-263: parse quoted sheet name that looks like a cell ref ('A1'!B2)") {
+    FormulaParser.parse("='A1'!B2") match
+      case Right(TExpr.SheetRef(sheet, at, _, _)) =>
+        assertEquals(sheet.value, "A1")
+        assertEquals(at.toA1, "B2")
+      case Right(TExpr.SheetPolyRef(sheet, at, _)) =>
+        assertEquals(sheet.value, "A1")
+        assertEquals(at.toA1, "B2")
+      case other => fail(s"Expected sheet-qualified ref to 'A1'!B2, got $other")
+  }
+
+  test("GH-263: printer quotes cell-ref-shaped sheet name back ('A1'!B2)") {
+    FormulaParser.parse("='A1'!B2") match
+      case Right(expr) => assertEquals(FormulaPrinter.print(expr), "='A1'!B2")
+      case Left(err) => fail(s"='A1'!B2 should parse: $err")
+  }
+
+  test("GH-263: printer quotes Q1-style sheet name inside function ranges") {
+    FormulaParser.parse("=SUM('Q1'!A1:B2)") match
+      case Right(expr) => assertEquals(FormulaPrinter.print(expr), "=SUM('Q1'!A1:B2)")
+      case Left(err) => fail(s"=SUM('Q1'!A1:B2) should parse: $err")
+  }
+
+  test("GH-263: leniently parsed unquoted form prints canonically quoted (=Q1!A1)") {
+    FormulaParser.parse("=Q1!A1") match
+      case Right(expr) => assertEquals(FormulaPrinter.print(expr), "='Q1'!A1")
+      case Left(err) => fail(s"=Q1!A1 should parse: $err")
+  }
+
+  test("GH-263: R1C1-shaped sheet name prints quoted") {
+    FormulaParser.parse("='R1C1'!A1") match
+      case Right(expr) => assertEquals(FormulaPrinter.print(expr), "='R1C1'!A1")
+      case Left(err) => fail(s"='R1C1'!A1 should parse: $err")
+  }
+
+  test("GH-263: safe sheet names still print bare (Sheet1!A1)") {
+    FormulaParser.parse("=Sheet1!A1") match
+      case Right(expr) => assertEquals(FormulaPrinter.print(expr), "=Sheet1!A1")
+      case Left(err) => fail(s"=Sheet1!A1 should parse: $err")
+  }
+
   test("parse decimal number") {
     val result = FormulaParser.parse("=3.14")
     assert(result.isRight)

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/FormulaParserSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/FormulaParserSpec.scala
@@ -216,6 +216,62 @@ class FormulaParserSpec extends ScalaCheckSuite:
     }
   }
 
+  // ==================== GH-271: Leading unary plus ====================
+  // Excel accepts a leading unary plus (=+E43, =+SUM(...)) — a pervasive banker idiom.
+  // Unary plus is identity: it parses to the SAME AST as the formula without it, so the
+  // printer normalizes it away and the parse∘print=id round-trip law stays intact.
+
+  test("GH-271: unary plus parses to the same AST as without it (=+A1)") {
+    val plus = FormulaParser.parse("=+A1")
+    assert(plus.isRight, s"=+A1 should parse, got $plus")
+    assertEquals(plus, FormulaParser.parse("=A1"))
+  }
+
+  test("GH-271: unary plus before function call (=+SUM(A1:B2))") {
+    val plus = FormulaParser.parse("=+SUM(A1:B2)")
+    assert(plus.isRight, s"=+SUM(A1:B2) should parse, got $plus")
+    assertEquals(plus, FormulaParser.parse("=SUM(A1:B2)"))
+  }
+
+  test("GH-271: chained unary plus (=++A1)") {
+    val plus = FormulaParser.parse("=++A1")
+    assert(plus.isRight, s"=++A1 should parse, got $plus")
+    assertEquals(plus, FormulaParser.parse("=A1"))
+  }
+
+  test("GH-271: unary plus followed by binary plus (=+1+2)") {
+    val plus = FormulaParser.parse("=+1+2")
+    assert(plus.isRight, s"=+1+2 should parse, got $plus")
+    assertEquals(plus, FormulaParser.parse("=1+2"))
+  }
+
+  test("GH-271: unary plus mixes with unary minus (=+-2)") {
+    val plus = FormulaParser.parse("=+-2")
+    assert(plus.isRight, s"=+-2 should parse, got $plus")
+    assertEquals(plus, FormulaParser.parse("=-2"))
+  }
+
+  test("GH-271: unary plus in power exponent (=2^+2)") {
+    val plus = FormulaParser.parse("=2^+2")
+    assert(plus.isRight, s"=2^+2 should parse, got $plus")
+    assertEquals(plus, FormulaParser.parse("=2^2"))
+  }
+
+  test("GH-271: printer normalizes unary plus away (=+A1 prints as =A1)") {
+    FormulaParser.parse("=+A1") match
+      case Right(expr) => assertEquals(FormulaPrinter.print(expr), "=A1")
+      case Left(err) => fail(s"=+A1 should parse: $err")
+  }
+
+  test("GH-271: unary plus formula evaluates (=+1+2 = 3)") {
+    val sheet = Sheet("Test")
+    val result = for
+      expr <- FormulaParser.parse("=+1+2")
+      value <- Evaluator.eval(expr, sheet)
+    yield value
+    assertEquals(result, Right(BigDecimal(3)))
+  }
+
   test("parse decimal number") {
     val result = FormulaParser.parse("=3.14")
     assert(result.isRight)

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/RecursionGuardSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/RecursionGuardSpec.scala
@@ -29,6 +29,13 @@ class RecursionGuardSpec extends FunSuite:
       case other => fail(s"expected NestingTooDeep, got $other")
   }
 
+  test("GH-271: deeply chained unary plus → NestingTooDeep, not StackOverflowError") {
+    val formula = "=" + ("+" * 300) + "1"
+    FormulaParser.parse(formula) match
+      case Left(_: ParseError.NestingTooDeep) => ()
+      case other => fail(s"expected NestingTooDeep, got $other")
+  }
+
   test("deeply nested function calls → NestingTooDeep") {
     val formula = "=" + ("ABS(" * 300) + "1" + (")" * 300)
     FormulaParser.parse(formula) match

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/SheetEvaluatorSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/SheetEvaluatorSpec.scala
@@ -522,6 +522,29 @@ class SheetEvaluatorSpec extends FunSuite:
     assert(result.isLeft)
   }
 
+  test("evaluateForRange: stops on first error in a dependency outside the range") {
+    // GH-48 behavioral pin: evaluation is fail-fast — an eval error in a transitive
+    // dependency (even outside the requested range) fails the whole call.
+    val sheet = sheetWith(
+      ref"B1" -> CellValue.Formula("=10/0"), // Outside range, fails
+      ref"C1" -> CellValue.Formula("=B1+1") // In range, depends on B1
+    )
+    val range = CellRange(ref"C1", ref"C1")
+    val result = sheet.evaluateForRange(range)
+    assert(result.isLeft)
+  }
+
+  test("evaluateForRange: error in one component does not yield partial results") {
+    // GH-48 behavioral pin: fail-fast discards results from independent components too.
+    val sheet = sheetWith(
+      ref"A1" -> CellValue.Formula("=10/0"), // In range, fails
+      ref"B1" -> CellValue.Formula("=1+1") // In range, independent, would succeed
+    )
+    val range = CellRange(ref"A1", ref"B1")
+    val result = sheet.evaluateForRange(range)
+    assert(result.isLeft)
+  }
+
   test("evaluateForRange: complex dependency chain") {
     // D1 = (A1 + B1) * C1 where each is a formula
     val sheet = sheetWith(

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/display/EvaluatingFormulaDisplaySpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/display/EvaluatingFormulaDisplaySpec.scala
@@ -175,6 +175,87 @@ class EvaluatingFormulaDisplaySpec extends FunSuite:
     assertEquals(result, "Total: 300")
   }
 
+  // ========== Cached value display (GH-275) ==========
+  // After wb.recalculate() caches values into CellValue.Formula cells, display must
+  // prefer the cached value; local re-evaluation (which has no workbook context and
+  // fails on cross-sheet refs) is only the fallback for uncached formulas.
+
+  test("GH-275: displayCell shows cached cross-sheet value after recalculate, not formula text") {
+    import com.tjclp.xl.display.syntax.*
+    import com.tjclp.xl.workbooks.Workbook
+
+    val sheet1 = Sheet(name = SheetName.unsafe("Sheet1"))
+      .put(ref"A1", CellValue.Number(BigDecimal(10)))
+    val sheet2 = Sheet(name = SheetName.unsafe("Sheet2"))
+      .put(ref"A1", CellValue.Formula("='Sheet1'!A1*2"))
+
+    val result = Workbook(Vector(sheet1, sheet2)).recalculate()
+    assert(result.isClean, s"recalculate must be clean: ${result.errors.map(_.render)}")
+
+    val recalced = result.workbook.sheets.filter(_.name.value == "Sheet2") match
+      case Vector(s) => s
+      case other => fail(s"expected exactly one Sheet2, got $other")
+
+    given FormulaDisplayStrategy = EvaluatingFormulaDisplay.evaluating
+    assertEquals(recalced.displayCell(ref"A1").formatted, "20")
+  }
+
+  test("GH-275: excel interpolator shows cached cross-sheet value after recalculate") {
+    import ExcelInterpolator.*
+    import DisplayConversions.given
+    import com.tjclp.xl.workbooks.Workbook
+
+    val sheet1 = Sheet(name = SheetName.unsafe("Sheet1"))
+      .put(ref"A1", CellValue.Number(BigDecimal(10)))
+    val sheet2 = Sheet(name = SheetName.unsafe("Sheet2"))
+      .put(ref"A1", CellValue.Formula("='Sheet1'!A1*2"))
+
+    val result = Workbook(Vector(sheet1, sheet2)).recalculate()
+    val recalced = result.workbook.sheets.filter(_.name.value == "Sheet2") match
+      case Vector(s) => s
+      case other => fail(s"expected exactly one Sheet2, got $other")
+
+    given Sheet = recalced
+    given FormulaDisplayStrategy = EvaluatingFormulaDisplay.evaluating
+    assertEquals(excel"Value: ${ref"A1"}", "Value: 20")
+  }
+
+  test("GH-275: cached value formats via the cell's explicit numFmt") {
+    import com.tjclp.xl.display.syntax.*
+
+    // Cross-sheet expr so local evaluation cannot accidentally succeed: only the
+    // cached value can produce a number here.
+    val sheet = Sheet(name = SheetName.unsafe("Test"))
+      .put(ref"B1", CellValue.Formula("='Other'!A1/'Other'!A2", Some(CellValue.Number(BigDecimal("0.5")))))
+      .style(ref"B1", CellStyle.default.withNumFmt(NumFmt.Percent))
+      .unsafe
+
+    given FormulaDisplayStrategy = EvaluatingFormulaDisplay.evaluating
+    assertEquals(sheet.displayCell(ref"B1").formatted, "50%")
+  }
+
+  test("GH-275: cached DateTime under General numFmt displays as a date") {
+    import com.tjclp.xl.display.syntax.*
+
+    val dt = LocalDate.of(2025, 11, 21).atStartOfDay()
+    val sheet = Sheet(name = SheetName.unsafe("Test"))
+      .put(ref"A1", CellValue.Formula("='Other'!A1", Some(CellValue.DateTime(dt))))
+
+    given FormulaDisplayStrategy = EvaluatingFormulaDisplay.evaluating
+    val displayed = sheet.displayCell(ref"A1").formatted
+    assert(displayed.contains("11/21/25"), s"expected date-formatted display, got: $displayed")
+  }
+
+  test("GH-275: default (non-evaluating) strategy ignores cached values, shows raw text") {
+    import com.tjclp.xl.display.syntax.*
+
+    val sheet = Sheet(name = SheetName.unsafe("Test"))
+      .put(ref"A1", CellValue.Formula("='Sheet1'!A1*2", Some(CellValue.Number(BigDecimal(20)))))
+
+    given FormulaDisplayStrategy = FormulaDisplayStrategy.default
+    assertEquals(sheet.displayCell(ref"A1").formatted, "='Sheet1'!A1*2")
+  }
+
   // ========== Edge Cases ==========
 
   test("Evaluating strategy handles circular reference gracefully") {

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/DirectSaxEmitter.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/DirectSaxEmitter.scala
@@ -7,6 +7,15 @@ import com.tjclp.xl.richtext.RichText
 import com.tjclp.xl.sheets.RowProperties
 import com.tjclp.xl.styles.Color
 import com.tjclp.xl.ooxml.SaxSupport.writeElem
+import com.tjclp.xl.ooxml.worksheet.{
+  buildHyperlinksElem,
+  buildPageMarginsElem,
+  buildSheetViewsElem,
+  collectHyperlinks,
+  mergeHeaderFooterElem,
+  mergePageSetupElem,
+  mergeSheetPrElem
+}
 import java.util.Arrays
 
 /**
@@ -62,9 +71,19 @@ object DirectSaxEmitter:
     writer.startDocument()
     writer.startElement("worksheet")
 
+    // GH-265: sheet metadata (sheetPr, sheetViews, hyperlinks, page setup) must come out of the
+    // streaming path too, in ECMA-376 18.3.1.99 schema order — mirroring the fresh-sheet branch of
+    // OoxmlWorksheet.fromDomainWithMetadata. The tiny metadata Elems reuse the SAME builders as the
+    // DOM writer (parity by construction); only the bulk sheetData stays hand-emitted for speed.
     SaxWriter.withAttributes(writer, "xmlns" -> nsSpreadsheetML, "xmlns:r" -> nsRelationships) {
+      // sheetPr carries the pageSetUpPr fitToPage flag (GH-266)
+      mergeSheetPrElem(None, sheet.pageSetup).foreach(writer.writeElem)
+
       // Calculate dimension from cells
       emitDimension(writer, sheet)
+
+      // Freeze panes + view settings (GH-258) — BEFORE cols/sheetData
+      buildSheetViewsElem(None, sheet.freezePane, sheet.viewSettings).foreach(writer.writeElem)
 
       // Emit column definitions if any
       emitCols(writer, sheet)
@@ -74,6 +93,14 @@ object DirectSaxEmitter:
 
       // Emit mergeCells if any
       emitMergeCells(writer, sheet)
+
+      // Hyperlinks (GH-235) — the sheet .rels for them are written on both backends
+      buildHyperlinksElem(collectHyperlinks(sheet)).foreach(writer.writeElem)
+
+      // Print setup (GH-259/GH-266) — AFTER sheetData/mergeCells, before drawings
+      buildPageMarginsElem(sheet.pageSetup).foreach(writer.writeElem)
+      mergePageSetupElem(None, sheet.pageSetup).foreach(writer.writeElem)
+      mergeHeaderFooterElem(None, sheet.pageSetup).foreach(writer.writeElem)
 
       // Emit legacyDrawing if comments are present
       emitLegacyDrawing(writer, sheet)

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/PrintNames.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/PrintNames.scala
@@ -31,14 +31,12 @@ private[ooxml] object PrintNames:
   private val RowSpanRe = """^\$([0-9]+):\$([0-9]+)$""".r
 
   /**
-   * Quote a sheet name for use in a defined-name formula, matching Excel's convention: simple names
-   * (letters/digits/underscore, not starting with a digit) stay bare, everything else is wrapped in
-   * single quotes with embedded quotes doubled.
+   * Quote a sheet name for use in a defined-name formula, matching Excel's convention. Delegates to
+   * the shared predicate (GH-263): simple names stay bare; names with special characters, leading
+   * digits, or that would parse as cell references (Q1, A1, R1C1) are wrapped in single quotes with
+   * embedded quotes doubled.
    */
-  def quoteSheetName(name: String): String =
-    val simple = name.nonEmpty && !name.charAt(0).isDigit &&
-      name.forall(c => c.isLetterOrDigit || c == '_')
-    if simple then name else s"'${name.replace("'", "''")}'"
+  def quoteSheetName(name: String): String = SheetName.quoteForFormula(name)
 
   /** Format a Print_Area formula, e.g. `Sheet1!$A$1:$D$20` or `'Q1 Report'!$A$1:$D$20`. */
   def printAreaFormula(sheet: SheetName, area: CellRange): String =

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/XlsxReader.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/XlsxReader.scala
@@ -919,14 +919,28 @@ object XlsxReader:
     yield PageMargins(left, right, top, bottom, header, footer)
 
   /**
-   * Parse the modeled odd header/footer from <headerFooter>. Returns Some only when an odd part is
-   * present; even/first-page variants are preserved as raw XML, not modeled.
+   * Parse the modeled header/footer from <headerFooter> (GH-266): all six page parts
+   * (odd/even/first × header/footer) plus the differentOddEven/differentFirst flags. Returns Some
+   * only when a modeled part or flag is present, so a headerFooter element carrying only unmodeled
+   * attributes (scaleWithDoc, ...) rides through as preserved XML.
    */
   private def parseHeaderFooter(elem: Elem): Option[HeaderFooter] =
-    val oddHeader = (elem \ "oddHeader").headOption.map(_.text).filter(_.nonEmpty)
-    val oddFooter = (elem \ "oddFooter").headOption.map(_.text).filter(_.nonEmpty)
-    if oddHeader.isEmpty && oddFooter.isEmpty then None
-    else Some(HeaderFooter(oddHeader, oddFooter))
+    def part(label: String): Option[String] =
+      (elem \ label).headOption.map(_.text).filter(_.nonEmpty)
+    def flag(name: String): Boolean =
+      val value = elem \@ name
+      value == "1" || value == "true"
+    val parsed = HeaderFooter(
+      oddHeader = part("oddHeader"),
+      oddFooter = part("oddFooter"),
+      evenHeader = part("evenHeader"),
+      evenFooter = part("evenFooter"),
+      firstHeader = part("firstHeader"),
+      firstFooter = part("firstFooter"),
+      differentOddEven = flag("differentOddEven"),
+      differentFirst = flag("differentFirst")
+    )
+    if parsed == HeaderFooter() then None else Some(parsed)
 
   /**
    * Parse sheet view settings (GH-258) from the first <sheetView>.

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/OoxmlWorksheet.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/OoxmlWorksheet.scala
@@ -472,8 +472,9 @@ object OoxmlWorksheet extends com.tjclp.xl.ooxml.XmlReadable[OoxmlWorksheet]:
         OoxmlWorksheet(
           allRows, // Use merged rows (with cells + empty rows)
           sheet.mergedRanges,
-          // Preserve all metadata from original, but use recalculated dimension
-          preserved.sheetPr,
+          // Preserve all metadata from original, but use recalculated dimension.
+          // GH-266: fitToWidth/fitToHeight require sheetPr/pageSetUpPr fitToPage="1"
+          mergeSheetPrElem(preserved.sheetPr, sheet.pageSetup),
           calculatedDimension.orElse(
             preserved.dimension
           ), // Use calculated dimension, fallback to preserved
@@ -507,6 +508,7 @@ object OoxmlWorksheet extends com.tjclp.xl.ooxml.XmlReadable[OoxmlWorksheet]:
         OoxmlWorksheet(
           rowsWithCells,
           sheet.mergedRanges,
+          sheetPr = mergeSheetPrElem(None, sheet.pageSetup), // GH-266: fitToPage flag
           dimension = calculatedDimension,
           sheetViews = applySheetViewOverrides(None, sheet.freezePane, sheet.viewSettings),
           cols = generatedCols,

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/OoxmlWorksheet.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/OoxmlWorksheet.scala
@@ -5,7 +5,7 @@ import scala.xml.*
 import com.tjclp.xl.addressing.{ARef, CellRange, Row}
 import com.tjclp.xl.ooxml.XmlUtil.{elem, nsRelationships}
 import com.tjclp.xl.ooxml.{SaxSerializable, SaxWriter, SharedStrings, XmlWritable}
-import com.tjclp.xl.sheets.{FreezePane, Sheet, SheetView}
+import com.tjclp.xl.sheets.Sheet
 
 /**
  * Worksheet for xl/worksheets/sheet#.xml
@@ -478,7 +478,7 @@ object OoxmlWorksheet extends com.tjclp.xl.ooxml.XmlReadable[OoxmlWorksheet]:
           calculatedDimension.orElse(
             preserved.dimension
           ), // Use calculated dimension, fallback to preserved
-          applySheetViewOverrides(preserved.sheetViews, sheet.freezePane, sheet.viewSettings),
+          buildSheetViewsElem(preserved.sheetViews, sheet.freezePane, sheet.viewSettings),
           preserved.sheetFormatPr,
           generatedCols.orElse(preserved.cols), // Prefer domain props over preserved XML
           preserved.conditionalFormatting,
@@ -510,7 +510,7 @@ object OoxmlWorksheet extends com.tjclp.xl.ooxml.XmlReadable[OoxmlWorksheet]:
           sheet.mergedRanges,
           sheetPr = mergeSheetPrElem(None, sheet.pageSetup), // GH-266: fitToPage flag
           dimension = calculatedDimension,
-          sheetViews = applySheetViewOverrides(None, sheet.freezePane, sheet.viewSettings),
+          sheetViews = buildSheetViewsElem(None, sheet.freezePane, sheet.viewSettings),
           cols = generatedCols,
           pageMargins = buildPageMarginsElem(sheet.pageSetup),
           pageSetup = mergePageSetupElem(None, sheet.pageSetup),
@@ -519,130 +519,3 @@ object OoxmlWorksheet extends com.tjclp.xl.ooxml.XmlReadable[OoxmlWorksheet]:
           tableParts = tableParts,
           preservedKnown = hyperlinksMap
         )
-
-  /**
-   * Apply freeze pane and view-settings overrides to sheetViews XML (GH-258).
-   *
-   * The freeze pane override runs first (creating a minimal `<sheetViews><sheetView/></sheetViews>`
-   * when needed), then view settings are merged onto the same `<sheetView>` element, so freeze
-   * panes and view settings always share ONE sheetView.
-   */
-  private def applySheetViewOverrides(
-    existing: Option[Elem],
-    freezeOverride: Option[FreezePane],
-    viewSettings: Option[SheetView]
-  ): Option[Elem] =
-    applyViewSettingsOverride(applyFreezePaneOverride(existing, freezeOverride), viewSettings)
-
-  /**
-   * Apply sheet view settings to sheetViews XML.
-   *
-   * When `None`, preserves existing sheetViews unchanged (passive default, mirroring freezePane).
-   * When `Some(view)`, sets `showGridLines` ("1"/"0", always written so the setting round-trips)
-   * and `zoomScale` (written when defined, removed when None) on every `<sheetView>` element,
-   * creating a minimal `<sheetViews><sheetView workbookViewId="0"/></sheetViews>` when absent.
-   * Unmodeled attributes (tabSelected, topLeftCell, view, ...) are preserved.
-   */
-  private def applyViewSettingsOverride(
-    existing: Option[Elem],
-    viewSettings: Option[SheetView]
-  ): Option[Elem] =
-    viewSettings match
-      case None => existing
-      case Some(view) =>
-        val base = existing.getOrElse(
-          elem("sheetViews")(elem("sheetView", "workbookViewId" -> "0")())
-        )
-        // Degenerate guard: a <sheetViews> without any <sheetView> child gets one appended
-        val hasSheetView = base.child.exists {
-          case e: Elem => e.label == "sheetView"
-          case _ => false
-        }
-        val withView =
-          if hasSheetView then base
-          else base.copy(child = base.child :+ elem("sheetView", "workbookViewId" -> "0")())
-        val newChildren = withView.child.map {
-          case e: Elem if e.label == "sheetView" => applyViewAttrs(e, view)
-          case other => other
-        }
-        Some(withView.copy(child = newChildren))
-
-  /** Set the modeled view attributes on a single `<sheetView>` element. */
-  private def applyViewAttrs(sheetView: Elem, view: SheetView): Elem =
-    val withGrid = sheetView % new UnprefixedAttribute(
-      "showGridLines",
-      if view.showGridLines then "1" else "0",
-      Null
-    )
-    view.zoomScale match
-      case Some(zoom) => withGrid % new UnprefixedAttribute("zoomScale", zoom.toString, Null)
-      case None => withGrid.copy(attributes = withGrid.attributes.remove("zoomScale"))
-
-  /**
-   * Apply freeze pane override to sheetViews XML.
-   *
-   * When `freezeOverride` is `Some(FreezePane.At(ref))`, injects a `<pane>` element. When
-   * `Some(FreezePane.Remove)`, strips `<pane>` from existing sheetViews. When `None`, preserves
-   * existing sheetViews unchanged.
-   */
-  private def applyFreezePaneOverride(
-    existing: Option[Elem],
-    freezeOverride: Option[FreezePane]
-  ): Option[Elem] =
-    freezeOverride match
-      case None => existing
-      case Some(FreezePane.Remove) =>
-        existing.map { sv =>
-          val newChildren = sv.child.map {
-            case e: Elem if e.label == "sheetView" =>
-              e.copy(child = e.child.filterNot {
-                case c: Elem => c.label == "pane"
-                case _ => false
-              })
-            case other => other
-          }
-          sv.copy(child = newChildren)
-        }
-      case Some(FreezePane.At(ref)) =>
-        val colSplit = ref.col.index0
-        val rowSplit = ref.row.index0
-        if colSplit == 0 && rowSplit == 0 then existing
-        else
-          val activePane = (colSplit > 0, rowSplit > 0) match
-            case (true, true) => "bottomRight"
-            case (false, true) => "bottomLeft"
-            case (true, false) => "topRight"
-            case _ => "bottomLeft"
-
-          val paneAttrs: Vector[(String, String)] =
-            (if colSplit > 0 then Vector("xSplit" -> colSplit.toString) else Vector.empty) ++
-              (if rowSplit > 0 then Vector("ySplit" -> rowSplit.toString) else Vector.empty) ++
-              Vector(
-                "topLeftCell" -> ref.toA1,
-                "activePane" -> activePane,
-                "state" -> "frozen"
-              )
-
-          val paneElem = elem("pane", paneAttrs*)()
-
-          // Inject pane into existing sheetViews or create new
-          existing match
-            case Some(sv) =>
-              val newChildren = sv.child.map {
-                case e: Elem if e.label == "sheetView" =>
-                  // Remove old pane, add new one at the beginning (before selection elements)
-                  val withoutPane = e.child.filterNot {
-                    case c: Elem => c.label == "pane"
-                    case _ => false
-                  }
-                  e.copy(child = paneElem +: withoutPane)
-                case other => other
-              }
-              Some(sv.copy(child = newChildren))
-            case None =>
-              // Create minimal sheetViews from scratch
-              val sheetView = elem(
-                "sheetView",
-                "workbookViewId" -> "0"
-              )(paneElem)
-              Some(elem("sheetViews")(sheetView))

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/WorksheetHelpers.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/WorksheetHelpers.scala
@@ -5,7 +5,14 @@ import scala.xml.*
 import com.tjclp.xl.addressing.{ARef, Column}
 import com.tjclp.xl.ooxml.XmlUtil
 import com.tjclp.xl.ooxml.XmlUtil.nsSpreadsheetML
-import com.tjclp.xl.sheets.{ColumnProperties, PageSetup, RowProperties, Sheet}
+import com.tjclp.xl.sheets.{
+  ColumnProperties,
+  FreezePane,
+  PageSetup,
+  RowProperties,
+  Sheet,
+  SheetView
+}
 
 // Default namespaces for generated worksheets. Real files capture the original scope/attributes to
 // avoid redundant declarations and preserve mc/x14/xr bindings from the source sheet.
@@ -214,6 +221,138 @@ private[ooxml] def buildColsElement(sheet: Sheet): Option[Elem] =
     }
     Some(XmlUtil.elem("cols")(colElems*))
 
+// ===== Sheet view authoring (GH-258) =====
+// Shared by the DOM writer (OoxmlWorksheet) and the streaming writer (DirectSaxEmitter, GH-265)
+// so freeze panes and view settings serialize identically on both paths.
+
+/**
+ * Build sheetViews XML from the modeled freeze pane and view settings (GH-258), overlaying any
+ * preserved `<sheetViews>` element.
+ *
+ * The freeze pane override runs first (creating a minimal `<sheetViews><sheetView/></sheetViews>`
+ * when needed), then view settings are merged onto the same `<sheetView>` element, so freeze panes
+ * and view settings always share ONE sheetView.
+ */
+private[ooxml] def buildSheetViewsElem(
+  existing: Option[Elem],
+  freezeOverride: Option[FreezePane],
+  viewSettings: Option[SheetView]
+): Option[Elem] =
+  applyViewSettingsOverride(applyFreezePaneOverride(existing, freezeOverride), viewSettings)
+
+/**
+ * Apply sheet view settings to sheetViews XML.
+ *
+ * When `None`, preserves existing sheetViews unchanged (passive default, mirroring freezePane).
+ * When `Some(view)`, sets `showGridLines` ("1"/"0", always written so the setting round-trips) and
+ * `zoomScale` (written when defined, removed when None) on every `<sheetView>` element, creating a
+ * minimal `<sheetViews><sheetView workbookViewId="0"/></sheetViews>` when absent. Unmodeled
+ * attributes (tabSelected, topLeftCell, view, ...) are preserved.
+ */
+private def applyViewSettingsOverride(
+  existing: Option[Elem],
+  viewSettings: Option[SheetView]
+): Option[Elem] =
+  viewSettings match
+    case None => existing
+    case Some(view) =>
+      val base = existing.getOrElse(
+        XmlUtil.elem("sheetViews")(XmlUtil.elem("sheetView", "workbookViewId" -> "0")())
+      )
+      // Degenerate guard: a <sheetViews> without any <sheetView> child gets one appended
+      val hasSheetView = base.child.exists {
+        case e: Elem => e.label == "sheetView"
+        case _ => false
+      }
+      val withView =
+        if hasSheetView then base
+        else base.copy(child = base.child :+ XmlUtil.elem("sheetView", "workbookViewId" -> "0")())
+      val newChildren = withView.child.map {
+        case e: Elem if e.label == "sheetView" => applyViewAttrs(e, view)
+        case other => other
+      }
+      Some(withView.copy(child = newChildren))
+
+/** Set the modeled view attributes on a single `<sheetView>` element. */
+private def applyViewAttrs(sheetView: Elem, view: SheetView): Elem =
+  val withGrid = sheetView % new UnprefixedAttribute(
+    "showGridLines",
+    if view.showGridLines then "1" else "0",
+    Null
+  )
+  view.zoomScale match
+    case Some(zoom) => withGrid % new UnprefixedAttribute("zoomScale", zoom.toString, Null)
+    case None => withGrid.copy(attributes = withGrid.attributes.remove("zoomScale"))
+
+/**
+ * Apply freeze pane override to sheetViews XML.
+ *
+ * When `freezeOverride` is `Some(FreezePane.At(ref))`, injects a `<pane>` element. When
+ * `Some(FreezePane.Remove)`, strips `<pane>` from existing sheetViews. When `None`, preserves
+ * existing sheetViews unchanged.
+ */
+private def applyFreezePaneOverride(
+  existing: Option[Elem],
+  freezeOverride: Option[FreezePane]
+): Option[Elem] =
+  freezeOverride match
+    case None => existing
+    case Some(FreezePane.Remove) =>
+      existing.map { sv =>
+        val newChildren = sv.child.map {
+          case e: Elem if e.label == "sheetView" =>
+            e.copy(child = e.child.filterNot {
+              case c: Elem => c.label == "pane"
+              case _ => false
+            })
+          case other => other
+        }
+        sv.copy(child = newChildren)
+      }
+    case Some(FreezePane.At(ref)) =>
+      val colSplit = ref.col.index0
+      val rowSplit = ref.row.index0
+      if colSplit == 0 && rowSplit == 0 then existing
+      else
+        val activePane = (colSplit > 0, rowSplit > 0) match
+          case (true, true) => "bottomRight"
+          case (false, true) => "bottomLeft"
+          case (true, false) => "topRight"
+          case _ => "bottomLeft"
+
+        val paneAttrs: Vector[(String, String)] =
+          (if colSplit > 0 then Vector("xSplit" -> colSplit.toString) else Vector.empty) ++
+            (if rowSplit > 0 then Vector("ySplit" -> rowSplit.toString) else Vector.empty) ++
+            Vector(
+              "topLeftCell" -> ref.toA1,
+              "activePane" -> activePane,
+              "state" -> "frozen"
+            )
+
+        val paneElem = XmlUtil.elem("pane", paneAttrs*)()
+
+        // Inject pane into existing sheetViews or create new
+        existing match
+          case Some(sv) =>
+            val newChildren = sv.child.map {
+              case e: Elem if e.label == "sheetView" =>
+                // Remove old pane, add new one at the beginning (before selection elements)
+                val withoutPane = e.child.filterNot {
+                  case c: Elem => c.label == "pane"
+                  case _ => false
+                }
+                e.copy(child = paneElem +: withoutPane)
+              case other => other
+            }
+            Some(sv.copy(child = newChildren))
+          case None =>
+            // Create minimal sheetViews from scratch
+            val sheetView = XmlUtil.elem(
+              "sheetView",
+              "workbookViewId" -> "0"
+            )(paneElem)
+            Some(XmlUtil.elem("sheetViews")(sheetView))
+
 // ===== Print setup authoring (GH-259, GH-266) =====
 // PageSetup is the typed model for <pageMargins>, <pageSetup>, <headerFooter>, and the
 // sheetPr/pageSetUpPr fitToPage flag. The merge helpers below overlay the modeled fields onto any
@@ -316,11 +455,11 @@ private[ooxml] def mergeHeaderFooterElem(
       if flagged.child.isEmpty && flagged.attributes == Null then None else Some(flagged)
 
 /**
- * Ensure `<sheetPr><pageSetUpPr fitToPage="1"/></sheetPr>` when the model requests page-fit
- * scaling (GH-266): Excel ignores pageSetup's fitToWidth/fitToHeight without this flag. When no
- * fitTo* is modeled, the preserved element rides through verbatim — absence of the model fields is
- * not evidence the source flag should be cleared (fitToWidth/fitToHeight default to 1 in OOXML, so
- * a bare flag without pageSetup attributes is still meaningful).
+ * Ensure `<sheetPr><pageSetUpPr fitToPage="1"/></sheetPr>` when the model requests page-fit scaling
+ * (GH-266): Excel ignores pageSetup's fitToWidth/fitToHeight without this flag. When no fitTo* is
+ * modeled, the preserved element rides through verbatim — absence of the model fields is not
+ * evidence the source flag should be cleared (fitToWidth/fitToHeight default to 1 in OOXML, so a
+ * bare flag without pageSetup attributes is still meaningful).
  */
 private[ooxml] def mergeSheetPrElem(
   existing: Option[Elem],

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/WorksheetHelpers.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/WorksheetHelpers.scala
@@ -214,10 +214,11 @@ private[ooxml] def buildColsElement(sheet: Sheet): Option[Elem] =
     }
     Some(XmlUtil.elem("cols")(colElems*))
 
-// ===== Print setup authoring (GH-259) =====
-// PageSetup is the typed model for <pageMargins>, <pageSetup>, and <headerFooter>. The merge
-// helpers below overlay the modeled fields onto any preserved source XML so unmodeled attributes
-// (paperSize, printer r:id, even/first-page headers, differentOddEven, ...) survive a rewrite.
+// ===== Print setup authoring (GH-259, GH-266) =====
+// PageSetup is the typed model for <pageMargins>, <pageSetup>, <headerFooter>, and the
+// sheetPr/pageSetUpPr fitToPage flag. The merge helpers below overlay the modeled fields onto any
+// preserved source XML so unmodeled attributes (paperSize, printer r:id, scaleWithDoc, ...)
+// survive a rewrite.
 
 /** Replace or remove an unprefixed attribute on an element (deterministic for a given input). */
 private def setOrRemoveAttr(e: Elem, key: String, value: Option[String]): Elem =
@@ -271,11 +272,16 @@ private[ooxml] def mergePageSetupElem(
       }
       if existing.isEmpty && updated.attributes == Null then None else Some(updated)
 
+/** CT_HeaderFooter child labels in schema sequence order (ECMA-376 18.3.1.46). */
+private val headerFooterPartLabels: Seq[String] =
+  Seq("oddHeader", "oddFooter", "evenHeader", "evenFooter", "firstHeader", "firstFooter")
+
 /**
- * Merge the modeled odd header/footer into the preserved `<headerFooter>` element, keeping
- * unmodeled children (evenHeader/evenFooter/firstHeader/firstFooter) and attributes
- * (differentOddEven, ...) intact. `headerFooter = None` preserves the source element verbatim;
- * `Some(HeaderFooter(None, None))` actively clears the odd header/footer.
+ * Merge the modeled header/footer into the preserved `<headerFooter>` element. All six page parts
+ * (odd/even/first × header/footer) plus the differentOddEven/differentFirst flags are modeled
+ * (GH-266); remaining unmodeled bits (scaleWithDoc/alignWithMargins attributes, foreign children)
+ * stay intact. `headerFooter = None` preserves the source element verbatim; `Some(HeaderFooter())`
+ * actively clears all modeled parts.
  */
 private[ooxml] def mergeHeaderFooterElem(
   existing: Option[Elem],
@@ -285,16 +291,59 @@ private[ooxml] def mergeHeaderFooterElem(
     case None => existing
     case Some(hf) =>
       val base = existing.getOrElse(XmlUtil.elem("headerFooter")())
-      val withoutOdd = base.child.filterNot {
-        case e: Elem => e.label == "oddHeader" || e.label == "oddFooter"
+      val unmodeled = base.child.filterNot {
+        case e: Elem => headerFooterPartLabels.contains(e.label)
         case _ => false
       }
-      // CT_HeaderFooter sequence starts with oddHeader, oddFooter — prepend in schema order
-      val oddElems: Seq[Node] =
-        hf.oddHeader.map(t => XmlUtil.elem("oddHeader")(Text(t))).toList ++
-          hf.oddFooter.map(t => XmlUtil.elem("oddFooter")(Text(t))).toList
-      val updated = base.copy(child = oddElems ++ withoutOdd)
-      if updated.child.isEmpty && updated.attributes == Null then None else Some(updated)
+      val parts: Seq[Option[String]] = Seq(
+        hf.oddHeader,
+        hf.oddFooter,
+        hf.evenHeader,
+        hf.evenFooter,
+        hf.firstHeader,
+        hf.firstFooter
+      )
+      // CT_HeaderFooter children precede any foreign content — prepend in schema order
+      val partElems: Seq[Node] = headerFooterPartLabels.zip(parts).flatMap { (label, text) =>
+        text.map(t => XmlUtil.elem(label)(Text(t)))
+      }
+      val flagged = Seq(
+        "differentOddEven" -> Option.when(hf.differentOddEven)("1"),
+        "differentFirst" -> Option.when(hf.differentFirst)("1")
+      ).foldLeft(base.copy(child = partElems ++ unmodeled)) { case (e, (key, value)) =>
+        setOrRemoveAttr(e, key, value)
+      }
+      if flagged.child.isEmpty && flagged.attributes == Null then None else Some(flagged)
+
+/**
+ * Ensure `<sheetPr><pageSetUpPr fitToPage="1"/></sheetPr>` when the model requests page-fit
+ * scaling (GH-266): Excel ignores pageSetup's fitToWidth/fitToHeight without this flag. When no
+ * fitTo* is modeled, the preserved element rides through verbatim — absence of the model fields is
+ * not evidence the source flag should be cleared (fitToWidth/fitToHeight default to 1 in OOXML, so
+ * a bare flag without pageSetup attributes is still meaningful).
+ */
+private[ooxml] def mergeSheetPrElem(
+  existing: Option[Elem],
+  pageSetup: Option[PageSetup]
+): Option[Elem] =
+  val wantsFit = pageSetup.exists(ps => ps.fitToWidth.isDefined || ps.fitToHeight.isDefined)
+  if !wantsFit then existing
+  else
+    val base = existing.getOrElse(XmlUtil.elem("sheetPr")())
+    val hasPageSetUpPr = base.child.exists {
+      case e: Elem => e.label == "pageSetUpPr"
+      case _ => false
+    }
+    val children =
+      if hasPageSetUpPr then
+        base.child.map {
+          case e: Elem if e.label == "pageSetUpPr" =>
+            e % new UnprefixedAttribute("fitToPage", "1", Null)
+          case other => other
+        }
+      // CT_SheetPr's child sequence ends with pageSetUpPr — appending keeps schema order
+      else base.child :+ XmlUtil.elem("pageSetUpPr", "fitToPage" -> "1")()
+    Some(base.copy(child = children))
 
 /**
  * Apply domain RowProperties to an OoxmlRow.

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/DirectSaxEmitterParitySpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/DirectSaxEmitterParitySpec.scala
@@ -3,12 +3,23 @@ package com.tjclp.xl.ooxml
 import munit.FunSuite
 import java.io.ByteArrayOutputStream
 import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path}
 import java.time.LocalDateTime
+import java.util.zip.ZipFile
 import scala.xml.{Elem, MetaData, Node, Null, PrefixedAttribute, Text, TopScope, UnprefixedAttribute, XML}
 import com.tjclp.xl.addressing.{ARef, CellRange, Column, Row, SheetName}
-import com.tjclp.xl.cells.{CellValue, Comment}
+import com.tjclp.xl.api.Workbook
+import com.tjclp.xl.cells.{Cell, CellValue, Comment}
 import com.tjclp.xl.richtext.RichText.*
-import com.tjclp.xl.sheets.{ColumnProperties, RowProperties, Sheet}
+import com.tjclp.xl.sheets.{
+  ColumnProperties,
+  HeaderFooter,
+  PageMargins,
+  PageSetup,
+  RowProperties,
+  Sheet,
+  SheetView
+}
 // DirectSaxEmitter is in the same package
 
 // Test code uses .get/.head for brevity in assertions
@@ -48,6 +59,93 @@ class DirectSaxEmitterParitySpec extends FunSuite:
     assert(formulaElem.isDefined, "Cell should have <f> element")
     assertEquals(formulaElem.get.text, "SUM(B1:B10)")
   }
+
+  test("GH-265: direct SAX emission matches DOM writer for fresh-sheet metadata") {
+    // Freeze panes, view settings, page setup (incl. even header + fitToPage), hyperlinks:
+    // everything the DOM writer emits for a fresh sheet must come out of the streaming path too.
+    val sheet = buildMetadataSheet()
+
+    val expected = OoxmlWorksheet.fromDomainWithSST(sheet, None, Map.empty, None)
+    val actual = emitDirect(sheet, None)
+
+    assertEquals(normalize(expected.toXml), normalize(actual))
+  }
+
+  test("GH-265: SaxStax streaming write round-trips metadata equal to the DOM writer") {
+    val wb = Workbook(Vector(buildMetadataSheet()))
+    val saxPath = Files.createTempFile("gh265-sax", ".xlsx")
+    val domPath = Files.createTempFile("gh265-dom", ".xlsx")
+    XlsxWriter
+      .writeWith(wb, saxPath, WriterConfig.saxStax)
+      .fold(e => fail(s"SaxStax write failed: $e"), identity)
+    XlsxWriter
+      .writeWith(wb, domPath, WriterConfig.scalaXml)
+      .fold(e => fail(s"ScalaXml write failed: $e"), identity)
+
+    val saxWb = XlsxReader.read(saxPath).fold(e => fail(s"SaxStax read failed: $e"), identity)
+    val domWb = XlsxReader.read(domPath).fold(e => fail(s"ScalaXml read failed: $e"), identity)
+    assertEquals(saxWb.copy(sourceContext = None), domWb.copy(sourceContext = None))
+
+    val xml = zipEntryString(saxPath, "xl/worksheets/sheet1.xml")
+    assert(xml.contains("<pane "), s"freeze pane missing from streaming output: $xml")
+    assert(xml.contains("showGridLines=\"0\""), s"view settings missing: $xml")
+    assert(xml.contains("orientation=\"landscape\""), s"pageSetup missing: $xml")
+    assert(xml.contains("<pageMargins "), s"pageMargins missing: $xml")
+    assert(xml.contains("<evenHeader>"), s"even header (GH-266) missing: $xml")
+    assert(xml.contains("fitToPage=\"1\""), s"sheetPr fitToPage flag missing: $xml")
+    // Schema order (ECMA-376 18.3.1.99): sheetPr < sheetViews < cols < sheetData < page*
+    val order = Seq(
+      "<sheetPr>",
+      "<dimension ",
+      "<sheetViews>",
+      "<cols>",
+      "<sheetData>",
+      "<mergeCells ",
+      "<hyperlinks>",
+      "<pageMargins ",
+      "<pageSetup ",
+      "<headerFooter ",
+      "<legacyDrawing "
+    ).map(tag => tag -> xml.indexOf(tag))
+    order.foreach((tag, idx) => assert(idx >= 0, s"$tag missing from streaming output: $xml"))
+    assert(
+      order.map(_._2) == order.map(_._2).sorted,
+      s"streaming output violates schema order: $order"
+    )
+    Files.deleteIfExists(saxPath)
+    Files.deleteIfExists(domPath)
+  }
+
+  private def zipEntryString(path: Path, entry: String): String =
+    val zf = new ZipFile(path.toFile)
+    try
+      val is = zf.getInputStream(zf.getEntry(entry))
+      try new String(is.readAllBytes(), StandardCharsets.UTF_8)
+      finally is.close()
+    finally zf.close()
+
+  /** Fresh sheet exercising every metadata block DirectSaxEmitter must emit (GH-265). */
+  private def buildMetadataSheet(): Sheet =
+    val b2 = ARef.from1(2, 2)
+    buildSheet()
+      .put(Cell(ARef.from1(4, 2), CellValue.Text("link")).withHyperlink("https://example.com"))
+      .freezeAt(b2)
+      .withViewSettings(SheetView(showGridLines = false, zoomScale = Some(85)))
+      .withPageSetup(
+        PageSetup(
+          orientation = Some("landscape"),
+          fitToWidth = Some(1),
+          headerFooter = Some(
+            HeaderFooter(
+              oddHeader = Some("&LXL"),
+              oddFooter = Some("&CPage &P of &N"),
+              evenHeader = Some("&REven"),
+              differentOddEven = true
+            )
+          ),
+          margins = Some(PageMargins.default)
+        )
+      )
 
   private def emitDirect(sheet: Sheet, tableParts: Option[Elem]): Elem =
     val output = new ByteArrayOutputStream()

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/PageSetupRoundTripSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/PageSetupRoundTripSpec.scala
@@ -252,6 +252,134 @@ class PageSetupRoundTripSpec extends FunSuite:
     Files.deleteIfExists(out)
   }
 
+  test("GH-266: even/first headers+footers round-trip with differentOddEven/differentFirst") {
+    val hf = HeaderFooter(
+      oddHeader = Some("&LOdd Head"),
+      oddFooter = Some("&CPage &P of &N"),
+      evenHeader = Some("&REven Head"),
+      evenFooter = Some("&CEven Foot"),
+      firstHeader = Some("&CFirst Head"),
+      firstFooter = Some("&CFirst Foot"),
+      differentOddEven = true,
+      differentFirst = true
+    )
+    val setup = PageSetup(headerFooter = Some(hf))
+    val wb = Workbook(Sheet("Sheet1").put(ref"A1" -> 1).withPageSetup(setup))
+    val (reread, out) = writeRead(wb)
+    assertEquals(sheetSetup(reread), setup)
+
+    val xml = zipEntryString(out, "xl/worksheets/sheet1.xml")
+    assert(xml.contains("differentOddEven=\"1\""), s"differentOddEven attr missing: $xml")
+    assert(xml.contains("differentFirst=\"1\""), s"differentFirst attr missing: $xml")
+    assert(xml.contains("<evenHeader>"), s"evenHeader missing: $xml")
+    assert(xml.contains("<evenFooter>"), s"evenFooter missing: $xml")
+    assert(xml.contains("<firstHeader>"), s"firstHeader missing: $xml")
+    assert(xml.contains("<firstFooter>"), s"firstFooter missing: $xml")
+    // CT_HeaderFooter child sequence: odd, even, first
+    val odd = xml.indexOf("<oddHeader>")
+    val even = xml.indexOf("<evenHeader>")
+    val first = xml.indexOf("<firstHeader>")
+    assert(odd < even && even < first, "headerFooter children must follow schema order")
+    Files.deleteIfExists(out)
+  }
+
+  test("GH-266: even header round-trips without first-page parts (flags independent)") {
+    val hf = HeaderFooter(
+      oddHeader = Some("&COdd"),
+      evenHeader = Some("&CEven"),
+      differentOddEven = true
+    )
+    val setup = PageSetup(headerFooter = Some(hf))
+    val wb = Workbook(Sheet("Sheet1").put(ref"A1" -> 1).withPageSetup(setup))
+    val (reread, out) = writeRead(wb)
+    assertEquals(sheetSetup(reread), setup)
+
+    val xml = zipEntryString(out, "xl/worksheets/sheet1.xml")
+    assert(!xml.contains("differentFirst"), s"spurious differentFirst attr: $xml")
+    assert(!xml.contains("<firstHeader>"), s"spurious firstHeader: $xml")
+    Files.deleteIfExists(out)
+  }
+
+  test("GH-266: surgical write (cell edit) preserves even/first header+footer parts") {
+    val hf = HeaderFooter(
+      oddFooter = Some("&CPage &P"),
+      evenFooter = Some("&CEven &P"),
+      firstHeader = Some("&CCover"),
+      differentOddEven = true,
+      differentFirst = true
+    )
+    val wb0 = Workbook(
+      Sheet("Sheet1").put(ref"A1" -> 1).withPageSetup(PageSetup(headerFooter = Some(hf)))
+    )
+    val src = Files.createTempFile("evenfirst-src", ".xlsx")
+    XlsxWriter.write(wb0, src).fold(e => fail(s"seed write failed: $e"), identity)
+
+    val edited = for
+      wb <- XlsxReader.read(src)
+      sheet <- wb("Sheet1")
+    yield wb.put(sheet.put(ref"B1" -> 2))
+    val wb1 = edited.fold(e => fail(s"edit failed: $e"), identity)
+
+    val out = Files.createTempFile("evenfirst-out", ".xlsx")
+    XlsxWriter.write(wb1, out).fold(e => fail(s"write failed: $e"), identity)
+    val reread = XlsxReader.read(out).fold(e => fail(s"reread failed: $e"), identity)
+    assertEquals(sheetSetup(reread).headerFooter, Some(hf))
+    Files.deleteIfExists(src)
+    Files.deleteIfExists(out)
+  }
+
+  test("GH-266: fitToWidth/fitToHeight emit sheetPr/pageSetUpPr fitToPage flag") {
+    val setup = PageSetup(fitToWidth = Some(1), fitToHeight = Some(0))
+    val wb = Workbook(Sheet("Sheet1").put(ref"A1" -> 1).withPageSetup(setup))
+    val (reread, out) = writeRead(wb)
+    assertEquals(sheetSetup(reread), setup)
+
+    val xml = zipEntryString(out, "xl/worksheets/sheet1.xml")
+    assert(xml.contains("<pageSetUpPr"), s"pageSetUpPr missing: $xml")
+    assert(xml.contains("fitToPage=\"1\""), s"fitToPage flag missing: $xml")
+    // sheetPr must come FIRST in the worksheet element order (ECMA-376 18.3.1.99)
+    val sheetPr = xml.indexOf("<sheetPr")
+    assert(sheetPr >= 0, s"sheetPr missing: $xml")
+    assert(sheetPr < xml.indexOf("<dimension"), "sheetPr must precede dimension")
+    assert(sheetPr < xml.indexOf("<sheetData"), "sheetPr must precede sheetData")
+    Files.deleteIfExists(out)
+  }
+
+  test("GH-266: no fitTo* means no fitToPage flag (sheetPr not invented)") {
+    val setup = PageSetup(scale = 80, orientation = Some("landscape"))
+    val wb = Workbook(Sheet("Sheet1").put(ref"A1" -> 1).withPageSetup(setup))
+    val (reread, out) = writeRead(wb)
+    assertEquals(sheetSetup(reread), setup)
+
+    val xml = zipEntryString(out, "xl/worksheets/sheet1.xml")
+    assert(!xml.contains("fitToPage"), s"spurious fitToPage flag: $xml")
+    assert(!xml.contains("<sheetPr"), s"spurious sheetPr element: $xml")
+    Files.deleteIfExists(out)
+  }
+
+  test("GH-266: surgical edit keeps fitToPage flag from the source file") {
+    val setup = PageSetup(fitToWidth = Some(2), fitToHeight = Some(1))
+    val wb0 = Workbook(Sheet("Sheet1").put(ref"A1" -> 1).withPageSetup(setup))
+    val src = Files.createTempFile("fittopage-src", ".xlsx")
+    XlsxWriter.write(wb0, src).fold(e => fail(s"seed write failed: $e"), identity)
+
+    val edited = for
+      wb <- XlsxReader.read(src)
+      sheet <- wb("Sheet1")
+    yield wb.put(sheet.put(ref"B1" -> 2))
+    val wb1 = edited.fold(e => fail(s"edit failed: $e"), identity)
+
+    val out = Files.createTempFile("fittopage-out", ".xlsx")
+    XlsxWriter.write(wb1, out).fold(e => fail(s"write failed: $e"), identity)
+
+    val xml = zipEntryString(out, "xl/worksheets/sheet1.xml")
+    assert(xml.contains("fitToPage=\"1\""), s"fitToPage lost on surgical edit: $xml")
+    val reread = XlsxReader.read(out).fold(e => fail(s"reread failed: $e"), identity)
+    assertEquals(sheetSetup(reread), setup)
+    Files.deleteIfExists(src)
+    Files.deleteIfExists(out)
+  }
+
   test("GH-258/GH-259: freeze panes + view settings + print setup round-trip together") {
     val view = SheetView(showGridLines = false, zoomScale = Some(90))
     val setup = PageSetup(

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/PageSetupRoundTripSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/PageSetupRoundTripSpec.scala
@@ -131,6 +131,23 @@ class PageSetupRoundTripSpec extends FunSuite:
     Files.deleteIfExists(out)
   }
 
+  test("GH-263: sheet named like a cell ref (Q1) produces quoted print formulas") {
+    val setup = PageSetup(printArea = Some(ref"A1:B2"), repeatRows = Some((1, 1)))
+    val sheet = Sheet(SheetName.unsafe("Q1")).put(ref"A1", 1).withPageSetup(setup)
+    val wb = Workbook(sheet)
+    val out = Files.createTempFile("pagesetup-cellref-name", ".xlsx")
+    XlsxWriter.write(wb, out).fold(e => fail(s"write failed: $e"), identity)
+
+    val workbookXml = zipEntryString(out, "xl/workbook.xml")
+    assert(workbookXml.contains("'Q1'!$A$1:$B$2"), s"quoted area formula missing: $workbookXml")
+    assert(workbookXml.contains("'Q1'!$1:$1"), s"quoted titles formula missing: $workbookXml")
+
+    val reread = XlsxReader.read(out).fold(e => fail(s"read failed: $e"), identity)
+    val rereadSheet = reread(SheetName.unsafe("Q1")).fold(e => fail(s"$e"), identity)
+    assertEquals(rereadSheet.pageSetup, Some(setup))
+    Files.deleteIfExists(out)
+  }
+
   test("GH-259: every print field round-trips together (full PageSetup equality)") {
     val setup = PageSetup(
       scale = 90,

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/PrintNamesSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/PrintNamesSpec.scala
@@ -1,0 +1,57 @@
+package com.tjclp.xl.ooxml
+
+import com.tjclp.xl.addressing.{CellRange, SheetName}
+import munit.FunSuite
+
+/**
+ * GH-263: sheet names that parse as cell references (Q1, A1, R1C1, ...) must be single-quoted in
+ * defined-name formulas, or the generated workbook.xml is spec-invalid (Excel writes
+ * `'Q1'!$A$1:$B$2`, never `Q1!$A$1:$B$2`). Quoting delegates to the shared
+ * `SheetName.needsQuoting` predicate.
+ */
+class PrintNamesSpec extends FunSuite:
+
+  private def range(s: String): CellRange =
+    CellRange.parse(s).fold(e => fail(s"bad range: $e"), identity)
+
+  test("GH-263: quoteSheetName quotes cell-ref-shaped names") {
+    assertEquals(PrintNames.quoteSheetName("Q1"), "'Q1'")
+    assertEquals(PrintNames.quoteSheetName("A1"), "'A1'")
+    assertEquals(PrintNames.quoteSheetName("XFD1048576"), "'XFD1048576'")
+    assertEquals(PrintNames.quoteSheetName("R1C1"), "'R1C1'")
+    assertEquals(PrintNames.quoteSheetName("RC"), "'RC'")
+  }
+
+  test("GH-263: quoteSheetName keeps safe names bare") {
+    assertEquals(PrintNames.quoteSheetName("Sheet1"), "Sheet1")
+    assertEquals(PrintNames.quoteSheetName("Sales_2024"), "Sales_2024")
+    assertEquals(PrintNames.quoteSheetName("XFE1"), "XFE1") // beyond max column: not a cell ref
+  }
+
+  test("GH-263: quoteSheetName quotes leading digits, spaces, and escapes quotes") {
+    assertEquals(PrintNames.quoteSheetName("2024Q1"), "'2024Q1'")
+    assertEquals(PrintNames.quoteSheetName("Q1 Report"), "'Q1 Report'")
+    assertEquals(PrintNames.quoteSheetName("It's Q1"), "'It''s Q1'")
+  }
+
+  test("GH-263: print-area defined-name formula for sheet Q1 is quoted") {
+    assertEquals(
+      PrintNames.printAreaFormula(SheetName.unsafe("Q1"), range("A1:B2")),
+      "'Q1'!$A$1:$B$2"
+    )
+  }
+
+  test("GH-263: print-titles defined-name formula for sheet Q1 is quoted") {
+    assertEquals(PrintNames.printTitlesFormula(SheetName.unsafe("Q1"), (1, 3)), "'Q1'!$1:$3")
+  }
+
+  test("GH-263: quoted print formulas parse back to the model (round-trip)") {
+    val sheet = SheetName.unsafe("Q1")
+    val area = range("A1:B2")
+    val areaFormula = PrintNames.printAreaFormula(sheet, area)
+    assertEquals(PrintNames.parsePrintArea(areaFormula, sheet), Some(area))
+    val titlesFormula = PrintNames.printTitlesFormula(sheet, (1, 3))
+    assertEquals(PrintNames.parsePrintTitles(titlesFormula, sheet), Some((1, 3)))
+  }
+
+end PrintNamesSpec

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/SaxStaxRoundTripSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/SaxStaxRoundTripSpec.scala
@@ -27,7 +27,9 @@ class SaxStaxRoundTripSpec extends FunSuite:
     val saxPath = tempDir.resolve("sax.xlsx")
     val scalaPath = tempDir.resolve("scala.xml.xlsx")
 
-    val saxConfig = WriterConfig.default.copy(sstPolicy = SstPolicy.Always)
+    // saxStax, not default: default is ScalaXml, which would make this spec compare
+    // ScalaXml against itself instead of exercising the SaxStax backend (GH-265)
+    val saxConfig = WriterConfig.saxStax.copy(sstPolicy = SstPolicy.Always)
     val scalaConfig = WriterConfig.scalaXml.copy(sstPolicy = SstPolicy.Always)
 
     XlsxWriter.writeWith(workbook, saxPath, saxConfig).getOrElse(fail("SaxStax write failed"))

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/SurgicalWhitespaceSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/SurgicalWhitespaceSpec.scala
@@ -1,0 +1,381 @@
+package com.tjclp.xl.ooxml
+
+import java.nio.file.{Files, Path}
+import java.util.zip.{ZipEntry, ZipFile, ZipOutputStream}
+
+import com.tjclp.xl.addressing.ARef
+import com.tjclp.xl.api.*
+import com.tjclp.xl.cells.CellValue
+import com.tjclp.xl.codec.CellCodec.given
+import com.tjclp.xl.macros.ref
+import com.tjclp.xl.ooxml.writer.{SstPolicy, WriterConfig}
+import munit.FunSuite
+
+/**
+ * Regression guard for GH-17: SST entries must keep exact whitespace (trailing/double/leading
+ * spaces, embedded newlines) through SURGICAL writes — read with source handle, modify one
+ * unrelated cell, write.
+ *
+ * Covers every SST sub-path of the surgical writer:
+ *   1. Modified sheet introduces a NEW string → preserved SST combined with new entries and
+ *      re-serialized (XlsxWriter combine logic + SharedStrings.toXml/writeSax)
+ *   1. Modified sheet introduces NO new strings → SST copied verbatim, sheet regenerated
+ *   1. Modification on a DIFFERENT sheet → referencing sheet copied verbatim, SST combined
+ *      (preserved entries must keep their indices)
+ *   1. Fixture authored by the xl writer itself (not raw XML), then surgically modified
+ *
+ * Each test asserts BOTH the reloaded domain values and the raw xl/sharedStrings.xml bytes
+ * (exact text content and xml:space="preserve" attributes).
+ */
+class SurgicalWhitespaceSpec extends FunSuite:
+
+  // Whitespace corpus from GH-17 (real-world Syndigo file)
+  private val trailingTwo = "Capital.  " // two trailing spaces
+  private val doubleInterior = "billion.  Resolute" // double interior space
+  private val leadingTwo = "  lead" // two leading spaces
+  private val embeddedNewline = "or \nOther" // embedded newline
+  private val plain = "Plain"
+
+  private val whitespaceCells: Map[ARef, String] = Map(
+    ref"A1" -> trailingTwo,
+    ref"A2" -> doubleInterior,
+    ref"A3" -> leadingTwo,
+    ref"A4" -> embeddedNewline
+  )
+
+  // ========== Scenario 1: new string on the SST-referencing sheet (SST combine path) ==========
+
+  test("GH-17: surgical write with new string preserves SST whitespace (combine path)") {
+    val source = createRawSstFixture(twoSheets = false)
+    val wb = XlsxReader.read(source).fold(err => fail(s"Read failed: $err"), identity)
+
+    // Precondition: the read path preserves whitespace (issue confirmed this works)
+    assertWhitespaceValues(wb, "Sheet1", "precondition (read)")
+
+    val modified = wb("Sheet1")
+      .map(sheet => wb.put(sheet.put(ref"D1" -> "Surgical Update")))
+      .fold(err => fail(s"Modify failed: $err"), identity)
+
+    val output = Files.createTempFile("gh17-combine", ".xlsx")
+    XlsxWriter.write(modified, output).fold(err => fail(s"Write failed: $err"), identity)
+
+    // Domain values survive the full surgical round-trip
+    val reloaded = XlsxReader.read(output).fold(err => fail(s"Reload failed: $err"), identity)
+    assertWhitespaceValues(reloaded, "Sheet1", "after surgical write (combine path)")
+    assertEquals(textAt(reloaded, "Sheet1", ref"D1"), Some("Surgical Update"))
+
+    // Prove the combine path actually ran: SST was re-serialized (new string forces regeneration)
+    val outSst = new String(readSstBytes(output), "UTF-8")
+    assert(
+      !java.util.Arrays.equals(readSstBytes(output), readSstBytes(source)),
+      "SST should be regenerated (not verbatim-copied) when a new string is introduced"
+    )
+    assert(outSst.contains("Surgical Update"), s"new string missing from combined SST:\n$outSst")
+
+    // Raw SST bytes: exact text content + xml:space="preserve" attributes survive re-emission
+    assertRawSstWhitespace(output, "combine path")
+
+    Files.deleteIfExists(source)
+    Files.deleteIfExists(output)
+  }
+
+  // ========== Scenario 2: numeric edit, no new strings (SST verbatim-copy path) ==========
+
+  test("GH-17: surgical numeric edit copies SST verbatim and keeps whitespace") {
+    val source = createRawSstFixture(twoSheets = false)
+    val wb = XlsxReader.read(source).fold(err => fail(s"Read failed: $err"), identity)
+
+    val modified = wb("Sheet1")
+      .map(sheet => wb.put(sheet.put(ref"D1" -> 42)))
+      .fold(err => fail(s"Modify failed: $err"), identity)
+
+    val output = Files.createTempFile("gh17-verbatim", ".xlsx")
+    XlsxWriter.write(modified, output).fold(err => fail(s"Write failed: $err"), identity)
+
+    // No new strings → preserved SST must be byte-identical (strongest guarantee)
+    assertEquals(
+      readSstBytes(output).toSeq,
+      readSstBytes(source).toSeq,
+      "SST should be copied byte-for-byte when no new strings are introduced"
+    )
+
+    // Domain values survive even though the modified sheet itself was regenerated
+    val reloaded = XlsxReader.read(output).fold(err => fail(s"Reload failed: $err"), identity)
+    assertWhitespaceValues(reloaded, "Sheet1", "after surgical write (verbatim SST path)")
+    assertEquals(
+      reloaded("Sheet1").toOption.flatMap(_.cells.get(ref"D1")).map(_.value),
+      Some(CellValue.Number(BigDecimal(42)))
+    )
+
+    Files.deleteIfExists(source)
+    Files.deleteIfExists(output)
+  }
+
+  // ========== Scenario 3: edit a DIFFERENT sheet (preserved sheet + combined SST) ==========
+
+  test("GH-17: surgical edit on another sheet keeps SST indices and whitespace") {
+    val source = createRawSstFixture(twoSheets = true)
+    val wb = XlsxReader.read(source).fold(err => fail(s"Read failed: $err"), identity)
+
+    val modified = wb("Sheet2")
+      .map(sheet => wb.put(sheet.put(ref"D1" -> "Surgical Update")))
+      .fold(err => fail(s"Modify failed: $err"), identity)
+
+    val output = Files.createTempFile("gh17-cross-sheet", ".xlsx")
+    XlsxWriter.write(modified, output).fold(err => fail(s"Write failed: $err"), identity)
+
+    // Sheet1 (untouched, references SST by index) must be copied byte-for-byte
+    assertEquals(
+      readEntry(output, "xl/worksheets/sheet1.xml").toSeq,
+      readEntry(source, "xl/worksheets/sheet1.xml").toSeq,
+      "Unmodified sheet1 should be byte-identical"
+    )
+
+    // Combined SST must keep preserved entries at their original indices, with whitespace
+    val reloaded = XlsxReader.read(output).fold(err => fail(s"Reload failed: $err"), identity)
+    assertWhitespaceValues(reloaded, "Sheet1", "preserved sheet after cross-sheet edit")
+    assertEquals(textAt(reloaded, "Sheet2", ref"D1"), Some("Surgical Update"))
+
+    // Combine path proof: SST re-serialized with the new entry appended after preserved ones
+    assert(
+      !java.util.Arrays.equals(readSstBytes(output), readSstBytes(source)),
+      "SST should be regenerated (not verbatim-copied) when a new string is introduced"
+    )
+    assertRawSstWhitespace(output, "cross-sheet combine path")
+
+    Files.deleteIfExists(source)
+    Files.deleteIfExists(output)
+  }
+
+  // ========== Scenario 3b: same combine path through the StAX backend ==========
+
+  test("GH-17: SaxStax backend surgical write preserves SST whitespace (combine path)") {
+    val source = createRawSstFixture(twoSheets = false)
+    val wb = XlsxReader.read(source).fold(err => fail(s"Read failed: $err"), identity)
+
+    val modified = wb("Sheet1")
+      .map(sheet => wb.put(sheet.put(ref"D1" -> "Surgical Update")))
+      .fold(err => fail(s"Modify failed: $err"), identity)
+
+    val output = Files.createTempFile("gh17-saxstax", ".xlsx")
+    XlsxWriter
+      .writeWith(modified, output, WriterConfig.saxStax)
+      .fold(err => fail(s"Write failed: $err"), identity)
+
+    val reloaded = XlsxReader.read(output).fold(err => fail(s"Reload failed: $err"), identity)
+    assertWhitespaceValues(reloaded, "Sheet1", "after surgical write (SaxStax backend)")
+    assertEquals(textAt(reloaded, "Sheet1", ref"D1"), Some("Surgical Update"))
+
+    // writeSax is a separate emission path from toXml: assert its raw bytes independently
+    assertRawSstWhitespace(output, "SaxStax combine path")
+
+    Files.deleteIfExists(source)
+    Files.deleteIfExists(output)
+  }
+
+  // ========== Scenario 4: fixture authored by the xl writer itself ==========
+
+  test("GH-17: xl-authored SST round-trips whitespace through surgical modification") {
+    val sheet = Sheet("Data").put(
+      ref"A1" -> trailingTwo,
+      ref"A2" -> doubleInterior,
+      ref"A3" -> leadingTwo,
+      ref"A4" -> embeddedNewline,
+      ref"B1" -> plain
+    )
+    val source = Files.createTempFile("gh17-xl-authored", ".xlsx")
+    XlsxWriter
+      .writeWith(Workbook(Vector(sheet)), source, WriterConfig(sstPolicy = SstPolicy.Always))
+      .fold(err => fail(s"Initial write failed: $err"), identity)
+
+    // Precondition: the writer actually produced an SST (not inline strings) with exact bytes
+    assertRawSstWhitespace(source, "xl-authored fixture")
+
+    val wb = XlsxReader.read(source).fold(err => fail(s"Read failed: $err"), identity)
+    assertWhitespaceValues(wb, "Data", "precondition (read of xl-authored file)")
+
+    val modified = wb("Data")
+      .map(s => wb.put(s.put(ref"D1" -> "Surgical Update")))
+      .fold(err => fail(s"Modify failed: $err"), identity)
+
+    val output = Files.createTempFile("gh17-xl-authored-out", ".xlsx")
+    XlsxWriter.write(modified, output).fold(err => fail(s"Write failed: $err"), identity)
+
+    val reloaded = XlsxReader.read(output).fold(err => fail(s"Reload failed: $err"), identity)
+    assertWhitespaceValues(reloaded, "Data", "after surgical write (xl-authored fixture)")
+    assertEquals(textAt(reloaded, "Data", ref"D1"), Some("Surgical Update"))
+
+    assertRawSstWhitespace(output, "xl-authored surgical output")
+
+    Files.deleteIfExists(source)
+    Files.deleteIfExists(output)
+  }
+
+  // ========== Assertion helpers ==========
+
+  private def textAt(wb: Workbook, sheetName: String, r: ARef): Option[String] =
+    wb(sheetName).toOption.flatMap(_.cells.get(r)).map(_.value).collect {
+      case CellValue.Text(s) => s
+    }
+
+  private def assertWhitespaceValues(wb: Workbook, sheetName: String, where: String): Unit =
+    whitespaceCells.foreach { case (r, expected) =>
+      val got = textAt(wb, sheetName, r)
+      assertEquals(
+        got,
+        Some(expected),
+        s"$where: $sheetName!${r.toA1} expected '${escapeWs(expected)}' " +
+          s"but got ${got.map(s => s"'${escapeWs(s)}'").getOrElse("<missing>")}"
+      )
+    }
+
+  /** Assert raw sharedStrings.xml bytes keep exact text and xml:space="preserve" attributes. */
+  private def assertRawSstWhitespace(path: Path, where: String): Unit =
+    val sst = new String(readEntry(path, "xl/sharedStrings.xml"), "UTF-8")
+    List(trailingTwo, doubleInterior, leadingTwo, embeddedNewline).foreach { s =>
+      assert(
+        sst.contains(s"""<t xml:space="preserve">$s</t>"""),
+        s"$where: raw SST lost whitespace or xml:space for '${escapeWs(s)}'. SST:\n$sst"
+      )
+    }
+
+  /** Make whitespace visible in failure messages (spaces → '·', control chars escaped). */
+  private def escapeWs(s: String): String =
+    s.flatMap {
+      case ' ' => "·"
+      case '\n' => "\\n"
+      case '\r' => "\\r"
+      case '\t' => "\\t"
+      case c => c.toString
+    }
+
+  // ========== ZIP helpers ==========
+
+  private def readEntry(path: Path, entryName: String): Array[Byte] =
+    val zip = new ZipFile(path.toFile)
+    try
+      val entry = zip.getEntry(entryName)
+      assert(entry != null, s"$entryName missing from $path")
+      val is = zip.getInputStream(entry)
+      try is.readAllBytes()
+      finally is.close()
+    finally zip.close()
+
+  private def readSstBytes(path: Path): Array[Byte] = readEntry(path, "xl/sharedStrings.xml")
+
+  private def writeEntry(out: ZipOutputStream, name: String, content: String): Unit =
+    out.putNextEntry(new ZipEntry(name))
+    out.write(content.getBytes("UTF-8"))
+    out.closeEntry()
+
+  // ========== Raw XML fixture (Excel-shaped, bypasses the xl writer on the way in) ==========
+
+  /**
+   * Build an xlsx whose SST carries the GH-17 whitespace corpus with xml:space="preserve",
+   * exactly as Excel emits it. Sheet1 references all entries via t="s"; the optional Sheet2 holds
+   * only a number (so cross-sheet edits leave Sheet1 untouched).
+   */
+  private def createRawSstFixture(twoSheets: Boolean): Path =
+    val path = Files.createTempFile(s"gh17-fixture-${if twoSheets then "2s" else "1s"}", ".xlsx")
+    val out = new ZipOutputStream(Files.newOutputStream(path))
+    out.setLevel(1)
+
+    val sheet2ContentType =
+      if twoSheets then
+        """
+  <Override PartName="/xl/worksheets/sheet2.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>"""
+      else ""
+    val sheet2Decl = if twoSheets then """
+    <sheet name="Sheet2" sheetId="2" r:id="rId2"/>""" else ""
+    val sheet2Rel =
+      if twoSheets then """
+  <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet2.xml"/>"""
+      else ""
+    val sstRelId = if twoSheets then "rId3" else "rId2"
+
+    try
+      writeEntry(
+        out,
+        "[Content_Types].xml",
+        s"""<?xml version="1.0"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+  <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>$sheet2ContentType
+  <Override PartName="/xl/sharedStrings.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml"/>
+</Types>"""
+      )
+
+      writeEntry(
+        out,
+        "_rels/.rels",
+        """<?xml version="1.0"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>"""
+      )
+
+      writeEntry(
+        out,
+        "xl/workbook.xml",
+        s"""<?xml version="1.0"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <sheets>
+    <sheet name="Sheet1" sheetId="1" r:id="rId1"/>$sheet2Decl
+  </sheets>
+</workbook>"""
+      )
+
+      writeEntry(
+        out,
+        "xl/_rels/workbook.xml.rels",
+        s"""<?xml version="1.0"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>$sheet2Rel
+  <Relationship Id="$sstRelId" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings" Target="sharedStrings.xml"/>
+</Relationships>"""
+      )
+
+      // SST entries on single lines: <t> content is EXACTLY the corpus strings
+      writeEntry(
+        out,
+        "xl/sharedStrings.xml",
+        "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n" +
+          "<sst xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" count=\"5\" uniqueCount=\"5\">" +
+          s"<si><t xml:space=\"preserve\">$trailingTwo</t></si>" +
+          s"<si><t xml:space=\"preserve\">$doubleInterior</t></si>" +
+          s"<si><t xml:space=\"preserve\">$leadingTwo</t></si>" +
+          s"<si><t xml:space=\"preserve\">$embeddedNewline</t></si>" +
+          s"<si><t>$plain</t></si>" +
+          "</sst>"
+      )
+
+      writeEntry(
+        out,
+        "xl/worksheets/sheet1.xml",
+        """<?xml version="1.0"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <sheetData>
+    <row r="1"><c r="A1" t="s"><v>0</v></c><c r="B1" t="s"><v>4</v></c><c r="C1"><v>7</v></c></row>
+    <row r="2"><c r="A2" t="s"><v>1</v></c></row>
+    <row r="3"><c r="A3" t="s"><v>2</v></c></row>
+    <row r="4"><c r="A4" t="s"><v>3</v></c></row>
+  </sheetData>
+</worksheet>"""
+      )
+
+      if twoSheets then
+        writeEntry(
+          out,
+          "xl/worksheets/sheet2.xml",
+          """<?xml version="1.0"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <sheetData>
+    <row r="1"><c r="A1"><v>1</v></c></row>
+  </sheetData>
+</worksheet>"""
+        )
+    finally out.close()
+
+    path


### PR DESCRIPTION
## Summary

Wave 1 of the [six-wave backlog burn-down](docs/plan/roadmap.md) (#272-era triage), executed via the new reusable `.claude/workflows/issue-wave.js`: baseline gate → 6 worktree-isolated TDD implementers → pipelined adversarial reviewers (revert-and-rerun refutation protocol). **6/6 clusters approved, zero rework rounds.**

### Fixed
- **#271** — leading unary plus (`=+A1`, `=+SUM(...)`, `=2^+2`) parses as identity; printer normalizes; chained `+` respects the recursion budget. The fx`""` macro/runtime-parser mismatch closes from the parser side.
- **#263** — sheet names that parse as cell refs (`Q1`, `A1`, `R1C1`, even `TRUE`) are quoted everywhere formulas are generated, via one shared predicate (`SheetName.needsQuoting`/`quoteForFormula`) replacing three divergent copies (RefType, FormulaPrinter, PrintNames). End-to-end: `'Q1'!$A$1:$B$2` in workbook.xml round-trips.
- **#262** — trailing empty format sections survive (`"0.0;;"` = hide-zero; `";;;"` = hide-everything); empty sections render empty, not General.
- **#275** — evaluating display strategy prefers `recalculate()`-cached values; cross-sheet formulas display numbers, not raw formula text.
- **#264** — streaming `StylePatcher` hardened against malformed numeric attributes (`indent="-2"` no longer throws through `Align`'s domain guard); full attribute-parse sweep, DOM-path parity asserted.
- **#266** — even/first-page headers+footers (`differentOddEven`/`differentFirst`) + `<sheetPr><pageSetUpPr fitToPage="1"/>` emission (Excel ignores `fitToWidth/Height` without it). Write→read round-trip.
- **#265** — `DirectSaxEmitter` emits `sheetPr`/`sheetViews`/`pageMargins`/`pageSetup`/`headerFooter` **and `hyperlinks`** for fresh sheets (all previously dropped silently on the streaming path; hyperlink rels were orphaned). Also fixed in passing: `SaxStaxRoundTripSpec` was comparing ScalaXml against itself (`WriterConfig.default` instead of `saxStax`) — a coverage hole now closed.

### Changed
- **#48** — `SheetEvaluator` is var-free: both mutable accumulation blocks → `foldLeft`, `@SuppressWarnings(Var)` exemptions removed; equivalence pinned against the old implementation.
- **#17** — **not reproducible** (verify-first protocol): issue's exact whitespace corpus survives surgical writes byte-for-byte; falsifiability proven by injecting three hypothesized bug classes into source — the new `SurgicalWhitespaceSpec` caught each. Spec stays as a permanent regression guard; closing with evidence.

### Infrastructure
- `.claude/workflows/issue-wave.js` — the reusable parameterized wave workflow (baseline gate, optional design panel, worktree TDD clusters, adversarial review with one rework round).
- Roadmap rewritten around the six-wave schedule; CHANGELOG Unreleased section added.
- `CrossSheetFormulaSpec.genSimpleSheetName` now honors its "unquoted names" contract (it could emit cell-ref shapes that #263 correctly quotes — seed-dependent flake caught at integration).

## Verification
- Baseline: 3005 tests green pre-wave (recorded by the baseline agent).
- Every fix developed TDD: reviewers reverted source (keeping tests) and confirmed each new test FAILS without its fix — no rubber stamps.
- Integrated `wave-1`: `./mill __.test` → **1028/1028 SUCCESS** (3005+ test results); `verify-skill-snippets.sh --local` → 17/17 compile.
- 9 commits cherry-picked in risk order; one auto-merge, no conflicts.

Closes #271
Closes #263
Closes #262
Closes #264
Closes #265
Closes #266
Closes #275
Closes #48

(#17 closed manually with evidence after merge.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)