### PR TITLE
chore(release): Bump version to 0.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.2] "Laws & Functions" - 2026-06-10
+
+Waves 2+3 of the backlog burn-down: the test-infrastructure release that ships its laws
+together with everything those laws caught, plus the evaluator-breadth batch (LET, RAND,
+INDIRECT, YEARFRAC parity, format inheritance — registry 104 → 107).
+
 ### Added (evaluator breadth, wave 3)
 
 - **LET** (#193): `LET(name1, value1, ..., calculation)` lexical bindings with let* semantics —

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ```scala 3 raw
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.11.1
+//> using dep com.tjclp::xl:0.11.2
 
 import com.tjclp.xl.{*, given}
 
@@ -55,13 +55,13 @@ import com.tjclp.xl.{*, given}
 
 ```scala 3 ignore
 // build.mill — single dependency for everything
-def ivyDeps = Agg(ivy"com.tjclp::xl:0.11.1")
+def ivyDeps = Agg(ivy"com.tjclp::xl:0.11.2")
 
 // Or individual modules for minimal footprint:
-// ivy"com.tjclp::xl-core:0.11.1"        — Pure domain model only
-// ivy"com.tjclp::xl-ooxml:0.11.1"       — Add OOXML read/write
-// ivy"com.tjclp::xl-cats-effect:0.11.1" — Add IO streaming
-// ivy"com.tjclp::xl-evaluator:0.11.1"   — Add formula evaluation
+// ivy"com.tjclp::xl-core:0.11.2"        — Pure domain model only
+// ivy"com.tjclp::xl-ooxml:0.11.2"       — Add OOXML read/write
+// ivy"com.tjclp::xl-cats-effect:0.11.2" — Add IO streaming
+// ivy"com.tjclp::xl-evaluator:0.11.2"   — Add formula evaluation
 ```
 
 ### Basic Usage

--- a/build.mill
+++ b/build.mill
@@ -14,7 +14,7 @@ val organization = "com.tjclp"
 /** Shared build configuration constants */
 object BuildConfig {
   /** Project version: CI sets PUBLISH_VERSION; local builds use this fallback */
-  val version: String = sys.env.getOrElse("PUBLISH_VERSION", "0.11.1")
+  val version: String = sys.env.getOrElse("PUBLISH_VERSION", "0.11.2")
 
   /** JVM options to silence Scala 3 LazyVals sun.misc.Unsafe deprecation warnings (JDK 21+) */
   val lazyValsJvmArgs: Seq[String] = Seq(

--- a/docs/QUICK-START.md
+++ b/docs/QUICK-START.md
@@ -12,19 +12,19 @@ import mill._, scalalib._
 
 object myproject extends ScalaModule {
   def scalaVersion = "3.8.3"
-  def ivyDeps = Agg(ivy"com.tjclp::xl:0.11.1")
+  def ivyDeps = Agg(ivy"com.tjclp::xl:0.11.2")
 }
 ```
 
 ### With sbt (build.sbt)
 ```scala
 scalaVersion := "3.8.3"
-libraryDependencies += "com.tjclp" %% "xl" % "0.11.1"
+libraryDependencies += "com.tjclp" %% "xl" % "0.11.2"
 ```
 
 ### With Scala CLI
 ```scala
-//> using dep com.tjclp::xl:0.11.1
+//> using dep com.tjclp::xl:0.11.2
 ```
 
 ### Individual Modules (Optional)
@@ -44,7 +44,7 @@ For scripts, skip the build setup entirely: a two-line `scala-cli` header and ON
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.11.1
+//> using dep com.tjclp::xl:0.11.2
 
 import com.tjclp.xl.scripting.{*, given}
 

--- a/docs/plan/roadmap.md
+++ b/docs/plan/roadmap.md
@@ -12,7 +12,7 @@
 
 **Current Status**: Production-ready with **104 formula functions** (incl. dynamic arrays SEQUENCE/SORT/UNIQUE/FILTER and OFFSET), **structural editing** (insert/delete rows & columns with formula rewriting), the **scripting prelude** (`com.tjclp.xl.scripting`), whole-workbook `recalculate`, named-range & hyperlink authoring, SAX streaming (36% faster than POI), Excel tables, and full OOXML round-trip. 3005+ tests passing.
 
-**Current Version**: **0.11.1 "Totality"** (released 2026-06-10)
+**Current Version**: **0.11.2 "Laws & Functions"** (released 2026-06-10)
 
 ---
 
@@ -39,12 +39,12 @@ All open bugs, one patch release (PR #276). Reviewer-discovered gaps filed as #2
 | [#48](https://github.com/TJC-LP/xl/issues/48) | `SheetEvaluator` var-free refactor |
 | [#17](https://github.com/TJC-LP/xl/issues/17) | SST surgical whitespace: not reproducible; regression spec added |
 
-### v0.11.2 "Laws & Functions" — waves 2 + 3
+### v0.11.2 "Laws & Functions" — waves 2 + 3 (Released 2026-06-10)
 
 | Wave | Issues |
 |------|--------|
-| 2 — test infrastructure | [#240](https://github.com/TJC-LP/xl/issues/240) real-fixture corpus + generative round-trip law + streaming/in-memory parity; [#40](https://github.com/TJC-LP/xl/issues/40) `Sheet.put` benchmark; [#47](https://github.com/TJC-LP/xl/issues/47) renderer edge tests |
-| 3 — evaluator breadth | [#193](https://github.com/TJC-LP/xl/issues/193) LET; [#274](https://github.com/TJC-LP/xl/issues/274) INDIRECT (design-first); [#93](https://github.com/TJC-LP/xl/issues/93) YEARFRAC parity; [#115](https://github.com/TJC-LP/xl/issues/115) RAND/RANDBETWEEN (seeded-RNG capability); [#184](https://github.com/TJC-LP/xl/issues/184) formula numFmt inheritance |
+| 2 — test infrastructure (PR #299) | [#240](https://github.com/TJC-LP/xl/issues/240) real-fixture corpus + generative round-trip law + streaming/in-memory parity; [#40](https://github.com/TJC-LP/xl/issues/40) `Sheet.put` benchmark; [#47](https://github.com/TJC-LP/xl/issues/47) renderer edge tests |
+| 3 — evaluator breadth + law-found fixes #277/#287-#290 (PR #300) | [#193](https://github.com/TJC-LP/xl/issues/193) LET; [#274](https://github.com/TJC-LP/xl/issues/274) INDIRECT (design-first); [#93](https://github.com/TJC-LP/xl/issues/93) YEARFRAC parity; [#115](https://github.com/TJC-LP/xl/issues/115) RAND/RANDBETWEEN (seeded-RNG capability); [#184](https://github.com/TJC-LP/xl/issues/184) formula numFmt inheritance |
 
 ### v0.11.3 "Robustness" — waves 4 + 5
 

--- a/docs/reference/scripting.md
+++ b/docs/reference/scripting.md
@@ -33,7 +33,7 @@ release bump is a mechanical substitution):
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.11.1
+//> using dep com.tjclp::xl:0.11.2
 import com.tjclp.xl.scripting.{*, given}
 
 val sheet = Sheet("Demo").put(ref"A1", "Hello").put(ref"B1", 42)
@@ -51,7 +51,7 @@ read and write is pure values.
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.11.1
+//> using dep com.tjclp::xl:0.11.2
 import com.tjclp.xl.scripting.{*, given}
 
 val wb = Excel.read("input.xlsx")
@@ -135,7 +135,7 @@ throw — they are collected per cell.
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.11.1
+//> using dep com.tjclp::xl:0.11.2
 import com.tjclp.xl.scripting.{*, given}
 
 val title = CellStyle.default.bold.size(14.0).center
@@ -161,6 +161,13 @@ Workbook(model).recalculate().toEither match
     errors.foreach(e => println(s"✗ ${e.render}"))
     sys.exit(1)
 ```
+
+Since 0.11.2, formulas may use `LET` (lexical bindings), `INDIRECT` (dynamic references —
+evaluated in a deferred last partition), and `RAND`/`RANDBETWEEN`. Randomness is an explicit
+capability: pass `Rng.seeded(42L)` to the rng-taking overloads (`wb.recalculate(clock, rng)`,
+`sheet.evaluateFormula(f, clock, rng)`) for reproducible runs; the default is `Rng.system`.
+For Excel-style format inheritance on formula entry, use the opt-in
+`sheet.putFormulaInheriting(ref, formula)`.
 
 `recalculate(clock: Clock = Clock.system)` returns a `RecalcResult`:
 
@@ -229,7 +236,7 @@ them explicitly:
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.11.1
+//> using dep com.tjclp::xl:0.11.2
 import com.tjclp.xl.scripting.{*, given}
 import com.tjclp.xl.sheets.{HeaderFooter, PageMargins, PageSetup, SheetView}
 
@@ -283,7 +290,7 @@ the whole workbook:
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.11.1
+//> using dep com.tjclp::xl:0.11.2
 import com.tjclp.xl.scripting.{*, given}
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global

--- a/examples/README.md
+++ b/examples/README.md
@@ -170,7 +170,7 @@ chmod +x examples/my_example.sc
 ./examples/my_example.sc
 ```
 
-The `project.scala` file centralizes dependencies (`com.tjclp::xl:0.11.1`) for all examples.
+The `project.scala` file centralizes dependencies (`com.tjclp::xl:0.11.2`) for all examples.
 
 ## Scripting Prelude & Skill
 

--- a/examples/project.scala
+++ b/examples/project.scala
@@ -2,4 +2,4 @@
 //> using repository ivy2Local
 
 // XL aggregate - includes all modules (core, ooxml, cats-effect, evaluator)
-//> using dep com.tjclp::xl:0.11.1
+//> using dep com.tjclp::xl:0.11.2

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "xl",
   "description": "LLM-friendly Excel tooling: the xl CLI for reading, writing, styling, and analyzing spreadsheets (xl-cli skill), plus type-safe Scala scripting against the xl library via scala-cli for bulk transformations, pipelines, and formula models (xl-scripting skill).",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "author": {
     "name": "TJC L.P.",
     "url": "https://github.com/TJC-LP"

--- a/plugin/skills/xl-scripting/SKILL.md
+++ b/plugin/skills/xl-scripting/SKILL.md
@@ -38,7 +38,7 @@ The canonical header for every script (this is the single source of truth — re
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.11.1
+//> using dep com.tjclp::xl:0.11.2
 
 import com.tjclp.xl.scripting.{*, given}
 
@@ -100,7 +100,7 @@ wb.update("Sales", f).unsafe                       // throws structured XLExcept
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.11.1
+//> using dep com.tjclp::xl:0.11.2
 import com.tjclp.xl.scripting.{*, given}
 
 val wb = Excel.read("input.xlsx")
@@ -235,7 +235,7 @@ Or lean on totality so there is nothing to unwrap: literal refs, `upsert`, range
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.11.1
+//> using dep com.tjclp::xl:0.11.2
 import com.tjclp.xl.scripting.{*, given}
 import java.nio.file.{Files, Paths}
 import scala.jdk.CollectionConverters.*
@@ -257,7 +257,7 @@ println(s"merged ${inputs.size} files, ${merged.sheets.size} sheets")
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.11.1
+//> using dep com.tjclp::xl:0.11.2
 import com.tjclp.xl.scripting.{*, given}
 
 val data = List(("North", 125000.50), ("South", 98000.25), ("West", 143500.00))
@@ -285,7 +285,7 @@ println(if result.isClean then "✓ report written" else result.errors.map(_.ren
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.11.1
+//> using dep com.tjclp::xl:0.11.2
 import com.tjclp.xl.scripting.{*, given}
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global

--- a/plugin/skills/xl-scripting/reference/API.md
+++ b/plugin/skills/xl-scripting/reference/API.md
@@ -185,9 +185,10 @@ Header/footer strings support Excel codes — `&P` page, `&N` total pages, `&D` 
 | Method | Returns | Notes |
 |--------|---------|-------|
 | `wb.evaluateFormula(formula, onSheet[, clock])` | `XLResult[CellValue]` | cross-sheet context automatic; onSheet: String or SheetName |
-| `wb.recalculate([clock])` | `RecalcResult` | total whole-workbook recalc, per-cell errors, cycle isolation |
+| `wb.recalculate([clock][, rng])` | `RecalcResult` | total whole-workbook recalc, per-cell errors, cycle isolation; `rng` (0.11.2+) seeds RAND — `Rng.seeded(42L)` for reproducible scripts |
 | `wb.withCachedFormulas([clock])` | `Workbook` | = `recalculate(clock).workbook` |
-| `sheet.evaluateFormula(formula[, clock][, workbook])` | `XLResult[CellValue]` | pass `Some(wb)` iff formula references other sheets |
+| `sheet.evaluateFormula(formula[, clock][, rng][, workbook])` | `XLResult[CellValue]` | pass `Some(wb)` iff formula references other sheets |
+| `sheet.putFormulaInheriting(ref, formula[, workbook])` | `XLResult[Sheet]` | 0.11.2+: puts the formula AND inherits the referenced cells' number format into a General target (Excel's entry behavior) |
 | `sheet.evaluateWithDependencyCheck([clock])` | `XLResult[Map[ARef, CellValue]]` | fail-fast on first error/cycle |
 | `FormulaParser.parse("=A1+B1")` | `Either[ParseError, TExpr[?]]` | AST access |
 | `DependencyGraph.fromSheet(sheet)` | `DependencyGraph` | `.precedents(ref)` / `.dependents(ref)` |

--- a/plugin/skills/xl-scripting/reference/RECIPES.md
+++ b/plugin/skills/xl-scripting/reference/RECIPES.md
@@ -10,7 +10,7 @@ Apply a 5% price increase to column C of every workbook in a directory, in place
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.11.1
+//> using dep com.tjclp::xl:0.11.2
 import com.tjclp.xl.scripting.{*, given}
 import java.nio.file.{Files, Paths}
 import scala.jdk.CollectionConverters.*
@@ -42,7 +42,7 @@ Read rows into case classes; collect per-cell validation failures into a new Iss
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.11.1
+//> using dep com.tjclp::xl:0.11.2
 import com.tjclp.xl.scripting.{*, given}
 
 final case class Order(id: Int, customer: String, amount: BigDecimal)
@@ -76,7 +76,7 @@ Three-year projection with growth formulas; fail the script if any formula error
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.11.1
+//> using dep com.tjclp::xl:0.11.2
 import com.tjclp.xl.scripting.{*, given}
 
 val header = CellStyle.default.bold.size(12.0).center
@@ -111,7 +111,7 @@ Stack the data rows of every input file under one header.
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.11.1
+//> using dep com.tjclp::xl:0.11.2
 import com.tjclp.xl.scripting.{*, given}
 import java.nio.file.{Files, Paths}
 import scala.jdk.CollectionConverters.*
@@ -147,7 +147,7 @@ println(s"combined ${files.size} files, ${combined.cells.size} cells")
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.11.1
+//> using dep com.tjclp::xl:0.11.2
 import com.tjclp.xl.scripting.{*, given}
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
@@ -176,7 +176,7 @@ println("✓ filtered (constant memory)")
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.11.1
+//> using dep com.tjclp::xl:0.11.2
 import com.tjclp.xl.scripting.{*, given}
 
 val before = Excel.read("before.xlsx")
@@ -204,7 +204,7 @@ else
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.11.1
+//> using dep com.tjclp::xl:0.11.2
 import com.tjclp.xl.scripting.{*, given}
 import java.nio.file.{Files, Paths}
 import scala.jdk.CollectionConverters.*

--- a/xl-core/src/com/tjclp/xl/workbooks/WorkbookMetadata.scala
+++ b/xl-core/src/com/tjclp/xl/workbooks/WorkbookMetadata.scala
@@ -16,7 +16,7 @@ final case class WorkbookMetadata(
   modified: Option[java.time.LocalDateTime] = None,
   lastModifiedBy: Option[String] = None,
   application: Option[String] = Some("XL - Pure Scala 3.8 Excel Library"),
-  appVersion: Option[String] = Some("0.11.1"),
+  appVersion: Option[String] = Some("0.11.2"),
   theme: ThemePalette = ThemePalette.office,
   definedNames: Vector[DefinedName] = Vector.empty,
   sheetStates: Map[SheetName, Option[String]] = Map.empty


### PR DESCRIPTION
Release prep for **0.11.2 "Laws & Functions"** (waves 2+3: #299 + #300).

- All pins → 0.11.2 (README, QUICK-START, examples, xl-scripting skill, scripting guide)
- `build.mill`, `plugin.json`, `WorkbookMetadata.appVersion` → 0.11.2
- CHANGELOG: Unreleased → `[0.11.2] "Laws & Functions" - 2026-06-10` with release framing
- Roadmap: waves 2+3 marked released
- Feature-doc cross-check: `Rng` capability + rng overloads, `putFormulaInheriting`, LET/INDIRECT/RAND notes added to skill API.md and scripting guide; 107-function lists landed in wave 3

Gates green locally: compile, full suite (1028/1028), test-examples.sh, verify-skill-snippets.sh --local, SNAPSHOT sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)