### PR TITLE
chore(release): Bump version to 0.11.1

### DIFF
--- a/.claude/commands/release-prep.md
+++ b/.claude/commands/release-prep.md
@@ -62,7 +62,7 @@ After updating all files:
 4. Run `./scripts/verify-skill-snippets.sh --local` (xl-scripting skill snippets compile)
 5. Run this to verify no SNAPSHOT refs remain:
    ```bash
-   grep -r "SNAPSHOT" --include="*.scala" --include="*.mill" --include="*.md" . | grep -v RELEASING.md | grep -v ".scala-build" | grep -v "out/"
+   grep -r "SNAPSHOT" --include="*.scala" --include="*.mill" --include="*.md" . | grep -v RELEASING.md | grep -v ".scala-build" | grep -v "out/" | grep -v ".claude/commands"
    ```
 6. Confirm new release features are documented in `plugin/skills/xl-scripting/reference/API.md`
    and `docs/reference/scripting.md` — cross-check the release's CHANGELOG entries against both

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.1] "Totality" - 2026-06-10
+
+Wave 1 of the post-0.11.0 backlog burn-down: every open bug, fixed TDD-first under
+adversarial review (each new test proven to fail without its fix).
+
 ### Added
 
 - **Leading unary plus in formulas** (#271): `=+A1`, `=+SUM(A1:B2)`, chained `=++A1`, and

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ```scala 3 raw
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.11.0
+//> using dep com.tjclp::xl:0.11.1
 
 import com.tjclp.xl.{*, given}
 
@@ -55,13 +55,13 @@ import com.tjclp.xl.{*, given}
 
 ```scala 3 ignore
 // build.mill — single dependency for everything
-def ivyDeps = Agg(ivy"com.tjclp::xl:0.11.0")
+def ivyDeps = Agg(ivy"com.tjclp::xl:0.11.1")
 
 // Or individual modules for minimal footprint:
-// ivy"com.tjclp::xl-core:0.11.0"        — Pure domain model only
-// ivy"com.tjclp::xl-ooxml:0.11.0"       — Add OOXML read/write
-// ivy"com.tjclp::xl-cats-effect:0.11.0" — Add IO streaming
-// ivy"com.tjclp::xl-evaluator:0.11.0"   — Add formula evaluation
+// ivy"com.tjclp::xl-core:0.11.1"        — Pure domain model only
+// ivy"com.tjclp::xl-ooxml:0.11.1"       — Add OOXML read/write
+// ivy"com.tjclp::xl-cats-effect:0.11.1" — Add IO streaming
+// ivy"com.tjclp::xl-evaluator:0.11.1"   — Add formula evaluation
 ```
 
 ### Basic Usage

--- a/build.mill
+++ b/build.mill
@@ -14,7 +14,7 @@ val organization = "com.tjclp"
 /** Shared build configuration constants */
 object BuildConfig {
   /** Project version: CI sets PUBLISH_VERSION; local builds use this fallback */
-  val version: String = sys.env.getOrElse("PUBLISH_VERSION", "0.11.0")
+  val version: String = sys.env.getOrElse("PUBLISH_VERSION", "0.11.1")
 
   /** JVM options to silence Scala 3 LazyVals sun.misc.Unsafe deprecation warnings (JDK 21+) */
   val lazyValsJvmArgs: Seq[String] = Seq(

--- a/docs/QUICK-START.md
+++ b/docs/QUICK-START.md
@@ -12,19 +12,19 @@ import mill._, scalalib._
 
 object myproject extends ScalaModule {
   def scalaVersion = "3.8.3"
-  def ivyDeps = Agg(ivy"com.tjclp::xl:0.11.0")
+  def ivyDeps = Agg(ivy"com.tjclp::xl:0.11.1")
 }
 ```
 
 ### With sbt (build.sbt)
 ```scala
 scalaVersion := "3.8.3"
-libraryDependencies += "com.tjclp" %% "xl" % "0.11.0"
+libraryDependencies += "com.tjclp" %% "xl" % "0.11.1"
 ```
 
 ### With Scala CLI
 ```scala
-//> using dep com.tjclp::xl:0.11.0
+//> using dep com.tjclp::xl:0.11.1
 ```
 
 ### Individual Modules (Optional)
@@ -44,7 +44,7 @@ For scripts, skip the build setup entirely: a two-line `scala-cli` header and ON
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.11.0
+//> using dep com.tjclp::xl:0.11.1
 
 import com.tjclp.xl.scripting.{*, given}
 

--- a/docs/plan/roadmap.md
+++ b/docs/plan/roadmap.md
@@ -12,7 +12,7 @@
 
 **Current Status**: Production-ready with **104 formula functions** (incl. dynamic arrays SEQUENCE/SORT/UNIQUE/FILTER and OFFSET), **structural editing** (insert/delete rows & columns with formula rewriting), the **scripting prelude** (`com.tjclp.xl.scripting`), whole-workbook `recalculate`, named-range & hyperlink authoring, SAX streaming (36% faster than POI), Excel tables, and full OOXML round-trip. 3005+ tests passing.
 
-**Current Version**: **0.11.0 "Scripting"** (released 2026-06-10)
+**Current Version**: **0.11.1 "Totality"** (released 2026-06-10)
 
 ---
 
@@ -23,9 +23,9 @@ executed as a parallel multi-agent run via `.claude/workflows/issue-wave.js` (ba
 worktree-isolated TDD clusters → adversarial review → integration). This roadmap is the single
 source of truth for scheduling.
 
-### v0.11.1 "Totality" — wave 1 (in flight)
+### v0.11.1 "Totality" — wave 1 (Released 2026-06-10)
 
-All open bugs, one patch release.
+All open bugs, one patch release (PR #276). Reviewer-discovered gaps filed as #277–#285.
 
 | Issue | Fix |
 |-------|-----|

--- a/docs/reference/scripting.md
+++ b/docs/reference/scripting.md
@@ -33,7 +33,7 @@ release bump is a mechanical substitution):
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.11.0
+//> using dep com.tjclp::xl:0.11.1
 import com.tjclp.xl.scripting.{*, given}
 
 val sheet = Sheet("Demo").put(ref"A1", "Hello").put(ref"B1", 42)
@@ -51,7 +51,7 @@ read and write is pure values.
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.11.0
+//> using dep com.tjclp::xl:0.11.1
 import com.tjclp.xl.scripting.{*, given}
 
 val wb = Excel.read("input.xlsx")
@@ -135,7 +135,7 @@ throw — they are collected per cell.
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.11.0
+//> using dep com.tjclp::xl:0.11.1
 import com.tjclp.xl.scripting.{*, given}
 
 val title = CellStyle.default.bold.size(14.0).center
@@ -229,7 +229,7 @@ them explicitly:
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.11.0
+//> using dep com.tjclp::xl:0.11.1
 import com.tjclp.xl.scripting.{*, given}
 import com.tjclp.xl.sheets.{HeaderFooter, PageMargins, PageSetup, SheetView}
 
@@ -240,6 +240,8 @@ val report = Sheet("Report")
     PageSetup(
       orientation = Some("landscape"),
       fitToWidth = Some(1),
+      // 0.11.1+: HeaderFooter also takes evenHeader/evenFooter/firstHeader/firstFooter
+      // with differentOddEven/differentFirst; fitToWidth/Height emit the fitToPage flag
       headerFooter = Some(HeaderFooter(oddFooter = Some("&LACME Corp&RPage &P of &N"))),
       margins = Some(PageMargins(left = 0.5, right = 0.5)),
       printArea = Some(ref"A1:H40"),     // _xlnm.Print_Area defined name
@@ -281,7 +283,7 @@ the whole workbook:
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.11.0
+//> using dep com.tjclp::xl:0.11.1
 import com.tjclp.xl.scripting.{*, given}
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global

--- a/examples/README.md
+++ b/examples/README.md
@@ -170,7 +170,7 @@ chmod +x examples/my_example.sc
 ./examples/my_example.sc
 ```
 
-The `project.scala` file centralizes dependencies (`com.tjclp::xl:0.11.0`) for all examples.
+The `project.scala` file centralizes dependencies (`com.tjclp::xl:0.11.1`) for all examples.
 
 ## Scripting Prelude & Skill
 

--- a/examples/project.scala
+++ b/examples/project.scala
@@ -2,4 +2,4 @@
 //> using repository ivy2Local
 
 // XL aggregate - includes all modules (core, ooxml, cats-effect, evaluator)
-//> using dep com.tjclp::xl:0.11.0
+//> using dep com.tjclp::xl:0.11.1

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "xl",
   "description": "LLM-friendly Excel tooling: the xl CLI for reading, writing, styling, and analyzing spreadsheets (xl-cli skill), plus type-safe Scala scripting against the xl library via scala-cli for bulk transformations, pipelines, and formula models (xl-scripting skill).",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "author": {
     "name": "TJC L.P.",
     "url": "https://github.com/TJC-LP"

--- a/plugin/skills/xl-scripting/SKILL.md
+++ b/plugin/skills/xl-scripting/SKILL.md
@@ -38,7 +38,7 @@ The canonical header for every script (this is the single source of truth — re
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.11.0
+//> using dep com.tjclp::xl:0.11.1
 
 import com.tjclp.xl.scripting.{*, given}
 
@@ -100,7 +100,7 @@ wb.update("Sales", f).unsafe                       // throws structured XLExcept
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.11.0
+//> using dep com.tjclp::xl:0.11.1
 import com.tjclp.xl.scripting.{*, given}
 
 val wb = Excel.read("input.xlsx")
@@ -235,7 +235,7 @@ Or lean on totality so there is nothing to unwrap: literal refs, `upsert`, range
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.11.0
+//> using dep com.tjclp::xl:0.11.1
 import com.tjclp.xl.scripting.{*, given}
 import java.nio.file.{Files, Paths}
 import scala.jdk.CollectionConverters.*
@@ -257,7 +257,7 @@ println(s"merged ${inputs.size} files, ${merged.sheets.size} sheets")
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.11.0
+//> using dep com.tjclp::xl:0.11.1
 import com.tjclp.xl.scripting.{*, given}
 
 val data = List(("North", 125000.50), ("South", 98000.25), ("West", 143500.00))
@@ -285,7 +285,7 @@ println(if result.isClean then "✓ report written" else result.errors.map(_.ren
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.11.0
+//> using dep com.tjclp::xl:0.11.1
 import com.tjclp.xl.scripting.{*, given}
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global

--- a/plugin/skills/xl-scripting/reference/API.md
+++ b/plugin/skills/xl-scripting/reference/API.md
@@ -164,8 +164,11 @@ sheet.withPageSetup(
   PageSetup(
     scale = 100,                                              // 10-400
     orientation = Some("landscape"),                          // or "portrait"
-    fitToWidth = Some(1),                                     // pages wide (also fitToHeight)
-    headerFooter = Some(HeaderFooter(oddFooter = Some("&CPage &P of &N"))),
+    fitToWidth = Some(1),                                     // pages wide (also fitToHeight; emits pageSetUpPr fitToPage)
+    headerFooter = Some(HeaderFooter(
+      oddFooter = Some("&CPage &P of &N"),
+      firstHeader = Some("&CCONFIDENTIAL"), differentFirst = true // 0.11.1+: even/first variants
+    )),                                                       // also evenHeader/evenFooter + differentOddEven
     margins = Some(PageMargins(left = 0.5, right = 0.5)),     // inches; defaults match Excel Normal
     printArea = Some(ref"A1:F40"),                            // _xlnm.Print_Area defined name
     repeatRows = Some((1, 2))                                 // 1-based rows repeated on every page

--- a/plugin/skills/xl-scripting/reference/RECIPES.md
+++ b/plugin/skills/xl-scripting/reference/RECIPES.md
@@ -10,7 +10,7 @@ Apply a 5% price increase to column C of every workbook in a directory, in place
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.11.0
+//> using dep com.tjclp::xl:0.11.1
 import com.tjclp.xl.scripting.{*, given}
 import java.nio.file.{Files, Paths}
 import scala.jdk.CollectionConverters.*
@@ -42,7 +42,7 @@ Read rows into case classes; collect per-cell validation failures into a new Iss
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.11.0
+//> using dep com.tjclp::xl:0.11.1
 import com.tjclp.xl.scripting.{*, given}
 
 final case class Order(id: Int, customer: String, amount: BigDecimal)
@@ -76,7 +76,7 @@ Three-year projection with growth formulas; fail the script if any formula error
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.11.0
+//> using dep com.tjclp::xl:0.11.1
 import com.tjclp.xl.scripting.{*, given}
 
 val header = CellStyle.default.bold.size(12.0).center
@@ -111,7 +111,7 @@ Stack the data rows of every input file under one header.
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.11.0
+//> using dep com.tjclp::xl:0.11.1
 import com.tjclp.xl.scripting.{*, given}
 import java.nio.file.{Files, Paths}
 import scala.jdk.CollectionConverters.*
@@ -147,7 +147,7 @@ println(s"combined ${files.size} files, ${combined.cells.size} cells")
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.11.0
+//> using dep com.tjclp::xl:0.11.1
 import com.tjclp.xl.scripting.{*, given}
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
@@ -176,7 +176,7 @@ println("✓ filtered (constant memory)")
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.11.0
+//> using dep com.tjclp::xl:0.11.1
 import com.tjclp.xl.scripting.{*, given}
 
 val before = Excel.read("before.xlsx")
@@ -204,7 +204,7 @@ else
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.11.0
+//> using dep com.tjclp::xl:0.11.1
 import com.tjclp.xl.scripting.{*, given}
 import java.nio.file.{Files, Paths}
 import scala.jdk.CollectionConverters.*

--- a/xl-core/src/com/tjclp/xl/workbooks/WorkbookMetadata.scala
+++ b/xl-core/src/com/tjclp/xl/workbooks/WorkbookMetadata.scala
@@ -16,7 +16,7 @@ final case class WorkbookMetadata(
   modified: Option[java.time.LocalDateTime] = None,
   lastModifiedBy: Option[String] = None,
   application: Option[String] = Some("XL - Pure Scala 3.8 Excel Library"),
-  appVersion: Option[String] = Some("0.11.0"),
+  appVersion: Option[String] = Some("0.11.1"),
   theme: ThemePalette = ThemePalette.office,
   definedNames: Vector[DefinedName] = Vector.empty,
   sheetStates: Map[SheetName, Option[String]] = Map.empty


### PR DESCRIPTION
Release prep for **0.11.1 "Totality"** (wave 1 of the backlog burn-down, merged in #276).

- All dependency pins → 0.11.1 (README, QUICK-START, examples, xl-scripting skill, docs/reference/scripting.md)
- `build.mill` fallback, `plugin.json`, `WorkbookMetadata.appVersion` → 0.11.1
- CHANGELOG: Unreleased → `[0.11.1] "Totality" - 2026-06-10`
- Roadmap: wave 1 marked released
- Feature-doc cross-check: extended `HeaderFooter` (even/first variants, `differentOddEven`/`differentFirst`) + fitToPage documented in skill API.md and scripting.md
- release-prep runbook: SNAPSHOT grep now excludes its own instruction text

Gates (all green locally): `./mill __.compile`, `./mill __.test` (1028/1028), `./scripts/test-examples.sh`, `./scripts/verify-skill-snippets.sh --local` (17/17), no stray SNAPSHOT refs.

After merge: annotated tag `v0.11.1` on the merge commit triggers the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)