### PR TITLE
Wave 4: streaming & OOXML robustness — docProps, streaming SST, 1904 dates, formats, reader parity, drawing fix (0.11.3 part 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added (streaming & OOXML robustness, wave 4)
+
+- **docProps emission** (#242): `docProps/core.xml` + `app.xml` written from `WorkbookMetadata`
+  (deterministic — only modeled fields, no GUIDs or wall-clock stamps); reader parses them back;
+  the model wins over preserved verbatim parts; metadata fields un-ignored in the generative
+  equivalence.
+- **Streaming SST + style registry** (#223): two-pass streaming writes emit a real
+  `sharedStrings.xml` (first-occurrence order, per-reference counts) and `styles.xml` instead of
+  inline strings everywhere — per the smart-streaming design; SST accumulator created per run
+  (referential transparency: re-running the same compiled `IO` no longer reuses a dirty
+  accumulator).
+- **1904 date system** (#243): `workbookPr date1904` parsed into `WorkbookMetadata`, preserved on
+  write, epoch-aware serial conversion (no phantom-leap-day in the 1904 system); streaming-edit
+  envelope documented.
+- **Fraction + conditional formats** (#243, #285): Excel fraction rendering (`# ?/?`, `# ??/??`,
+  fixed denominators; continued-fraction nearest under the digit budget, total for BigDecimal
+  beyond Double range) and `[>100]`-style condition-prefix section routing.
+
+### Fixed (wave 4)
+
+- **Date display gaps** (#283): General + date value renders the serial (Excel behavior);
+  custom date codes route through sections (`;;;` hides dates).
+- **Streaming reader parity** (#293, #305): inlineStr cells keep their `s=` style indices;
+  `<f>` formula text trimmed like the DOM reader; `_xHHHH_` escapes decode per-run (bare `<t>`
+  ignored when rich runs present, matching DOM).
+- **StyleParser totality** (#278): malformed `<sz val>` (and sibling numeric attributes) no
+  longer throw through Font's domain guard on read.
+- **Drawing corruption on modify** (#291): namespace prefixes (`xmlns:r`) stay bound when
+  regenerating worksheets with preserved drawings — bindings retained at capture AND hoisted at
+  re-emission; modifying cells in chart/image sheets now produces valid workbooks (unblocks the
+  0.12.0 Visual theme).
+
 ## [0.11.2] "Laws & Functions" - 2026-06-10
 
 Waves 2+3 of the backlog burn-down: the test-infrastructure release that ships its laws

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -32,6 +32,7 @@ This document provides a comprehensive overview of what XL can and cannot do tod
 - ✅ **Performance optimizations**: Inline hot paths, zero-overhead abstractions
 - ✅ **Style Application**: Full end-to-end formatting with fonts, colors, fills, borders
 - ✅ **DateTime Serialization**: Proper Excel serial number conversion
+- ✅ **1904 date system** (GH-243): `<workbookPr date1904="1"/>` (legacy Mac Excel) is read into `WorkbookMetadata.date1904`, preserved on write, and `DateTime` cells are serialized with the 1904 epoch; epoch-aware conversions via `CellValue.excelSerialToDateTime(serial, date1904 = true)`. Display formatting, typed codec reads, and formula evaluation still assume the 1900 system — interpret raw serials with the metadata flag for 1904 files.
 - ✅ **Security Hardening**: ZIP bomb detection, XXE prevention, formula injection guards (WI-30)
 
 ### Developer Experience

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -32,7 +32,7 @@ This document provides a comprehensive overview of what XL can and cannot do tod
 - ✅ **Performance optimizations**: Inline hot paths, zero-overhead abstractions
 - ✅ **Style Application**: Full end-to-end formatting with fonts, colors, fills, borders
 - ✅ **DateTime Serialization**: Proper Excel serial number conversion
-- ✅ **1904 date system** (GH-243): `<workbookPr date1904="1"/>` (legacy Mac Excel) is read into `WorkbookMetadata.date1904`, preserved on write, and `DateTime` cells are serialized with the 1904 epoch; epoch-aware conversions via `CellValue.excelSerialToDateTime(serial, date1904 = true)`. Display formatting, typed codec reads, and formula evaluation still assume the 1900 system — interpret raw serials with the metadata flag for 1904 files.
+- ✅ **1904 date system** (GH-243): `<workbookPr date1904="1"/>` (legacy Mac Excel) is read into `WorkbookMetadata.date1904`, preserved on write, and `DateTime` cells are serialized with the 1904 epoch; epoch-aware conversions via `CellValue.excelSerialToDateTime(serial, date1904 = true)`. Display formatting, typed codec reads, and formula evaluation still assume the 1900 system — interpret raw serials with the metadata flag for 1904 files. **Streaming-edit exception**: streaming writes (CLI `--stream batch` via `StreamingTransform`) still serialize *new* date values with the 1900 epoch while the output keeps `date1904="1"`, so those cells land 1,462 days off — avoid streaming date puts into 1904-system files; in-memory writes (the default, via `XlsxWriter`) are epoch-correct.
 - ✅ **Security Hardening**: ZIP bomb detection, XXE prevention, formula injection guards (WI-30)
 
 ### Developer Experience

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -220,33 +220,32 @@ Color.Theme(ThemeSlot.Accent1, tint = 0.5).toResolvedHex(theme)  // "#RRGGBB"
 
 ---
 
-#### 8. No Shared Strings Table (SST) in Streaming Write
-**Status**: Streaming write always uses inline strings
-**Impact**: Larger file sizes for repeated strings
-**Plan**: see [plan/roadmap.md](plan/roadmap.md)
+#### 8. Shared Strings Table (SST) in Streaming Write ✅ NOW SUPPORTED (GH-223)
+**Status**: Implemented — streaming writes deduplicate strings through an SST by default
+**Impact**: Plain-text cells are emitted as `t="s"` index references; `xl/sharedStrings.xml` is
+written after the worksheets with correct `count` (references) / `uniqueCount` (distinct) values.
 
-**Current State**:
-- `writeStream` uses `type="inlineStr"` for all text cells
-- Each cell carries full string (no deduplication)
-- File size: ~2x larger for files with repeated strings
+**How it works** (two-pass design from `design/smart-streaming.md`):
+- Pass 1: while rows stream, an `SstAccumulator` assigns SST indices in first-occurrence order —
+  an index is final the moment it is assigned, so the worksheet body needs no second pass
+- Pass 2: after the worksheet entries, the accumulated table is emitted as `sharedStrings.xml`
 
-**Example**:
-```scala
-// 100k rows with same company name
-RowData(i, Map(0 -> CellValue.Text("ACME Corporation")))
-// TODAY: "ACME Corporation" written 100k times (~1.7MB)
-// WITH SST: Written once in SST, cells reference index (~200KB)
-```
+Applies to `writeStream`, `writeStreamWithAutoDetect`, `writeStreamsSeq` (one workbook-global SST
+shared across sheets), `writeStreamsSeqWithAutoDetect`, and the new `writeStreamStyled`.
 
-**Why It's Hard**:
-- Streaming write consumes rows once (cannot scan twice)
-- Two-pass approach: 1) collect strings, 2) write with indices (breaks streaming)
-- Online SST building: Track duplicates as stream flows (complex state)
+**Styles** (GH-223 phase 2): `ExcelIO.writeStreamStyled(path, sheet, styles)` takes a
+`Vector[CellStyle]` table; `StyledRowData.cellStyles` values index into it. The table is
+deduplicated into `xl/styles.xml` (cellXf 0 = default) and cell `s=` attributes are remapped to
+the emitted indices — formatted 100k+ row files no longer require the in-memory path.
 
-**Effort**: 4-5 days
-**LOC**: ~200 in SST streaming builder
-
-**Workaround**: Acceptable for most use cases (disk space is cheap)
+**Remaining envelope / limitations**:
+- Memory is O(distinct strings) for the accumulator — the accepted envelope per the design doc
+  (100k rows with 100 distinct strings keeps exactly 100 entries; 1M unique strings ≈ tens of MB)
+- `SstPolicy.Never` (`WriterConfig`) keeps the previous inline-string dialect; `Auto`/`Always`
+  both deduplicate (streaming cannot pre-scan, so `Auto` opts into SST — note this changes the
+  default streaming output dialect from inline strings to SST as of GH-223)
+- RichText cells stay `inlineStr` even in SST mode (mixed dialects are valid OOXML)
+- Merged-cell emission from streaming writers (phase 3 of GH-223) is still future work
 
 ---
 

--- a/xl-cats-effect/src/com/tjclp/xl/io/ExcelIO.scala
+++ b/xl-cats-effect/src/com/tjclp/xl/io/ExcelIO.scala
@@ -15,7 +15,9 @@ import com.tjclp.xl.addressing.{ARef, SheetName}
 import com.tjclp.xl.cells.Comment
 import com.tjclp.xl.ooxml.{
   OoxmlComments,
+  OoxmlStyles,
   Relationships,
+  SstPolicy,
   XlsxReader,
   XlsxWriter,
   SharedStrings,
@@ -559,6 +561,11 @@ class ExcelIO[F[_]: Async](warningHandler: XlsxReader.Warning => F[Unit])
    * instant metadata queries. Otherwise, dimension is omitted (use `writeStreamWithAutoDetect` for
    * automatic dimension detection at the cost of 2x I/O).
    *
+   * Shared strings (GH-223): unless `config.sstPolicy` is `SstPolicy.Never`, plain-text cells are
+   * deduplicated through a shared strings table — indices are assigned in first-occurrence order
+   * while rows stream, and xl/sharedStrings.xml is emitted after the worksheet. Memory cost is
+   * O(distinct strings). `SstPolicy.Never` keeps the previous inline-string dialect.
+   *
    * @param path
    *   Output file path
    * @param sheetName
@@ -579,45 +586,119 @@ class ExcelIO[F[_]: Async](warningHandler: XlsxReader.Warning => F[Unit])
     dimension: Option[CellRange] = None
   ): Pipe[F, RowData, Unit] =
     rows =>
-      // Validate sheet index
-      if sheetIndex < 1 then
-        Stream.raiseError[F](
-          new IllegalArgumentException(s"Sheet index must be >= 1, got: $sheetIndex")
-        )
-      else
-        Stream
-          .bracket(
-            Sync[F].delay(new ZipOutputStream(new FileOutputStream(path.toFile)))
-          )(zip => Sync[F].delay(zip.close()))
-          .flatMap { zip =>
-            // 1. Write static parts first
-            Stream.eval(Sync[F].delay(writeStaticPartsSync(zip, sheetName, sheetIndex, config))) ++
-              // 2. Open worksheet entry
-              Stream.eval(
-                Sync[F].delay {
-                  val entry = new ZipEntry(s"xl/worksheets/sheet$sheetIndex.xml")
-                  entry.setMethod(ZipEntry.DEFLATED)
-                  zip.putNextEntry(entry)
-                  // Write header with optional dimension
-                  writeWorksheetHeader(zip, dimension)
-                }
-              ) ++
-              // 3. Stream XML events → bytes → ZIP
-              StreamingXmlWriter
-                .worksheetBody(rows, config.formulaInjectionPolicy)
-                .through(xml.render.raw())
-                .through(fs2.text.utf8.encode)
-                .chunks
-                .evalMap(chunk => Sync[F].delay(zip.write(chunk.toArray))) ++
-              // 4. Write footer and close entry
-              Stream.eval(
-                Sync[F].delay {
-                  writeWorksheetFooter(zip)
-                  zip.closeEntry()
-                }
-              )
-          }
-          .drain
+      writeStreamImpl(
+        path,
+        sheetName,
+        sheetIndex,
+        config,
+        dimension,
+        OoxmlStyles.minimal,
+        sst => StreamingXmlWriter.worksheetBody(rows, config.formulaInjectionPolicy, sst)
+      )
+
+  /**
+   * Streaming write with cell styles AND shared strings (GH-223).
+   *
+   * `styles(i)` is the CellStyle that a `StyledRowData.cellStyles` value `i` refers to. The style
+   * table is deduplicated (by canonical key) into xl/styles.xml up front — cellXf 0 is always the
+   * default style — and each row's style indices are remapped to the emitted indices before the
+   * `s="N"` attribute is written. Indices outside the table fall back to the default style.
+   *
+   * Strings follow the same SST policy as [[writeStream]] (Auto/Always dedup, Never inline).
+   */
+  def writeStreamStyled(
+    path: Path,
+    sheetName: String,
+    styles: Vector[com.tjclp.xl.styles.CellStyle],
+    sheetIndex: Int = 1,
+    config: com.tjclp.xl.ooxml.WriterConfig = com.tjclp.xl.ooxml.WriterConfig.default,
+    dimension: Option[CellRange] = None
+  ): Pipe[F, StyledRowData, Unit] =
+    rows =>
+      val (ooxmlStyles, remap) = StreamingXmlWriter.buildStyleTable(styles)
+      val remapped = rows.map { row =>
+        row.copy(cellStyles = row.cellStyles.flatMap { case (col, sid) =>
+          remap.get(sid).map(col -> _)
+        })
+      }
+      writeStreamImpl(
+        path,
+        sheetName,
+        sheetIndex,
+        config,
+        dimension,
+        ooxmlStyles,
+        sst => StreamingXmlWriter.worksheetBodyStyled(remapped, config.formulaInjectionPolicy, sst)
+      )
+
+  /** GH-223: SST accumulation policy for streaming writes — Auto/Always dedup, Never inline. */
+  private def sstAccumulatorFor(config: com.tjclp.xl.ooxml.WriterConfig): Option[SstAccumulator] =
+    config.sstPolicy match
+      case SstPolicy.Never => None
+      case _ => Some(new SstAccumulator)
+
+  /** Emit xl/sharedStrings.xml from the accumulated table (pass 2 of GH-223). */
+  private def writeSharedStringsSync(
+    zip: ZipOutputStream,
+    sst: SstAccumulator,
+    config: com.tjclp.xl.ooxml.WriterConfig
+  ): Unit =
+    writePartSync(zip, "xl/sharedStrings.xml", sst.toSharedStrings.toXml, config)
+
+  /** Shared single-sheet streaming write: static parts, worksheet body, then SST (GH-223). */
+  private def writeStreamImpl(
+    path: Path,
+    sheetName: String,
+    sheetIndex: Int,
+    config: com.tjclp.xl.ooxml.WriterConfig,
+    dimension: Option[CellRange],
+    styles: OoxmlStyles,
+    body: Option[SstAccumulator] => Stream[F, fs2.data.xml.XmlEvent]
+  ): Stream[F, Unit] =
+    // Validate sheet index
+    if sheetIndex < 1 then
+      Stream.raiseError[F](
+        new IllegalArgumentException(s"Sheet index must be >= 1, got: $sheetIndex")
+      )
+    else
+      val sst = sstAccumulatorFor(config)
+      Stream
+        .bracket(
+          Sync[F].delay(new ZipOutputStream(new FileOutputStream(path.toFile)))
+        )(zip => Sync[F].delay(zip.close()))
+        .flatMap { zip =>
+          // 1. Write static parts first (SST is declared up front; an empty table is valid)
+          Stream.eval(
+            Sync[F].delay(
+              writeStaticPartsSync(zip, sheetName, sheetIndex, config, sst.isDefined, styles)
+            )
+          ) ++
+            // 2. Open worksheet entry
+            Stream.eval(
+              Sync[F].delay {
+                val entry = new ZipEntry(s"xl/worksheets/sheet$sheetIndex.xml")
+                entry.setMethod(ZipEntry.DEFLATED)
+                zip.putNextEntry(entry)
+                // Write header with optional dimension
+                writeWorksheetHeader(zip, dimension)
+              }
+            ) ++
+            // 3. Stream XML events → bytes → ZIP (pass 1: SST indices assigned on first occurrence)
+            body(sst)
+              .through(xml.render.raw())
+              .through(fs2.text.utf8.encode)
+              .chunks
+              .evalMap(chunk => Sync[F].delay(zip.write(chunk.toArray))) ++
+            // 4. Write footer, close entry, then emit the accumulated SST (pass 2)
+            Stream.eval(
+              Sync[F].delay {
+                writeWorksheetFooter(zip)
+                zip.closeEntry()
+                sst.foreach(writeSharedStringsSync(zip, _, config))
+              }
+            )
+        }
+        .drain
 
   /**
    * Streaming write with automatic dimension detection.
@@ -650,14 +731,18 @@ class ExcelIO[F[_]: Async](warningHandler: XlsxReader.Warning => F[Unit])
             Sync[F].delay(JFiles.deleteIfExists(tempFile)).void
           }
           .flatMap { case (tempFile, bounds) =>
+            // GH-223: SST indices are assigned during phase 1 (first occurrence), so the temp-file
+            // body already carries final t="s" references; phase 2 just emits the table.
+            val sst = sstAccumulatorFor(config)
+
             // Phase 1: Stream rows to temp file, track bounds
             val writeTemp = rows
               .evalTap(row => Sync[F].delay(bounds.update(row)))
-              .through(rowsToTempXml(tempFile, config))
+              .through(rowsToTempXml(tempFile, config, sst))
 
             // Phase 2: Assemble final ZIP with dimension
             val assembleZip = Stream.eval(
-              assembleWorksheetZip(path, tempFile, bounds, sheetName, sheetIndex, config)
+              assembleWorksheetZip(path, tempFile, bounds, sheetName, sheetIndex, config, sst)
             )
 
             writeTemp ++ assembleZip
@@ -667,7 +752,8 @@ class ExcelIO[F[_]: Async](warningHandler: XlsxReader.Warning => F[Unit])
   // Helper: Stream rows to temp XML file (body only, no header/footer)
   private def rowsToTempXml(
     tempFile: Path,
-    config: com.tjclp.xl.ooxml.WriterConfig
+    config: com.tjclp.xl.ooxml.WriterConfig,
+    sst: Option[SstAccumulator]
   ): Pipe[F, RowData, Unit] =
     rows =>
       Stream
@@ -676,7 +762,7 @@ class ExcelIO[F[_]: Async](warningHandler: XlsxReader.Warning => F[Unit])
         )(os => Sync[F].delay(os.close()))
         .flatMap { os =>
           StreamingXmlWriter
-            .worksheetBody(rows, config.formulaInjectionPolicy)
+            .worksheetBody(rows, config.formulaInjectionPolicy, sst)
             .through(xml.render.raw())
             .through(fs2.text.utf8.encode)
             .chunks
@@ -690,13 +776,14 @@ class ExcelIO[F[_]: Async](warningHandler: XlsxReader.Warning => F[Unit])
     bounds: BoundsAccumulator,
     sheetName: String,
     sheetIndex: Int,
-    config: com.tjclp.xl.ooxml.WriterConfig
+    config: com.tjclp.xl.ooxml.WriterConfig,
+    sst: Option[SstAccumulator]
   ): F[Unit] =
     Sync[F].delay {
       val zip = new ZipOutputStream(new FileOutputStream(path.toFile))
       try
         // 1. Write static parts
-        writeStaticPartsSync(zip, sheetName, sheetIndex, config)
+        writeStaticPartsSync(zip, sheetName, sheetIndex, config, sst.isDefined, OoxmlStyles.minimal)
 
         // 2. Write worksheet with dimension
         val wsEntry = new ZipEntry(s"xl/worksheets/sheet$sheetIndex.xml")
@@ -713,6 +800,9 @@ class ExcelIO[F[_]: Async](warningHandler: XlsxReader.Warning => F[Unit])
         writeWorksheetFooter(zip)
 
         zip.closeEntry()
+
+        // 3. Emit the SST accumulated during phase 1 (GH-223)
+        sst.foreach(writeSharedStringsSync(zip, _, config))
       finally zip.close()
     }
 
@@ -735,27 +825,37 @@ class ExcelIO[F[_]: Async](warningHandler: XlsxReader.Warning => F[Unit])
   private def writeWorksheetFooter(out: java.io.OutputStream): Unit =
     out.write("</sheetData></worksheet>".getBytes(StandardCharsets.UTF_8))
 
-  // Helper: Sync version of writeStaticParts for use in assembleWorksheetZip
+  // Helper: Sync version of writeStaticParts for use in streaming writes.
+  // hasSharedStrings declares the SST up front (the part itself is emitted after the worksheets);
+  // styles carries the GH-223 style table (OoxmlStyles.minimal when unstyled).
   private def writeStaticPartsSync(
     zip: ZipOutputStream,
     sheetName: String,
     sheetIndex: Int,
-    config: com.tjclp.xl.ooxml.WriterConfig
+    config: com.tjclp.xl.ooxml.WriterConfig,
+    hasSharedStrings: Boolean,
+    styles: OoxmlStyles
   ): Unit =
     import com.tjclp.xl.ooxml.*
     import com.tjclp.xl.addressing.SheetName
 
     val contentTypes =
-      ContentTypes.forSheetIndices(Seq(sheetIndex), hasStyles = true, hasSharedStrings = false)
+      ContentTypes.forSheetIndices(
+        Seq(sheetIndex),
+        hasStyles = true,
+        hasSharedStrings = hasSharedStrings
+      )
     val rootRels = Relationships.root()
     val workbookRels =
-      Relationships.workbookWithIndices(Seq(sheetIndex), hasStyles = true, hasSharedStrings = false)
+      Relationships.workbookWithIndices(
+        Seq(sheetIndex),
+        hasStyles = true,
+        hasSharedStrings = hasSharedStrings
+      )
 
     val ooxmlWb = OoxmlWorkbook(
       sheets = Vector(SheetRef(SheetName.unsafe(sheetName), sheetIndex, "rId1"))
     )
-
-    val styles = OoxmlStyles.minimal
 
     writePartSync(zip, "[Content_Types].xml", contentTypes.toXml, config)
     writePartSync(zip, "_rels/.rels", rootRels.toXml, config)
@@ -861,6 +961,9 @@ class ExcelIO[F[_]: Async](warningHandler: XlsxReader.Warning => F[Unit])
         (name, idx + 1, rows, dim)
       }
 
+      // GH-223: ONE workbook-global SST shared by all sheets (dedup across sheets)
+      val sst = sstAccumulatorFor(config)
+
       Stream
         .bracket(
           Sync[F].delay(new ZipOutputStream(new FileOutputStream(path.toFile)))
@@ -872,7 +975,8 @@ class ExcelIO[F[_]: Async](warningHandler: XlsxReader.Warning => F[Unit])
               writeStaticPartsMultiSync(
                 zip,
                 sheetsWithIndices.map { case (name, idx, _, _) => (name, idx) },
-                config
+                config,
+                hasSharedStrings = sst.isDefined
               )
             }
           ) ++
@@ -891,7 +995,7 @@ class ExcelIO[F[_]: Async](warningHandler: XlsxReader.Warning => F[Unit])
                 ) ++
                   // Stream XML events → bytes → ZIP
                   StreamingXmlWriter
-                    .worksheetBody(rows, config.formulaInjectionPolicy)
+                    .worksheetBody(rows, config.formulaInjectionPolicy, sst)
                     .through(xml.render.raw())
                     .through(fs2.text.utf8.encode)
                     .chunks
@@ -903,7 +1007,9 @@ class ExcelIO[F[_]: Async](warningHandler: XlsxReader.Warning => F[Unit])
                       zip.closeEntry()
                     }
                   )
-              }
+              } ++
+            // 3. Emit the accumulated workbook-global SST (GH-223)
+            Stream.eval(Sync[F].delay(sst.foreach(writeSharedStringsSync(zip, _, config))))
         }
         .compile
         .drain
@@ -951,18 +1057,21 @@ class ExcelIO[F[_]: Async](warningHandler: XlsxReader.Warning => F[Unit])
           }.void
         }
         .flatMap { resources =>
+          // GH-223: ONE workbook-global SST; indices assigned during phase 1 are final
+          val sst = sstAccumulatorFor(config)
+
           // Phase 1: Stream each sheet's rows to its temp file
           val writePhase = Stream
             .emits(sheetsWithIndices.zip(resources))
             .flatMap { case ((_, _, rows), (_, _, tempFile, bounds)) =>
               rows
                 .evalTap(row => Sync[F].delay(bounds.update(row)))
-                .through(rowsToTempXml(tempFile, config))
+                .through(rowsToTempXml(tempFile, config, sst))
             }
 
           // Phase 2: Assemble final ZIP with all worksheets
           val assemblePhase = Stream.eval(
-            assembleMultiSheetZip(path, resources, config)
+            assembleMultiSheetZip(path, resources, config, sst)
           )
 
           writePhase ++ assemblePhase
@@ -996,7 +1105,8 @@ class ExcelIO[F[_]: Async](warningHandler: XlsxReader.Warning => F[Unit])
   private def assembleMultiSheetZip(
     path: Path,
     resources: Seq[(String, Int, Path, BoundsAccumulator)],
-    config: com.tjclp.xl.ooxml.WriterConfig
+    config: com.tjclp.xl.ooxml.WriterConfig,
+    sst: Option[SstAccumulator]
   ): F[Unit] =
     Sync[F].delay {
       val zip = new ZipOutputStream(new FileOutputStream(path.toFile))
@@ -1005,7 +1115,8 @@ class ExcelIO[F[_]: Async](warningHandler: XlsxReader.Warning => F[Unit])
         writeStaticPartsMultiSync(
           zip,
           resources.map { case (name, idx, _, _) => (name, idx) },
-          config
+          config,
+          hasSharedStrings = sst.isDefined
         )
 
         // 2. Write each worksheet with its dimension
@@ -1025,6 +1136,9 @@ class ExcelIO[F[_]: Async](warningHandler: XlsxReader.Warning => F[Unit])
 
           zip.closeEntry()
         }
+
+        // 3. Emit the SST accumulated during phase 1 (GH-223)
+        sst.foreach(writeSharedStringsSync(zip, _, config))
       finally zip.close()
     }
 
@@ -1032,7 +1146,8 @@ class ExcelIO[F[_]: Async](warningHandler: XlsxReader.Warning => F[Unit])
   private def writeStaticPartsMultiSync(
     zip: ZipOutputStream,
     sheets: Seq[(String, Int)],
-    config: com.tjclp.xl.ooxml.WriterConfig
+    config: com.tjclp.xl.ooxml.WriterConfig,
+    hasSharedStrings: Boolean
   ): Unit =
     import com.tjclp.xl.ooxml.*
     import com.tjclp.xl.addressing.SheetName
@@ -1040,13 +1155,13 @@ class ExcelIO[F[_]: Async](warningHandler: XlsxReader.Warning => F[Unit])
     val contentTypes = ContentTypes.forSheetIndices(
       sheetIndices = sheets.map(_._2),
       hasStyles = true,
-      hasSharedStrings = false
+      hasSharedStrings = hasSharedStrings
     )
     val rootRels = Relationships.root()
     val workbookRels = Relationships.workbook(
       sheetCount = sheets.size,
       hasStyles = true,
-      hasSharedStrings = false
+      hasSharedStrings = hasSharedStrings
     )
 
     val sheetRefs = sheets.map { case (name, idx) =>

--- a/xl-cats-effect/src/com/tjclp/xl/io/ExcelIO.scala
+++ b/xl-cats-effect/src/com/tjclp/xl/io/ExcelIO.scala
@@ -661,42 +661,47 @@ class ExcelIO[F[_]: Async](warningHandler: XlsxReader.Warning => F[Unit])
         new IllegalArgumentException(s"Sheet index must be >= 1, got: $sheetIndex")
       )
     else
-      val sst = sstAccumulatorFor(config)
+      // Accumulator is created inside the stream (not at construction) so each RUN of the
+      // compiled effect gets a fresh one — re-running must not inherit a previous run's strings.
       Stream
-        .bracket(
-          Sync[F].delay(new ZipOutputStream(new FileOutputStream(path.toFile)))
-        )(zip => Sync[F].delay(zip.close()))
-        .flatMap { zip =>
-          // 1. Write static parts first (SST is declared up front; an empty table is valid)
-          Stream.eval(
-            Sync[F].delay(
-              writeStaticPartsSync(zip, sheetName, sheetIndex, config, sst.isDefined, styles)
-            )
-          ) ++
-            // 2. Open worksheet entry
-            Stream.eval(
-              Sync[F].delay {
-                val entry = new ZipEntry(s"xl/worksheets/sheet$sheetIndex.xml")
-                entry.setMethod(ZipEntry.DEFLATED)
-                zip.putNextEntry(entry)
-                // Write header with optional dimension
-                writeWorksheetHeader(zip, dimension)
-              }
-            ) ++
-            // 3. Stream XML events → bytes → ZIP (pass 1: SST indices assigned on first occurrence)
-            body(sst)
-              .through(xml.render.raw())
-              .through(fs2.text.utf8.encode)
-              .chunks
-              .evalMap(chunk => Sync[F].delay(zip.write(chunk.toArray))) ++
-            // 4. Write footer, close entry, then emit the accumulated SST (pass 2)
-            Stream.eval(
-              Sync[F].delay {
-                writeWorksheetFooter(zip)
-                zip.closeEntry()
-                sst.foreach(writeSharedStringsSync(zip, _, config))
-              }
-            )
+        .eval(Sync[F].delay(sstAccumulatorFor(config)))
+        .flatMap { sst =>
+          Stream
+            .bracket(
+              Sync[F].delay(new ZipOutputStream(new FileOutputStream(path.toFile)))
+            )(zip => Sync[F].delay(zip.close()))
+            .flatMap { zip =>
+              // 1. Write static parts first (SST is declared up front; an empty table is valid)
+              Stream.eval(
+                Sync[F].delay(
+                  writeStaticPartsSync(zip, sheetName, sheetIndex, config, sst.isDefined, styles)
+                )
+              ) ++
+                // 2. Open worksheet entry
+                Stream.eval(
+                  Sync[F].delay {
+                    val entry = new ZipEntry(s"xl/worksheets/sheet$sheetIndex.xml")
+                    entry.setMethod(ZipEntry.DEFLATED)
+                    zip.putNextEntry(entry)
+                    // Write header with optional dimension
+                    writeWorksheetHeader(zip, dimension)
+                  }
+                ) ++
+                // 3. Stream XML events → bytes → ZIP (pass 1: SST indices assigned on first use)
+                body(sst)
+                  .through(xml.render.raw())
+                  .through(fs2.text.utf8.encode)
+                  .chunks
+                  .evalMap(chunk => Sync[F].delay(zip.write(chunk.toArray))) ++
+                // 4. Write footer, close entry, then emit the accumulated SST (pass 2)
+                Stream.eval(
+                  Sync[F].delay {
+                    writeWorksheetFooter(zip)
+                    zip.closeEntry()
+                    sst.foreach(writeSharedStringsSync(zip, _, config))
+                  }
+                )
+            }
         }
         .drain
 
@@ -961,55 +966,58 @@ class ExcelIO[F[_]: Async](warningHandler: XlsxReader.Warning => F[Unit])
         (name, idx + 1, rows, dim)
       }
 
-      // GH-223: ONE workbook-global SST shared by all sheets (dedup across sheets)
-      val sst = sstAccumulatorFor(config)
-
+      // GH-223: ONE workbook-global SST shared by all sheets (dedup across sheets), created
+      // inside the stream so each run of the returned F gets a fresh accumulator.
       Stream
-        .bracket(
-          Sync[F].delay(new ZipOutputStream(new FileOutputStream(path.toFile)))
-        )(zip => Sync[F].delay(zip.close()))
-        .flatMap { zip =>
-          // 1. Write static parts with all sheet metadata
-          Stream.eval(
-            Sync[F].delay {
-              writeStaticPartsMultiSync(
-                zip,
-                sheetsWithIndices.map { case (name, idx, _, _) => (name, idx) },
-                config,
-                hasSharedStrings = sst.isDefined
-              )
-            }
-          ) ++
-            // 2. Stream each sheet sequentially
-            Stream
-              .emits(sheetsWithIndices)
-              .flatMap { case (_, sheetIndex, rows, dimension) =>
-                // Open worksheet entry
-                Stream.eval(
-                  Sync[F].delay {
-                    val entry = new ZipEntry(s"xl/worksheets/sheet$sheetIndex.xml")
-                    entry.setMethod(ZipEntry.DEFLATED)
-                    zip.putNextEntry(entry)
-                    writeWorksheetHeader(zip, dimension)
-                  }
-                ) ++
-                  // Stream XML events → bytes → ZIP
-                  StreamingXmlWriter
-                    .worksheetBody(rows, config.formulaInjectionPolicy, sst)
-                    .through(xml.render.raw())
-                    .through(fs2.text.utf8.encode)
-                    .chunks
-                    .evalMap(chunk => Sync[F].delay(zip.write(chunk.toArray))) ++
-                  // Close entry
-                  Stream.eval(
-                    Sync[F].delay {
-                      writeWorksheetFooter(zip)
-                      zip.closeEntry()
-                    }
+        .eval(Sync[F].delay(sstAccumulatorFor(config)))
+        .flatMap { sst =>
+          Stream
+            .bracket(
+              Sync[F].delay(new ZipOutputStream(new FileOutputStream(path.toFile)))
+            )(zip => Sync[F].delay(zip.close()))
+            .flatMap { zip =>
+              // 1. Write static parts with all sheet metadata
+              Stream.eval(
+                Sync[F].delay {
+                  writeStaticPartsMultiSync(
+                    zip,
+                    sheetsWithIndices.map { case (name, idx, _, _) => (name, idx) },
+                    config,
+                    hasSharedStrings = sst.isDefined
                   )
-              } ++
-            // 3. Emit the accumulated workbook-global SST (GH-223)
-            Stream.eval(Sync[F].delay(sst.foreach(writeSharedStringsSync(zip, _, config))))
+                }
+              ) ++
+                // 2. Stream each sheet sequentially
+                Stream
+                  .emits(sheetsWithIndices)
+                  .flatMap { case (_, sheetIndex, rows, dimension) =>
+                    // Open worksheet entry
+                    Stream.eval(
+                      Sync[F].delay {
+                        val entry = new ZipEntry(s"xl/worksheets/sheet$sheetIndex.xml")
+                        entry.setMethod(ZipEntry.DEFLATED)
+                        zip.putNextEntry(entry)
+                        writeWorksheetHeader(zip, dimension)
+                      }
+                    ) ++
+                      // Stream XML events → bytes → ZIP
+                      StreamingXmlWriter
+                        .worksheetBody(rows, config.formulaInjectionPolicy, sst)
+                        .through(xml.render.raw())
+                        .through(fs2.text.utf8.encode)
+                        .chunks
+                        .evalMap(chunk => Sync[F].delay(zip.write(chunk.toArray))) ++
+                      // Close entry
+                      Stream.eval(
+                        Sync[F].delay {
+                          writeWorksheetFooter(zip)
+                          zip.closeEntry()
+                        }
+                      )
+                  } ++
+                // 3. Emit the accumulated workbook-global SST (GH-223)
+                Stream.eval(Sync[F].delay(sst.foreach(writeSharedStringsSync(zip, _, config))))
+            }
         }
         .compile
         .drain

--- a/xl-cats-effect/src/com/tjclp/xl/io/SaxStreamingReader.scala
+++ b/xl-cats-effect/src/com/tjclp/xl/io/SaxStreamingReader.scala
@@ -173,6 +173,8 @@ object SaxStreamingReader:
     var inFormula = false
     var inInlineStr = false
     var inPhoneticRun = false
+    var inInlineRun = false
+    var sawInlineRun = false
     var inTextElement = false
     var cachedValue: Option[String] = None
     var formulaText: Option[String] = None
@@ -180,6 +182,9 @@ object SaxStreamingReader:
     val valueText = new StringBuilder
     // Decoded inline-string runs for the current cell (each run decoded at </t>, GH-305)
     val inlineRuns = new StringBuilder
+    // Bare <t> text directly under <is> (CT_Rst is (t?, r*, rPh*, phoneticPr?)); the DOM
+    // reader ignores it whenever <r> runs exist, so it is accumulated separately.
+    val bareInlineText = new StringBuilder
 
     // Check cancelled less frequently - every 10k elements
     private var elementCount = 0
@@ -229,6 +234,11 @@ object SaxStreamingReader:
         case "is" =>
           inInlineStr = true
           inlineRuns.clear()
+          bareInlineText.clear()
+          sawInlineRun = false
+
+        case "r" if inInlineStr && !inPhoneticRun =>
+          inInlineRun = true
 
         case "rPh" if inInlineStr =>
           // Phonetic (furigana) runs are presentation metadata, not cell text;
@@ -264,20 +274,34 @@ object SaxStreamingReader:
         case "t" if inTextElement =>
           // GH-305: decode each run BEFORE concatenation, mirroring the DOM reader's
           // per-run decode - an _xHHHH_ escape is only honored within a single <t>,
-          // never across run boundaries.
-          inlineRuns.append(XmlUtil.decodeXstring(valueText.toString))
+          // never across run boundaries. Bare <t> text (outside any <r>) is stashed
+          // separately: the DOM reader ignores it whenever <r> runs exist.
+          val decoded = XmlUtil.decodeXstring(valueText.toString)
+          if inInlineRun then
+            sawInlineRun = true
+            inlineRuns.append(decoded)
+          else bareInlineText.append(decoded)
           inTextElement = false
           valueText.clear()
+
+        case "r" if inInlineRun =>
+          inInlineRun = false
 
         case "rPh" if inPhoneticRun =>
           inPhoneticRun = false
 
         case "is" if inInlineStr =>
           // GH-293: defer the commit to </c> so the s= style index is recorded there,
-          // exactly like SST and number cells.
-          if !skipRow && !skipCell then inlineValue = Some(inlineRuns.toString)
+          // exactly like SST and number cells. Runs win over a coexisting bare <t>
+          // (DOM reader's rElems.nonEmpty dispatch); the bare <t> contributes only
+          // when the <is> contains no runs.
+          if !skipRow && !skipCell then
+            inlineValue = Some(
+              if sawInlineRun then inlineRuns.toString else bareInlineText.toString
+            )
           inInlineStr = false
           inlineRuns.clear()
+          bareInlineText.clear()
 
         case "c" =>
           if !skipRow && !skipCell then
@@ -316,9 +340,12 @@ object SaxStreamingReader:
           inFormula = false
           inInlineStr = false
           inPhoneticRun = false
+          inInlineRun = false
+          sawInlineRun = false
           inTextElement = false
           valueText.clear()
           inlineRuns.clear()
+          bareInlineText.clear()
 
         case "row" if inRow =>
           if !skipRow then

--- a/xl-cats-effect/src/com/tjclp/xl/io/SaxStreamingReader.scala
+++ b/xl-cats-effect/src/com/tjclp/xl/io/SaxStreamingReader.scala
@@ -172,10 +172,14 @@ object SaxStreamingReader:
     var inValue = false
     var inFormula = false
     var inInlineStr = false
+    var inPhoneticRun = false
     var inTextElement = false
     var cachedValue: Option[String] = None
     var formulaText: Option[String] = None
+    var inlineValue: Option[String] = None
     val valueText = new StringBuilder
+    // Decoded inline-string runs for the current cell (each run decoded at </t>, GH-305)
+    val inlineRuns = new StringBuilder
 
     // Check cancelled less frequently - every 10k elements
     private var elementCount = 0
@@ -224,8 +228,14 @@ object SaxStreamingReader:
 
         case "is" =>
           inInlineStr = true
+          inlineRuns.clear()
 
-        case "t" if inInlineStr =>
+        case "rPh" if inInlineStr =>
+          // Phonetic (furigana) runs are presentation metadata, not cell text;
+          // the DOM reader and the SAX SST reader both exclude them.
+          inPhoneticRun = true
+
+        case "t" if inInlineStr && !inPhoneticRun =>
           inTextElement = true
           valueText.clear()
 
@@ -243,34 +253,52 @@ object SaxStreamingReader:
           valueText.clear()
 
         case "f" if inFormula =>
-          if !skipRow && !skipCell then formulaText = Some(valueText.toString)
+          if !skipRow && !skipCell then
+            // GH-293: the in-memory reader trims <f> text and treats a whitespace-only
+            // formula as absent (WorksheetReader `.text.trim` + nonEmpty guard); match it.
+            val trimmed = valueText.toString.trim
+            formulaText = Option.when(trimmed.nonEmpty)(trimmed)
           inFormula = false
           valueText.clear()
 
         case "t" if inTextElement =>
+          // GH-305: decode each run BEFORE concatenation, mirroring the DOM reader's
+          // per-run decode - an _xHHHH_ escape is only honored within a single <t>,
+          // never across run boundaries.
+          inlineRuns.append(XmlUtil.decodeXstring(valueText.toString))
           inTextElement = false
+          valueText.clear()
+
+        case "rPh" if inPhoneticRun =>
+          inPhoneticRun = false
 
         case "is" if inInlineStr =>
-          if !skipRow && !skipCell then
-            val text = XmlUtil.decodeXstring(valueText.toString)
-            for colIdx <- currentCellColIdx do currentRowCells(colIdx) = CellValue.Text(text)
+          // GH-293: defer the commit to </c> so the s= style index is recorded there,
+          // exactly like SST and number cells.
+          if !skipRow && !skipCell then inlineValue = Some(inlineRuns.toString)
           inInlineStr = false
-          valueText.clear()
+          inlineRuns.clear()
 
         case "c" =>
           if !skipRow && !skipCell then
             for colIdx <- currentCellColIdx do
-              val cellValue = (formulaText, cachedValue) match
-                case (Some(formula), Some(cached)) =>
+              // Mirror of the DOM reader's dispatch (WorksheetReader.parseCellValue):
+              // a nonEmpty formula wins; otherwise <is> wins for inline-string cell
+              // types; otherwise interpret <v>.
+              val inlineText = inlineValue.filter(_ => isInlineStringType)
+              val cellValue = (formulaText, inlineText, cachedValue) match
+                case (Some(formula), _, Some(cached)) =>
                   val parsedCached = interpretCellValue(cached, currentCellType, sst)
                   val cachedOpt =
                     if parsedCached == CellValue.Empty then None else Some(parsedCached)
                   CellValue.Formula(formula, cachedOpt)
-                case (Some(formula), None) =>
+                case (Some(formula), _, None) =>
                   CellValue.Formula(formula, None)
-                case (None, Some(value)) =>
+                case (None, Some(text), _) =>
+                  CellValue.Text(text)
+                case (None, None, Some(value)) =>
                   interpretCellValue(value, currentCellType, sst)
-                case (None, None) =>
+                case (None, None, None) =>
                   CellValue.Empty
               if cellValue != CellValue.Empty then
                 currentRowCells(colIdx) = cellValue
@@ -283,11 +311,14 @@ object SaxStreamingReader:
           skipCell = false
           cachedValue = None
           formulaText = None
+          inlineValue = None
           inValue = false
           inFormula = false
           inInlineStr = false
+          inPhoneticRun = false
           inTextElement = false
           valueText.clear()
+          inlineRuns.clear()
 
         case "row" if inRow =>
           if !skipRow then
@@ -296,6 +327,10 @@ object SaxStreamingReader:
           skipRow = false
 
         case _ => ()
+
+    /** Cell types whose value may come from an <is> inline string (DOM reader contract). */
+    private def isInlineStringType: Boolean =
+      currentCellType.exists(t => t == "inlineStr" || t == "str")
 
     private def parseCellColumn(cellRef: String): Option[Int] =
       val col = cellRef.takeWhile(_.isLetter)

--- a/xl-cats-effect/src/com/tjclp/xl/io/StreamingXmlWriter.scala
+++ b/xl-cats-effect/src/com/tjclp/xl/io/StreamingXmlWriter.scala
@@ -5,7 +5,14 @@ import fs2.data.xml.*
 import fs2.data.xml.XmlEvent.*
 import com.tjclp.xl.addressing.{ARef, CellRange, Column, Row}
 import com.tjclp.xl.cells.CellValue
-import com.tjclp.xl.ooxml.{FormulaInjectionPolicy, XmlUtil}
+import com.tjclp.xl.ooxml.{FormulaInjectionPolicy, SSTEntry, SharedStrings, XmlUtil}
+import com.tjclp.xl.ooxml.style.{OoxmlStyles, StyleIndex}
+import com.tjclp.xl.styles.CellStyle
+import com.tjclp.xl.styles.border.Border
+import com.tjclp.xl.styles.fill.Fill
+import com.tjclp.xl.styles.font.Font
+import com.tjclp.xl.styles.numfmt.NumFmt
+import com.tjclp.xl.styles.units.StyleId
 
 /**
  * Tracks worksheet bounds during streaming. O(1) memory (4 integers).
@@ -65,6 +72,38 @@ final class BoundsAccumulator:
     else None
 
 /**
+ * Two-pass shared-strings accumulator for streaming writes (GH-223).
+ *
+ * Pass 1 (while rows stream): every plain-text cell calls [[indexFor]], which assigns SST indices
+ * in FIRST-OCCURRENCE order — so the index a cell emits is final the moment it is assigned, and the
+ * worksheet body never needs a second pass. Pass 2 (after the body): [[toSharedStrings]] yields the
+ * table for xl/sharedStrings.xml.
+ *
+ * Memory: O(distinct strings) — the accepted envelope per docs/design/smart-streaming.md. The
+ * reference count feeds the SST `count` attribute (counts references, not unique entries).
+ *
+ * Thread-safety: NOT thread-safe; single-fiber use only (same contract as [[BoundsAccumulator]]).
+ */
+@SuppressWarnings(Array("org.wartremover.warts.Var"))
+final class SstAccumulator:
+  private val indexByString = scala.collection.mutable.LinkedHashMap.empty[String, Int]
+  private var references: Int = 0
+
+  /** SST index for `s`, assigning the next first-occurrence index when unseen. */
+  def indexFor(s: String): Int =
+    references += 1
+    indexByString.getOrElseUpdate(s, indexByString.size)
+
+  def uniqueCount: Int = indexByString.size
+
+  def referenceCount: Int = references
+
+  /** Build the table for xl/sharedStrings.xml: entries in first-occurrence order. */
+  def toSharedStrings: SharedStrings =
+    val entries = indexByString.keysIterator.map(s => Left(s): SSTEntry).toVector
+    SharedStrings(entries, indexByString.toMap, references)
+
+/**
  * True streaming XML writer using fs2-data-xml for constant-memory writes.
  *
  * Emits XML events incrementally as rows arrive, never materializing the full document tree in
@@ -75,6 +114,10 @@ final class BoundsAccumulator:
  *   - Phase 2: Assemble final ZIP with dimension element (from tracked bounds)
  *
  * This maintains O(1) memory while producing files with instant metadata queries.
+ *
+ * Shared strings (GH-223): pass an [[SstAccumulator]] to the body/row/cell helpers to emit plain
+ * text as `t="s"` SST references (first-occurrence indices); without one, text stays
+ * `t="inlineStr"`. RichText always stays inline (mixed dialects are valid OOXML).
  */
 object StreamingXmlWriter:
 
@@ -124,6 +167,9 @@ object StreamingXmlWriter:
    *   Formula injection escaping policy (default: None)
    * @param styleId
    *   Optional style index for s="N" attribute (from StyleIndex)
+   * @param sst
+   *   Optional SST accumulator (GH-223): when present, plain text is emitted as a t="s" reference
+   *   whose index is assigned on first occurrence; when absent, text stays inline
    * @return
    *   List of XML events representing the cell
    */
@@ -132,7 +178,8 @@ object StreamingXmlWriter:
     rowIndex: Int,
     value: CellValue,
     injectionPolicy: FormulaInjectionPolicy = FormulaInjectionPolicy.None,
-    styleId: Option[Int] = None
+    styleId: Option[Int] = None,
+    sst: Option[SstAccumulator] = None
   ): List[XmlEvent] =
     val ref = s"${columnToLetter(colIndex)}$rowIndex"
 
@@ -141,31 +188,46 @@ object StreamingXmlWriter:
         ("", Nil)
 
       case CellValue.Text(s) =>
-        // <c r="A1" t="inlineStr"><is><t>text</t></is></c>
-        // Apply formula injection escaping if policy requires it, then _xHHHH_ escapes (GH-288)
+        // Apply formula injection escaping if policy requires it (BEFORE SST accumulation, so the
+        // table stores the escaped text), then _xHHHH_ escapes for the inline dialect (GH-288)
         val injectionEscaped = injectionPolicy match
           case FormulaInjectionPolicy.Escape => CellValue.escape(s)
           case FormulaInjectionPolicy.None => s
-        val escaped = XmlUtil.escapeXstring(injectionEscaped)
-        // Add xml:space="preserve" for text with leading/trailing/multiple spaces
-        // Note: we check the escaped text because whitespace in the original (e.g., "  =formula")
-        // must still be preserved after escaping adds a leading quote (e.g., "'  =formula")
-        val needsPreserve = XmlUtil.needsXmlSpacePreserve(escaped)
-        val tAttrs =
-          if needsPreserve then
-            List(Attr(QName(Some("xml"), "space"), List(XmlString("preserve", false))))
-          else Nil
+        sst match
+          case Some(acc) =>
+            // <c r="A1" t="s"><v>idx</v></c> — SST reference (GH-223). The accumulator stores the
+            // raw string; SharedStrings serialization applies _xHHHH_/xml:space at emission.
+            val idx = acc.indexFor(injectionEscaped)
+            (
+              "s",
+              List(
+                XmlEvent.StartTag(QName("v"), Nil, false),
+                XmlEvent.XmlString(idx.toString, false),
+                XmlEvent.EndTag(QName("v"))
+              )
+            )
+          case None =>
+            // <c r="A1" t="inlineStr"><is><t>text</t></is></c>
+            val escaped = XmlUtil.escapeXstring(injectionEscaped)
+            // Add xml:space="preserve" for text with leading/trailing/multiple spaces
+            // Note: we check the escaped text because whitespace in the original (e.g., "  =formula")
+            // must still be preserved after escaping adds a leading quote (e.g., "'  =formula")
+            val needsPreserve = XmlUtil.needsXmlSpacePreserve(escaped)
+            val tAttrs =
+              if needsPreserve then
+                List(Attr(QName(Some("xml"), "space"), List(XmlString("preserve", false))))
+              else Nil
 
-        (
-          "inlineStr",
-          List(
-            XmlEvent.StartTag(QName("is"), Nil, false),
-            XmlEvent.StartTag(QName("t"), tAttrs, false),
-            XmlEvent.XmlString(escaped, false),
-            XmlEvent.EndTag(QName("t")),
-            XmlEvent.EndTag(QName("is"))
-          )
-        )
+            (
+              "inlineStr",
+              List(
+                XmlEvent.StartTag(QName("is"), Nil, false),
+                XmlEvent.StartTag(QName("t"), tAttrs, false),
+                XmlEvent.XmlString(escaped, false),
+                XmlEvent.EndTag(QName("t")),
+                XmlEvent.EndTag(QName("is"))
+              )
+            )
 
       case CellValue.Number(n) =>
         // <c r="A1" t="n"><v>42</v></c>
@@ -261,35 +323,34 @@ object StreamingXmlWriter:
         val isEvents = richText.runs.flatMap { run =>
           val rStart = XmlEvent.StartTag(QName("r"), Nil, false)
 
-          // Optional <rPr> with font properties
+          // Optional <rPr> with font properties.
+          // NOTE: fs2-data-xml renders StartTag(isEmpty = true) as a self-closing element by
+          // pairing it with its MATCHING EndTag event — an isEmpty StartTag without an EndTag
+          // desynchronizes the renderer and swallows the next close tag (</rPr> went missing,
+          // producing malformed worksheets for any styled rich-text run).
           val rPrEvents = run.font.toList.flatMap { f =>
             val propsBuilder = List.newBuilder[XmlEvent]
 
+            def selfClosing(label: String, attrs: List[Attr] = Nil): Unit =
+              propsBuilder += XmlEvent.StartTag(QName(label), attrs, true)
+              propsBuilder += XmlEvent.EndTag(QName(label))
+
             // Font style properties
-            if f.bold then propsBuilder += XmlEvent.StartTag(QName("b"), Nil, true)
-            if f.italic then propsBuilder += XmlEvent.StartTag(QName("i"), Nil, true)
-            if f.underline then propsBuilder += XmlEvent.StartTag(QName("u"), Nil, true)
+            if f.bold then selfClosing("b")
+            if f.italic then selfClosing("i")
+            if f.underline then selfClosing("u")
 
             // Color
             f.color.foreach { c =>
-              propsBuilder += XmlEvent.StartTag(
-                QName("color"),
-                List(Attr(QName("rgb"), List(XmlString(c.toHex.drop(1), false)))),
-                true
+              selfClosing(
+                "color",
+                List(Attr(QName("rgb"), List(XmlString(c.toHex.drop(1), false))))
               )
             }
 
             // Size and name
-            propsBuilder += XmlEvent.StartTag(
-              QName("sz"),
-              List(Attr(QName("val"), List(XmlString(f.sizePt.toString, false)))),
-              true
-            )
-            propsBuilder += XmlEvent.StartTag(
-              QName("name"),
-              List(Attr(QName("val"), List(XmlString(f.name, false)))),
-              true
-            )
+            selfClosing("sz", List(Attr(QName("val"), List(XmlString(f.sizePt.toString, false)))))
+            selfClosing("name", List(Attr(QName("val"), List(XmlString(f.name, false)))))
 
             XmlEvent.StartTag(QName("rPr"), Nil, false) :: propsBuilder.result() ::: List(
               XmlEvent.EndTag(QName("rPr"))
@@ -337,7 +398,8 @@ object StreamingXmlWriter:
   /** Generate XML events for a row */
   def rowToEvents(
     rowData: RowData,
-    injectionPolicy: FormulaInjectionPolicy = FormulaInjectionPolicy.None
+    injectionPolicy: FormulaInjectionPolicy = FormulaInjectionPolicy.None,
+    sst: Option[SstAccumulator] = None
   ): List[XmlEvent] =
     val rowAttrs = List(attr("r", rowData.rowIndex.toString))
 
@@ -345,7 +407,7 @@ object StreamingXmlWriter:
     val cellEvents = rowData.cells.toList
       .sortBy(_._1)
       .flatMap { case (colIdx, value) =>
-        cellToEvents(colIdx, rowData.rowIndex, value, injectionPolicy)
+        cellToEvents(colIdx, rowData.rowIndex, value, injectionPolicy, None, sst)
       }
 
     if cellEvents.isEmpty then Nil // Skip empty rows
@@ -357,7 +419,8 @@ object StreamingXmlWriter:
   /** Generate XML events for a styled row (with s="N" attributes) */
   def styledRowToEvents(
     rowData: StyledRowData,
-    injectionPolicy: FormulaInjectionPolicy = FormulaInjectionPolicy.None
+    injectionPolicy: FormulaInjectionPolicy = FormulaInjectionPolicy.None,
+    sst: Option[SstAccumulator] = None
   ): List[XmlEvent] =
     val rowAttrs = List(attr("r", rowData.rowIndex.toString))
 
@@ -366,7 +429,7 @@ object StreamingXmlWriter:
       .sortBy(_._1)
       .flatMap { case (colIdx, value) =>
         val styleId = rowData.cellStyles.get(colIdx)
-        cellToEvents(colIdx, rowData.rowIndex, value, injectionPolicy, styleId)
+        cellToEvents(colIdx, rowData.rowIndex, value, injectionPolicy, styleId, sst)
       }
 
     if cellEvents.isEmpty then Nil // Skip empty rows
@@ -393,7 +456,10 @@ object StreamingXmlWriter:
           QName("dimension"),
           List(attr("ref", range.toA1)),
           true // self-closing: <dimension ref="A1:Z100"/>
-        )
+        ),
+        // fs2-data-xml pairs an isEmpty StartTag with its matching EndTag to render the
+        // self-closing form; an unpaired isEmpty StartTag desynchronizes the renderer
+        XmlEvent.EndTag(QName("dimension"))
       )
     }
 
@@ -419,14 +485,17 @@ object StreamingXmlWriter:
    *   Stream of row data
    * @param injectionPolicy
    *   Formula injection escaping policy
+   * @param sst
+   *   Optional SST accumulator (GH-223) for t="s" string references
    * @return
    *   Stream of XML events for all rows
    */
   def worksheetBody[F[_]](
     rows: Stream[F, RowData],
-    injectionPolicy: FormulaInjectionPolicy = FormulaInjectionPolicy.None
+    injectionPolicy: FormulaInjectionPolicy = FormulaInjectionPolicy.None,
+    sst: Option[SstAccumulator] = None
   ): Stream[F, XmlEvent] =
-    rows.flatMap(row => Stream.emits(rowToEvents(row, injectionPolicy)))
+    rows.flatMap(row => Stream.emits(rowToEvents(row, injectionPolicy, sst)))
 
   /**
    * Generate row events for styled worksheet body.
@@ -438,14 +507,17 @@ object StreamingXmlWriter:
    *   Stream of styled row data
    * @param injectionPolicy
    *   Formula injection escaping policy
+   * @param sst
+   *   Optional SST accumulator (GH-223) for t="s" string references
    * @return
    *   Stream of XML events for all rows with styles
    */
   def worksheetBodyStyled[F[_]](
     rows: Stream[F, StyledRowData],
-    injectionPolicy: FormulaInjectionPolicy = FormulaInjectionPolicy.None
+    injectionPolicy: FormulaInjectionPolicy = FormulaInjectionPolicy.None,
+    sst: Option[SstAccumulator] = None
   ): Stream[F, XmlEvent] =
-    rows.flatMap(row => Stream.emits(styledRowToEvents(row, injectionPolicy)))
+    rows.flatMap(row => Stream.emits(styledRowToEvents(row, injectionPolicy, sst)))
 
   /**
    * Generate worksheet footer events.
@@ -477,3 +549,50 @@ object StreamingXmlWriter:
     Stream.emits(worksheetHeader(None)) ++
       worksheetBody(rows, injectionPolicy) ++
       Stream.emits(worksheetFooter)
+
+  /**
+   * Build the styles.xml registry for a styled streaming write (GH-223).
+   *
+   * `styles(i)` is the CellStyle a `StyledRowData.cellStyles` value `i` refers to. Returns the
+   * serializable [[OoxmlStyles]] (cellXf 0 is always CellStyle.default; duplicates collapse by
+   * canonicalKey) plus the caller-index → emitted-cellXf-index remap to apply to each row's
+   * `cellStyles` before emission. Deterministic: emitted order is default + first occurrence.
+   */
+  def buildStyleTable(styles: Vector[CellStyle]): (OoxmlStyles, Map[Int, Int]) =
+    import scala.collection.mutable
+    val emitted =
+      mutable.LinkedHashMap[String, (Int, CellStyle)](
+        CellStyle.default.canonicalKey -> (0, CellStyle.default)
+      )
+    val remap = styles.zipWithIndex.map { case (style, callerIdx) =>
+      val (idx, _) = emitted.getOrElseUpdate(style.canonicalKey, (emitted.size, style))
+      callerIdx -> idx
+    }.toMap
+    val unified = emitted.valuesIterator.map(_._2).toVector
+
+    // Component dedup in first-occurrence order (mirrors StyleIndex.fromWorkbookWithoutSource)
+    val fonts = mutable.LinkedHashSet.empty[Font]
+    val fills = mutable.LinkedHashSet.empty[Fill]
+    val borders = mutable.LinkedHashSet.empty[Border]
+    val customCodes = mutable.LinkedHashSet.empty[String]
+    unified.foreach { style =>
+      fonts += style.font
+      fills += style.fill
+      borders += style.border
+      style.numFmt match
+        case NumFmt.Custom(code) => customCodes += code
+        case _ => ()
+    }
+    val customNumFmts = customCodes.toVector.zipWithIndex.map { case (code, idx) =>
+      (164 + idx, NumFmt.Custom(code): NumFmt)
+    }
+
+    val index = StyleIndex(
+      fonts = fonts.toVector,
+      fills = fills.toVector,
+      borders = borders.toVector,
+      numFmts = customNumFmts,
+      cellStyles = unified,
+      styleToIndex = emitted.view.map { case (key, (idx, _)) => key -> StyleId(idx) }.toMap
+    )
+    (OoxmlStyles(index), remap)

--- a/xl-cats-effect/test/src/com/tjclp/xl/io/StreamingParitySpec.scala
+++ b/xl-cats-effect/test/src/com/tjclp/xl/io/StreamingParitySpec.scala
@@ -393,3 +393,45 @@ class StreamingParitySpec extends CatsEffectSuite:
       }
     }
   }
+
+  test("GH-305: bare <t> coexisting with <r> runs is ignored, matching the in-memory reader") {
+    // ECMA-376 CT_Rst is (t?, r*, rPh*, phoneticPr?): a bare <t> may legally coexist
+    // with rich runs. The in-memory reader ignores the bare <t> whenever <r> runs are
+    // present (parseCellValueWithoutFormula: rElems.nonEmpty wins) - streaming must
+    // not concatenate it into the value. B1 pins the no-runs case: with no <r>, the
+    // bare <t> IS the value.
+    val sheetXml =
+      """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        |<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+        |  <sheetData>
+        |    <row r="1">
+        |      <c r="A1" t="inlineStr"><is><t>X</t><r><t>Y</t></r></is></c>
+        |      <c r="B1" t="inlineStr"><is><t>X</t></is></c>
+        |    </row>
+        |  </sheetData>
+        |</worksheet>
+        |""".stripMargin
+    rawXlsx("mixed-bare-t-and-runs", sheetXml).flatMap { path =>
+      loadInMemory("mixed-bare-t-and-runs", path).flatMap { wb =>
+        val expected = inMemoryValues(wb.sheets(0))
+        assertEquals(
+          expected.get((1, 0)).flatMap(plainTextOf),
+          Some("Y"),
+          "in-memory reader ignores the bare <t> when <r> runs are present"
+        )
+        assertEquals(expected.get((1, 1)).flatMap(plainTextOf), Some("X"))
+        streamedValues(path, "Sheet1").map { streamed =>
+          assertEquals(
+            streamed.get((1, 0)).flatMap(plainTextOf),
+            Some("Y"),
+            "streaming must ignore the bare <t> when <r> runs are present (GH-305)"
+          )
+          assertEquals(
+            streamed.get((1, 1)).flatMap(plainTextOf),
+            Some("X"),
+            "streaming must keep the bare <t> as the value when there are no runs (GH-305)"
+          )
+        }
+      }
+    }
+  }

--- a/xl-cats-effect/test/src/com/tjclp/xl/io/StreamingParitySpec.scala
+++ b/xl-cats-effect/test/src/com/tjclp/xl/io/StreamingParitySpec.scala
@@ -229,6 +229,37 @@ class StreamingParitySpec extends CatsEffectSuite:
     }
   }
 
+  // ========== GH-223: streaming-WRITTEN files (SST dialect) ==========
+
+  test("GH-223 parity: streaming-written SST file - streaming and in-memory readers agree") {
+    val path = Files.createTempFile("xl-parity-stream-sst-", ".xlsx")
+    path.toFile.deleteOnExit()
+    val rows = fs2.Stream
+      .emits(
+        (1 to 50).toList.map { i =>
+          RowData(
+            i,
+            Map(
+              0 -> CellValue.Text(s"name-${i % 7}"), // duplicates -> SST dedup
+              1 -> CellValue.Number(BigDecimal(i)),
+              2 -> CellValue.Bool(i % 2 == 0)
+            )
+          )
+        }
+      )
+      .covary[IO]
+    rows.through(excel.writeStream(path, "Data")).compile.drain >>
+      loadInMemory("stream-sst", path).flatMap { wb =>
+        val expected = inMemoryValues(wb.sheets(0))
+        assertEquals(expected.size, 150, "expected 50 rows x 3 cells")
+        assertEquals(expected.get((1, 0)), Some(CellValue.Text("name-1")))
+        streamedValues(path, "Data").map { streamed =>
+          assertEquals(streamed, expected, "streaming vs in-memory drift on streaming-written SST file")
+        }
+      }
+  }
+
+
   // ========== GH-293 / GH-305: raw-XML dialect probes ==========
   // XL's own writer never emits whitespace-padded formulas or escape sequences
   // split across rich runs, so these parity probes are built from raw part XML.

--- a/xl-cats-effect/test/src/com/tjclp/xl/io/StreamingParitySpec.scala
+++ b/xl-cats-effect/test/src/com/tjclp/xl/io/StreamingParitySpec.scala
@@ -177,29 +177,37 @@ class StreamingParitySpec extends CatsEffectSuite:
     }
   }
 
-  test("KNOWN GAP: streaming drops s= style indices for inlineStr cells (styled.xlsx)") {
-    // Every cell in styled.xlsx carries an s= attribute in the XML (s=1..8) and
-    // the in-memory reader assigns a styleId to all 8 cells. The streaming
-    // reader, however, commits inline-string values inside the </is> handler,
-    // which bypasses the </c> branch that records currentCellStyleId - so the
-    // s= index is silently dropped for every t="inlineStr" cell. openpyxl
-    // writes ALL strings as inlineStr, so streaming style preservation sees no
-    // style for any openpyxl text cell. Number cells (t="n") keep theirs.
-    // This pins the current behavior; when SaxStreamingReader is fixed, flip
-    // this test to assert full agreement with the in-memory styleIds.
+  test("GH-293: streaming surfaces s= style indices for inlineStr cells (styled.xlsx)") {
+    // Every cell in styled.xlsx (openpyxl inline-string dialect) carries an s=
+    // attribute in the XML (s=1..8). The streaming reader used to commit
+    // inline-string values inside the </is> handler, bypassing the </c> branch
+    // that records currentCellStyleId - so the s= index was silently dropped for
+    // every t="inlineStr" cell while t="n" cells kept theirs. Both readers must
+    // surface the same raw style index for every styled, non-empty cell.
     val path = fixturePath("styled.xlsx")
+    val expectedRawStyleIdx = Map(
+      (1, 0) -> 1, // A1 inlineStr "bold red on yellow"
+      (1, 1) -> 2, // B1 n
+      (1, 2) -> 3, // C1 inlineStr
+      (1, 3) -> 4, // D1 inlineStr
+      (2, 0) -> 5, // A2 inlineStr
+      (2, 1) -> 6, // B2 n
+      (3, 1) -> 7, // B3 n
+      (4, 0) -> 8 // A4 inlineStr
+    )
     loadInMemory("styled.xlsx", path).flatMap { wb =>
       val sheet = wb.sheets(0)
-      // .iterator: collecting (Int, Int) pairs straight from the Map would build
-      // a Map[Int, Int] and collapse rows
-      val inMemoryStyled = sheet.cells.iterator.collect {
-        case (ref, cell) if cell.styleId.isDefined && cell.value != CellValue.Empty =>
-          (ref.row.index1, ref.col.index0)
-      }.toSet
+      // .iterator: collecting pairs straight from the Map would build a
+      // Map[Int, Int] and collapse rows
+      val inMemoryStyleIdx = sheet.cells.iterator.flatMap { case (ref, cell) =>
+        cell.styleId
+          .filter(_ => cell.value != CellValue.Empty)
+          .map(sid => (ref.row.index1, ref.col.index0) -> sid.value)
+      }.toMap
       assertEquals(
-        inMemoryStyled,
-        Set((1, 0), (1, 1), (1, 2), (1, 3), (2, 0), (2, 1), (3, 1), (4, 0)),
-        "in-memory reader should style all 8 cells"
+        inMemoryStyleIdx,
+        expectedRawStyleIdx,
+        "in-memory reader should keep the raw s= index for all 8 cells"
       )
       excel
         .readSheetStream(path, sheet.name.value)
@@ -213,11 +221,175 @@ class StreamingParitySpec extends CatsEffectSuite:
             .toMap
           assertEquals(
             streamedStyles,
-            Map((1, 1) -> 2, (2, 1) -> 6, (3, 1) -> 7),
-            "streaming currently surfaces s= only for the three t=\"n\" cells; if " +
-              "inlineStr cells now appear, the gap was fixed - flip this test to " +
-              "assert parity with the in-memory styleIds"
+            inMemoryStyleIdx,
+            "streaming must surface the same s= index as the in-memory reader for " +
+              "every styled cell, including t=\"inlineStr\" (GH-293)"
           )
         }
+    }
+  }
+
+  // ========== GH-293 / GH-305: raw-XML dialect probes ==========
+  // XL's own writer never emits whitespace-padded formulas or escape sequences
+  // split across rich runs, so these parity probes are built from raw part XML.
+
+  private val minimalWorkbookXml =
+    """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+      |<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+      |          xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+      |  <sheets>
+      |    <sheet name="Sheet1" sheetId="1" r:id="rId1"/>
+      |  </sheets>
+      |</workbook>
+      |""".stripMargin
+
+  private val minimalWorkbookRelsXml =
+    """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+      |<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+      |  <Relationship Id="rId1"
+      |                Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"
+      |                Target="worksheets/sheet1.xml"/>
+      |</Relationships>
+      |""".stripMargin
+
+  private val minimalContentTypesXml =
+    """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+      |<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+      |  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+      |  <Default Extension="xml" ContentType="application/xml"/>
+      |  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+      |  <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+      |</Types>
+      |""".stripMargin
+
+  private val minimalRootRelsXml =
+    """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+      |<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+      |  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+      |</Relationships>
+      |""".stripMargin
+
+  /** Hand-built single-sheet xlsx from raw worksheet XML. */
+  private def rawXlsx(name: String, sheetXml: String): IO[Path] = IO {
+    import java.nio.charset.StandardCharsets
+    import java.util.zip.{ZipEntry, ZipOutputStream}
+    val path = Files.createTempFile(s"xl-parity-raw-$name-", ".xlsx")
+    path.toFile.deleteOnExit()
+    val zipOut = new ZipOutputStream(Files.newOutputStream(path))
+    try
+      List(
+        "[Content_Types].xml" -> minimalContentTypesXml,
+        "_rels/.rels" -> minimalRootRelsXml,
+        "xl/workbook.xml" -> minimalWorkbookXml,
+        "xl/_rels/workbook.xml.rels" -> minimalWorkbookRelsXml,
+        "xl/worksheets/sheet1.xml" -> sheetXml
+      ).foreach { case (entryName, content) =>
+        val entry = new ZipEntry(entryName)
+        entry.setTime(0L)
+        zipOut.putNextEntry(entry)
+        zipOut.write(content.getBytes(StandardCharsets.UTF_8))
+        zipOut.closeEntry()
+      }
+    finally zipOut.close()
+    path
+  }
+
+  /**
+   * Text content regardless of rich formatting. The streaming reader surfaces inline rich text as
+   * plain CellValue.Text (it carries no run formatting), so the cross-reader law for rich inline
+   * strings is over text content, not CellValue equality.
+   */
+  private def plainTextOf(cv: CellValue): Option[String] = cv match
+    case CellValue.Text(t) => Some(t)
+    case CellValue.RichText(rt) => Some(rt.toPlainText)
+    case _ => None
+
+  test("GH-293: streaming trims <f> formula text exactly like the in-memory reader") {
+    // The in-memory WorksheetReader reads formulas via `.text.trim`; pretty-printed
+    // part XML (newline + indent inside <f>) must not leak whitespace into the
+    // formula expression on the streaming path either.
+    val sheetXml =
+      """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        |<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+        |  <sheetData>
+        |    <row r="1">
+        |      <c r="A1"><f>
+        |        SUM(B1:C1)  </f><v>5</v></c>
+        |      <c r="B1"><v>2</v></c>
+        |      <c r="C1"><v>3</v></c>
+        |    </row>
+        |  </sheetData>
+        |</worksheet>
+        |""".stripMargin
+    rawXlsx("formula-trim", sheetXml).flatMap { path =>
+      loadInMemory("formula-trim", path).flatMap { wb =>
+        val expected = inMemoryValues(wb.sheets(0))
+        assertEquals(
+          expected.get((1, 0)),
+          Some(CellValue.Formula("SUM(B1:C1)", Some(CellValue.Number(BigDecimal(5))))),
+          "in-memory reader trims <f> text"
+        )
+        streamedValues(path, "Sheet1").map { streamed =>
+          assertEquals(
+            streamed,
+            expected,
+            "whitespace-padded formulas must trim identically on both paths (GH-293)"
+          )
+        }
+      }
+    }
+  }
+
+  test("GH-305: _xHHHH_ escape split across rich inline-string runs decodes per-run") {
+    // A1: run1 ends "_x00", run2 starts "0D_". Neither run contains a complete
+    // escape, so the decoded value is the literal concatenation "seg_x000D_tail"
+    // - NOT a CR. Decoding after concatenation would fabricate a CR; the DOM
+    // reader decodes per-run. B1 pins multi-run concatenation itself. C1 pins
+    // phonetic-run (rPh) exclusion: furigana text is not part of the cell value
+    // on either path.
+    val sheetXml =
+      """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        |<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+        |  <sheetData>
+        |    <row r="1">
+        |      <c r="A1" t="inlineStr"><is><r><t>seg_x00</t></r><r><t>0D_tail</t></r></is></c>
+        |      <c r="B1" t="inlineStr"><is><r><rPr><b/></rPr><t>Alpha</t></r><r><t>Beta</t></r></is></c>
+        |      <c r="C1" t="inlineStr"><is><r><t>kanji</t></r><rPh sb="0" eb="1"><t>kana</t></rPh></is></c>
+        |    </row>
+        |  </sheetData>
+        |</worksheet>
+        |""".stripMargin
+    rawXlsx("split-escape", sheetXml).flatMap { path =>
+      loadInMemory("split-escape", path).flatMap { wb =>
+        val expected = inMemoryValues(wb.sheets(0))
+        assertEquals(
+          expected.get((1, 0)).flatMap(plainTextOf),
+          Some("seg_x000D_tail"),
+          "in-memory reader decodes per-run: literal pieces, no CR"
+        )
+        assertEquals(expected.get((1, 1)).flatMap(plainTextOf), Some("AlphaBeta"))
+        assertEquals(expected.get((1, 2)).flatMap(plainTextOf), Some("kanji"))
+        streamedValues(path, "Sheet1").map { streamed =>
+          assertEquals(
+            streamed.get((1, 0)).flatMap(plainTextOf),
+            Some("seg_x000D_tail"),
+            "streaming must decode each run before concatenation (GH-305)"
+          )
+          assert(
+            streamed.get((1, 0)).flatMap(plainTextOf).forall(!_.contains('\r')),
+            "a CR must not materialize from an escape split across runs (GH-305)"
+          )
+          assertEquals(
+            streamed.get((1, 1)).flatMap(plainTextOf),
+            Some("AlphaBeta"),
+            "streaming must concatenate ALL runs, not keep the last one (GH-305)"
+          )
+          assertEquals(
+            streamed.get((1, 2)).flatMap(plainTextOf),
+            Some("kanji"),
+            "streaming must exclude phonetic <rPh> runs like the in-memory reader (GH-305)"
+          )
+        }
+      }
     }
   }

--- a/xl-cats-effect/test/src/com/tjclp/xl/io/streaming/StreamingSstSpec.scala
+++ b/xl-cats-effect/test/src/com/tjclp/xl/io/streaming/StreamingSstSpec.scala
@@ -1,0 +1,235 @@
+package com.tjclp.xl.io.streaming
+
+import java.nio.file.{Files, Path}
+import java.util.zip.ZipFile
+
+import cats.effect.IO
+import munit.CatsEffectSuite
+
+import com.tjclp.xl.cells.CellValue
+import com.tjclp.xl.io.{ExcelIO, RowData, StyledRowData}
+import com.tjclp.xl.macros.ref
+import com.tjclp.xl.ooxml.{XlsxReader, XmlSecurity}
+import com.tjclp.xl.ooxml.writer.{SstPolicy, WriterConfig}
+import com.tjclp.xl.styles.CellStyle
+import com.tjclp.xl.styles.font.Font
+import com.tjclp.xl.styles.numfmt.NumFmt
+
+/**
+ * GH-223: two-pass streaming writes — SST deduplication and style registry.
+ *
+ * Pass 1 accumulates unique strings (first-occurrence order) and the style table while rows
+ * stream; pass 2 emits cells as t="s" SST references plus s= style indices, then writes
+ * sharedStrings.xml / styles.xml from the accumulators. Memory: O(distinct strings), per the
+ * smart-streaming design envelope.
+ *
+ * The inline-string dialect stays available behind the existing config: SstPolicy.Never.
+ */
+class StreamingSstSpec extends CatsEffectSuite:
+
+  private val excel = ExcelIO.instance[IO]
+
+  private def tempXlsx(label: String): Path =
+    val p = Files.createTempFile(s"xl-stream-sst-$label-", ".xlsx")
+    p.toFile.deleteOnExit()
+    p
+
+  private def entryText(path: Path, name: String): String =
+    val zip = new ZipFile(path.toFile)
+    try
+      Option(zip.getEntry(name)) match
+        case Some(e) => new String(zip.getInputStream(e).readAllBytes(), "UTF-8")
+        case None => fail(s"zip entry $name not found in ${zip.entries()}")
+    finally zip.close()
+
+  private def hasEntry(path: Path, name: String): Boolean =
+    val zip = new ZipFile(path.toFile)
+    try Option(zip.getEntry(name)).isDefined
+    finally zip.close()
+
+  /** (count, uniqueCount, entries in document order) from xl/sharedStrings.xml. */
+  private def parseSst(path: Path): (Int, Int, Vector[String]) =
+    val xml = entryText(path, "xl/sharedStrings.xml")
+    val elem = XmlSecurity.parseSafe(xml, "sst").fold(e => fail(s"sst parse: ${e.message}"), identity)
+    val count = (elem \@ "count").toInt
+    val unique = (elem \@ "uniqueCount").toInt
+    val entries = (elem \ "si").map(si => (si \ "t").text).toVector
+    (count, unique, entries)
+
+  private val dupRows = fs2.Stream
+    .emits(
+      List(
+        RowData(1, Map(0 -> CellValue.Text("alpha"), 1 -> CellValue.Number(BigDecimal(1)))),
+        RowData(2, Map(0 -> CellValue.Text("beta"))),
+        RowData(3, Map(0 -> CellValue.Text("alpha"))),
+        RowData(4, Map(0 -> CellValue.Text("gamma"))),
+        RowData(5, Map(0 -> CellValue.Text("beta")))
+      )
+    )
+    .covary[IO]
+
+  test("writeStream (default) emits SST: first-occurrence order, count=refs, uniqueCount=distinct") {
+    val path = tempXlsx("dedup")
+    dupRows.through(excel.writeStream(path, "Data")).compile.drain.map { _ =>
+      assert(hasEntry(path, "xl/sharedStrings.xml"), "sharedStrings.xml missing")
+      val (count, unique, entries) = parseSst(path)
+      assertEquals(entries, Vector("alpha", "beta", "gamma"), "SST order must be first occurrence")
+      assertEquals(unique, 3)
+      assertEquals(count, 5, "count attribute counts references, not unique strings")
+
+      val sheetXml = entryText(path, "xl/worksheets/sheet1.xml")
+      assert(sheetXml.contains("t=\"s\""), s"cells must reference SST by index: $sheetXml")
+      assert(!sheetXml.contains("inlineStr"), s"no inline strings expected in SST mode: $sheetXml")
+      // First occurrence of alpha is index 0, beta 1, gamma 2
+      assert(sheetXml.contains("<v>0</v>"), "alpha must be referenced as index 0")
+      assert(sheetXml.contains("<v>2</v>"), "gamma must be referenced as index 2")
+    }
+  }
+
+  test("writeStream with SstPolicy.Never keeps the inline-string dialect (no SST part)") {
+    val path = tempXlsx("inline")
+    dupRows
+      .through(excel.writeStream(path, "Data", config = WriterConfig(sstPolicy = SstPolicy.Never)))
+      .compile
+      .drain
+      .map { _ =>
+        assert(!hasEntry(path, "xl/sharedStrings.xml"), "SstPolicy.Never must not emit an SST")
+        val sheetXml = entryText(path, "xl/worksheets/sheet1.xml")
+        assert(sheetXml.contains("inlineStr"), s"inline dialect expected: $sheetXml")
+      }
+  }
+
+  test("SST-written file reads back identical values via the in-memory reader") {
+    val path = tempXlsx("readback")
+    dupRows.through(excel.writeStream(path, "Data")).compile.drain.map { _ =>
+      val wb = XlsxReader.read(path).fold(e => fail(s"read: ${e.message}"), identity)
+      val sheet = wb.sheets(0)
+      assertEquals(sheet(ref"A1").value, CellValue.Text("alpha"))
+      assertEquals(sheet(ref"A3").value, CellValue.Text("alpha"))
+      assertEquals(sheet(ref"A4").value, CellValue.Text("gamma"))
+      assertEquals(sheet(ref"B1").value, CellValue.Number(BigDecimal(1)))
+    }
+  }
+
+  test("RichText cells stay inline while plain text uses the SST (mixed dialect is valid OOXML)") {
+    import com.tjclp.xl.richtext.{RichText, TextRun}
+    val rich = RichText(Vector(TextRun("bold bit", Some(Font.default.copy(bold = true)))))
+    val rows = fs2.Stream
+      .emits(
+        List(
+          RowData(1, Map(0 -> CellValue.Text("plain"), 1 -> CellValue.RichText(rich)))
+        )
+      )
+      .covary[IO]
+    val path = tempXlsx("richtext")
+    rows.through(excel.writeStream(path, "Data")).compile.drain.map { _ =>
+      val sheetXml = entryText(path, "xl/worksheets/sheet1.xml")
+      assert(sheetXml.contains("t=\"s\""), "plain text must use SST")
+      assert(sheetXml.contains("inlineStr"), "rich text stays inline")
+      val (_, unique, entries) = parseSst(path)
+      assertEquals(entries, Vector("plain"))
+      assertEquals(unique, 1)
+      val wb = XlsxReader.read(path).fold(e => fail(s"read: ${e.message}"), identity)
+      assertEquals(wb.sheets(0)(ref"A1").value, CellValue.Text("plain"))
+    }
+  }
+
+  test("formula-injection escaping applies before SST accumulation (secure config)") {
+    val rows = fs2.Stream
+      .emits(List(RowData(1, Map(0 -> CellValue.Text("=cmd()")))))
+      .covary[IO]
+    val path = tempXlsx("secure")
+    rows
+      .through(excel.writeStream(path, "Data", config = WriterConfig.secure))
+      .compile
+      .drain
+      .map { _ =>
+        val (_, _, entries) = parseSst(path)
+        assertEquals(entries, Vector("'=cmd()"), "SST must store the escaped text")
+      }
+  }
+
+  test("writeStreamsSeq shares a single SST across sheets (workbook-global dedup)") {
+    val sheet1 = fs2.Stream
+      .emits(List(RowData(1, Map(0 -> CellValue.Text("shared"), 1 -> CellValue.Text("only-1")))))
+      .covary[IO]
+    val sheet2 = fs2.Stream
+      .emits(List(RowData(1, Map(0 -> CellValue.Text("shared"), 1 -> CellValue.Text("only-2")))))
+      .covary[IO]
+    val path = tempXlsx("multisheet")
+    excel.writeStreamsSeq(path, Seq("S1" -> sheet1, "S2" -> sheet2)).map { _ =>
+      val (count, unique, entries) = parseSst(path)
+      assertEquals(entries, Vector("shared", "only-1", "only-2"))
+      assertEquals(unique, 3)
+      assertEquals(count, 4)
+      val wb = XlsxReader.read(path).fold(e => fail(s"read: ${e.message}"), identity)
+      assertEquals(wb.sheets(0)(ref"A1").value, CellValue.Text("shared"))
+      assertEquals(wb.sheets(1)(ref"A1").value, CellValue.Text("shared"))
+      assertEquals(wb.sheets(1)(ref"B1").value, CellValue.Text("only-2"))
+    }
+  }
+
+  test("writeStreamWithAutoDetect emits both the dimension element and the SST") {
+    val path = tempXlsx("autodetect")
+    dupRows.through(excel.writeStreamWithAutoDetect(path, "Data")).compile.drain.map { _ =>
+      val sheetXml = entryText(path, "xl/worksheets/sheet1.xml")
+      assert(sheetXml.contains("<dimension ref=\"A1:B5\"/>"), s"dimension missing: $sheetXml")
+      val (_, unique, entries) = parseSst(path)
+      assertEquals(entries, Vector("alpha", "beta", "gamma"))
+      assertEquals(unique, 3)
+    }
+  }
+
+  test("writeStreamStyled emits styles.xml from the style table and cells round-trip styles") {
+    val bold = CellStyle.default.copy(font = Font.default.copy(bold = true))
+    val percent = CellStyle.default.withNumFmt(NumFmt.Percent)
+    val rows = fs2.Stream
+      .emits(
+        List(
+          StyledRowData(
+            1,
+            Map(0 -> CellValue.Text("Header"), 1 -> CellValue.Number(BigDecimal("0.25"))),
+            Map(0 -> 0, 1 -> 1) // indices into the style table below
+          ),
+          StyledRowData(2, Map(0 -> CellValue.Text("Plain")), Map.empty)
+        )
+      )
+      .covary[IO]
+    val path = tempXlsx("styled")
+    rows
+      .through(excel.writeStreamStyled(path, "Data", Vector(bold, percent)))
+      .compile
+      .drain
+      .map { _ =>
+        val wb = XlsxReader.read(path).fold(e => fail(s"read: ${e.message}"), identity)
+        val sheet = wb.sheets(0)
+
+        def resolved(r: com.tjclp.xl.addressing.ARef): CellStyle =
+          sheet(r).styleId
+            .flatMap(sheet.styleRegistry.get)
+            .getOrElse(CellStyle.default)
+
+        assert(resolved(ref"A1").font.bold, "A1 must resolve to the bold style")
+        assertEquals(resolved(ref"B1").numFmt, NumFmt.Percent, "B1 must resolve to percent format")
+        assertEquals(sheet(ref"A2").styleId, None, "unstyled cell stays default")
+
+        // Values survive alongside styles (SST still applies)
+        assertEquals(sheet(ref"A1").value, CellValue.Text("Header"))
+        assertEquals(sheet(ref"B1").value, CellValue.Number(BigDecimal("0.25")))
+        val (_, unique, _) = parseSst(path)
+        assertEquals(unique, 2)
+      }
+  }
+
+  test("memory envelope: 100k rows with 100 distinct strings -> SST has exactly 100 entries") {
+    val path = tempXlsx("bigdedup")
+    val rows = fs2.Stream
+      .range(1, 100_001)
+      .map(i => RowData(i, Map(0 -> CellValue.Text(s"Company-${i % 100}"))))
+      .covary[IO]
+    rows.through(excel.writeStream(path, "Big")).compile.drain.map { _ =>
+      val (count, unique, _) = parseSst(path)
+      assertEquals(unique, 100, "SST must contain only the distinct strings")
+      assertEquals(count, 100_000, "count attribute counts every reference")
+    }
+  }

--- a/xl-cats-effect/test/src/com/tjclp/xl/io/streaming/StreamingSstSpec.scala
+++ b/xl-cats-effect/test/src/com/tjclp/xl/io/streaming/StreamingSstSpec.scala
@@ -233,3 +233,34 @@ class StreamingSstSpec extends CatsEffectSuite:
       assertEquals(count, 100_000, "count attribute counts every reference")
     }
   }
+
+  // Purity law: the accumulator must be created per RUN, not per stream construction —
+  // otherwise re-running the same compiled effect (e.g. a retry) inherits the previous
+  // run's strings as stale SST entries.
+
+  test("re-running the same compiled writeStream IO produces an identical SST (fresh per run)") {
+    val path = tempXlsx("rerun-single")
+    val io = dupRows.through(excel.writeStream(path, "Data")).compile.drain
+    for
+      _ <- io
+      first = parseSst(path)
+      _ <- io
+      second = parseSst(path)
+    yield
+      assertEquals(second, first, "second run of the same IO must not reuse the accumulator")
+      assertEquals(first, (5, 3, Vector("alpha", "beta", "gamma")))
+  }
+
+  test("re-running the same writeStreamsSeq F produces an identical SST (fresh per run)") {
+    val path = tempXlsx("rerun-multi")
+    val rows = fs2.Stream.emits(List(RowData(1, Map(0 -> CellValue.Text("x"))))).covary[IO]
+    val io = excel.writeStreamsSeq(path, Seq("S1" -> rows))
+    for
+      _ <- io
+      first = parseSst(path)
+      _ <- io
+      second = parseSst(path)
+    yield
+      assertEquals(second, first, "second run of the same F must not reuse the accumulator")
+      assertEquals(first, (1, 1, Vector("x")))
+  }

--- a/xl-core/src/com/tjclp/xl/cells/CellValue.scala
+++ b/xl-core/src/com/tjclp/xl/cells/CellValue.scala
@@ -71,8 +71,14 @@ object CellValue:
     )
     Formula(expression, cachedValue)
 
+  // Excel epoch for the 1900 date system: December 30, 1899 (not Jan 1, 1900, to account for
+  // Excel's 1900 leap-year bug). Epoch for the 1904 date system (legacy Mac Excel): January 1,
+  // 1904 = serial 0; that system has NO phantom leap day.
+  private val epoch1900 = LocalDateTime.of(1899, 12, 30, 0, 0, 0)
+  private val epoch1904 = LocalDateTime.of(1904, 1, 1, 0, 0, 0)
+
   /**
-   * Convert LocalDateTime to Excel serial number.
+   * Convert LocalDateTime to Excel serial number in the default 1900 date system.
    *
    * Excel represents dates as the number of days since December 30, 1899, with fractional days
    * representing time. Excel has a bug where it treats 1900 as a leap year (it wasn't); this
@@ -85,17 +91,34 @@ object CellValue:
    *   Excel serial number (days since 1899-12-30 + fractional time)
    */
   def dateTimeToExcelSerial(dt: LocalDateTime): Double =
+    dateTimeToExcelSerial(dt, date1904 = false)
+
+  /**
+   * Convert LocalDateTime to Excel serial number in the given date system (GH-243).
+   *
+   * In the 1904 date system (`<workbookPr date1904="1"/>`, legacy Mac Excel) serials count days
+   * since 1904-01-01 (= serial 0). The 1900 system's phantom 1900-02-29 does not exist in the 1904
+   * system, so no leap-day adjustment is applied. For the same date on/after 1900-03-01 the two
+   * systems differ by exactly 1462 days.
+   *
+   * @param dt
+   *   The LocalDateTime to convert
+   * @param date1904
+   *   true for the 1904 date system, false for the default 1900 system
+   * @return
+   *   Excel serial number (days since the system epoch + fractional time)
+   */
+  def dateTimeToExcelSerial(dt: LocalDateTime, date1904: Boolean): Double =
     import java.time.temporal.ChronoUnit
 
-    // Excel epoch: December 30, 1899 (not Jan 1, 1900, to account for 1900 leap year bug)
-    val epoch1900 = LocalDateTime.of(1899, 12, 30, 0, 0, 0)
-
-    // Calculate days since epoch
-    val rawDays = ChronoUnit.DAYS.between(epoch1900, dt)
-    // Excel 1900 leap-year bug: it counts a phantom 1900-02-29 (serial 60), so real dates before
-    // 1900-03-01 (rawDays < 61 from the 1899-12-30 epoch) are one higher than Excel. Subtract it
-    // back so 1900-01-01 -> 1 and 1900-02-28 -> 59. Dates on/after 1900-03-01 are already correct.
-    val days = if rawDays < 61 then rawDays - 1 else rawDays
+    val days =
+      if date1904 then ChronoUnit.DAYS.between(epoch1904, dt)
+      else
+        val rawDays = ChronoUnit.DAYS.between(epoch1900, dt)
+        // Excel 1900 leap-year bug: it counts a phantom 1900-02-29 (serial 60), so real dates before
+        // 1900-03-01 (rawDays < 61 from the 1899-12-30 epoch) are one higher than Excel. Subtract it
+        // back so 1900-01-01 -> 1 and 1900-02-28 -> 59. Dates on/after 1900-03-01 are already correct.
+        if rawDays < 61 then rawDays - 1 else rawDays
 
     // Calculate fractional day for time component
     val dayStart = dt.toLocalDate.atStartOfDay
@@ -105,7 +128,7 @@ object CellValue:
     days.toDouble + fractionOfDay
 
   /**
-   * Convert Excel serial number to LocalDateTime.
+   * Convert Excel serial number to LocalDateTime in the default 1900 date system.
    *
    * Excel represents dates as the number of days since December 30, 1899, with fractional days
    * representing time. This is the inverse of dateTimeToExcelSerial.
@@ -116,20 +139,33 @@ object CellValue:
    *   LocalDateTime corresponding to the serial number
    */
   def excelSerialToDateTime(serial: Double): LocalDateTime =
-    import java.time.temporal.ChronoUnit
+    excelSerialToDateTime(serial, date1904 = false)
 
-    // Excel epoch: December 30, 1899
-    val epoch1900 = LocalDateTime.of(1899, 12, 30, 0, 0, 0)
-
+  /**
+   * Convert Excel serial number to LocalDateTime in the given date system (GH-243).
+   *
+   * In the 1904 date system serial 0 = 1904-01-01 and no phantom-leap-day inverse adjustment is
+   * applied. This is the inverse of `dateTimeToExcelSerial(dt, date1904)`.
+   *
+   * @param serial
+   *   Excel serial number (days since the system epoch + fractional time)
+   * @param date1904
+   *   true for the 1904 date system, false for the default 1900 system
+   * @return
+   *   LocalDateTime corresponding to the serial number
+   */
+  def excelSerialToDateTime(serial: Double, date1904: Boolean): LocalDateTime =
     // Extract whole days and fractional day
     val wholeDays = serial.toLong
     val fractionOfDay = serial - wholeDays
     val seconds = (fractionOfDay * 86400.0).toLong
 
-    // Inverse of the 1900 leap-year adjustment: serials below 60 are shifted one day forward;
-    // serial 60 is Excel's phantom 1900-02-29, mapped here to 1900-02-28. Serials >= 61 are exact.
-    val dayShift = if wholeDays < 60 then 1L else 0L
-    epoch1900.plusDays(wholeDays + dayShift).plusSeconds(seconds)
+    if date1904 then epoch1904.plusDays(wholeDays).plusSeconds(seconds)
+    else
+      // Inverse of the 1900 leap-year adjustment: serials below 60 are shifted one day forward;
+      // serial 60 is Excel's phantom 1900-02-29, mapped here to 1900-02-28. Serials >= 61 are exact.
+      val dayShift = if wholeDays < 60 then 1L else 0L
+      epoch1900.plusDays(wholeDays + dayShift).plusSeconds(seconds)
 
   /**
    * Characters that trigger formula injection when at the start of a cell value.

--- a/xl-core/src/com/tjclp/xl/display/FormatCodeParser.scala
+++ b/xl-core/src/com/tjclp/xl/display/FormatCodeParser.scala
@@ -127,8 +127,12 @@ object FormatCodeParser:
     /** AM/PM marker */
     case AmPm(format: String)
 
-    /** Fraction: # ?/? or # ??/?? */
-    case Fraction(wholePart: Boolean, numDigits: Int, denomDigits: Int)
+    /**
+     * Fraction: digit-placeholder runs around `/` (e.g. `?/?`, `??/??`) or a fixed literal
+     * denominator (e.g. `?/8`). `numerator`/`denominator` hold the raw placeholder runs;
+     * `fixedDenominator` is defined when the denominator is a literal integer.
+     */
+    case Fraction(numerator: String, denominator: String, fixedDenominator: Option[Long])
 
     /** Elapsed time: [h], [m], [s] */
     case Elapsed(unit: Char)
@@ -386,9 +390,36 @@ object FormatCodeParser:
           i += 3
 
         case '/' =>
-          // Could be part of date format or fraction - treat as literal
-          tokens += FormatToken.Literal("/")
-          i += 1
+          // Fraction when digit placeholders directly flank the slash (GH-243): pop the
+          // numerator run and consume the denominator (placeholder run or fixed integer).
+          // Date separators (m/d/yy) reach here between DatePart tokens and stay literal.
+          val denominator =
+            val sb = new StringBuilder
+            var j = i + 1
+            while j < pattern.length && isFractionChar(pattern(j)) do
+              sb += pattern(j)
+              j += 1
+            sb.toString
+          var numeratorLen = 0
+          while numeratorLen < tokens.length && (tokens(tokens.length - 1 - numeratorLen) match
+              case FormatToken.Digit(_) => true
+              case _ => false)
+          do numeratorLen += 1
+          if denominator.nonEmpty && numeratorLen > 0 then
+            val numerator = tokens
+              .takeRight(numeratorLen)
+              .collect { case FormatToken.Digit(ch) => ch }
+              .mkString
+            tokens.dropRightInPlace(numeratorLen)
+            val fixed =
+              if denominator.forall(_.isDigit) && denominator.exists(_ != '0') then
+                denominator.toLongOption
+              else None
+            tokens += FormatToken.Fraction(numerator, denominator, fixed)
+            i += 1 + denominator.length
+          else
+            tokens += FormatToken.Literal("/")
+            i += 1
 
         case ':' =>
           // Time separator
@@ -406,6 +437,10 @@ object FormatCodeParser:
           i += 1
 
     FormatPattern(tokens.toVector, hasThousands, hasPercent)
+
+  /** Characters that may appear in a fraction numerator/denominator run. */
+  private def isFractionChar(c: Char): Boolean =
+    c == '#' || c == '?' || (c >= '0' && c <= '9')
 
   // ========== Formatter ==========
 
@@ -451,6 +486,15 @@ object FormatCodeParser:
    * literals.
    */
   private def applyPattern(value: BigDecimal, pattern: FormatPattern): String =
+    val fracIdx = pattern.tokens.indexWhere {
+      case _: FormatToken.Fraction => true
+      case _ => false
+    }
+    pattern.tokens.lift(fracIdx) match
+      case Some(f: FormatToken.Fraction) => applyFractionPattern(value, pattern.tokens, fracIdx, f)
+      case _ => applyNumericPattern(value, pattern)
+
+  private def applyNumericPattern(value: BigDecimal, pattern: FormatPattern): String =
     // Handle percent: multiply by 100
     val adjustedValue = if pattern.hasPercent then value * 100 else value
 
@@ -551,6 +595,147 @@ object FormatCodeParser:
       if posFromEnd > 0 && posFromEnd % 3 == 0 then s"$c,"
       else c.toString
     }.mkString
+
+  /**
+   * Render a fraction pattern (GH-243).
+   *
+   * Excel semantics (verified against the Excel-corpus-tested SheetJS/SSF algorithm):
+   *   - variable denominators (`?/?`, `??/??`) use the last continued-fraction convergent whose
+   *     denominator fits the placeholder budget (`10^digits - 1`, digits capped at 7)
+   *   - fixed denominators (`?/8`) round to that denominator and never reduce (4/8 stays 4/8)
+   *   - a whole value blanks the fraction area with spaces to preserve column alignment
+   *   - unfilled `?` placeholders render as spaces, `0` as zeros, `#` as nothing; numerators
+   *     right-align within their placeholders, denominators left-align
+   *
+   * The sign is handled by [[applyFormat]] (section literals or the default leading minus).
+   */
+  private def applyFractionPattern(
+    value: BigDecimal,
+    tokens: Vector[FormatToken],
+    fracIdx: Int,
+    frac: FormatToken.Fraction
+  ): String =
+    val abs = value.abs
+    val wholePlaceholders = tokens
+      .take(fracIdx)
+      .collect { case FormatToken.Digit(ch) => ch }
+      .mkString
+    val mixed = wholePlaceholders.nonEmpty
+
+    val (whole, num, den) = frac.fixedDenominator match
+      case Some(d) =>
+        val rr = (abs * d).setScale(0, BigDecimal.RoundingMode.HALF_UP).toBigInt
+        (rr / d, rr % d, d)
+      case None =>
+        val digits = math.min(math.max(frac.numerator.length, frac.denominator.length), 7)
+        val maxDen = math.pow(10, digits.toDouble) - 1
+        // Excel stores values as IEEE-754 doubles and runs the search on the FULL value:
+        // the whole part's binary noise is observable (12.3 → 12 1/3, but 0.3 → 2/7).
+        val (p, q) = nearestFraction(abs.toDouble, maxDen)
+        val wholeD = math.floor(p / q)
+        // p/q are exact-integer doubles for all values below 2^53 (Excel's own precision);
+        // the max(0, _) keeps the numerator total for astronomically large inputs.
+        (BigDecimal(wholeD).toBigInt, BigInt(math.max(0.0, p - wholeD * q).toLong), q.toLong)
+
+    val improperNumerator = whole * den + num
+
+    val denWidth = frac.fixedDenominator
+      .fold(visibleWidth(frac.denominator))(_.toString.length)
+    val fractionPart =
+      if num == 0 && mixed then " " * (visibleWidth(frac.numerator) + 1 + denWidth)
+      else
+        val numerator = if mixed then num else improperNumerator
+        val denStr = frac.fixedDenominator match
+          case Some(d) => d.toString
+          case None => padPlaceholders(den.toString, frac.denominator, alignRight = false)
+        padPlaceholders(numerator.toString, frac.numerator, alignRight = true) + "/" + denStr
+
+    val wholeStr =
+      if !mixed then ""
+      else if whole != 0 then padPlaceholders(whole.toString, wholePlaceholders, alignRight = true)
+      else if num == 0 then "0"
+      else padPlaceholders("", wholePlaceholders, alignRight = true)
+
+    val result = new StringBuilder
+    var wholeEmitted = false
+    tokens.zipWithIndex.foreach { case (token, idx) =>
+      token match
+        case FormatToken.Digit(_) if idx < fracIdx =>
+          if !wholeEmitted then
+            result ++= wholeStr
+            wholeEmitted = true
+        case _: FormatToken.Fraction =>
+          result ++= fractionPart
+        case FormatToken.Literal(text) =>
+          result ++= text
+        case FormatToken.Spacer(_) =>
+          result += ' '
+        case _ =>
+          () // fills, percent, date tokens: not meaningful inside fraction patterns
+    }
+    result.toString
+
+  /**
+   * Last continued-fraction convergent P/Q of `x` (non-negative) with Q <= maxDen.
+   *
+   * A verbatim port of the SheetJS/SSF `frac` algorithm (reverse-engineered from Excel and
+   * validated against an Excel-generated corpus): convergents are generated in IEEE-754 double
+   * arithmetic until the denominator budget is exceeded, then the previous convergent wins.
+   * Double state is deliberate — Excel stores values as doubles and the binary noise is
+   * observable in the chosen convergent (12.3 → 12 1/3 but 0.3 → 2/7).
+   */
+  private def nearestFraction(x: Double, maxDen: Double): (Double, Double) =
+    var b = x
+    var p2 = 0.0
+    var p1 = 1.0
+    var q2 = 1.0
+    var q1 = 0.0
+    var p = 0.0
+    var q = 0.0
+    var continue = true
+    while continue && q1 < maxDen do
+      val a = math.floor(b)
+      p = a * p1 + p2
+      q = a * q1 + q2
+      if b - a < 0.00000005 then continue = false
+      else
+        b = 1.0 / (b - a)
+        p2 = p1
+        p1 = p
+        q2 = q1
+        q1 = q
+    if q > maxDen then
+      if q1 > maxDen then
+        q = q2
+        p = p2
+      else
+        q = q1
+        p = p1
+    (p, q)
+
+  /**
+   * Width a placeholder run occupies when blanked out: `?`, `0` and literal digits reserve one
+   * space each; `#` reserves nothing.
+   */
+  private def visibleWidth(placeholders: String): Int =
+    placeholders.count(c => c == '?' || (c >= '0' && c <= '9'))
+
+  /**
+   * Align digits within a placeholder run: unfilled `?` positions become spaces, `0` becomes
+   * zeros, `#` adds nothing. Numerators/wholes right-align (pad left), denominators left-align
+   * (pad right).
+   */
+  private def padPlaceholders(digits: String, placeholders: String, alignRight: Boolean): String =
+    val diff = placeholders.length - digits.length
+    if diff <= 0 then digits
+    else
+      val unfilled = if alignRight then placeholders.take(diff) else placeholders.takeRight(diff)
+      val fill = unfilled.flatMap {
+        case '?' => " "
+        case '0' => "0"
+        case _ => ""
+      }
+      if alignRight then fill + digits else digits + fill
 
   /**
    * Apply a format code to text.

--- a/xl-core/src/com/tjclp/xl/display/FormatCodeParser.scala
+++ b/xl-core/src/com/tjclp/xl/display/FormatCodeParser.scala
@@ -455,8 +455,8 @@ object FormatCodeParser:
    *   - 2 sections: positive and zero use the 1st, negative uses the 2nd
    *   - 3+ sections: positive uses the 1st, negative the 2nd, zero the 3rd
    *   - compare conditions on the first two sections override positional routing (GH-285)
-   *   - a trailing `@` section among fewer than 4 sections is the text section and never
-   *     receives numbers
+   *   - a trailing `@` section among fewer than 4 sections is the text section and never receives
+   *     numbers
    *
    * Multi-section formats render the absolute value (any minus sign must be written in the
    * pattern); only single-section formats receive the default leading minus.
@@ -483,16 +483,16 @@ object FormatCodeParser:
    * Route a numeric value to its format section per Excel semantics (GH-254/262/283/285).
    *
    * Mirrors SheetJS/SSF `choose_fmt` (reverse-engineered from Excel):
-   *   - a trailing `@` section among fewer than 4 sections is the text section and drops out
-   *     of numeric routing
+   *   - a trailing `@` section among fewer than 4 sections is the text section and drops out of
+   *     numeric routing
    *   - without compare conditions, routing is positional with padding: 1 section serves all
    *     values, 2 sections serve [pos+zero, neg], 3+ serve [pos, neg, zero]
    *   - with compare conditions (honored on the first two sections only): the first matching
-   *     condition wins; an unmatched value falls back to the third padded section when both
-   *     leading sections carry conditions, otherwise to the second
+   *     condition wins; an unmatched value falls back to the third padded section when both leading
+   *     sections carry conditions, otherwise to the second
    *
-   * Returns None when the code has no numeric section (a lone `@` text format) — Excel renders
-   * such numbers in General format.
+   * Returns None when the code has no numeric section (a lone `@` text format) — Excel renders such
+   * numbers in General format.
    */
   def selectSection(value: BigDecimal, format: FormatCode): Option[FormatSection] =
     val sections = numericSections(format)
@@ -740,9 +740,9 @@ object FormatCodeParser:
    *
    * A verbatim port of the SheetJS/SSF `frac` algorithm (reverse-engineered from Excel and
    * validated against an Excel-generated corpus): convergents are generated in IEEE-754 double
-   * arithmetic until the denominator budget is exceeded, then the previous convergent wins.
-   * Double state is deliberate — Excel stores values as doubles and the binary noise is
-   * observable in the chosen convergent (12.3 → 12 1/3 but 0.3 → 2/7).
+   * arithmetic until the denominator budget is exceeded, then the previous convergent wins. Double
+   * state is deliberate — Excel stores values as doubles and the binary noise is observable in the
+   * chosen convergent (12.3 → 12 1/3 but 0.3 → 2/7).
    */
   private def nearestFraction(x: Double, maxDen: Double): (Double, Double) =
     var b = x
@@ -781,9 +781,9 @@ object FormatCodeParser:
     placeholders.count(c => c == '?' || (c >= '0' && c <= '9'))
 
   /**
-   * Align digits within a placeholder run: unfilled `?` positions become spaces, `0` becomes
-   * zeros, `#` adds nothing. Numerators/wholes right-align (pad left), denominators left-align
-   * (pad right).
+   * Align digits within a placeholder run: unfilled `?` positions become spaces, `0` becomes zeros,
+   * `#` adds nothing. Numerators/wholes right-align (pad left), denominators left-align (pad
+   * right).
    */
   private def padPlaceholders(digits: String, placeholders: String, alignRight: Boolean): String =
     val diff = placeholders.length - digits.length
@@ -800,8 +800,8 @@ object FormatCodeParser:
   /**
    * Apply a format code to text.
    *
-   * The text section is the 4th section when present; otherwise a trailing `@` section among
-   * fewer than 4 sections (GH-285). Without either, text echoes unchanged.
+   * The text section is the 4th section when present; otherwise a trailing `@` section among fewer
+   * than 4 sections (GH-285). Without either, text echoes unchanged.
    */
   def applyTextFormat(text: String, format: FormatCode): String =
     val all = Vector(format.positive) ++ format.negative ++ format.zero ++ format.text
@@ -822,16 +822,23 @@ object FormatCodeParser:
   // ========== Date/Time Formatter ==========
 
   /**
-   * Check if a format code contains date/time tokens.
+   * Check if a format code's first section contains date/time tokens.
    */
   def hasDateTokens(format: FormatCode): Boolean =
-    format.positive.pattern.tokens.exists {
+    hasDateTokens(format.positive)
+
+  /**
+   * Check if a single format section contains date/time tokens (GH-283: sections of one code may
+   * mix calendar and numeric patterns, so callers route per section).
+   */
+  def hasDateTokens(section: FormatSection): Boolean =
+    section.pattern.tokens.exists {
       case FormatToken.DatePart(_) | FormatToken.AmPm(_) | FormatToken.Elapsed(_) => true
       case _ => false
     }
 
   /**
-   * Apply a parsed format code to a LocalDateTime value.
+   * Apply a parsed format code's first section to a LocalDateTime value.
    *
    * @param dt
    *   The datetime to format
@@ -841,7 +848,14 @@ object FormatCodeParser:
    *   Formatted date/time string
    */
   def applyDateFormat(dt: LocalDateTime, format: FormatCode): String =
-    val tokens = format.positive.pattern.tokens
+    applyDateFormat(dt, format.positive)
+
+  /**
+   * Apply a single format section to a LocalDateTime value (GH-283: the section is chosen by
+   * [[selectSection]] on the date's serial number).
+   */
+  def applyDateFormat(dt: LocalDateTime, section: FormatSection): String =
+    val tokens = section.pattern.tokens
     val minutePositions = findMinutePositions(tokens)
     tokens.zipWithIndex.map { case (token, idx) =>
       renderDateToken(dt, token, minutePositions.contains(idx))

--- a/xl-core/src/com/tjclp/xl/display/FormatCodeParser.scala
+++ b/xl-core/src/com/tjclp/xl/display/FormatCodeParser.scala
@@ -55,17 +55,20 @@ object FormatCodeParser:
   )
 
   /**
-   * A single format section with optional condition and pattern.
+   * A single format section with stacked conditions and a pattern.
    *
-   * @param condition
-   *   Optional color or value condition (e.g., [Red], [>100])
+   * @param conditions
+   *   Leading bracket modifiers in order (e.g. `[Red][<=100]` stacks a color and a compare
+   *   condition on the same section)
    * @param pattern
    *   The formatting pattern
    */
   case class FormatSection(
-    condition: Option[Condition] = None,
+    conditions: Vector[Condition] = Vector.empty,
     pattern: FormatPattern
-  )
+  ):
+    /** The last parsed condition, if any (legacy accessor; conditions stack since GH-285). */
+    def condition: Option[Condition] = conditions.lastOption
 
   /**
    * A condition modifier for a format section.
@@ -216,9 +219,9 @@ object FormatCodeParser:
   private def parseSection(section: String): Either[String, FormatSection] =
     boundary:
       var remaining = section
-      var condition: Option[Condition] = None
+      var conditions = Vector.empty[Condition]
 
-      // Extract leading conditions like [Red], [>100], [$-409]
+      // Extract leading conditions like [Red], [>100], [$-409] — they stack (GH-285)
       while remaining.startsWith("[") do
         val endBracket = remaining.indexOf(']')
         if endBracket < 0 then break(Left(s"Unclosed bracket in: $section"))
@@ -226,17 +229,17 @@ object FormatCodeParser:
         val bracketContent = remaining.substring(1, endBracket)
         parseCondition(bracketContent) match
           case Some(cond) =>
-            condition = Some(cond)
+            conditions = conditions :+ cond
           case None =>
             // Unknown bracket content - might be elapsed time [h], [m], [s]
             // Pass through as part of pattern
             val pattern = parsePattern(remaining)
-            break(Right(FormatSection(condition, pattern)))
+            break(Right(FormatSection(conditions, pattern)))
 
         remaining = remaining.substring(endBracket + 1)
 
       val pattern = parsePattern(remaining)
-      Right(FormatSection(condition, pattern))
+      Right(FormatSection(conditions, pattern))
 
   /**
    * Parse a condition from bracket content.
@@ -447,10 +450,16 @@ object FormatCodeParser:
   /**
    * Apply a parsed format code to a numeric value.
    *
-   * Section selection follows Excel's rules:
+   * Section selection follows Excel's rules (see [[selectSection]]):
    *   - 1 section: all numbers use it (negatives keep their default minus sign)
    *   - 2 sections: positive and zero use the 1st, negative uses the 2nd
    *   - 3+ sections: positive uses the 1st, negative the 2nd, zero the 3rd
+   *   - compare conditions on the first two sections override positional routing (GH-285)
+   *   - a trailing `@` section among fewer than 4 sections is the text section and never
+   *     receives numbers
+   *
+   * Multi-section formats render the absolute value (any minus sign must be written in the
+   * pattern); only single-section formats receive the default leading minus.
    *
    * @param value
    *   The number to format
@@ -460,24 +469,75 @@ object FormatCodeParser:
    *   Tuple of (formatted string, optional color)
    */
   def applyFormat(value: BigDecimal, format: FormatCode): (String, Option[String]) =
-    // Select appropriate section based on value sign
-    val (section, effectiveValue) =
-      if value > 0 then (format.positive, value)
-      else if value < 0 then
-        format.negative match
-          case Some(neg) => (neg, value.abs) // Negative section uses absolute value
-          case None => (format.positive, value) // Fall back to positive
-      else
-        format.zero match
-          case Some(z) => (z, value)
-          case None => (format.positive, value) // Excel: zero uses positive section (GH-254)
-
-    val color = section.condition.collect { case Condition.Color(c) => c }
-    val formatted = applyPattern(effectiveValue, section.pattern)
+    val section = selectSection(value, format).getOrElse(format.positive)
+    val color = section.conditions.collectFirst { case Condition.Color(c) => c }
+    val formatted = applyPattern(value, section.pattern)
     val withDefaultSign =
-      if value < 0 && format.negative.isEmpty && !formatted.startsWith("-") then s"-$formatted"
+      if value < 0 && numericSections(format).sizeIs <= 1 && formatted.nonEmpty &&
+        !formatted.startsWith("-")
+      then s"-$formatted"
       else formatted
     (withDefaultSign, color)
+
+  /**
+   * Route a numeric value to its format section per Excel semantics (GH-254/262/283/285).
+   *
+   * Mirrors SheetJS/SSF `choose_fmt` (reverse-engineered from Excel):
+   *   - a trailing `@` section among fewer than 4 sections is the text section and drops out
+   *     of numeric routing
+   *   - without compare conditions, routing is positional with padding: 1 section serves all
+   *     values, 2 sections serve [pos+zero, neg], 3+ serve [pos, neg, zero]
+   *   - with compare conditions (honored on the first two sections only): the first matching
+   *     condition wins; an unmatched value falls back to the third padded section when both
+   *     leading sections carry conditions, otherwise to the second
+   *
+   * Returns None when the code has no numeric section (a lone `@` text format) — Excel renders
+   * such numbers in General format.
+   */
+  def selectSection(value: BigDecimal, format: FormatCode): Option[FormatSection] =
+    val sections = numericSections(format)
+    if sections.isEmpty then None
+    else
+      val padded = sections.size match
+        case 1 => Vector(sections(0), sections(0), sections(0))
+        case 2 => Vector(sections(0), sections(1), sections(0))
+        case _ => Vector(sections(0), sections(1), sections(2))
+      val cmp1 = compareCondition(padded(0))
+      val cmp2 = compareCondition(padded(1))
+      val chosen =
+        if cmp1.isEmpty && cmp2.isEmpty then
+          if value > 0 then padded(0)
+          else if value < 0 then padded(1)
+          else padded(2) // Excel: zero uses the positive section when unpadded (GH-254)
+        else if cmp1.exists(conditionMatches(value, _)) then padded(0)
+        else if cmp2.exists(conditionMatches(value, _)) then padded(1)
+        else if cmp1.isDefined && cmp2.isDefined then padded(2)
+        else padded(1)
+      Some(chosen)
+
+  /**
+   * The sections that participate in numeric routing: all sections except a trailing `@` text
+   * section among fewer than 4 sections (SSF `choose_fmt` `lat` adjustment).
+   */
+  private def numericSections(format: FormatCode): Vector[FormatSection] =
+    val all = Vector(format.positive) ++ format.negative ++ format.zero ++ format.text
+    val trailingAt = all.sizeIs < 4 &&
+      all.lastOption.exists(_.pattern.tokens.contains(FormatToken.TextPlaceholder))
+    if trailingAt then all.dropRight(1) else all
+
+  private def compareCondition(section: FormatSection): Option[Condition.Compare] =
+    section.conditions.collectFirst { case c: Condition.Compare => c }
+
+  private def conditionMatches(value: BigDecimal, condition: Condition.Compare): Boolean =
+    val cmp = value.compare(condition.value)
+    condition.op match
+      case "=" => cmp == 0
+      case ">" => cmp > 0
+      case "<" => cmp < 0
+      case ">=" => cmp >= 0
+      case "<=" => cmp <= 0
+      case "<>" => cmp != 0
+      case _ => false
 
   /**
    * Apply a format pattern to a number.
@@ -739,9 +799,18 @@ object FormatCodeParser:
 
   /**
    * Apply a format code to text.
+   *
+   * The text section is the 4th section when present; otherwise a trailing `@` section among
+   * fewer than 4 sections (GH-285). Without either, text echoes unchanged.
    */
   def applyTextFormat(text: String, format: FormatCode): String =
-    format.text match
+    val all = Vector(format.positive) ++ format.negative ++ format.zero ++ format.text
+    val textSection = format.text.orElse(
+      if all.sizeIs < 4 then
+        all.lastOption.filter(_.pattern.tokens.contains(FormatToken.TextPlaceholder))
+      else None
+    )
+    textSection match
       case Some(section) =>
         section.pattern.tokens.map {
           case FormatToken.TextPlaceholder => text

--- a/xl-core/src/com/tjclp/xl/display/FormatCodeParser.scala
+++ b/xl-core/src/com/tjclp/xl/display/FormatCodeParser.scala
@@ -668,6 +668,13 @@ object FormatCodeParser:
    *     right-align within their placeholders, denominators left-align
    *
    * The sign is handled by [[applyFormat]] (section literals or the default leading minus).
+   *
+   * Known divergences from Excel/SSF (corpus-checked, asymmetric-exotica only): codes with unequal
+   * numerator/denominator placeholder widths (`# ??/?????????`) align per-placeholder here, while
+   * Excel pads the numerator to the shared budget width `min(max(numLen, denLen), 7)` and
+   * blank-fills `2*width + 1`; codes with spaces around the slash (`# ?? / ??`) are not tokenized
+   * as fractions. Symmetric codes — everything Excel's Format Cells dialog offers — match the
+   * Excel-generated corpus exactly.
    */
   private def applyFractionPattern(
     value: BigDecimal,
@@ -691,11 +698,18 @@ object FormatCodeParser:
         val maxDen = math.pow(10, digits.toDouble) - 1
         // Excel stores values as IEEE-754 doubles and runs the search on the FULL value:
         // the whole part's binary noise is observable (12.3 → 12 1/3, but 0.3 → 2/7).
-        val (p, q) = nearestFraction(abs.toDouble, maxDen)
-        val wholeD = math.floor(p / q)
-        // p/q are exact-integer doubles for all values below 2^53 (Excel's own precision);
-        // the max(0, _) keeps the numerator total for astronomically large inputs.
-        (BigDecimal(wholeD).toBigInt, BigInt(math.max(0.0, p - wholeD * q).toLong), q.toLong)
+        val d = abs.toDouble
+        if d.isInfinite then
+          // |value| overflows Double (BigDecimal admits > ~1.8E308): the convergent search
+          // cannot run, and no fractional part is representable at that magnitude anyway —
+          // render the whole-number form (num == 0 blanks the fraction area), staying total.
+          (abs.setScale(0, BigDecimal.RoundingMode.HALF_UP).toBigInt, BigInt(0), 1L)
+        else
+          val (p, q) = nearestFraction(d, maxDen)
+          val wholeD = math.floor(p / q)
+          // p/q are exact-integer doubles for all values below 2^53 (Excel's own precision);
+          // the max(0, _) keeps the numerator total for astronomically large inputs.
+          (BigDecimal(wholeD).toBigInt, BigInt(math.max(0.0, p - wholeD * q).toLong), q.toLong)
 
     val improperNumerator = whole * den + num
 

--- a/xl-core/src/com/tjclp/xl/display/NumFmtFormatter.scala
+++ b/xl-core/src/com/tjclp/xl/display/NumFmtFormatter.scala
@@ -17,6 +17,10 @@ import java.time.format.DateTimeFormatter
  */
 object NumFmtFormatter:
 
+  /** Parsed pattern for the built-in NumFmt.Fraction (format id 12, "# ?/?"). */
+  private val builtInFractionFormat: Either[String, FormatCodeParser.FormatCode] =
+    FormatCodeParser.parse("# ?/?")
+
   /**
    * Format a cell value according to its number format.
    *
@@ -98,8 +102,10 @@ object NumFmtFormatter:
         f"$hours%d:$minutes%02d:$seconds%02d"
 
       case NumFmt.Fraction =>
-        // TODO: Implement fraction formatting (e.g., 0.5 → "1/2")
-        formatGeneral(n)
+        // Built-in fraction format id 12: "# ?/?" (up to one denominator digit, GH-243)
+        builtInFractionFormat match
+          case Right(fmt) => FormatCodeParser.applyFormat(n, fmt)._1
+          case Left(_) => formatGeneral(n)
 
       case NumFmt.Text =>
         // Text format displays numbers as text

--- a/xl-core/src/com/tjclp/xl/display/NumFmtFormatter.scala
+++ b/xl-core/src/com/tjclp/xl/display/NumFmtFormatter.scala
@@ -113,14 +113,8 @@ object NumFmtFormatter:
 
       case NumFmt.Custom(code) =>
         FormatCodeParser.parse(code) match
-          case Right(fmt) if FormatCodeParser.hasDateTokens(fmt) =>
-            // Custom date format: convert serial number to LocalDateTime
-            val dt = excelSerialToDateTime(n)
-            FormatCodeParser.applyDateFormat(dt, fmt)
-          case Right(fmt) =>
-            FormatCodeParser.applyFormat(n, fmt)._1
-          case Left(_) =>
-            formatGeneral(n) // Fallback for unparseable formats
+          case Right(fmt) => formatCustom(n, serialToDateTime(n), fmt)
+          case Left(_) => formatGeneral(n) // Fallback for unparseable formats
 
   /**
    * Format in General style (Excel's default number format).
@@ -175,13 +169,57 @@ object NumFmtFormatter:
         dt.toLocalTime.format(DateTimeFormatter.ofPattern("H:mm:ss")) // 24-hour format
 
       case NumFmt.Custom(code) =>
+        // Route through section selection on the serial (GH-283): ';;;' hides dates,
+        // numeric sections render the serial, conditional codes pick sections by serial
         FormatCodeParser.parse(code) match
-          case Right(fmt) if FormatCodeParser.hasDateTokens(fmt) =>
-            FormatCodeParser.applyDateFormat(dt, fmt)
-          case _ => dt.toString // Fallback for non-date formats or parse errors
+          case Right(fmt) => formatCustom(dateTimeSerial(dt), Some(dt), fmt)
+          case Left(_) => dt.toString // Fallback for parse errors
 
-      case _ =>
-        dt.toString
+      case other =>
+        // Dates ARE numbers in Excel: any numeric format (General included) displays
+        // the underlying serial number, never ISO text (GH-283)
+        formatNumber(dateTimeSerial(dt), other)
+
+  /**
+   * Render a numeric value through a parsed custom code with full section routing (GH-283/285): the
+   * section chosen for the value decides between calendar rendering (date tokens), General
+   * (text-only codes like a lone `@`) and numeric pattern rendering.
+   *
+   * @param n
+   *   The numeric value (a date serial when the value is date-typed)
+   * @param dt
+   *   The calendar view of `n` for date-token sections; None marks a serial outside Excel's
+   *   displayable date range, rendered as `######` like Excel's unrepresentable-date fill
+   * @param fmt
+   *   The parsed format code
+   */
+  private def formatCustom(
+    n: BigDecimal,
+    dt: => Option[LocalDateTime],
+    fmt: FormatCodeParser.FormatCode
+  ): String =
+    FormatCodeParser.selectSection(n, fmt) match
+      case None => formatGeneral(n)
+      case Some(section) if FormatCodeParser.hasDateTokens(section) =>
+        dt match
+          case Some(d) => FormatCodeParser.applyDateFormat(d, section)
+          case None => "######"
+      case Some(_) => FormatCodeParser.applyFormat(n, fmt)._1
+
+  /** Exclusive upper bound of Excel's displayable date serials (9999-12-31 is 2958465). */
+  private val maxDateSerialExclusive = BigDecimal(2958466)
+
+  /**
+   * Calendar view of a date serial, or None when the serial lies outside Excel's displayable range
+   * (negative or on/after 10000-01-01) — Excel fills such cells with `#` (GH-283).
+   */
+  private def serialToDateTime(serial: BigDecimal): Option[LocalDateTime] =
+    if serial < 0 || serial >= maxDateSerialExclusive then None
+    else Some(excelSerialToDateTime(serial))
+
+  /** Excel serial number (days since 1899-12-30 + day fraction) of a LocalDateTime. */
+  private def dateTimeSerial(dt: LocalDateTime): BigDecimal =
+    BigDecimal(CellValue.dateTimeToExcelSerial(dt))
 
   /**
    * Convert Excel date serial number to LocalDateTime.

--- a/xl-core/src/com/tjclp/xl/workbooks/WorkbookMetadata.scala
+++ b/xl-core/src/com/tjclp/xl/workbooks/WorkbookMetadata.scala
@@ -9,6 +9,11 @@ import com.tjclp.xl.styles.color.ThemePalette
  * @param sheetStates
  *   Sheet visibility overrides: SheetName -> state where state is None (visible), Some("hidden"),
  *   or Some("veryHidden"). Only sheets with non-default visibility are stored.
+ * @param date1904
+ *   True when the workbook uses the 1904 date system (`<workbookPr date1904="1"/>`, legacy Mac
+ *   Excel): date serials count days since 1904-01-01 instead of the default 1900 system (GH-243).
+ *   Read from workbookPr and preserved on write; DateTime cells are serialized with the matching
+ *   epoch (see `CellValue.dateTimeToExcelSerial(dt, date1904)`).
  */
 final case class WorkbookMetadata(
   creator: Option[String] = None,
@@ -19,5 +24,6 @@ final case class WorkbookMetadata(
   appVersion: Option[String] = Some("0.11.2"),
   theme: ThemePalette = ThemePalette.office,
   definedNames: Vector[DefinedName] = Vector.empty,
-  sheetStates: Map[SheetName, Option[String]] = Map.empty
+  sheetStates: Map[SheetName, Option[String]] = Map.empty,
+  date1904: Boolean = false
 )

--- a/xl-core/test/src/com/tjclp/xl/DateTimeSpec.scala
+++ b/xl-core/test/src/com/tjclp/xl/DateTimeSpec.scala
@@ -92,3 +92,84 @@ class DateTimeSpec extends FunSuite:
       )
     }
   }
+
+  // GH-243: 1904 date system (legacy Mac Excel). Epoch is 1904-01-01 = serial 0; the 1900
+  // system's phantom leap day (serial 60) does not exist in the 1904 system.
+
+  test("GH-243: 1904 system: 1904-01-01 is serial 0 and 1904-01-02 is serial 1") {
+    val jan1 = LocalDateTime.of(1904, 1, 1, 0, 0, 0)
+    val jan2 = LocalDateTime.of(1904, 1, 2, 0, 0, 0)
+    assertEquals(CellValue.dateTimeToExcelSerial(jan1, date1904 = true), 0.0, 0.001)
+    assertEquals(CellValue.dateTimeToExcelSerial(jan2, date1904 = true), 1.0, 0.001)
+  }
+
+  test("GH-243: 1904 system: 1998-07-05 is serial 34519 (Microsoft documented example)") {
+    val dt = LocalDateTime.of(1998, 7, 5, 0, 0, 0)
+    assertEquals(CellValue.dateTimeToExcelSerial(dt, date1904 = true), 34519.0, 0.001)
+    assertEquals(
+      CellValue.excelSerialToDateTime(34519.0, date1904 = true),
+      dt
+    )
+  }
+
+  test("GH-243: 1904 system has no phantom leap day (1904 is a real leap year)") {
+    // Serial 58/59/60 are consecutive real days — no Excel leap-year-bug gap.
+    assertEquals(
+      CellValue.excelSerialToDateTime(58.0, date1904 = true).toLocalDate,
+      java.time.LocalDate.of(1904, 2, 28)
+    )
+    assertEquals(
+      CellValue.excelSerialToDateTime(59.0, date1904 = true).toLocalDate,
+      java.time.LocalDate.of(1904, 2, 29)
+    )
+    assertEquals(
+      CellValue.excelSerialToDateTime(60.0, date1904 = true).toLocalDate,
+      java.time.LocalDate.of(1904, 3, 1)
+    )
+  }
+
+  test("GH-243: the two systems differ by exactly 1462 days for dates on/after 1900-03-01") {
+    val dates = List(
+      LocalDateTime.of(1904, 1, 1, 0, 0, 0),
+      LocalDateTime.of(1998, 7, 5, 0, 0, 0),
+      LocalDateTime.of(2000, 1, 1, 0, 0, 0),
+      LocalDateTime.of(2026, 6, 10, 0, 0, 0)
+    )
+    dates.foreach { dt =>
+      val serial1900 = CellValue.dateTimeToExcelSerial(dt)
+      val serial1904 = CellValue.dateTimeToExcelSerial(dt, date1904 = true)
+      assertEquals(serial1900 - serial1904, 1462.0, s"offset law failed for $dt")
+    }
+  }
+
+  test("GH-243: 1904 serial round-trips including time-of-day fractions") {
+    // Quarter-day fractions (.0/.25/.5/.75) are exact in Double, matching the precision the
+    // 1900-system round-trip tests pin (sub-second FP truncation is a shared, pre-existing quirk).
+    val dates = List(
+      LocalDateTime.of(1904, 1, 1, 0, 0, 0),
+      LocalDateTime.of(1904, 2, 29, 12, 0, 0),
+      LocalDateTime.of(1998, 7, 5, 6, 0, 0),
+      LocalDateTime.of(2026, 6, 10, 18, 0, 0)
+    )
+    dates.foreach { dt =>
+      val serial = CellValue.dateTimeToExcelSerial(dt, date1904 = true)
+      assertEquals(
+        CellValue.excelSerialToDateTime(serial, date1904 = true),
+        dt,
+        s"1904 round-trip failed for $dt (serial $serial)"
+      )
+    }
+  }
+
+  test("GH-243: single-argument conversions remain the 1900 system (API compat)") {
+    val dt = LocalDateTime.of(2000, 1, 1, 0, 0, 0)
+    assertEquals(
+      CellValue.dateTimeToExcelSerial(dt),
+      CellValue.dateTimeToExcelSerial(dt, date1904 = false),
+      0.0
+    )
+    assertEquals(
+      CellValue.excelSerialToDateTime(36526.0),
+      CellValue.excelSerialToDateTime(36526.0, date1904 = false)
+    )
+  }

--- a/xl-core/test/src/com/tjclp/xl/display/FormatCodeParserSpec.scala
+++ b/xl-core/test/src/com/tjclp/xl/display/FormatCodeParserSpec.scala
@@ -474,6 +474,76 @@ class FormatCodeParserSpec extends FunSuite:
     assertEquals(FormatCodeParser.applyTextFormat("abc", code), "val: abc")
   }
 
+  // ========== Date display gaps (GH-283) ==========
+  // 1. General on a date-typed value shows the Excel SERIAL NUMBER (dates ARE
+  //    numbers; Excel's General does not pretty-print them) — not ISO text.
+  // 2. Custom codes applied to dates route through section selection like any
+  //    number (the serial is the routed value): ';;;' hides dates, numeric
+  //    sections render the serial, conditional date codes pick sections by serial.
+  // 3. Date-token sections fed an out-of-range serial (negative or >= 10000-01-01)
+  //    render '######' like Excel's unrepresentable-date fill.
+
+  test("formatDateTime: General shows the date serial, not ISO text (GH-283)") {
+    val dt = java.time.LocalDateTime.of(2025, 11, 21, 0, 0, 0)
+    assertEquals(NumFmtFormatter.formatDateTime(dt, NumFmt.General), "45982")
+  }
+
+  test("formatDateTime: General with a time component shows the fractional serial (GH-283)") {
+    val noon = java.time.LocalDateTime.of(2025, 11, 21, 12, 0, 0)
+    assertEquals(NumFmtFormatter.formatDateTime(noon, NumFmt.General), "45982.5")
+  }
+
+  test("formatValue: DateTime cell under General renders the serial (GH-283)") {
+    import com.tjclp.xl.cells.CellValue
+    val value = CellValue.DateTime(java.time.LocalDateTime.of(2025, 11, 21, 0, 0, 0))
+    assertEquals(NumFmtFormatter.formatValue(value, NumFmt.General), "45982")
+  }
+
+  test("formatDateTime: numeric built-in formats apply to the serial (GH-283)") {
+    val dt = java.time.LocalDateTime.of(2025, 11, 21, 0, 0, 0)
+    assertEquals(NumFmtFormatter.formatDateTime(dt, NumFmt.Integer), "45982")
+    assertEquals(NumFmtFormatter.formatDateTime(dt, NumFmt.ThousandsSeparator), "45,982")
+  }
+
+  test("formatDateTime: ';;;' hides a date value (GH-283)") {
+    val dt = java.time.LocalDateTime.of(2025, 11, 21, 0, 0, 0)
+    assertEquals(NumFmtFormatter.formatDateTime(dt, NumFmt.Custom(";;;")), "")
+  }
+
+  test("formatDateTime: custom NUMERIC code renders the serial, not ISO text (GH-283)") {
+    val dt = java.time.LocalDateTime.of(2025, 11, 21, 0, 0, 0)
+    assertEquals(NumFmtFormatter.formatDateTime(dt, NumFmt.Custom("0.00")), "45982.00")
+  }
+
+  test("formatDateTime: conditional date code routes sections by serial (GH-283/285)") {
+    val fmt = NumFmt.Custom("[<45000]m/d/yy;yyyy")
+    val recent = java.time.LocalDateTime.of(2025, 11, 21, 0, 0, 0) // serial 45982
+    val old = java.time.LocalDateTime.of(2020, 1, 1, 0, 0, 0) // serial 43831
+    assertEquals(NumFmtFormatter.formatDateTime(recent, fmt), "2025")
+    assertEquals(NumFmtFormatter.formatDateTime(old, fmt), "1/1/20")
+  }
+
+  test("formatDateTime: 'm/d/yy;@' still renders via the date section (GH-283 regression)") {
+    val dt = java.time.LocalDateTime.of(2025, 11, 21, 0, 0, 0)
+    assertEquals(NumFmtFormatter.formatDateTime(dt, NumFmt.Custom("m/d/yy;@")), "11/21/25")
+  }
+
+  test("formatNumber: serial with a date code still renders the date (GH-283 regression)") {
+    assertEquals(NumFmtFormatter.formatNumber(BigDecimal(45982), NumFmt.Custom("m/d/yy")), "11/21/25")
+    assertEquals(
+      NumFmtFormatter.formatNumber(BigDecimal("0.5"), NumFmt.Custom("h:mm AM/PM")),
+      "12:00 PM"
+    )
+  }
+
+  test("formatNumber: out-of-range serial with a date code renders ###### (GH-283)") {
+    assertEquals(NumFmtFormatter.formatNumber(BigDecimal(-5), NumFmt.Custom("m/d/yy")), "######")
+    assertEquals(
+      NumFmtFormatter.formatNumber(BigDecimal(3000000), NumFmt.Custom("m/d/yy")),
+      "######"
+    )
+  }
+
   // ========== Date/Time Formatting Tests ==========
 
   test("applyDateFormat: simple date m/d/yy") {

--- a/xl-core/test/src/com/tjclp/xl/display/FormatCodeParserSpec.scala
+++ b/xl-core/test/src/com/tjclp/xl/display/FormatCodeParserSpec.scala
@@ -845,3 +845,31 @@ class FormatCodeParserSpec extends FunSuite:
     val fmt = NumFmt.Custom("# ?/?;(# ?/?)")
     assertEquals(NumFmtFormatter.formatNumber(BigDecimal("-1.5"), fmt), "(1 1/2)")
   }
+
+  // Totality: BigDecimal holds values beyond Double range (the evaluator can produce
+  // >1E308). The convergent search runs on doubles, so out-of-range magnitudes must
+  // bypass it and render the whole-number form (blank fraction area) — the same shape
+  // huge-but-finite values already produce — instead of throwing.
+
+  test("fraction totality: 1E400 (beyond Double range) renders the whole form, no throw (GH-243)") {
+    val expected = "1" + "0" * 400 + "    "
+    assertEquals(NumFmtFormatter.formatNumber(BigDecimal("1E400"), NumFmt.Fraction), expected)
+    // Consistency pin: huge-but-finite values take the convergent path to the same shape.
+    assertEquals(
+      NumFmtFormatter.formatNumber(BigDecimal("1E20"), NumFmt.Fraction),
+      "100000000000000000000    "
+    )
+  }
+
+  test("fraction totality: custom # ?/? with 1E400 renders the whole form, no throw (GH-243)") {
+    val expected = "1" + "0" * 400 + "    "
+    assertEquals(NumFmtFormatter.formatNumber(BigDecimal("1E400"), NumFmt.Custom("# ?/?")), expected)
+  }
+
+  test("fraction totality: # ??/?? with -1E400 keeps the default minus, no throw (GH-243)") {
+    val expected = "-1" + "0" * 400 + "      "
+    assertEquals(
+      NumFmtFormatter.formatNumber(BigDecimal("-1E400"), NumFmt.Custom("# ??/??")),
+      expected
+    )
+  }

--- a/xl-core/test/src/com/tjclp/xl/display/FormatCodeParserSpec.scala
+++ b/xl-core/test/src/com/tjclp/xl/display/FormatCodeParserSpec.scala
@@ -393,6 +393,87 @@ class FormatCodeParserSpec extends FunSuite:
     assertEquals(NumFmtFormatter.formatNumber(BigDecimal("2.5"), fmt), "2.5")
   }
 
+  // ========== Conditional sections (GH-285) ==========
+  // Excel semantics per SheetJS/SSF choose_fmt (validated against Excel corpora):
+  //   - compare conditions are honored on the first two sections only
+  //   - the first matching condition wins; an unmatched value falls back to the
+  //     third section when BOTH leading sections carry conditions, otherwise to the
+  //     second (sections pad positionally: 1 section -> [s1,s1,s1], 2 -> [s1,s2,s1])
+  //   - when conditions are present, sign/zero positional routing is suspended
+  //   - multi-section formats render |value|; the minus sign must be written
+  //     explicitly in the pattern; single-section formats keep the default minus
+  //   - there is no ###### fallback: Excel's no-match-no-fallback behavior is
+  //     undocumented (MS docs and major guides define no such case) and SSF's
+  //     Excel-validated routing always resolves to a section
+
+  test("conditional routing: [>100]#,##0;[<=0]0.00;0.0 — first match wins, else fallback (GH-285)") {
+    val code = FormatCodeParser.parse("[>100]#,##0;[<=0]0.00;0.0").toOption.get
+    assertEquals(FormatCodeParser.applyFormat(BigDecimal(250), code)._1, "250")
+    assertEquals(FormatCodeParser.applyFormat(BigDecimal(-5), code)._1, "5.00")
+    assertEquals(FormatCodeParser.applyFormat(BigDecimal(0), code)._1, "0.00")
+    assertEquals(FormatCodeParser.applyFormat(BigDecimal(50), code)._1, "50.0")
+  }
+
+  test("conditional routing: [>100]0;0.0 — unconditioned second section is the else branch (GH-285)") {
+    val code = FormatCodeParser.parse("[>100]0;0.0").toOption.get
+    assertEquals(FormatCodeParser.applyFormat(BigDecimal(250), code)._1, "250")
+    assertEquals(FormatCodeParser.applyFormat(BigDecimal(50), code)._1, "50.0")
+    assertEquals(FormatCodeParser.applyFormat(BigDecimal(0), code)._1, "0.0")
+    // Multi-section: |value| is rendered; the sign must be explicit in the pattern
+    assertEquals(FormatCodeParser.applyFormat(BigDecimal(-50), code)._1, "50.0")
+  }
+
+  test("conditional routing: stacked color and condition [Red][<=100]0;[Blue][>100]0 (GH-285)") {
+    val code = FormatCodeParser.parse("[Red][<=100]0;[Blue][>100]0").toOption.get
+    assertEquals(FormatCodeParser.applyFormat(BigDecimal(50), code), ("50", Some("Red")))
+    assertEquals(FormatCodeParser.applyFormat(BigDecimal(500), code), ("500", Some("Blue")))
+    assertEquals(FormatCodeParser.applyFormat(BigDecimal(-3), code), ("3", Some("Red")))
+  }
+
+  test("conditional routing: both conditions unmatched, no third section → first pattern (GH-285)") {
+    // SSF pads 2 sections to [s1, s2, s1], so the no-match fallback is the FIRST
+    // section's pattern (its condition ignored). No ###### — see block comment.
+    val code = FormatCodeParser.parse("[>100]0;[<0]0.00").toOption.get
+    assertEquals(FormatCodeParser.applyFormat(BigDecimal(50), code)._1, "50")
+    assertEquals(FormatCodeParser.applyFormat(BigDecimal(250), code)._1, "250")
+    assertEquals(FormatCodeParser.applyFormat(BigDecimal(-5), code)._1, "5.00")
+  }
+
+  test("conditional routing: single conditional section formats all values, sign kept (GH-285)") {
+    val code = FormatCodeParser.parse("[>100]0").toOption.get
+    assertEquals(FormatCodeParser.applyFormat(BigDecimal(250), code)._1, "250")
+    assertEquals(FormatCodeParser.applyFormat(BigDecimal(50), code)._1, "50")
+    assertEquals(FormatCodeParser.applyFormat(BigDecimal(-50), code)._1, "-50")
+  }
+
+  test("conditional ops: =, <>, >= comparisons (GH-285)") {
+    val eq = FormatCodeParser.parse("[=5]\"five\";0").toOption.get
+    assertEquals(FormatCodeParser.applyFormat(BigDecimal(5), eq)._1, "five")
+    assertEquals(FormatCodeParser.applyFormat(BigDecimal(4), eq)._1, "4")
+
+    val ne = FormatCodeParser.parse("[<>0]0.0;\"zero\"").toOption.get
+    assertEquals(FormatCodeParser.applyFormat(BigDecimal(5), ne)._1, "5.0")
+    assertEquals(FormatCodeParser.applyFormat(BigDecimal(0), ne)._1, "zero")
+
+    val ge = FormatCodeParser.parse("[>=10]\"big\";\"small\"").toOption.get
+    assertEquals(FormatCodeParser.applyFormat(BigDecimal(10), ge)._1, "big")
+    assertEquals(FormatCodeParser.applyFormat(BigDecimal(9), ge)._1, "small")
+  }
+
+  test("trailing @ among <4 sections is the text section, not the negative (GH-285)") {
+    // SSF choose_fmt: "0.0;@" has ONE numeric section — negatives keep the default
+    // minus instead of routing into the text section (which previously hid them).
+    val code = FormatCodeParser.parse("0.0;@").toOption.get
+    assertEquals(FormatCodeParser.applyFormat(BigDecimal(-5), code)._1, "-5.0")
+    assertEquals(FormatCodeParser.applyFormat(BigDecimal(0), code)._1, "0.0")
+    assertEquals(FormatCodeParser.applyTextFormat("abc", code), "abc")
+  }
+
+  test("trailing @ section with literals formats text values (GH-285)") {
+    val code = FormatCodeParser.parse("0;0;\"val: \"@").toOption.get
+    assertEquals(FormatCodeParser.applyTextFormat("abc", code), "val: abc")
+  }
+
   // ========== Date/Time Formatting Tests ==========
 
   test("applyDateFormat: simple date m/d/yy") {

--- a/xl-core/test/src/com/tjclp/xl/display/FormatCodeParserSpec.scala
+++ b/xl-core/test/src/com/tjclp/xl/display/FormatCodeParserSpec.scala
@@ -524,3 +524,173 @@ class FormatCodeParserSpec extends FunSuite:
     val result = FormatCodeParser.applyDateFormat(dt, code)
     assertEquals(result, "January 15, 2025")
   }
+
+  // ========== Fractions (GH-243) ==========
+  // Excel picks the last continued-fraction convergent whose denominator fits the
+  // placeholder budget (1 digit for ?/?, 2 for ??/??), computed in IEEE-754 double
+  // arithmetic over the FULL value. The algorithm is a verbatim port of SheetJS/SSF
+  // `frac` (reverse-engineered from Excel); the "Excel corpus" tests below pin
+  // expected strings taken directly from SSF's Excel-generated test/fraction.json.
+  // Double noise is part of the spec: 12.3 → "12 1/3" but bare 0.3 → " 2/7".
+  // Alignment: `?` placeholders pad with spaces (numerator right-aligns, denominator
+  // left-aligns); a whole number blanks the fraction area to preserve width.
+
+  test("fraction parse: # ?/? produces a Fraction token (GH-243)") {
+    val code = FormatCodeParser.parse("# ?/?").toOption.get
+    val fracTokens = code.positive.pattern.tokens.collect { case f: FormatToken.Fraction => f }
+    assertEquals(fracTokens, Vector(FormatToken.Fraction("?", "?", None)))
+  }
+
+  test("fraction parse: fixed denominator # ?/8 captures the literal denominator (GH-243)") {
+    val code = FormatCodeParser.parse("# ?/8").toOption.get
+    val fracTokens = code.positive.pattern.tokens.collect { case f: FormatToken.Fraction => f }
+    assertEquals(fracTokens, Vector(FormatToken.Fraction("?", "8", Some(8L))))
+  }
+
+  test("fraction parse: date separators are untouched — m/d/yy has no Fraction token (GH-243)") {
+    val code = FormatCodeParser.parse("m/d/yy").toOption.get
+    val fracTokens = code.positive.pattern.tokens.collect { case f: FormatToken.Fraction => f }
+    assertEquals(fracTokens, Vector.empty)
+  }
+
+  test("NumFmt.Fraction: simple halves 0.5 → ' 1/2' (GH-243)") {
+    assertEquals(NumFmtFormatter.formatNumber(BigDecimal("0.5"), NumFmt.Fraction), " 1/2")
+  }
+
+  test("NumFmt.Fraction: mixed number 1.5 → '1 1/2' (GH-243)") {
+    assertEquals(NumFmtFormatter.formatNumber(BigDecimal("1.5"), NumFmt.Fraction), "1 1/2")
+  }
+
+  test("NumFmt.Fraction: 5.25 → '5 1/4' (MS docs example, GH-243)") {
+    assertEquals(NumFmtFormatter.formatNumber(BigDecimal("5.25"), NumFmt.Fraction), "5 1/4")
+  }
+
+  test("NumFmt.Fraction: 3.14159 → '3 1/7' (GH-243)") {
+    assertEquals(NumFmtFormatter.formatNumber(BigDecimal("3.14159"), NumFmt.Fraction), "3 1/7")
+  }
+
+  test("NumFmt.Fraction: 0.3 → ' 2/7' — double of 0.3 sits below 3/10 so the CF path differs from 12.3 (GH-243)") {
+    assertEquals(NumFmtFormatter.formatNumber(BigDecimal("0.3"), NumFmt.Fraction), " 2/7")
+  }
+
+  test("Excel corpus: # ?/? values from SSF fraction.json (GH-243)") {
+    val cases = Vector(
+      BigDecimal("1") -> "1    ",
+      BigDecimal("-1.2") -> "-1 1/5",
+      BigDecimal("12.3") -> "12 1/3",
+      BigDecimal("-12.34") -> "-12 1/3",
+      BigDecimal("123.45") -> "123 4/9",
+      BigDecimal("-123.456") -> "-123 1/2",
+      BigDecimal("1234.567") -> "1234 4/7",
+      BigDecimal("-1234.5678") -> "-1234 4/7",
+      BigDecimal("12345.6789") -> "12345 2/3",
+      BigDecimal("-12345.67891") -> "-12345 2/3"
+    )
+    cases.foreach { case (value, expected) =>
+      assertEquals(
+        NumFmtFormatter.formatNumber(value, NumFmt.Custom("# ?/?")),
+        expected,
+        s"value $value"
+      )
+    }
+  }
+
+  test("Excel corpus: # ??/?? values from SSF fraction.json (GH-243)") {
+    val cases = Vector(
+      BigDecimal("1") -> "1      ",
+      BigDecimal("-1.2") -> "-1  1/5 ",
+      BigDecimal("12.3") -> "12  3/10",
+      BigDecimal("-12.34") -> "-12 17/50",
+      BigDecimal("123.45") -> "123  9/20",
+      BigDecimal("-123.456") -> "-123 26/57",
+      BigDecimal("1234.567") -> "1234 55/97",
+      BigDecimal("-1234.5678") -> "-1234 46/81",
+      BigDecimal("12345.6789") -> "12345 55/81",
+      BigDecimal("-12345.67891") -> "-12345 55/81"
+    )
+    cases.foreach { case (value, expected) =>
+      assertEquals(
+        NumFmtFormatter.formatNumber(value, NumFmt.Custom("# ??/??")),
+        expected,
+        s"value $value"
+      )
+    }
+  }
+
+  test("Excel corpus: fixed denominators # ?/2 and # ?/4 from SSF fraction.json (GH-243)") {
+    val halfCases = Vector(
+      BigDecimal("1") -> "1    ",
+      BigDecimal("-1.2") -> "-1    ",
+      BigDecimal("12.3") -> "12 1/2",
+      BigDecimal("-12.34") -> "-12 1/2"
+    )
+    halfCases.foreach { case (value, expected) =>
+      assertEquals(
+        NumFmtFormatter.formatNumber(value, NumFmt.Custom("# ?/2")),
+        expected,
+        s"value $value"
+      )
+    }
+    val quarterCases = Vector(
+      BigDecimal("-1.2") -> "-1 1/4",
+      BigDecimal("123.45") -> "123 2/4"
+    )
+    quarterCases.foreach { case (value, expected) =>
+      assertEquals(
+        NumFmtFormatter.formatNumber(value, NumFmt.Custom("# ?/4")),
+        expected,
+        s"value $value"
+      )
+    }
+  }
+
+  test("NumFmt.Fraction: whole number blanks the fraction area: 2 → '2    ' (GH-243)") {
+    assertEquals(NumFmtFormatter.formatNumber(BigDecimal("2"), NumFmt.Fraction), "2    ")
+  }
+
+  test("NumFmt.Fraction: zero → '0    ' (GH-243)") {
+    assertEquals(NumFmtFormatter.formatNumber(BigDecimal("0"), NumFmt.Fraction), "0    ")
+  }
+
+  test("NumFmt.Fraction: negative mixed -1.5 → '-1 1/2' (GH-243)") {
+    assertEquals(NumFmtFormatter.formatNumber(BigDecimal("-1.5"), NumFmt.Fraction), "-1 1/2")
+  }
+
+  test("NumFmt.Fraction: negative pure fraction -0.5 → '- 1/2' (GH-243)") {
+    assertEquals(NumFmtFormatter.formatNumber(BigDecimal("-0.5"), NumFmt.Fraction), "- 1/2")
+  }
+
+  test("custom fraction: # ??/?? gives 5.3 → '5  3/10' (MS docs example, GH-243)") {
+    val fmt = NumFmt.Custom("# ??/??")
+    assertEquals(NumFmtFormatter.formatNumber(BigDecimal("5.3"), fmt), "5  3/10")
+  }
+
+  test("custom fraction: # ??/?? pads numerator left, denominator right: 0.5 → '  1/2 ' (GH-243)") {
+    val fmt = NumFmt.Custom("# ??/??")
+    assertEquals(NumFmtFormatter.formatNumber(BigDecimal("0.5"), fmt), "  1/2 ")
+  }
+
+  test("custom fraction: fixed denominator # ?/8 does not reduce: 0.5 → ' 4/8' (GH-243)") {
+    val fmt = NumFmt.Custom("# ?/8")
+    assertEquals(NumFmtFormatter.formatNumber(BigDecimal("0.5"), fmt), " 4/8")
+  }
+
+  test("custom fraction: fixed denominator rounds into the whole part: 0.96 → '1    ' (GH-243)") {
+    val fmt = NumFmt.Custom("# ?/8")
+    assertEquals(NumFmtFormatter.formatNumber(BigDecimal("0.96"), fmt), "1    ")
+  }
+
+  test("custom fraction: fixed denominator # ?/8: 0.3 → ' 2/8' (GH-243)") {
+    val fmt = NumFmt.Custom("# ?/8")
+    assertEquals(NumFmtFormatter.formatNumber(BigDecimal("0.3"), fmt), " 2/8")
+  }
+
+  test("custom fraction: improper ?/? without whole part: 1.5 → '3/2' (GH-243)") {
+    val fmt = NumFmt.Custom("?/?")
+    assertEquals(NumFmtFormatter.formatNumber(BigDecimal("1.5"), fmt), "3/2")
+  }
+
+  test("custom fraction: negative section applies: # ?/?;(# ?/?) → -1.5 → '(1 1/2)' (GH-243)") {
+    val fmt = NumFmt.Custom("# ?/?;(# ?/?)")
+    assertEquals(NumFmtFormatter.formatNumber(BigDecimal("-1.5"), fmt), "(1 1/2)")
+  }

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/ContentTypes.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/ContentTypes.scala
@@ -30,6 +30,25 @@ case class ContentTypes(
       val overridesToAdd = ContentTypes.tableOverrides(tableCount)
       copy(overrides = overrides ++ overridesToAdd)
 
+  /**
+   * Reconcile docProps overrides with what the writer actually emits (GH-242).
+   *
+   * Idempotent: adds the override when the part is emitted, removes any stale override when it is
+   * not (e.g. a preserved [Content_Types].xml whose source had docProps that the model no longer
+   * carries).
+   */
+  def withDocPropsOverrides(hasCore: Boolean, hasApp: Boolean): ContentTypes =
+    def adjust(ov: Map[String, String], present: Boolean, part: String, ct: String) =
+      if present then ov + (part -> ct) else ov - part
+    copy(overrides =
+      adjust(
+        adjust(overrides, hasCore, "/docProps/core.xml", ctCoreProperties),
+        hasApp,
+        "/docProps/app.xml",
+        ctExtendedProperties
+      )
+    )
+
   def toXml: Elem =
     val defaultElems = defaults.toSeq.sortBy(_._1).map { (ext, ct) =>
       elem("Default", "Extension" -> ext, "ContentType" -> ct)()

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/DocProps.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/DocProps.scala
@@ -1,0 +1,158 @@
+package com.tjclp.xl.ooxml
+
+import java.time.{LocalDate, LocalDateTime, OffsetDateTime, ZoneOffset}
+import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
+
+import scala.util.Try
+import scala.xml.*
+
+import com.tjclp.xl.workbooks.WorkbookMetadata
+
+/**
+ * Document properties parts (GH-242): docProps/core.xml (OPC core properties) and docProps/app.xml
+ * (extended properties).
+ *
+ * Emission is deterministic and model-driven: ONLY fields present on [[WorkbookMetadata]] are
+ * emitted — no GUIDs, no wall-clock timestamps. `created`/`modified` serialize in W3CDTF (UTC,
+ * second precision) iff set. A part with no present fields is omitted entirely.
+ *
+ * Parsing is lenient (foreign files carry many unmodeled fields — title, keywords, revision, ... —
+ * which are ignored): element absent → None, element present → Some(text). W3CDTF values with an
+ * explicit offset are normalized to UTC; date-only values parse to midnight.
+ */
+object DocProps:
+
+  /** Zip entry paths for the two modeled docProps parts. */
+  val corePath = "docProps/core.xml"
+  val appPath = "docProps/app.xml"
+
+  // Namespaces for core.xml (OPC core properties, ECMA-376 Part 2 §11)
+  private val nsCoreProps =
+    "http://schemas.openxmlformats.org/package/2006/metadata/core-properties"
+  private val nsDc = "http://purl.org/dc/elements/1.1/"
+  private val nsDcTerms = "http://purl.org/dc/terms/"
+  private val nsDcmiType = "http://purl.org/dc/dcmitype/"
+  private val nsXsi = "http://www.w3.org/2001/XMLSchema-instance"
+
+  // Namespaces for app.xml (extended properties, ECMA-376 Part 1 §22.2)
+  private val nsExtendedProps =
+    "http://schemas.openxmlformats.org/officeDocument/2006/extended-properties"
+  private val nsVt =
+    "http://schemas.openxmlformats.org/officeDocument/2006/docPropsVTypes"
+
+  /** Modeled docProps fields parsed from a package (all None when parts are absent). */
+  final case class Data(
+    creator: Option[String] = None,
+    created: Option[LocalDateTime] = None,
+    modified: Option[LocalDateTime] = None,
+    lastModifiedBy: Option[String] = None,
+    application: Option[String] = None,
+    appVersion: Option[String] = None
+  ) derives CanEqual
+
+  object Data:
+    val empty: Data = Data()
+
+  private val w3cDtfFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'")
+
+  /** W3CDTF rendering of a model datetime: treated as UTC, truncated to seconds. */
+  def formatW3cDtf(dt: LocalDateTime): String =
+    dt.truncatedTo(ChronoUnit.SECONDS).format(w3cDtfFormatter)
+
+  /**
+   * Lenient W3CDTF parse: offset forms are normalized to UTC, zone-less forms are taken as UTC,
+   * date-only forms parse to midnight. Unparseable text → None (never an error: docProps in the
+   * wild are too messy to fail a read over).
+   */
+  def parseW3cDtf(s: String): Option[LocalDateTime] =
+    val trimmed = s.trim
+    if trimmed.isEmpty then None
+    else
+      Try(
+        OffsetDateTime.parse(trimmed).withOffsetSameInstant(ZoneOffset.UTC).toLocalDateTime
+      ).toOption
+        .orElse(Try(LocalDateTime.parse(trimmed)).toOption)
+        .orElse(Try(LocalDate.parse(trimmed).atStartOfDay).toOption)
+
+  /** Scope chain for `<cp:coreProperties>` (constructed once; deterministic rendering). */
+  private val coreScope: NamespaceBinding =
+    NamespaceBinding(
+      "cp",
+      nsCoreProps,
+      NamespaceBinding(
+        "dc",
+        nsDc,
+        NamespaceBinding(
+          "dcterms",
+          nsDcTerms,
+          NamespaceBinding("dcmitype", nsDcmiType, NamespaceBinding("xsi", nsXsi, TopScope))
+        )
+      )
+    )
+
+  private def prefixed(prefix: String, label: String, text: String): Elem =
+    Elem(prefix, label, Null, TopScope, minimizeEmpty = true, Text(text))
+
+  private def w3cDtfElem(label: String, dt: LocalDateTime): Elem =
+    Elem(
+      "dcterms",
+      label,
+      new PrefixedAttribute("xsi", "type", "dcterms:W3CDTF", Null),
+      TopScope,
+      minimizeEmpty = true,
+      Text(formatW3cDtf(dt))
+    )
+
+  /**
+   * Build docProps/core.xml from the model. Returns None when no core field is set (the part is
+   * omitted, along with its content-type override and package relationship).
+   */
+  def buildCoreXml(meta: WorkbookMetadata): Option[Elem] =
+    val children = Vector(
+      meta.creator.map(prefixed("dc", "creator", _)),
+      meta.lastModifiedBy.map(prefixed("cp", "lastModifiedBy", _)),
+      meta.created.map(w3cDtfElem("created", _)),
+      meta.modified.map(w3cDtfElem("modified", _))
+    ).flatten
+    Option.when(children.nonEmpty)(
+      Elem("cp", "coreProperties", Null, coreScope, minimizeEmpty = true, children*)
+    )
+
+  /**
+   * Build docProps/app.xml from the model. Returns None when neither application nor appVersion is
+   * set.
+   */
+  def buildAppXml(meta: WorkbookMetadata): Option[Elem] =
+    val children = Vector(
+      meta.application.map(a => Elem(null, "Application", Null, TopScope, true, Text(a))),
+      meta.appVersion.map(v => Elem(null, "AppVersion", Null, TopScope, true, Text(v)))
+    ).flatten
+    val scope = NamespaceBinding(null, nsExtendedProps, NamespaceBinding("vt", nsVt, TopScope))
+    Option.when(children.nonEmpty)(
+      Elem(null, "Properties", Null, scope, minimizeEmpty = true, children*)
+    )
+
+  /** Element text by local name; present-but-empty elements yield Some(""). */
+  private def textOf(elem: Elem, label: String): Option[String] =
+    (elem \ label).headOption.map(_.text)
+
+  /** Parse the modeled fields of docProps/core.xml (unmodeled fields are ignored). */
+  def parseCoreXml(elem: Elem): Data =
+    Data(
+      creator = textOf(elem, "creator"),
+      created = textOf(elem, "created").flatMap(parseW3cDtf),
+      modified = textOf(elem, "modified").flatMap(parseW3cDtf),
+      lastModifiedBy = textOf(elem, "lastModifiedBy")
+    )
+
+  /** Parse the modeled fields of docProps/app.xml (unmodeled fields are ignored). */
+  def parseAppXml(elem: Elem): Data =
+    Data(
+      application = textOf(elem, "Application"),
+      appVersion = textOf(elem, "AppVersion")
+    )
+
+  /** Merge core- and app-derived fields (disjoint by construction). */
+  def merge(core: Data, app: Data): Data =
+    core.copy(application = app.application, appVersion = app.appVersion)

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/Relationships.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/Relationships.scala
@@ -67,6 +67,32 @@ final case class Relationships(
   def findAllByType(`type`: String): Seq[Relationship] =
     relationships.filter(_.`type` == `type`)
 
+  /**
+   * Reconcile package-level docProps relationships with what the writer emits (GH-242).
+   *
+   * Existing relationships of the right type are kept verbatim (stable rIds for preserved
+   * `_rels/.rels`); missing ones are appended with the next free numeric rId; stale ones (part no
+   * longer emitted) are removed. Deterministic for a given input.
+   */
+  def withDocProps(hasCore: Boolean, hasApp: Boolean): Relationships =
+    def nextId(rels: Seq[Relationship]): String =
+      val maxNum = rels.flatMap(r => r.id.stripPrefix("rId").toIntOption).maxOption.getOrElse(0)
+      s"rId${maxNum + 1}"
+    def ensure(
+      rels: Seq[Relationship],
+      present: Boolean,
+      relType: String,
+      target: String
+    ): Seq[Relationship] =
+      if present then
+        if rels.exists(_.`type` == relType) then rels
+        else rels :+ Relationship(nextId(rels), relType, target)
+      else rels.filterNot(_.`type` == relType)
+
+    val withCore = ensure(relationships, hasCore, relTypeCoreProperties, "docProps/core.xml")
+    val withApp = ensure(withCore, hasApp, relTypeExtendedProperties, "docProps/app.xml")
+    Relationships(withApp)
+
 object Relationships extends XmlReadable[Relationships]:
   val empty: Relationships = Relationships(Seq.empty)
 

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/Workbook.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/Workbook.scala
@@ -77,6 +77,12 @@ case class OoxmlWorkbook(
       SaxSerializable:
 
   /**
+   * True when this workbook uses the 1904 date system (`<workbookPr date1904="1"/>`, GH-243). Date
+   * serials then count days since 1904-01-01 instead of the default 1900 system.
+   */
+  def date1904: Boolean = OoxmlWorkbook.parseDate1904(workbookPr)
+
+  /**
    * Update sheets while preserving all workbook metadata.
    *
    * Maps domain sheets to SheetRefs, preserving original sheetIds from the source file. For new
@@ -208,10 +214,18 @@ object OoxmlWorkbook extends XmlReadable[OoxmlWorkbook]:
       val state = wb.metadata.sheetStates.get(sheet.name).flatten
       SheetRef(sheet.name, idx + 1, s"rId${idx + 1}", state)
     }
+    // GH-243: preserve-the-system — declare the 1904 date system when the model says so, so the
+    // raw serials riding through (and DateTime cells serialized with the 1904 epoch) stay correct.
+    val workbookPr =
+      if wb.metadata.date1904 then Some(elem("workbookPr", "date1904" -> "1")()) else None
     // GH-236: serialize named ranges from the typed model (previously dropped on write).
     // GH-259: print area / repeat rows live on Sheet.pageSetup and are appended here as
     // sheet-scoped _xlnm.Print_Area / _xlnm.Print_Titles names.
-    OoxmlWorkbook(sheetRefs, definedNames = buildDefinedNames(PrintNames.effective(wb)))
+    OoxmlWorkbook(
+      sheetRefs,
+      workbookPr = workbookPr,
+      definedNames = buildDefinedNames(PrintNames.effective(wb))
+    )
 
   /**
    * Build a `<definedNames>` element from the typed model (GH-236), or None when empty. Order
@@ -230,6 +244,17 @@ object OoxmlWorkbook extends XmlReadable[OoxmlWorkbook]:
         elemOrdered("definedName", attrs.result()*)(Text(dn.formula))
       }
       Some(elem("definedNames")(children*))
+
+  /**
+   * Parse the `date1904` attribute of a raw `<workbookPr>` element (GH-243). Single source of truth
+   * shared by the full reader and the lightweight metadata reader. OOXML uses xsd:boolean, so both
+   * "1" and "true" mean the 1904 date system; absent attribute/element means 1900.
+   */
+  def parseDate1904(workbookPr: Option[Elem]): Boolean =
+    workbookPr.exists { e =>
+      val value = e \@ "date1904"
+      value == "1" || value == "true"
+    }
 
   /**
    * Parse `<definedNames>` into the typed model. Single source of truth shared by the reader and

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/XlsxReader.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/XlsxReader.scala
@@ -112,7 +112,11 @@ object XlsxReader:
     "xl/_rels/workbook.xml.rels",
     "xl/styles.xml",
     "xl/sharedStrings.xml",
-    "xl/theme/theme1.xml"
+    "xl/theme/theme1.xml",
+    // GH-242: docProps are parsed into WorkbookMetadata and re-emitted from the model on write
+    // (NOT preserved verbatim — the model wins). docProps/custom.xml stays unparsed/preserved.
+    DocProps.corePath,
+    DocProps.appPath
   )
 
   /**
@@ -355,6 +359,9 @@ object XlsxReader:
         .map(ref => ref.name -> ref.state)
         .toMap
 
+      // GH-242: parse document properties (lenient — absent/malformed parts yield empty fields)
+      docProps = parseDocProps(parts)
+
       // Assemble workbook with optional SourceContext
       workbook <- assembleWorkbook(
         sheets,
@@ -365,9 +372,28 @@ object XlsxReader:
         definedNames,
         sheetStates,
         commentPathMapping,
-        date1904 = ooxmlWb.date1904
+        date1904 = ooxmlWb.date1904,
+        docProps
       )
     yield ReadResult(workbook, styleWarnings)
+
+  /**
+   * Parse docProps/core.xml + app.xml into the modeled metadata fields (GH-242).
+   *
+   * Lenient by design: docProps in the wild are messy and must never fail a read. Absent or
+   * malformed parts contribute no fields; unmodeled fields (title, keywords, ...) are ignored.
+   */
+  private def parseDocProps(parts: Map[String, String]): DocProps.Data =
+    def parsePart(path: String, parse: Elem => DocProps.Data): DocProps.Data =
+      parts
+        .get(path)
+        .flatMap(xml => XmlSecurity.parseSafe(xml, path).toOption)
+        .map(parse)
+        .getOrElse(DocProps.Data.empty)
+    DocProps.merge(
+      parsePart(DocProps.corePath, DocProps.parseCoreXml),
+      parsePart(DocProps.appPath, DocProps.parseAppXml)
+    )
 
   /** Parse optional shared strings table */
   private def parseOptionalSST(parts: Map[String, String]): XLResult[Option[SharedStrings]] =
@@ -983,6 +1009,8 @@ object XlsxReader:
    *   Mapping from 0-based sheet index to comment file path (e.g., "xl/comments1.xml")
    * @param date1904
    *   True when workbookPr declares the 1904 date system (GH-243)
+   * @param docProps
+   *   Document properties parsed from docProps/core.xml + app.xml (GH-242)
    * @return
    *   Workbook with optional SourceContext
    */
@@ -995,7 +1023,8 @@ object XlsxReader:
     definedNames: Vector[DefinedName],
     sheetStates: Map[SheetName, Option[String]],
     commentPathMapping: Map[Int, String],
-    date1904: Boolean
+    date1904: Boolean,
+    docProps: DocProps.Data
   ): XLResult[Workbook] =
     if sheets.isEmpty then Left(XLError.InvalidWorkbook("Workbook must have at least one sheet"))
     else
@@ -1013,8 +1042,16 @@ object XlsxReader:
       // into Sheet.pageSetup; unmodelable forms stay in metadata.definedNames verbatim.
       val (sheetsWithPrint, remainingNames) = PrintNames.extract(sheets, definedNames)
 
+      // GH-242: docProps fields reflect the FILE exactly (None when absent) — never the
+      // WorkbookMetadata defaults, so write(read(f)) round-trips document properties.
       val metadata =
         WorkbookMetadata(
+          creator = docProps.creator,
+          created = docProps.created,
+          modified = docProps.modified,
+          lastModifiedBy = docProps.lastModifiedBy,
+          application = docProps.application,
+          appVersion = docProps.appVersion,
           theme = theme,
           definedNames = remainingNames,
           sheetStates = sheetStates,

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/XlsxReader.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/XlsxReader.scala
@@ -364,7 +364,8 @@ object XlsxReader:
         theme,
         definedNames,
         sheetStates,
-        commentPathMapping
+        commentPathMapping,
+        date1904 = ooxmlWb.date1904
       )
     yield ReadResult(workbook, styleWarnings)
 
@@ -980,6 +981,8 @@ object XlsxReader:
    *   Sheet visibility states from workbook.xml
    * @param commentPathMapping
    *   Mapping from 0-based sheet index to comment file path (e.g., "xl/comments1.xml")
+   * @param date1904
+   *   True when workbookPr declares the 1904 date system (GH-243)
    * @return
    *   Workbook with optional SourceContext
    */
@@ -991,7 +994,8 @@ object XlsxReader:
     theme: ThemePalette,
     definedNames: Vector[DefinedName],
     sheetStates: Map[SheetName, Option[String]],
-    commentPathMapping: Map[Int, String]
+    commentPathMapping: Map[Int, String],
+    date1904: Boolean
   ): XLResult[Workbook] =
     if sheets.isEmpty then Left(XLError.InvalidWorkbook("Workbook must have at least one sheet"))
     else
@@ -1010,7 +1014,12 @@ object XlsxReader:
       val (sheetsWithPrint, remainingNames) = PrintNames.extract(sheets, definedNames)
 
       val metadata =
-        WorkbookMetadata(theme = theme, definedNames = remainingNames, sheetStates = sheetStates)
+        WorkbookMetadata(
+          theme = theme,
+          definedNames = remainingNames,
+          sheetStates = sheetStates,
+          date1904 = date1904
+        )
       sourceContextEither.map(ctx =>
         Workbook(sheets = sheetsWithPrint, metadata = metadata, sourceContext = ctx)
       )

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/XlsxWriter.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/XlsxWriter.scala
@@ -95,8 +95,10 @@ object XlsxWriter:
   ): XLResult[Unit] =
     try
       val escapeFormulas = formulaEscapingRequested(config)
+      // GH-243: serialize DateTime cells with the workbook's date system before any write path.
+      val normalized = withDates1904Normalized(workbook)
 
-      workbook.sourceContext match
+      normalized.sourceContext match
         case Some(ctx) if ctx.isClean && !escapeFormulas =>
           // Clean workbook + file target → verbatim copy (ultra-fast)
           target match
@@ -104,23 +106,53 @@ object XlsxWriter:
               copyVerbatim(ctx, path)
             case OutputStreamTarget(_) =>
               // Can't copy to stream, use unified write (will copy all parts)
-              unifiedWrite(workbook, workbook.sourceContext, target, config)
+              unifiedWrite(normalized, normalized.sourceContext, target, config)
 
         case Some(ctx) =>
           // Surgical mode with source: use atomic temp file to prevent corruption
           target match
             case OutputPath(destPath) =>
-              writeAtomically(workbook, Some(ctx), destPath, config)
+              writeAtomically(normalized, Some(ctx), destPath, config)
             case _ =>
-              unifiedWrite(workbook, workbook.sourceContext, target, config)
+              unifiedWrite(normalized, normalized.sourceContext, target, config)
 
         case None =>
           // No source context: safe to write directly (no surgical preservation)
-          unifiedWrite(workbook, None, target, config)
+          unifiedWrite(normalized, None, target, config)
 
       Right(())
 
     catch case e: Exception => Left(XLError.IOError(s"Failed to write XLSX: ${e.getMessage}"))
+
+  /**
+   * Re-express DateTime cells as raw serial Numbers using the workbook's date system (GH-243).
+   *
+   * The cell emitters (OoxmlCell/OoxmlWorksheet/DirectSaxEmitter) convert any remaining DateTime
+   * values with the default 1900 epoch, so for 1904-system workbooks the conversion must happen
+   * here, once, before dispatching to any write path. No-op for 1900-system workbooks (the
+   * emitters' inline conversion is identical) and for workbooks without DateTime cells — in
+   * particular, freshly read workbooks store date serials as Numbers, so surgical-write
+   * modification tracking is unaffected.
+   */
+  private def withDates1904Normalized(workbook: Workbook): Workbook =
+    if !workbook.metadata.date1904 then workbook
+    else
+      val normalizedSheets = workbook.sheets.map { sheet =>
+        val hasDateTime = sheet.cells.values.exists(_.value match
+          case CellValue.DateTime(_) => true
+          case _ => false)
+        if !hasDateTime then sheet
+        else
+          val cells = sheet.cells.map { case (ref, cell) =>
+            cell.value match
+              case CellValue.DateTime(dt) =>
+                val serial = CellValue.dateTimeToExcelSerial(dt, date1904 = true)
+                ref -> cell.copy(value = CellValue.Number(BigDecimal(serial)))
+              case _ => ref -> cell
+          }
+          sheet.copy(cells = cells)
+      }
+      workbook.copy(sheets = normalizedSheets)
 
   /**
    * Write to file atomically via temp file + rename.

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/XlsxWriter.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/XlsxWriter.scala
@@ -1410,6 +1410,12 @@ object XlsxWriter:
         // PageSetup-derived print names (GH-259).
         OoxmlWorkbook.fromDomain(workbook)
 
+    // GH-242: document properties are model-driven. The reader parses docProps/core.xml and
+    // app.xml into WorkbookMetadata (and marks them parsed, so they are never copied verbatim);
+    // here the model decides what ships — emitted iff at least one field is present.
+    val corePropsXml = DocProps.buildCoreXml(workbook.metadata)
+    val appPropsXml = DocProps.buildAppXml(workbook.metadata)
+
     // Content types: preserve from source when available, otherwise generate minimal.
     // IMPORTANT: Don't call withCommentOverrides when preserving - the source already has
     // correct comment entries with Excel's sequential numbering (comments1.xml, comments2.xml...)
@@ -1424,7 +1430,9 @@ object XlsxWriter:
             )
           else preserved
         // Only add table overrides (comments already in preserved Content_Types)
-        withSst.withTableOverrides(totalTableCount)
+        withSst
+          .withTableOverrides(totalTableCount)
+          .withDocPropsOverrides(corePropsXml.isDefined, appPropsXml.isDefined)
       case None =>
         ContentTypes
           .minimal(
@@ -1435,8 +1443,11 @@ object XlsxWriter:
           )
           .withCommentOverrides(sheetsWithComments)
           .withTableOverrides(totalTableCount)
+          .withDocPropsOverrides(corePropsXml.isDefined, appPropsXml.isDefined)
 
-    val rootRels = preservedRootRels.getOrElse(Relationships.root())
+    val rootRels = preservedRootRels
+      .getOrElse(Relationships.root())
+      .withDocProps(corePropsXml.isDefined, appPropsXml.isDefined)
 
     val workbookRels = preservedWorkbookRels match
       case Some(preserved) =>
@@ -1467,6 +1478,12 @@ object XlsxWriter:
       // Write structural parts (always regenerated)
       writePart(zip, "[Content_Types].xml", contentTypes, config)
       writePart(zip, "_rels/.rels", rootRels, config)
+
+      // GH-242: document properties — deterministic, model-driven (no GUIDs/wall-clock values).
+      // The reader marks docProps as parsed, so these never collide with preserved parts.
+      corePropsXml.foreach(x => writePart(zip, DocProps.corePath, x, config))
+      appPropsXml.foreach(x => writePart(zip, DocProps.appPath, x, config))
+
       writePart(zip, "xl/workbook.xml", ooxmlWb, config)
       writePart(zip, "xl/_rels/workbook.xml.rels", workbookRels, config)
       writeStyles(zip, "xl/styles.xml", styles, config)

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/metadata/WorkbookMetadataReader.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/metadata/WorkbookMetadataReader.scala
@@ -18,10 +18,14 @@ import com.tjclp.xl.workbooks.DefinedName
  *   Sheet info including name, ID, visibility, and dimension
  * @param definedNames
  *   Named ranges/formulas defined in the workbook
+ * @param date1904
+ *   True when workbookPr declares the 1904 date system (GH-243); date serials then count days since
+ *   1904-01-01 instead of the default 1900 system
  */
 final case class LightMetadata(
   sheets: Vector[SheetInfo],
-  definedNames: Vector[DefinedName]
+  definedNames: Vector[DefinedName],
+  date1904: Boolean = false
 )
 
 /**
@@ -105,7 +109,12 @@ object WorkbookMetadataReader:
           }
         yield
           val definedNames = parseDefinedNames(wbElem)
-          LightMetadata(sheetsWithDimensions, definedNames)
+          // GH-243: surface the 1904 date system flag so streaming consumers can interpret
+          // date serials with the correct epoch (shared parser with the full reader).
+          val date1904 = com.tjclp.xl.ooxml.OoxmlWorkbook.parseDate1904(
+            (wbElem \ "workbookPr").headOption.collect { case e: Elem => e }
+          )
+          LightMetadata(sheetsWithDimensions, definedNames, date1904)
       finally zipFile.close()
     }
 

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/style/StyleParser.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/style/StyleParser.scala
@@ -78,9 +78,12 @@ object WorkbookStyles:
       .map(_.text)
       .filter(_.nonEmpty)
       .getOrElse(Font.default.name)
+    // Font requires sizePt > 0; treat non-positive (or NaN) sizes from malformed
+    // files as absent so the parser stays total (GH-278, DOM analog of GH-264)
     val size = (fontElem \ "sz").headOption
       .flatMap(_.attribute("val"))
       .flatMap(v => v.text.toDoubleOption)
+      .filter(_ > 0)
       .getOrElse(Font.default.sizePt)
     val bold = (fontElem \ "b").nonEmpty
     val italic = (fontElem \ "i").nonEmpty

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/OoxmlWorksheet.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/OoxmlWorksheet.scala
@@ -87,10 +87,51 @@ case class OoxmlWorksheet(
 ) extends XmlWritable,
       SaxSerializable:
 
+  /**
+   * Preserved/generated child elements re-emitted into the regenerated worksheet. Used only to
+   * collect namespace bindings (GH-291), so emission order is irrelevant; preservedKnown is
+   * label-sorted for determinism.
+   */
+  private def preservedChildElems: Seq[Elem] =
+    Seq(
+      sheetPr,
+      dimension,
+      sheetViews,
+      sheetFormatPr,
+      cols,
+      printOptions,
+      rowBreaks,
+      colBreaks,
+      customPropertiesWs,
+      pageMargins,
+      pageSetup,
+      headerFooter,
+      drawing,
+      legacyDrawing,
+      picture,
+      oleObjects,
+      controls,
+      tableParts,
+      extLst
+    ).flatten ++ conditionalFormatting ++
+      preservedKnown.toSeq.sortBy(_._1).map(_._2) ++ otherElements
+
+  /**
+   * Root scope extended with any namespace binding used by a re-emitted child but missing from the
+   * root (GH-291): openpyxl binds xmlns:r locally on `<drawing>`; child scopes are stripped on
+   * re-emission, so required bindings are hoisted onto the regenerated root — the standard Excel
+   * layout. Shared by both writer backends (toXml and writeSax).
+   */
+  private def emissionScope: NamespaceBinding =
+    val base = Option(rootScope).getOrElse(defaultWorksheetScope)
+    val hoisted = hoistUsedBindings(base, preservedChildElems)
+    if rows.exists(_.dyDescent.isDefined) then ensureWellKnownPrefix(hoisted, "x14ac")
+    else hoisted
+
   def writeSax(writer: SaxWriter): Unit =
     writer.startDocument()
 
-    val scope = Option(rootScope).getOrElse(defaultWorksheetScope)
+    val scope = emissionScope
     val rootAttrs = Option(rootAttributes).getOrElse(Null)
 
     writer.startElement("worksheet")
@@ -248,7 +289,7 @@ case class OoxmlWorksheet(
     // Any other elements
     otherElements.foreach(e => children += cleanNamespaces(e))
 
-    val scope = Option(rootScope).getOrElse(defaultWorksheetScope)
+    val scope = emissionScope
     val attrs = Option(rootAttributes).getOrElse(Null)
 
     Elem(null, "worksheet", attrs, scope, minimizeEmpty = false, children.result()*)
@@ -460,15 +501,10 @@ object OoxmlWorksheet extends com.tjclp.xl.ooxml.XmlReadable[OoxmlWorksheet]:
         .getOrElse(Map.empty)
 
     // If preservedMetadata is provided, use its metadata fields; otherwise use defaults (None)
+    // (a generated legacyDrawing/hyperlinks element carries its own r: binding, which emission
+    // hoists onto the root when the preserved scope lacks it — GH-291)
     preservedMetadata match
       case Some(preserved) =>
-        // Ensure rootScope includes 'r:' namespace if we're adding a new legacyDrawing element
-        // (source worksheet might not have had comments, so its scope might lack the r: prefix)
-        val needsRNamespace = sheet.comments.nonEmpty && preserved.legacyDrawing.isEmpty
-        val adjustedScope =
-          if needsRNamespace && !scopeHasPrefix(preserved.rootScope, "r") then
-            NamespaceBinding("r", nsRelationships, preserved.rootScope)
-          else preserved.rootScope
         OoxmlWorksheet(
           allRows, // Use merged rows (with cells + empty rows)
           sheet.mergedRanges,
@@ -499,7 +535,7 @@ object OoxmlWorksheet extends com.tjclp.xl.ooxml.XmlReadable[OoxmlWorksheet]:
           preserved.extLst,
           preserved.otherElements,
           preserved.rootAttributes,
-          adjustedScope,
+          preserved.rootScope,
           // GH-232 preserve inline elements + GH-235 model-driven hyperlinks (overrides any raw)
           preserved.preservedKnown ++ hyperlinksMap
         )

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/WorksheetHelpers.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/WorksheetHelpers.scala
@@ -35,6 +35,102 @@ private[ooxml] def cleanNamespaces(elem: Elem): Elem =
   }
   elem.copy(scope = TopScope, child = cleanedChildren)
 
+// ===== Namespace preservation on regeneration (GH-291) =====
+// Some producers (openpyxl) bind a prefix locally on a child element — e.g.
+// `<drawing xmlns:r="…" r:id="rId1"/>` — instead of on the worksheet root. Regeneration strips
+// child scopes (cleanNamespaces) to avoid redundant re-declarations, so a binding that exists
+// ONLY on a child must be re-bound or the emitted prefix is unbound and Excel reports the
+// workbook as corrupt. The reader captures each preserved subtree with the bindings it actually
+// uses (rebindUsedNamespaces); emission hoists any binding the root lacks onto the regenerated
+// worksheet root (hoistUsedBindings) — the standard Excel layout.
+
+/**
+ * Well-known OOXML prefixes, used as a last resort when a used prefix's binding was lost before
+ * capture (mirrors StaxSaxWriter.knownNamespaces, which heals the same way on the StAX path).
+ */
+private val wellKnownNamespaces: Map[String, String] = Map(
+  "r" -> XmlUtil.nsRelationships,
+  "mc" -> "http://schemas.openxmlformats.org/markup-compatibility/2006",
+  "xr" -> "http://schemas.microsoft.com/office/spreadsheetml/2014/revision",
+  "x14ac" -> "http://schemas.microsoft.com/office/spreadsheetml/2009/9/ac"
+)
+
+/**
+ * Prefix -> URI for every namespace prefix USED by the tree (on element tags and attributes),
+ * resolved against the scope in effect at the point of use, falling back to wellKnownNamespaces.
+ * First binding wins (document order); unresolvable prefixes are omitted (the input was already
+ * namespace-broken). `xml` and `xmlns` are never collected. Attributes built via XmlUtil.elem carry
+ * the prefix inside the key ("x14ac:dyDescent"), so colon-keys are treated as prefixed. Parsed
+ * trees carry full scope chains on every element; for programmatically built trees (child scope
+ * TopScope) the nearest ancestor scope is consulted instead.
+ */
+private[ooxml] def usedPrefixBindings(root: Elem): Seq[(String, String)] =
+  @annotation.tailrec
+  def attrPrefixes(md: MetaData, acc: List[String]): List[String] = md match
+    case Null => acc.reverse
+    case PrefixedAttribute(pre, _, _, next) => attrPrefixes(next, pre :: acc)
+    case UnprefixedAttribute(key, _, next) =>
+      key.split(":", 2) match
+        case Array(pre, _) => attrPrefixes(next, pre :: acc)
+        case _ => attrPrefixes(next, acc)
+  def collect(e: Elem, inherited: NamespaceBinding): Vector[(String, String)] =
+    val own = Option(e.scope).filterNot(_ == TopScope)
+    val effectiveScope = own.getOrElse(inherited)
+    val prefixes = (Option(e.prefix).toList ++ attrPrefixes(e.attributes, Nil))
+      .filter(p => p.nonEmpty && p != "xml" && p != "xmlns")
+    val here = prefixes.flatMap { p =>
+      Option(effectiveScope.getURI(p))
+        .orElse(wellKnownNamespaces.get(p))
+        .map(p -> _)
+    }
+    here.toVector ++
+      e.child.collect { case c: Elem => c }.toVector.flatMap(collect(_, effectiveScope))
+  collect(root, TopScope).distinctBy(_._1)
+
+/**
+ * cleanNamespaces, then re-bind the prefixes the subtree actually uses on the subtree root, so a
+ * preserved element stays namespace-well-formed in isolation (GH-291). Bindings are attached in
+ * sorted-prefix order for deterministic output.
+ */
+private[ooxml] def rebindUsedNamespaces(elem: Elem): Elem =
+  val used = usedPrefixBindings(elem)
+  val cleaned = cleanNamespaces(elem)
+  if used.isEmpty then cleaned
+  else
+    val scope = used.sortBy(_._1).foldRight(TopScope: NamespaceBinding) {
+      case ((prefix, uri), parent) => NamespaceBinding(prefix, uri, parent)
+    }
+    cleaned.copy(scope = scope)
+
+/**
+ * Extend `base` with bindings for prefixes used by `children` but not bound on `base` — hoisting
+ * locally-declared child bindings onto the regenerated worksheet root, the standard Excel layout
+ * (GH-291). Missing prefixes are prepended in sorted order for deterministic output. A prefix
+ * already bound on `base` (even to a different URI) is left untouched.
+ */
+private[ooxml] def hoistUsedBindings(
+  base: NamespaceBinding,
+  children: Seq[Elem]
+): NamespaceBinding =
+  children
+    .flatMap(usedPrefixBindings)
+    .distinctBy(_._1)
+    .filterNot { case (prefix, _) => scopeHasPrefix(base, prefix) }
+    .sortBy(_._1)
+    .foldRight(base) { case ((prefix, uri), parent) => NamespaceBinding(prefix, uri, parent) }
+
+/**
+ * Ensure a single well-known prefix is bound on `scope` (no-op for unknown prefixes). Rows re-emit
+ * `x14ac:dyDescent` as a raw qualified attribute outside the Elem-based collection, so
+ * OoxmlWorksheet binds that prefix explicitly when any row carries the attribute (GH-291).
+ */
+private[worksheet] def ensureWellKnownPrefix(
+  scope: NamespaceBinding,
+  prefix: String
+): NamespaceBinding =
+  if scopeHasPrefix(scope, prefix) then scope
+  else wellKnownNamespaces.get(prefix).fold(scope)(uri => NamespaceBinding(prefix, uri, scope))
+
 // ===== Preserved inline worksheet elements (GH-232) =====
 // Inline CT_Worksheet children that are listed in WorksheetReader.knownElements (so they are
 // excluded from the `otherElements` catch-all) but have NO dedicated field on OoxmlWorksheet.
@@ -160,7 +256,11 @@ private[ooxml] def buildHyperlinksElem(entries: Seq[HyperlinkEntry]): Option[Ele
       val attrs = new UnprefixedAttribute("ref", e.ref.toA1, tail)
       Elem(null, "hyperlink", attrs, TopScope, minimizeEmpty = true)
     }
-    Some(Elem(null, "hyperlinks", Null, TopScope, minimizeEmpty = false, children*))
+    // External entries use r:id — carry the binding so emission can hoist it (GH-291)
+    val scope =
+      if entries.exists(_.external) then NamespaceBinding("r", XmlUtil.nsRelationships, TopScope)
+      else TopScope
+    Some(Elem(null, "hyperlinks", Null, scope, minimizeEmpty = false, children*))
 
 /**
  * Group consecutive columns with identical properties into spans.

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/WorksheetReader.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/WorksheetReader.scala
@@ -34,43 +34,59 @@ object WorksheetReader extends XmlReadable[OoxmlWorksheet]:
       mergedRanges <- parseMergeCells(elem)
 
       // Extract ALL preserved metadata elements (all optional)
-      sheetPr = (elem \ "sheetPr").headOption.collect { case e: Elem => cleanNamespaces(e) }
-      dimension = (elem \ "dimension").headOption.collect { case e: Elem => cleanNamespaces(e) }
-      sheetViews = (elem \ "sheetViews").headOption.collect { case e: Elem => cleanNamespaces(e) }
-      sheetFormatPr = (elem \ "sheetFormatPr").headOption.collect { case e: Elem =>
-        cleanNamespaces(e)
+      sheetPr = (elem \ "sheetPr").headOption.collect { case e: Elem => rebindUsedNamespaces(e) }
+      dimension = (elem \ "dimension").headOption.collect { case e: Elem =>
+        rebindUsedNamespaces(e)
       }
-      cols = (elem \ "cols").headOption.collect { case e: Elem => cleanNamespaces(e) }
+      sheetViews = (elem \ "sheetViews").headOption.collect { case e: Elem =>
+        rebindUsedNamespaces(e)
+      }
+      sheetFormatPr = (elem \ "sheetFormatPr").headOption.collect { case e: Elem =>
+        rebindUsedNamespaces(e)
+      }
+      cols = (elem \ "cols").headOption.collect { case e: Elem => rebindUsedNamespaces(e) }
 
       conditionalFormatting = elem.child.collect {
-        case e: Elem if e.label == "conditionalFormatting" => cleanNamespaces(e)
+        case e: Elem if e.label == "conditionalFormatting" => rebindUsedNamespaces(e)
       }
       printOptions = (elem \ "printOptions").headOption.collect { case e: Elem =>
-        cleanNamespaces(e)
+        rebindUsedNamespaces(e)
       }
-      rowBreaks = (elem \ "rowBreaks").headOption.collect { case e: Elem => cleanNamespaces(e) }
-      colBreaks = (elem \ "colBreaks").headOption.collect { case e: Elem => cleanNamespaces(e) }
+      rowBreaks = (elem \ "rowBreaks").headOption.collect { case e: Elem =>
+        rebindUsedNamespaces(e)
+      }
+      colBreaks = (elem \ "colBreaks").headOption.collect { case e: Elem =>
+        rebindUsedNamespaces(e)
+      }
       customPropertiesWs = (elem \ "customProperties").headOption.collect { case e: Elem =>
-        cleanNamespaces(e)
+        rebindUsedNamespaces(e)
       }
 
-      pageMargins = (elem \ "pageMargins").headOption.collect { case e: Elem => cleanNamespaces(e) }
-      pageSetup = (elem \ "pageSetup").headOption.collect { case e: Elem => cleanNamespaces(e) }
+      pageMargins = (elem \ "pageMargins").headOption.collect { case e: Elem =>
+        rebindUsedNamespaces(e)
+      }
+      pageSetup = (elem \ "pageSetup").headOption.collect { case e: Elem =>
+        rebindUsedNamespaces(e)
+      }
       headerFooter = (elem \ "headerFooter").headOption.collect { case e: Elem =>
-        cleanNamespaces(e)
+        rebindUsedNamespaces(e)
       }
 
-      drawing = (elem \ "drawing").headOption.collect { case e: Elem => cleanNamespaces(e) }
+      drawing = (elem \ "drawing").headOption.collect { case e: Elem => rebindUsedNamespaces(e) }
       legacyDrawing = (elem \ "legacyDrawing").headOption.collect { case e: Elem =>
-        cleanNamespaces(e)
+        rebindUsedNamespaces(e)
       }
-      picture = (elem \ "picture").headOption.collect { case e: Elem => cleanNamespaces(e) }
-      oleObjects = (elem \ "oleObjects").headOption.collect { case e: Elem => cleanNamespaces(e) }
-      controls = (elem \ "controls").headOption.collect { case e: Elem => cleanNamespaces(e) }
+      picture = (elem \ "picture").headOption.collect { case e: Elem => rebindUsedNamespaces(e) }
+      oleObjects = (elem \ "oleObjects").headOption.collect { case e: Elem =>
+        rebindUsedNamespaces(e)
+      }
+      controls = (elem \ "controls").headOption.collect { case e: Elem => rebindUsedNamespaces(e) }
 
-      tableParts = (elem \ "tableParts").headOption.collect { case e: Elem => cleanNamespaces(e) }
+      tableParts = (elem \ "tableParts").headOption.collect { case e: Elem =>
+        rebindUsedNamespaces(e)
+      }
 
-      extLst = (elem \ "extLst").headOption.collect { case e: Elem => cleanNamespaces(e) }
+      extLst = (elem \ "extLst").headOption.collect { case e: Elem => rebindUsedNamespaces(e) }
 
       // Inline labels we recognize (single source of truth in WorksheetHelpers so the
       // preservation invariant can be guarded by a test — see worksheetKnownElements).
@@ -80,7 +96,7 @@ object WorksheetReader extends XmlReadable[OoxmlWorksheet]:
       // GH-232: capture inline known elements that have NO dedicated field (dataValidations,
       // sheetProtection, autoFilter, hyperlinks, ...) so they survive a sheet modification.
       preservedKnownMap = elem.child.collect {
-        case e: Elem if preservedKnownLabels.contains(e.label) => e.label -> cleanNamespaces(e)
+        case e: Elem if preservedKnownLabels.contains(e.label) => e.label -> rebindUsedNamespaces(e)
       }.toMap
     yield OoxmlWorksheet(
       rows,

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/xml.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/xml.scala
@@ -349,15 +349,19 @@ object XmlUtil:
         }
       }
 
+    // Font requires sizePt > 0 and a nonEmpty name; filter malformed values so
+    // rich-text parsing stays total instead of throwing through require (GH-278)
     val sizePt = (rPrElem \ "sz").headOption
       .collect { case elem: Elem => elem }
       .flatMap(e => getAttrOpt(e, "val"))
       .flatMap(_.toDoubleOption)
+      .filter(_ > 0)
       .getOrElse(11.0)
 
     val name = (rPrElem \ "name").headOption
       .collect { case elem: Elem => elem }
       .flatMap(e => getAttrOpt(e, "val"))
+      .filter(_.nonEmpty)
       .getOrElse("Calibri")
 
     Font(

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/xml.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/xml.scala
@@ -46,6 +46,11 @@ object XmlUtil:
     "http://schemas.openxmlformats.org/officeDocument/2006/relationships/table"
   val relTypeHyperlink =
     "http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink"
+  // docProps relationships (GH-242): core props is a PACKAGE relationship type, app is officeDocument
+  val relTypeCoreProperties =
+    "http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties"
+  val relTypeExtendedProperties =
+    "http://schemas.openxmlformats.org/officeDocument/2006/relationships/extended-properties"
 
   /** Content type URIs */
   val ctWorkbook = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"
@@ -57,6 +62,9 @@ object XmlUtil:
   val ctVmlDrawing = "application/vnd.openxmlformats-officedocument.vmlDrawing"
   val ctTable = "application/vnd.openxmlformats-officedocument.spreadsheetml.table+xml"
   val ctRelationships = "application/vnd.openxmlformats-package.relationships+xml"
+  val ctCoreProperties = "application/vnd.openxmlformats-package.core-properties+xml"
+  val ctExtendedProperties =
+    "application/vnd.openxmlformats-officedocument.extended-properties+xml"
 
   /** Sort attributes by name for deterministic output */
   def sortAttributes(attrs: MetaData): MetaData =

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/Date1904Spec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/Date1904Spec.scala
@@ -1,0 +1,289 @@
+package com.tjclp.xl.ooxml
+
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
+import java.nio.charset.StandardCharsets
+import java.util.zip.{ZipEntry, ZipInputStream, ZipOutputStream}
+
+import java.time.LocalDateTime
+
+import munit.FunSuite
+
+import com.tjclp.xl.addressing.SheetName
+import com.tjclp.xl.api.{Sheet, Workbook}
+import com.tjclp.xl.cells.CellValue
+import com.tjclp.xl.macros.ref
+
+/**
+ * GH-243: 1904 date system support.
+ *
+ * Files written by legacy Mac Excel set `<workbookPr date1904="1"/>` and store date serials
+ * counted from the 1904-01-01 epoch (no phantom 1900 leap day). Dropping the flag silently shifts
+ * every date by 1462 days (~4 years). These tests pin: the flag is read into
+ * `WorkbookMetadata.date1904`, preserved on write (preserve-the-system), and DateTime values are
+ * serialized with the 1904 epoch when the flag is set.
+ */
+class Date1904Spec extends FunSuite:
+
+  // Microsoft's documented example pair: July 5, 1998 is serial 34519 in the 1904
+  // date system and serial 35981 (= 34519 + 1462) in the 1900 date system.
+  private val july5_1998Serial1904 = 34519.0
+
+  private val contentTypesXml =
+    """<?xml version="1.0" encoding="UTF-8"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+  <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+  <Override PartName="/xl/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"/>
+</Types>"""
+
+  private val rootRelationshipsXml =
+    """<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>"""
+
+  private val workbookRelationshipsXml =
+    """<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+</Relationships>"""
+
+  /** workbook.xml with a configurable workbookPr element (legacy Mac Excel shape). */
+  private def workbookXml(workbookPr: String): String =
+    s"""<?xml version="1.0" encoding="UTF-8"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+          xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  $workbookPr
+  <sheets>
+    <sheet name="Sheet1" sheetId="1" r:id="rId1"/>
+  </sheets>
+</workbook>"""
+
+  /** Worksheet with A1 = serial 34519 styled with the built-in date format (numFmtId 14). */
+  private val worksheetXml =
+    """<?xml version="1.0" encoding="UTF-8"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <sheetData>
+    <row r="1">
+      <c r="A1" s="1"><v>34519</v></c>
+    </row>
+  </sheetData>
+</worksheet>"""
+
+  private val stylesXml =
+    """<?xml version="1.0" encoding="UTF-8"?>
+<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <fonts count="1"><font><sz val="11"/><name val="Calibri"/></font></fonts>
+  <fills count="1"><fill><patternFill patternType="none"/></fill></fills>
+  <borders count="1"><border/></borders>
+  <cellStyleXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0"/></cellStyleXfs>
+  <cellXfs count="2">
+    <xf numFmtId="0" fontId="0" fillId="0" borderId="0"/>
+    <xf numFmtId="14" fontId="0" fillId="0" borderId="0" applyNumberFormat="1"/>
+  </cellXfs>
+  <cellStyles count="1"><cellStyle name="Normal" xfId="0" builtinId="0"/></cellStyles>
+</styleSheet>"""
+
+  /** Build a minimal xlsx from raw parts, with the given workbookPr element. */
+  private def build1904Workbook(workbookPr: String = """<workbookPr date1904="1"/>"""): Array[Byte] =
+    val parts = Map(
+      "[Content_Types].xml" -> contentTypesXml,
+      "_rels/.rels" -> rootRelationshipsXml,
+      "xl/workbook.xml" -> workbookXml(workbookPr),
+      "xl/_rels/workbook.xml.rels" -> workbookRelationshipsXml,
+      "xl/worksheets/sheet1.xml" -> worksheetXml,
+      "xl/styles.xml" -> stylesXml
+    )
+    writeZip(parts)
+
+  private def writeZip(parts: Map[String, String]): Array[Byte] =
+    val baos = new ByteArrayOutputStream()
+    val zip = new ZipOutputStream(baos)
+    parts.foreach { case (name, content) =>
+      zip.putNextEntry(new ZipEntry(name))
+      zip.write(content.getBytes(StandardCharsets.UTF_8))
+      zip.closeEntry()
+    }
+    zip.close()
+    baos.toByteArray
+
+  /** Extract one entry from an xlsx byte array as UTF-8 text. */
+  @SuppressWarnings(Array("org.wartremover.warts.Var", "org.wartremover.warts.While"))
+  private def zipEntryText(bytes: Array[Byte], entryName: String): Option[String] =
+    val zip = new ZipInputStream(new ByteArrayInputStream(bytes))
+    try
+      var entry = zip.getNextEntry
+      var found: Option[String] = None
+      while entry != null && found.isEmpty do
+        if entry.getName == entryName then
+          found = Some(new String(zip.readAllBytes(), StandardCharsets.UTF_8))
+        entry = zip.getNextEntry
+      found
+    finally zip.close()
+
+  // ---------------------------------------------------------------------------
+  // Round-trip preservation (preserve-the-system)
+  // ---------------------------------------------------------------------------
+
+  test("GH-243: date1904 flag survives read → write → read (full regeneration)") {
+    val wb = XlsxReader
+      .readFromBytes(build1904Workbook())
+      .getOrElse(fail("Failed to read 1904 fixture"))
+
+    val written = XlsxWriter.writeToBytes(wb).getOrElse(fail("Failed to write workbook"))
+    val workbookXmlOut = zipEntryText(written, "xl/workbook.xml").getOrElse(
+      fail("Written xlsx missing xl/workbook.xml")
+    )
+
+    assert(
+      workbookXmlOut.contains("date1904=\"1\""),
+      s"date1904 flag dropped on write; serials would silently shift by 1462 days. Got: $workbookXmlOut"
+    )
+
+    // And the raw serial must ride through unchanged (the system travels with it).
+    val reread = XlsxReader.readFromBytes(written).getOrElse(fail("Failed to re-read"))
+    val sheet = reread("Sheet1").getOrElse(fail("Missing Sheet1"))
+    assertEquals(sheet(ref"A1").value, CellValue.Number(BigDecimal(34519)))
+    assert(reread.metadata.date1904, "re-read workbook must keep date1904 = true")
+  }
+
+  // ---------------------------------------------------------------------------
+  // Reading the flag into WorkbookMetadata
+  // ---------------------------------------------------------------------------
+
+  test("GH-243: reader populates WorkbookMetadata.date1904 from workbookPr") {
+    val wb = XlsxReader
+      .readFromBytes(build1904Workbook())
+      .getOrElse(fail("Failed to read 1904 fixture"))
+
+    assert(wb.metadata.date1904, "expected date1904 = true from <workbookPr date1904=\"1\"/>")
+
+    // The serial stays raw on read; interpreting it with the workbook's system yields the
+    // documented date (1998-07-05 = serial 34519 in the 1904 system).
+    val sheet = wb("Sheet1").getOrElse(fail("Missing Sheet1"))
+    sheet(ref"A1").value match
+      case CellValue.Number(serial) =>
+        assertEquals(
+          CellValue.excelSerialToDateTime(serial.toDouble, date1904 = true),
+          LocalDateTime.of(1998, 7, 5, 0, 0, 0)
+        )
+      case other => fail(s"Expected Number cell, got $other")
+  }
+
+  test("GH-243: reader accepts the xsd:boolean form date1904=\"true\"") {
+    val wb = XlsxReader
+      .readFromBytes(build1904Workbook("""<workbookPr date1904="true"/>"""))
+      .getOrElse(fail("Failed to read fixture"))
+    assert(wb.metadata.date1904)
+  }
+
+  test("GH-243: date1904 defaults to false (absent attribute, absent workbookPr, explicit 0)") {
+    val absentAttr = XlsxReader
+      .readFromBytes(build1904Workbook("<workbookPr/>"))
+      .getOrElse(fail("Failed to read fixture"))
+    assert(!absentAttr.metadata.date1904)
+
+    val absentElem = XlsxReader
+      .readFromBytes(build1904Workbook(""))
+      .getOrElse(fail("Failed to read fixture"))
+    assert(!absentElem.metadata.date1904)
+
+    val explicitZero = XlsxReader
+      .readFromBytes(build1904Workbook("""<workbookPr date1904="0"/>"""))
+      .getOrElse(fail("Failed to read fixture"))
+    assert(!explicitZero.metadata.date1904)
+
+    val explicitFalse = XlsxReader
+      .readFromBytes(build1904Workbook("""<workbookPr date1904="false"/>"""))
+      .getOrElse(fail("Failed to read fixture"))
+    assert(!explicitFalse.metadata.date1904)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Writing: DateTime serials use the workbook's date system
+  // ---------------------------------------------------------------------------
+
+  test("GH-243: DateTime cells in a date1904 workbook are serialized with the 1904 epoch") {
+    val dt = LocalDateTime.of(1998, 7, 5, 0, 0, 0)
+    val sheet = Sheet(SheetName.unsafe("Dates")).put(ref"A1", CellValue.DateTime(dt))
+    val wb = Workbook(Vector(sheet))
+    val wb1904 = wb.copy(metadata = wb.metadata.copy(date1904 = true))
+
+    val written = XlsxWriter.writeToBytes(wb1904).getOrElse(fail("Failed to write workbook"))
+
+    val workbookXmlOut = zipEntryText(written, "xl/workbook.xml").getOrElse(
+      fail("Written xlsx missing xl/workbook.xml")
+    )
+    assert(
+      workbookXmlOut.contains("date1904=\"1\""),
+      s"workbookPr must declare the 1904 system. Got: $workbookXmlOut"
+    )
+
+    val reread = XlsxReader.readFromBytes(written).getOrElse(fail("Failed to re-read"))
+    assert(reread.metadata.date1904)
+    val rereadSheet = reread("Dates").getOrElse(fail("Missing Dates sheet"))
+    rereadSheet(ref"A1").value match
+      case CellValue.Number(serial) =>
+        // 1904-system serial (34519), NOT the 1900-system serial (35981 = 34519 + 1462).
+        assertEquals(serial.toDouble, 34519.0)
+        assertEquals(CellValue.excelSerialToDateTime(serial.toDouble, date1904 = true), dt)
+      case other => fail(s"Expected Number cell after round-trip, got $other")
+  }
+
+  test("GH-243: surgical write keeps the 1904 system when editing a 1904 file") {
+    val srcPath = java.nio.file.Files.createTempFile("xl-1904-", ".xlsx")
+    val outPath = java.nio.file.Files.createTempFile("xl-1904-out-", ".xlsx")
+    try
+      java.nio.file.Files.write(srcPath, build1904Workbook())
+
+      // File read attaches a SourceContext → write goes down the surgical path.
+      val wb = XlsxReader.read(srcPath).getOrElse(fail("Failed to read 1904 file"))
+      assert(wb.metadata.date1904)
+
+      val dt = LocalDateTime.of(2026, 6, 10, 0, 0, 0)
+      val edited = wb
+        .update(SheetName.unsafe("Sheet1"), _.put(ref"B1", CellValue.DateTime(dt)))
+        .getOrElse(fail("Failed to update sheet"))
+      XlsxWriter.write(edited, outPath).getOrElse(fail("Failed to write surgically"))
+
+      val reread = XlsxReader.read(outPath).getOrElse(fail("Failed to re-read"))
+      assert(reread.metadata.date1904, "surgical write must preserve the 1904 flag")
+      val sheet = reread("Sheet1").getOrElse(fail("Missing Sheet1"))
+      // Untouched 1904 serial rides through; the new DateTime is written with the 1904 epoch.
+      assertEquals(sheet(ref"A1").value, CellValue.Number(BigDecimal(34519)))
+      sheet(ref"B1").value match
+        case CellValue.Number(serial) =>
+          assertEquals(CellValue.excelSerialToDateTime(serial.toDouble, date1904 = true), dt)
+          assertEquals(
+            serial.toDouble,
+            CellValue.dateTimeToExcelSerial(dt, date1904 = true)
+          )
+        case other => fail(s"Expected Number cell for B1, got $other")
+    finally
+      java.nio.file.Files.deleteIfExists(srcPath)
+      java.nio.file.Files.deleteIfExists(outPath)
+  }
+
+  test("GH-243: default workbooks keep the 1900 system (no date1904 attribute, 1900 serials)") {
+    val dt = LocalDateTime.of(1998, 7, 5, 0, 0, 0)
+    val sheet = Sheet(SheetName.unsafe("Dates")).put(ref"A1", CellValue.DateTime(dt))
+    val wb = Workbook(Vector(sheet))
+
+    val written = XlsxWriter.writeToBytes(wb).getOrElse(fail("Failed to write workbook"))
+
+    val workbookXmlOut = zipEntryText(written, "xl/workbook.xml").getOrElse(
+      fail("Written xlsx missing xl/workbook.xml")
+    )
+    assert(
+      !workbookXmlOut.contains("date1904"),
+      s"1900-system workbooks must not declare date1904. Got: $workbookXmlOut"
+    )
+
+    val reread = XlsxReader.readFromBytes(written).getOrElse(fail("Failed to re-read"))
+    assert(!reread.metadata.date1904)
+    val rereadSheet = reread("Dates").getOrElse(fail("Missing Dates sheet"))
+    rereadSheet(ref"A1").value match
+      case CellValue.Number(serial) => assertEquals(serial.toDouble, 35981.0)
+      case other => fail(s"Expected Number cell after round-trip, got $other")
+  }

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/Date1904Spec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/Date1904Spec.scala
@@ -231,6 +231,28 @@ class Date1904Spec extends FunSuite:
       case other => fail(s"Expected Number cell after round-trip, got $other")
   }
 
+  test("GH-243: 1904 DateTime serials render byte-identically to the shared plainNumber rule") {
+    // The 1904 normalization stores Number(BigDecimal(serial)) whose rendering must equal
+    // XmlUtil.plainNumber(serial: Double) — the rule every 1900-path DateTime emitter
+    // (OoxmlCell/OoxmlWorksheet/DirectSaxEmitter) uses. Pins that the two date systems
+    // cannot drift cosmetically if either formatting routine changes independently.
+    val dt = LocalDateTime.of(1998, 7, 5, 0, 0, 0)
+    val sheet = Sheet(SheetName.unsafe("Dates")).put(ref"A1", CellValue.DateTime(dt))
+    val wb = Workbook(Vector(sheet))
+    val wb1904 = wb.copy(metadata = wb.metadata.copy(date1904 = true))
+
+    val written = XlsxWriter.writeToBytes(wb1904).getOrElse(fail("Failed to write workbook"))
+    val sheetXml = zipEntryText(written, "xl/worksheets/sheet1.xml").getOrElse(
+      fail("Written xlsx missing xl/worksheets/sheet1.xml")
+    )
+
+    val expected = s"<v>${XmlUtil.plainNumber(july5_1998Serial1904)}</v>"
+    assert(
+      sheetXml.contains(expected),
+      s"1904 serial must use the shared plainNumber rendering $expected. Got: $sheetXml"
+    )
+  }
+
   test("GH-243: surgical write keeps the 1904 system when editing a 1904 file") {
     val srcPath = java.nio.file.Files.createTempFile("xl-1904-", ".xlsx")
     val outPath = java.nio.file.Files.createTempFile("xl-1904-out-", ".xlsx")

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/DocPropsSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/DocPropsSpec.scala
@@ -1,0 +1,184 @@
+package com.tjclp.xl.ooxml
+
+import java.nio.file.Files
+import java.time.LocalDateTime
+import java.util.zip.{ZipEntry, ZipInputStream}
+
+import munit.FunSuite
+
+import com.tjclp.xl.api.*
+import com.tjclp.xl.cells.CellValue
+import com.tjclp.xl.macros.ref
+import com.tjclp.xl.workbooks.WorkbookMetadata
+
+/**
+ * GH-242: document properties (docProps/core.xml + docProps/app.xml) are emitted on save.
+ *
+ * The contract:
+ *   - core.xml carries creator/created/modified/lastModifiedBy; emitted iff at least one is set
+ *   - app.xml carries Application/AppVersion; emitted iff at least one is set
+ *   - both parts are registered in [Content_Types].xml and the package-level _rels/.rels
+ *   - output is deterministic: no GUIDs, no wall-clock timestamps — only model fields, with
+ *     created/modified in W3CDTF (UTC, second precision)
+ *   - reading a written file restores the metadata (round-trip)
+ *   - surgically re-writing a read file emits the MODEL's docProps exactly once (no duplicate-entry
+ *     collision with preserved unknown parts)
+ */
+class DocPropsSpec extends FunSuite:
+
+  private val fullMetadata = WorkbookMetadata(
+    creator = Some("Jane Analyst"),
+    created = Some(LocalDateTime.of(2024, 1, 15, 10, 30, 0)),
+    modified = Some(LocalDateTime.of(2025, 6, 1, 8, 0, 0)),
+    lastModifiedBy = Some("Bob Reviewer"),
+    application = Some("XL Test Suite"),
+    appVersion = Some("1.0")
+  )
+
+  private def workbookWith(meta: WorkbookMetadata): Workbook =
+    val sheet = Sheet(com.tjclp.xl.addressing.SheetName.unsafe("Data"))
+      .put(ref"A1", CellValue.Text("hello"))
+    Workbook(Vector(sheet), metadata = meta)
+
+  private def writeBytes(wb: Workbook): Array[Byte] =
+    XlsxWriter.writeToBytes(wb).fold(err => fail(s"write failed: ${err.message}"), identity)
+
+  /** All zip entry names -> UTF-8 content. */
+  private def entryMap(bytes: Array[Byte]): Map[String, String] =
+    val zis = new ZipInputStream(new java.io.ByteArrayInputStream(bytes))
+    try
+      Iterator
+        .continually(zis.getNextEntry)
+        .takeWhile(_ != null)
+        .collect { case e: ZipEntry if !e.isDirectory => e.getName -> new String(zis.readAllBytes(), "UTF-8") }
+        .toMap
+    finally zis.close()
+
+  test("write emits docProps/core.xml and docProps/app.xml with model fields") {
+    val parts = entryMap(writeBytes(workbookWith(fullMetadata)))
+
+    val core = parts.getOrElse("docProps/core.xml", fail("docProps/core.xml missing from output"))
+    assert(core.contains("<dc:creator>Jane Analyst</dc:creator>"), s"creator missing: $core")
+    assert(core.contains("<cp:lastModifiedBy>Bob Reviewer</cp:lastModifiedBy>"), s"lastModifiedBy missing: $core")
+    assert(core.contains("2024-01-15T10:30:00Z"), s"created W3CDTF missing: $core")
+    assert(core.contains("2025-06-01T08:00:00Z"), s"modified W3CDTF missing: $core")
+    assert(core.contains("dcterms:W3CDTF"), s"xsi:type W3CDTF marker missing: $core")
+
+    val app = parts.getOrElse("docProps/app.xml", fail("docProps/app.xml missing from output"))
+    assert(app.contains("<Application>XL Test Suite</Application>"), s"Application missing: $app")
+    assert(app.contains("<AppVersion>1.0</AppVersion>"), s"AppVersion missing: $app")
+  }
+
+  test("content types and package rels register both docProps parts") {
+    val parts = entryMap(writeBytes(workbookWith(fullMetadata)))
+
+    val ct = parts.getOrElse("[Content_Types].xml", fail("no content types"))
+    assert(
+      ct.contains("/docProps/core.xml") &&
+        ct.contains("application/vnd.openxmlformats-package.core-properties+xml"),
+      s"core.xml override missing: $ct"
+    )
+    assert(
+      ct.contains("/docProps/app.xml") &&
+        ct.contains("application/vnd.openxmlformats-officedocument.extended-properties+xml"),
+      s"app.xml override missing: $ct"
+    )
+
+    val rels = parts.getOrElse("_rels/.rels", fail("no package rels"))
+    assert(
+      rels.contains("relationships/metadata/core-properties") && rels.contains("docProps/core.xml"),
+      s"core props relationship missing: $rels"
+    )
+    assert(
+      rels.contains("relationships/extended-properties") && rels.contains("docProps/app.xml"),
+      s"app props relationship missing: $rels"
+    )
+  }
+
+  test("core.xml omitted when no core fields set; app.xml still written from defaults") {
+    // Default WorkbookMetadata: creator/created/modified/lastModifiedBy = None,
+    // application/appVersion default to the XL identifiers
+    val parts = entryMap(writeBytes(workbookWith(WorkbookMetadata())))
+    assert(!parts.contains("docProps/core.xml"), "core.xml should be omitted when all fields are None")
+    assert(parts.contains("docProps/app.xml"), "app.xml should be emitted from default application/appVersion")
+    val ct = parts.getOrElse("[Content_Types].xml", fail("no content types"))
+    assert(!ct.contains("/docProps/core.xml"), "stale core.xml content-type override")
+    val rels = parts.getOrElse("_rels/.rels", fail("no package rels"))
+    assert(!rels.contains("core-properties"), "stale core props relationship")
+  }
+
+  test("app.xml omitted when application and appVersion are both None") {
+    val meta = WorkbookMetadata(application = None, appVersion = None)
+    val parts = entryMap(writeBytes(workbookWith(meta)))
+    assert(!parts.contains("docProps/app.xml"), "app.xml should be omitted when both fields are None")
+  }
+
+  test("round-trip: write metadata -> read -> metadata equal") {
+    val bytes = writeBytes(workbookWith(fullMetadata))
+    val readBack = XlsxReader.readFromBytes(bytes).fold(err => fail(s"read failed: ${err.message}"), identity)
+    assertEquals(readBack.metadata.creator, fullMetadata.creator)
+    assertEquals(readBack.metadata.created, fullMetadata.created)
+    assertEquals(readBack.metadata.modified, fullMetadata.modified)
+    assertEquals(readBack.metadata.lastModifiedBy, fullMetadata.lastModifiedBy)
+    assertEquals(readBack.metadata.application, fullMetadata.application)
+    assertEquals(readBack.metadata.appVersion, fullMetadata.appVersion)
+  }
+
+  test("round-trip: XML-escapable characters in creator survive") {
+    val meta = WorkbookMetadata(creator = Some("""R&D <Team> "quoted""""))
+    val bytes = writeBytes(workbookWith(meta))
+    val readBack = XlsxReader.readFromBytes(bytes).fold(err => fail(s"read failed: ${err.message}"), identity)
+    assertEquals(readBack.metadata.creator, meta.creator)
+  }
+
+  test("reading a file without docProps yields empty docProps metadata fields") {
+    // Write a workbook with NO app/core fields at all, read it back
+    val meta = WorkbookMetadata(application = None, appVersion = None)
+    val bytes = writeBytes(workbookWith(meta))
+    val readBack = XlsxReader.readFromBytes(bytes).fold(err => fail(s"read failed: ${err.message}"), identity)
+    assertEquals(readBack.metadata.creator, None)
+    assertEquals(readBack.metadata.application, None)
+    assertEquals(readBack.metadata.appVersion, None)
+  }
+
+  test("deterministic: two writes of the same workbook produce identical docProps bytes") {
+    val wb = workbookWith(fullMetadata)
+    val parts1 = entryMap(writeBytes(wb))
+    val parts2 = entryMap(writeBytes(wb))
+    assertEquals(parts1.get("docProps/core.xml"), parts2.get("docProps/core.xml"))
+    assertEquals(parts1.get("docProps/app.xml"), parts2.get("docProps/app.xml"))
+  }
+
+  test("surgical rewrite of a read file emits docProps exactly once (no duplicate collision)") {
+    // 1. Write a file with metadata, 2. read it from disk (SourceContext present),
+    // 3. modify a cell, 4. write again — docProps must come from the model, exactly once.
+    val src = Files.createTempFile("xl-docprops-src-", ".xlsx")
+    val dst = Files.createTempFile("xl-docprops-dst-", ".xlsx")
+    src.toFile.deleteOnExit()
+    dst.toFile.deleteOnExit()
+
+    XlsxWriter
+      .write(workbookWith(fullMetadata), src)
+      .fold(err => fail(s"seed write failed: ${err.message}"), identity)
+
+    val wb = XlsxReader.read(src).fold(err => fail(s"read failed: ${err.message}"), identity)
+    assertEquals(wb.metadata.creator, fullMetadata.creator, "reader must surface docProps creator")
+
+    val modified = wb
+      .update(wb.sheets(0).name, _.put(ref"B2", CellValue.Number(BigDecimal(42))))
+      .fold(err => fail(s"update failed: $err"), identity)
+
+    XlsxWriter.write(modified, dst).fold(err => fail(s"surgical write failed: ${err.message}"), identity)
+
+    // Count occurrences of each docProps entry: duplicate zip entries would corrupt the file
+    val zis = new ZipInputStream(new java.io.FileInputStream(dst.toFile))
+    val names =
+      try Iterator.continually(zis.getNextEntry).takeWhile(_ != null).map(_.getName).toList
+      finally zis.close()
+    assertEquals(names.count(_ == "docProps/core.xml"), 1, s"core.xml count in $names")
+    assertEquals(names.count(_ == "docProps/app.xml"), 1, s"app.xml count in $names")
+
+    val readBack = XlsxReader.read(dst).fold(err => fail(s"re-read failed: ${err.message}"), identity)
+    assertEquals(readBack.metadata.creator, fullMetadata.creator)
+    assertEquals(readBack.metadata.application, fullMetadata.application)
+  }

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/FixturePreservationSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/FixturePreservationSpec.scala
@@ -1,13 +1,16 @@
 package com.tjclp.xl.ooxml
 
+import java.io.StringReader
 import java.nio.file.{Files, Path}
 import java.security.MessageDigest
 import java.util.zip.ZipFile
+import javax.xml.parsers.DocumentBuilderFactory
 
 import munit.FunSuite
 import com.tjclp.xl.api.*
 import com.tjclp.xl.cells.CellValue
 import com.tjclp.xl.macros.ref
+import com.tjclp.xl.ooxml.writer.WriterConfig
 
 /**
  * Visual-preservation pre-check for GH-240 (ground truth for the GH-221/GH-222 work): what happens
@@ -44,9 +47,14 @@ class FixturePreservationSpec extends FunSuite:
     (path, wb)
 
   private def writeTo(wb: Workbook, label: String): Path =
+    writeToWith(wb, label, WriterConfig())
+
+  private def writeToWith(wb: Workbook, label: String, config: WriterConfig): Path =
     val out = Files.createTempFile(s"xl-preserve-$label-", ".xlsx")
     out.toFile.deleteOnExit()
-    XlsxWriter.write(wb, out).fold(err => fail(s"$label write failed: ${err.message}"), _ => ())
+    XlsxWriter
+      .writeWith(wb, out, config)
+      .fold(err => fail(s"$label write failed: ${err.message}"), _ => ())
     out
 
   List("chart-bar.xlsx", "image.xlsx").foreach { fixture =>
@@ -71,40 +79,55 @@ class FixturePreservationSpec extends FunSuite:
       assertEquals(after, before, s"$fixture visual parts drifted on modified write")
     }
 
-    test(s"$fixture: KNOWN BUG - cell-modified write emits unbound r: prefix on <drawing>") {
-      // openpyxl binds xmlns:r ON the <drawing> element itself:
-      //   <drawing xmlns:r="...officeDocument/2006/relationships" r:id="rId1"/>
-      // When a cell modification forces worksheet regeneration, the preserved
-      // <drawing> is re-emitted as <drawing r:id="rId1"/> WITHOUT the xmlns:r
-      // binding, so the output worksheet is not well-formed XML and XlsxReader
-      // refuses to re-read the file it just wrote. The chart/image survives in
-      // the zip but the workbook is corrupt. This pins the current behavior for
-      // GH-221/GH-222; when fixed, flip these assertions to a successful re-read.
-      val (_, wb) = readFixture(fixture)
-      val sheetName = wb.sheets(0).name
-      val modified = wb
-        .update(sheetName, _.put(ref"A20", CellValue.Text("modified after read")))
-        .fold(err => fail(s"$fixture update failed: $err"), identity)
-      val out = writeTo(modified, "nsbug")
-      val sheetXml = entryText(out, "xl/worksheets/sheet1.xml")
-      assert(sheetXml.contains("<drawing"), "drawing element vanished entirely")
-      assert(sheetXml.contains("r:id"), "drawing lost its r:id attribute")
-      assert(
-        !sheetXml.contains("xmlns:r"),
-        "regenerated worksheet now binds xmlns:r - the namespace bug may be fixed; " +
-          "flip this test to assert a successful re-read instead"
-      )
-      XlsxReader.read(out) match
-        case Left(err) =>
-          assert(
-            err.message.contains("prefix") || err.message.contains("parse"),
-            s"expected namespace parse failure, got: ${err.message}"
-          )
-        case Right(_) =>
-          fail(
-            "XlsxReader re-read its own modified-write output - the xmlns:r bug " +
-              "may be fixed; flip this test to assert the round-trip instead"
-          )
+    // GH-291: openpyxl binds xmlns:r ON the <drawing> element itself; regenerating a modified
+    // worksheet must keep that prefix bound (hoisted to the root) or the workbook is corrupt.
+    // Both writer backends regenerate modified sheets, so both must produce valid output.
+    List(
+      "ScalaXml" -> WriterConfig.scalaXml,
+      "SaxStax" -> WriterConfig.saxStax
+    ).foreach { case (backend, config) =>
+      test(s"$fixture/$backend: cell-modified write stays namespace-valid and re-readable") {
+        val (in, wb) = readFixture(fixture)
+        val sheetName = wb.sheets(0).name
+        val modified = wb
+          .update(sheetName, _.put(ref"A20", CellValue.Text("modified after read")))
+          .fold(err => fail(s"$fixture update failed: $err"), identity)
+        val out = writeToWith(modified, s"valid-$backend", config)
+
+        // Drawing survived regeneration
+        val sheetXml = entryText(out, "xl/worksheets/sheet1.xml")
+        assert(sheetXml.contains("<drawing"), "drawing element vanished entirely")
+
+        // Namespace well-formedness: a namespace-aware parser accepts the worksheet
+        // (an unbound r: prefix on <drawing> throws here)
+        val doc = parseNamespaceAware(sheetXml, s"$fixture/$backend regenerated worksheet")
+
+        // The drawing's r:id attribute resolves in the relationships namespace
+        val drawings = doc.getElementsByTagNameNS("*", "drawing")
+        assertEquals(drawings.getLength, 1, "expected exactly one <drawing>")
+        val drawingId = Option(drawings.item(0))
+          .collect { case e: org.w3c.dom.Element => e.getAttributeNS(nsRel, "id") }
+          .filter(_.nonEmpty)
+          .getOrElse(fail("drawing r:id missing or not in the relationships namespace"))
+
+        // Zip-level structure: every r:id referenced from the worksheet exists in sheet rels
+        val relIds = relationshipIdsOf(out, "xl/worksheets/_rels/sheet1.xml.rels")
+        val referenced = relationshipRefs(doc)
+        assert(referenced.contains(drawingId), "drawing r:id not among collected references")
+        assert(
+          referenced.subsetOf(relIds),
+          s"worksheet references missing from sheet rels: ${(referenced -- relIds).mkString(", ")}"
+        )
+
+        // The output re-reads cleanly (the original GH-291 failure mode)
+        val reread = XlsxReader
+          .read(out)
+          .fold(err => fail(s"re-read of modified write failed: ${err.message}"), identity)
+        assertEquals(reread.sheets(0).name, sheetName)
+
+        // Visual parts survive byte-identically
+        assertEquals(visualParts(out), visualParts(in), "visual parts drifted")
+      }
     }
   }
 
@@ -136,3 +159,37 @@ class FixturePreservationSpec extends FunSuite:
           new String(zip.getInputStream(e).readAllBytes(), java.nio.charset.StandardCharsets.UTF_8)
         case None => fail(s"zip entry $name not found in $path")
     finally zip.close()
+
+  private val nsRel = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+
+  /** Parse with a namespace-aware parser; an unbound prefix fails the test. */
+  private def parseNamespaceAware(xml: String, label: String): org.w3c.dom.Document =
+    val factory = DocumentBuilderFactory.newInstance()
+    factory.setNamespaceAware(true)
+    try factory.newDocumentBuilder().parse(new org.xml.sax.InputSource(new StringReader(xml)))
+    catch
+      case e: org.xml.sax.SAXException =>
+        fail(s"$label is not namespace-well-formed: ${e.getMessage}")
+
+  /** Every r:id value (relationships-namespace `id` attribute) referenced in the document. */
+  private def relationshipRefs(doc: org.w3c.dom.Document): Set[String] =
+    val all = doc.getElementsByTagNameNS("*", "*")
+    (0 until all.getLength)
+      .flatMap { i =>
+        Option(all.item(i)).collect { case e: org.w3c.dom.Element =>
+          Option(e.getAttributeNS(nsRel, "id")).filter(_.nonEmpty)
+        }.flatten
+      }
+      .toSet
+
+  /** Relationship Ids declared in a rels part of the zip. */
+  private def relationshipIdsOf(path: Path, relsEntry: String): Set[String] =
+    val relsDoc = parseNamespaceAware(entryText(path, relsEntry), relsEntry)
+    val rels = relsDoc.getElementsByTagNameNS("*", "Relationship")
+    (0 until rels.getLength)
+      .flatMap { i =>
+        Option(rels.item(i)).collect { case e: org.w3c.dom.Element =>
+          Option(e.getAttribute("Id")).filter(_.nonEmpty)
+        }.flatten
+      }
+      .toSet

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/OoxmlGenerativeRoundTripSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/OoxmlGenerativeRoundTripSpec.scala
@@ -31,9 +31,9 @@ import com.tjclp.xl.styles.numfmt.NumFmt
  * specs). In short: same sheet names in order; same cell refs; CellValue equal (formulas by text,
  * numbers by BigDecimal compare, DateTime ≈ stored serial); RESOLVED cell styles equal (registry
  * indices may be renumbered by dedup, numFmtId is reader-filled metadata); comments equal by (plain
- * text, author); hyperlinks equal; merges set-equal; viewSettings/pageSetup equal. Explicitly
- * ignored serialization noise: styleId numbering, SST ordering, workbook metadata +
- * activeSheetIndex (not serialized — GH-242), dimension/defaultColWidth-style derived props,
+ * text, author); hyperlinks equal; merges set-equal; viewSettings/pageSetup equal; docProps
+ * metadata fields equal (GH-242). Explicitly ignored serialization noise: styleId numbering, SST
+ * ordering, activeSheetIndex (not serialized), dimension/defaultColWidth-style derived props,
  * write-only freezePane, cached formula values, and Rgb alpha-00 ≡ alpha-FF (the parser
  * deliberately canonicalizes 00 alpha to opaque, matching Excel/openpyxl's 00RRGGBB convention).
  *

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/StyleParserHardeningSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/StyleParserHardeningSpec.scala
@@ -1,0 +1,93 @@
+package com.tjclp.xl.ooxml
+
+import scala.xml.XML
+
+import munit.FunSuite
+
+import com.tjclp.xl.ooxml.style.WorkbookStyles
+import com.tjclp.xl.styles.font.Font
+
+/**
+ * GH-278: the DOM StyleParser must stay total on malformed numeric attributes.
+ *
+ * `Font` carries domain guards (`sizePt > 0`, nonEmpty name); the parser must filter values that
+ * would violate them and fall back to defaults instead of throwing through `require` during read.
+ * This is the DOM-side analog of the GH-264 streaming fix (StylePatcher).
+ */
+class StyleParserHardeningSpec extends FunSuite:
+
+  private def stylesXml(fontXml: String): scala.xml.Elem =
+    XML.loadString(
+      s"""<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+         |  <fonts count="2">
+         |    <font><sz val="11"/><name val="Calibri"/></font>
+         |    $fontXml
+         |  </fonts>
+         |  <fills count="1"><fill><patternFill patternType="none"/></fill></fills>
+         |  <borders count="1"><border/></borders>
+         |  <cellXfs count="2">
+         |    <xf numFmtId="0" fontId="0" fillId="0" borderId="0"/>
+         |    <xf numFmtId="0" fontId="1" fillId="0" borderId="0"/>
+         |  </cellXfs>
+         |</styleSheet>""".stripMargin
+    )
+
+  private def secondFont(fontXml: String): Font =
+    WorkbookStyles.fromXml(stylesXml(fontXml)) match
+      case Right(styles) =>
+        styles.fonts.lift(1).getOrElse(fail("expected two parsed fonts"))
+      case Left(err) => fail(s"styles parse must not fail: $err")
+
+  test("GH-278: negative font sz falls back to default size instead of throwing") {
+    val font = secondFont("""<font><sz val="-4"/><name val="Arial"/></font>""")
+    assertEquals(font.sizePt, Font.default.sizePt)
+    assertEquals(font.name, "Arial", "fallback must only affect the size")
+  }
+
+  test("GH-278: zero font sz falls back to default size instead of throwing") {
+    val font = secondFont("""<font><sz val="0"/><name val="Arial"/></font>""")
+    assertEquals(font.sizePt, Font.default.sizePt)
+  }
+
+  test("GH-278: NaN font sz falls back to default size instead of throwing") {
+    // "NaN".toDoubleOption parses; require(NaN > 0) would still throw
+    val font = secondFont("""<font><sz val="NaN"/><name val="Arial"/></font>""")
+    assertEquals(font.sizePt, Font.default.sizePt)
+  }
+
+  test("GH-278: unparseable font sz keeps default size (regression)") {
+    val font = secondFont("""<font><sz val="big"/><name val="Arial"/></font>""")
+    assertEquals(font.sizePt, Font.default.sizePt)
+  }
+
+  test("GH-278: valid font sz still parses exactly (regression)") {
+    val font = secondFont("""<font><sz val="14.5"/><name val="Arial"/></font>""")
+    assertEquals(font.sizePt, 14.5)
+  }
+
+  // ---- sweep: the same hole in rich-text run properties (<rPr>), reachable from
+  // ---- both the DOM reader (parseTextRuns) and the SAX SST reader
+
+  test("GH-278 sweep: rich-run <rPr> non-positive sz falls back to default size") {
+    val rPr = XML.loadString("""<rPr><sz val="-2"/><name val="Arial"/></rPr>""")
+    val font = XmlUtil.parseRunProperties(rPr)
+    assertEquals(font.sizePt, Font.default.sizePt)
+    assertEquals(font.name, "Arial")
+  }
+
+  test("GH-278 sweep: rich-run <rPr> NaN sz falls back to default size") {
+    val rPr = XML.loadString("""<rPr><sz val="NaN"/></rPr>""")
+    assertEquals(XmlUtil.parseRunProperties(rPr).sizePt, Font.default.sizePt)
+  }
+
+  test("GH-278 sweep: rich-run <rPr> empty name falls back to default name") {
+    val rPr = XML.loadString("""<rPr><name val=""/></rPr>""")
+    assertEquals(XmlUtil.parseRunProperties(rPr).name, Font.default.name)
+  }
+
+  test("GH-278 sweep: rich-run <rPr> valid sz and name still parse (regression)") {
+    val rPr = XML.loadString("""<rPr><sz val="9.5"/><name val="Consolas"/></rPr>""")
+    val font = XmlUtil.parseRunProperties(rPr)
+    assertEquals(font.sizePt, 9.5)
+    assertEquals(font.name, "Consolas")
+  }

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/WorkbookEquivalence.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/WorkbookEquivalence.scala
@@ -36,12 +36,14 @@ import com.tjclp.xl.styles.fill.Fill
  *   - (c) sheet-level: viewSettings equal; pageSetup equal (an authored PageSetup always
  *     round-trips when it has at least one visible field; all-default PageSetup serializes to no
  *     XML and reads back None by design — generators only produce visible ones)
+ *   - (d) workbook-level: docProps metadata fields equal (GH-242 — creator, lastModifiedBy,
+ *     application, appVersion exact; created/modified at W3CDTF second precision)
  *
  * EXPLICITLY IGNORED (serialization noise or known write-only fields):
  *   - styleId numbering (dedup may renumber; only resolved styles matter)
  *   - SST ordering / inline-vs-shared string encoding
- *   - workbook metadata (docProps not written on save — GH-242) and activeSheetIndex (not
- *     serialized to bookViews)
+ *   - activeSheetIndex (not serialized to bookViews) and metadata theme/definedNames/sheetStates
+ *     (separate parts with their own round-trip specs)
  *   - the worksheet dimension element and derived defaults (defaultColWidth etc.)
  *   - freezePane (three-valued write-only override: None means "preserve", so the reader never
  *     populates it)
@@ -68,7 +70,29 @@ object WorkbookEquivalence:
         .zip(actual.sheets)
         .flatMap { case (exp, act) => sheetDiff(exp, act) }
         .toList
-    nameDiffs ++ sheetDiffs
+    nameDiffs ++ metadataDiff(expected, actual) ++ sheetDiffs
+
+  /**
+   * docProps metadata fields round-trip since GH-242: creator/lastModifiedBy/application/appVersion
+   * exact, created/modified at the W3CDTF second precision the part stores.
+   */
+  private def metadataDiff(expected: Workbook, actual: Workbook): List[String] =
+    def field[A](name: String, exp: A, act: A): Option[String] =
+      Option.when(exp != act)(s"metadata.$name mismatch: expected $exp, actual $act")
+    def seconds(
+      dt: Option[java.time.LocalDateTime]
+    ): Option[java.time.LocalDateTime] =
+      dt.map(_.truncatedTo(java.time.temporal.ChronoUnit.SECONDS))
+    val em = expected.metadata
+    val am = actual.metadata
+    List(
+      field("creator", em.creator, am.creator),
+      field("created", seconds(em.created), seconds(am.created)),
+      field("modified", seconds(em.modified), seconds(am.modified)),
+      field("lastModifiedBy", em.lastModifiedBy, am.lastModifiedBy),
+      field("application", em.application, am.application),
+      field("appVersion", em.appVersion, am.appVersion)
+    ).flatten
 
   /** True when `diff` reports no violations. */
   def equivalent(expected: Workbook, actual: Workbook): Boolean =

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/WorksheetNamespaceSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/WorksheetNamespaceSpec.scala
@@ -1,10 +1,127 @@
 package com.tjclp.xl.ooxml
 
+import java.io.{ByteArrayOutputStream, StringReader}
+import javax.xml.parsers.DocumentBuilderFactory
+
 import munit.FunSuite
 
 import scala.xml.XML
 
 class WorksheetNamespaceSpec extends FunSuite:
+
+  private val nsRel = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+
+  private def parseNamespaceAware(xml: String): org.w3c.dom.Document =
+    val factory = DocumentBuilderFactory.newInstance()
+    factory.setNamespaceAware(true)
+    try factory.newDocumentBuilder().parse(new org.xml.sax.InputSource(new StringReader(xml)))
+    catch
+      case e: org.xml.sax.SAXException =>
+        fail(s"output is not namespace-well-formed: ${e.getMessage}\n$xml")
+
+  private def parseWorksheet(input: String): worksheet.OoxmlWorksheet =
+    OoxmlWorksheet
+      .fromXml(XML.loadString(input))
+      .fold(err => fail(s"Failed to parse worksheet: $err"), identity)
+
+  // GH-291: openpyxl declares xmlns:r locally on <drawing>, not on the worksheet root. The
+  // regenerated worksheet must keep the prefix bound (hoisted onto the root, the standard Excel
+  // layout) on BOTH emission paths or Excel reports the workbook as corrupt.
+  private val openpyxlStyleInput =
+    """
+      |<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+      |  <sheetData>
+      |    <row r="1">
+      |      <c r="A1" t="inlineStr"><is><t>Hello</t></is></c>
+      |    </row>
+      |  </sheetData>
+      |  <drawing xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+      |           r:id="rId1"/>
+      |</worksheet>
+      |""".stripMargin
+
+  test("GH-291: toXml keeps locally-declared xmlns:r on <drawing> bound (hoisted to root)") {
+    val regenerated = parseWorksheet(openpyxlStyleInput).toXml
+
+    assertEquals(Option(regenerated.scope.getURI("r")), Some(nsRel))
+
+    val doc = parseNamespaceAware(XmlUtil.compact(regenerated))
+    val drawings = doc.getElementsByTagNameNS("*", "drawing")
+    assertEquals(drawings.getLength, 1)
+    val id = drawings.item(0) match
+      case e: org.w3c.dom.Element => e.getAttributeNS(nsRel, "id")
+      case other => fail(s"unexpected node: $other")
+    assertEquals(id, "rId1")
+  }
+
+  test("GH-291: writeSax keeps locally-declared xmlns:r on <drawing> bound (hoisted to root)") {
+    val ws = parseWorksheet(openpyxlStyleInput)
+    val out = new ByteArrayOutputStream()
+    val saxWriter = StaxSaxWriter.create(out)
+    ws.writeSax(saxWriter)
+    val xml = out.toString("UTF-8")
+
+    val doc = parseNamespaceAware(xml)
+    // Bound at the ROOT (standard Excel layout, parity with the ScalaXml backend)
+    assertEquals(Option(doc.getDocumentElement.lookupNamespaceURI("r")), Some(nsRel))
+    val drawings = doc.getElementsByTagNameNS("*", "drawing")
+    assertEquals(drawings.getLength, 1)
+    val id = drawings.item(0) match
+      case e: org.w3c.dom.Element => e.getAttributeNS(nsRel, "id")
+      case other => fail(s"unexpected node: $other")
+    assertEquals(id, "rId1")
+  }
+
+  test("GH-291: row-level x14ac:dyDescent stays bound when the root lacks the prefix") {
+    // Rows re-emit x14ac:dyDescent as a raw qualified attribute; a source that bound the prefix
+    // locally on <row> (legal XML) must not regenerate into an unbound prefix.
+    val input =
+      """
+        |<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+        |  <sheetData>
+        |    <row r="1" x14ac:dyDescent="0.25"
+        |         xmlns:x14ac="http://schemas.microsoft.com/office/spreadsheetml/2009/9/ac">
+        |      <c r="A1" t="inlineStr"><is><t>Hello</t></is></c>
+        |    </row>
+        |  </sheetData>
+        |</worksheet>
+        |""".stripMargin
+
+    val regenerated = parseWorksheet(input).toXml
+    val doc = parseNamespaceAware(XmlUtil.compact(regenerated))
+    assertEquals(
+      Option(doc.getDocumentElement.lookupNamespaceURI("x14ac")),
+      Some("http://schemas.microsoft.com/office/spreadsheetml/2009/9/ac")
+    )
+  }
+
+  test("GH-291: locally-declared prefix inside extLst survives regeneration") {
+    // x14 is NOT in any well-known fallback table: the binding must be carried from the source.
+    val input =
+      """
+        |<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+        |  <sheetData>
+        |    <row r="1">
+        |      <c r="A1" t="inlineStr"><is><t>Hello</t></is></c>
+        |    </row>
+        |  </sheetData>
+        |  <extLst>
+        |    <ext uri="{example}" xmlns:x14="http://schemas.microsoft.com/office/spreadsheetml/2009/9/main">
+        |      <x14:sparklineGroups/>
+        |    </ext>
+        |  </extLst>
+        |</worksheet>
+        |""".stripMargin
+
+    val regenerated = parseWorksheet(input).toXml
+    val doc = parseNamespaceAware(XmlUtil.compact(regenerated))
+    val groups =
+      doc.getElementsByTagNameNS(
+        "http://schemas.microsoft.com/office/spreadsheetml/2009/9/main",
+        "sparklineGroups"
+      )
+    assertEquals(groups.getLength, 1, "x14:sparklineGroups lost its namespace binding")
+  }
 
   test("worksheet preserves namespaces and avoids pollution") {
     val input =

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/XlsxReaderErrorSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/XlsxReaderErrorSpec.scala
@@ -134,6 +134,24 @@ class XlsxReaderErrorSpec extends FunSuite:
       case other => fail(s"Expected ParseError for malformed styles, got $other")
   }
 
+  test("XlsxReader survives non-positive font sz in styles.xml (GH-278)") {
+    // Font requires sizePt > 0; a malformed val="-4" must fall back to the
+    // default size at the parse site instead of throwing through the require.
+    val malformedStyles =
+      """<?xml version="1.0" encoding="UTF-8"?>
+<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <fonts count="1"><font><sz val="-4"/><name val="Calibri"/></font></fonts>
+  <fills count="1"><fill><patternFill patternType="none"/></fill></fills>
+  <borders count="1"><border/></borders>
+  <cellXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0"/></cellXfs>
+</styleSheet>"""
+    val bytes = buildWorkbook(overrides = Map("xl/styles.xml" -> malformedStyles))
+    XlsxReader.readFromBytes(bytes) match
+      case Right(wb) =>
+        assertEquals(wb.sheets(0)(ref"A1").value, CellValue.Text("Hello"))
+      case Left(err) => fail(s"read must not fail on a malformed font size: $err")
+  }
+
   test("XlsxReader errors when worksheet part referenced by workbook is missing") {
     val bytes = buildWorkbook(omit = Set("xl/worksheets/sheet1.xml"))
     assertParseError(

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/metadata/WorkbookMetadataReaderSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/metadata/WorkbookMetadataReaderSpec.scala
@@ -119,3 +119,22 @@ class WorkbookMetadataReaderSpec extends FunSuite:
     val result = WorkbookMetadataReader.read(path)
     assert(result.isLeft, "Expected error for non-existent file")
   }
+
+  test("read: extracts date1904 flag from workbookPr (GH-243)") {
+    val sheets = Vector(Sheet(SheetName.unsafe("Dates")))
+    val path = Files.createTempFile("metadata-test-1904-", ".xlsx")
+    val wb = Workbook(sheets)
+    XlsxWriter.write(wb.copy(metadata = wb.metadata.copy(date1904 = true)), path)
+    try
+      val meta = WorkbookMetadataReader.read(path).toOption.get
+      assert(meta.date1904, "expected date1904 = true from written workbookPr")
+    finally Files.deleteIfExists(path)
+  }
+
+  test("read: date1904 defaults to false for 1900-system workbooks (GH-243)") {
+    val path = createTempWorkbook(Vector(Sheet(SheetName.unsafe("Plain"))))
+    try
+      val meta = WorkbookMetadataReader.read(path).toOption.get
+      assert(!meta.date1904)
+    finally Files.deleteIfExists(path)
+  }


### PR DESCRIPTION
## Summary

Wave 4 of the [burn-down](docs/plan/roadmap.md) via `issue-wave.js`: 5 worktree TDD clusters, pipelined adversarial review. **5/5 approved — four required a rework round** (the reviewers are earning their keep on harder material):

- **zip-writer**: #242 docProps emission (model-wins-over-verbatim, deterministic, equivalence un-ignores metadata) + #223 two-pass streaming SST/styles. The rework round caught a textbook **referential-transparency bug**: the SST accumulator was created at stream-construction time, so re-running the same compiled `IO` reused a dirty accumulator — fixed with `Stream.eval(Sync[F].delay(...))` deferral; reviewer verified with a 4-probe discrimination matrix including retry-after-transient-failure.
- **date-1904**: #243's epoch propagation — `date1904` into `WorkbookMetadata`, preserve-the-system on write, no phantom-leap-day in 1904 conversion; streaming-edit envelope disclosed in LIMITATIONS.
- **display-formats**: Excel fraction rendering (`# ?/?` family, continued-fraction search, total beyond Double range), `[>100]` condition routing (#285), date display gaps (#283: General renders the serial; sections apply to date codes).
- **streaming-parity**: #293 (inlineStr style indices + formula trim), #305 (per-run `_xHHHH_` decode), #278 (StyleParser font-size totality) — all parity-asserted against the DOM reader over the fixture corpus.
- **drawing-preserve**: **#291 — the Visual blocker.** Root cause had two halves: `cleanNamespaces` destroyed openpyxl's local `xmlns:r` binding at *capture* time, and re-emission never re-bound it. Both fixed; wave-2's corruption-pinning tests flipped to validity assertions (namespace-aware re-parse, rels resolution).

## Integration notes
`WorkbookMetadata` took both clusters' new fields (date1904 + docProps); `StreamingParitySpec` was rebuilt at the seam after a conflict split a test mid-body; a wave-2 KNOWN-GAP pinning test resurrected by that rebuild was removed per its own "flip when fixed" instruction.

## Verification
Baseline 3349 green pre-wave. Integrated: `./mill clean` + full suite **1028/1028 SUCCESS**, prelude probes green, generative law at 500 cases green. All TDD; revert-and-rerun refutation per cluster.

Closes #242
Closes #223
Closes #243
Closes #283
Closes #285
Closes #293
Closes #305
Closes #278
Closes #291

🤖 Generated with [Claude Code](https://claude.com/claude-code)