### PR TITLE
chore(release): Bump version to 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0] "Visual" - 2026-06-11
+
+The Visual release: embedded pictures and typed charts with hybrid preservation —
+the drawing layer xl could previously only carry verbatim is now a first-class,
+law-governed part of the model. Closes the original 0.12.0 theme (#221, #222).
+
 ### Added (Visual wave 6b)
 
 - **Typed chart model** (#222): `com.tjclp.xl.charts.Chart` — bar, line, pie with series

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ```scala 3 raw
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.11.3
+//> using dep com.tjclp::xl:0.12.0
 
 import com.tjclp.xl.{*, given}
 
@@ -55,13 +55,13 @@ import com.tjclp.xl.{*, given}
 
 ```scala 3 ignore
 // build.mill — single dependency for everything
-def ivyDeps = Agg(ivy"com.tjclp::xl:0.11.3")
+def ivyDeps = Agg(ivy"com.tjclp::xl:0.12.0")
 
 // Or individual modules for minimal footprint:
-// ivy"com.tjclp::xl-core:0.11.3"        — Pure domain model only
-// ivy"com.tjclp::xl-ooxml:0.11.3"       — Add OOXML read/write
-// ivy"com.tjclp::xl-cats-effect:0.11.3" — Add IO streaming
-// ivy"com.tjclp::xl-evaluator:0.11.3"   — Add formula evaluation
+// ivy"com.tjclp::xl-core:0.12.0"        — Pure domain model only
+// ivy"com.tjclp::xl-ooxml:0.12.0"       — Add OOXML read/write
+// ivy"com.tjclp::xl-cats-effect:0.12.0" — Add IO streaming
+// ivy"com.tjclp::xl-evaluator:0.12.0"   — Add formula evaluation
 ```
 
 ### Basic Usage

--- a/build.mill
+++ b/build.mill
@@ -14,7 +14,7 @@ val organization = "com.tjclp"
 /** Shared build configuration constants */
 object BuildConfig {
   /** Project version: CI sets PUBLISH_VERSION; local builds use this fallback */
-  val version: String = sys.env.getOrElse("PUBLISH_VERSION", "0.11.3")
+  val version: String = sys.env.getOrElse("PUBLISH_VERSION", "0.12.0")
 
   /** JVM options to silence Scala 3 LazyVals sun.misc.Unsafe deprecation warnings (JDK 21+) */
   val lazyValsJvmArgs: Seq[String] = Seq(

--- a/docs/QUICK-START.md
+++ b/docs/QUICK-START.md
@@ -12,19 +12,19 @@ import mill._, scalalib._
 
 object myproject extends ScalaModule {
   def scalaVersion = "3.8.3"
-  def ivyDeps = Agg(ivy"com.tjclp::xl:0.11.3")
+  def ivyDeps = Agg(ivy"com.tjclp::xl:0.12.0")
 }
 ```
 
 ### With sbt (build.sbt)
 ```scala
 scalaVersion := "3.8.3"
-libraryDependencies += "com.tjclp" %% "xl" % "0.11.3"
+libraryDependencies += "com.tjclp" %% "xl" % "0.12.0"
 ```
 
 ### With Scala CLI
 ```scala
-//> using dep com.tjclp::xl:0.11.3
+//> using dep com.tjclp::xl:0.12.0
 ```
 
 ### Individual Modules (Optional)
@@ -44,7 +44,7 @@ For scripts, skip the build setup entirely: a two-line `scala-cli` header and ON
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.11.3
+//> using dep com.tjclp::xl:0.12.0
 
 import com.tjclp.xl.scripting.{*, given}
 

--- a/docs/plan/roadmap.md
+++ b/docs/plan/roadmap.md
@@ -12,7 +12,7 @@
 
 **Current Status**: Production-ready with **104 formula functions** (incl. dynamic arrays SEQUENCE/SORT/UNIQUE/FILTER and OFFSET), **structural editing** (insert/delete rows & columns with formula rewriting), the **scripting prelude** (`com.tjclp.xl.scripting`), whole-workbook `recalculate`, named-range & hyperlink authoring, SAX streaming (36% faster than POI), Excel tables, and full OOXML round-trip. 3005+ tests passing.
 
-**Current Version**: **0.11.3 "Robustness"** (released 2026-06-11)
+**Current Version**: **0.12.0 "Visual"** (released 2026-06-11)
 
 ---
 
@@ -53,7 +53,7 @@ All open bugs, one patch release (PR #276). Reviewer-discovered gaps filed as #2
 | 4 — streaming/OOXML + parity/totality follow-ups #278/#283/#285/#291/#293/#305 (PR #310) | [#223](https://github.com/TJC-LP/xl/issues/223) two-pass streaming SST + style registry; [#242](https://github.com/TJC-LP/xl/issues/242) docProps emission; [#243](https://github.com/TJC-LP/xl/issues/243) 1904 dates + `NumFmt.Fraction` + autofilter authoring |
 | 5 — CLI/UX + display/SVG/evaluator follow-ups #279-#282/#296/#298/#301/#302/#306-#308 (PR #311) | [#134](https://github.com/TJC-LP/xl/issues/134) `filter --where` (row predicates); [#137](https://github.com/TJC-LP/xl/issues/137) `diff`; [#159](https://github.com/TJC-LP/xl/issues/159) markdown import; [#156](https://github.com/TJC-LP/xl/issues/156) AWT-metric autofit; [#86](https://github.com/TJC-LP/xl/issues/86) Batik-first rasterization |
 
-### v0.12.0 "Visual" — wave 6 (design-first)
+### v0.12.0 "Visual" — wave 6 (Released 2026-06-11)
 
 Phased: (a) verbatim chart/drawing preservation proven by the wave-2 fixture corpus; (b) `Drawing`/`Image`/anchor domain model + image authoring ([#221](https://github.com/TJC-LP/xl/issues/221)); (c) typed chart AST (bar/line/pie) + authoring + `xl chart` CLI ([#222](https://github.com/TJC-LP/xl/issues/222)). Re-scoped by its own design panel when reached.
 

--- a/docs/reference/scripting.md
+++ b/docs/reference/scripting.md
@@ -33,7 +33,7 @@ release bump is a mechanical substitution):
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.11.3
+//> using dep com.tjclp::xl:0.12.0
 import com.tjclp.xl.scripting.{*, given}
 
 val sheet = Sheet("Demo").put(ref"A1", "Hello").put(ref"B1", 42)
@@ -51,7 +51,7 @@ read and write is pure values.
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.11.3
+//> using dep com.tjclp::xl:0.12.0
 import com.tjclp.xl.scripting.{*, given}
 
 val wb = Excel.read("input.xlsx")
@@ -135,7 +135,7 @@ throw — they are collected per cell.
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.11.3
+//> using dep com.tjclp::xl:0.12.0
 import com.tjclp.xl.scripting.{*, given}
 
 val title = CellStyle.default.bold.size(14.0).center
@@ -161,6 +161,11 @@ Workbook(model).recalculate().toEither match
     errors.foreach(e => println(s"✗ ${e.render}"))
     sys.exit(1)
 ```
+
+Since 0.12.0 the prelude also exposes the drawing layer: `sheet.addImage(bytes, format, at)`
+embeds pictures (7 formats, natural-size PNG/JPEG sniffing) and `com.tjclp.xl.charts.Chart`
+authors bar/line/pie charts anchored to ranges — both round-trip through OOXML with unmodeled
+content preserved byte-faithfully.
 
 Since 0.11.2, formulas may use `LET` (lexical bindings), `INDIRECT` (dynamic references —
 evaluated in a deferred last partition), and `RAND`/`RANDBETWEEN`. Randomness is an explicit
@@ -236,7 +241,7 @@ them explicitly:
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.11.3
+//> using dep com.tjclp::xl:0.12.0
 import com.tjclp.xl.scripting.{*, given}
 import com.tjclp.xl.sheets.{HeaderFooter, PageMargins, PageSetup, SheetView}
 
@@ -290,7 +295,7 @@ the whole workbook:
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.11.3
+//> using dep com.tjclp::xl:0.12.0
 import com.tjclp.xl.scripting.{*, given}
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global

--- a/examples/README.md
+++ b/examples/README.md
@@ -170,7 +170,7 @@ chmod +x examples/my_example.sc
 ./examples/my_example.sc
 ```
 
-The `project.scala` file centralizes dependencies (`com.tjclp::xl:0.11.3`) for all examples.
+The `project.scala` file centralizes dependencies (`com.tjclp::xl:0.12.0`) for all examples.
 
 ## Scripting Prelude & Skill
 

--- a/examples/project.scala
+++ b/examples/project.scala
@@ -2,4 +2,4 @@
 //> using repository ivy2Local
 
 // XL aggregate - includes all modules (core, ooxml, cats-effect, evaluator)
-//> using dep com.tjclp::xl:0.11.3
+//> using dep com.tjclp::xl:0.12.0

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "xl",
   "description": "LLM-friendly Excel tooling: the xl CLI for reading, writing, styling, and analyzing spreadsheets (xl-cli skill), plus type-safe Scala scripting against the xl library via scala-cli for bulk transformations, pipelines, and formula models (xl-scripting skill).",
-  "version": "0.11.3",
+  "version": "0.12.0",
   "author": {
     "name": "TJC L.P.",
     "url": "https://github.com/TJC-LP"

--- a/plugin/skills/xl-cli/SKILL.md
+++ b/plugin/skills/xl-cli/SKILL.md
@@ -110,6 +110,12 @@ xl -f <file> -s <sheet> filter --where "B > 100 AND D = TRUE" --header --format 
 xl -f <file> -s <sheet> filter --where "Name LIKE 'Acme%'" --columns A,C:E --limit 20
 ```
 
+### Images & Charts (require `-o`, 0.12.0+)
+```bash
+xl -f <file> -s <sheet> -o <out> add-image logo.png --at B2          # Embed picture (png/jpeg/gif/bmp...)
+xl -f <file> -s <sheet> -o <out> chart add --type bar --data B2:D10 --categories A2:A10 --title "Revenue" --at F2:K15
+```
+
 ### Row/Column Operations (require `-o`)
 ```bash
 xl -f <file> -s <sheet> -o <out> row <n> --height 30

--- a/plugin/skills/xl-scripting/SKILL.md
+++ b/plugin/skills/xl-scripting/SKILL.md
@@ -38,7 +38,7 @@ The canonical header for every script (this is the single source of truth — re
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.11.3
+//> using dep com.tjclp::xl:0.12.0
 
 import com.tjclp.xl.scripting.{*, given}
 
@@ -100,7 +100,7 @@ wb.update("Sales", f).unsafe                       // throws structured XLExcept
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.11.3
+//> using dep com.tjclp::xl:0.12.0
 import com.tjclp.xl.scripting.{*, given}
 
 val wb = Excel.read("input.xlsx")
@@ -235,7 +235,7 @@ Or lean on totality so there is nothing to unwrap: literal refs, `upsert`, range
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.11.3
+//> using dep com.tjclp::xl:0.12.0
 import com.tjclp.xl.scripting.{*, given}
 import java.nio.file.{Files, Paths}
 import scala.jdk.CollectionConverters.*
@@ -257,7 +257,7 @@ println(s"merged ${inputs.size} files, ${merged.sheets.size} sheets")
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.11.3
+//> using dep com.tjclp::xl:0.12.0
 import com.tjclp.xl.scripting.{*, given}
 
 val data = List(("North", 125000.50), ("South", 98000.25), ("West", 143500.00))
@@ -285,7 +285,7 @@ println(if result.isClean then "✓ report written" else result.errors.map(_.ren
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.11.3
+//> using dep com.tjclp::xl:0.12.0
 import com.tjclp.xl.scripting.{*, given}
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global

--- a/plugin/skills/xl-scripting/reference/API.md
+++ b/plugin/skills/xl-scripting/reference/API.md
@@ -157,6 +157,14 @@ import com.tjclp.xl.sheets.{HeaderFooter, PageMargins, PageSetup, SheetView}
 
 ```scala
 // Display: gridlines off (professional templates), zoom 10-400
+// Pictures & charts (0.12.0+) — drawing layer with hybrid preservation
+val image = ImageData.detect(bytes).unsafe                     // XLResult: format from magic bytes
+sheet.addImage(image, ref"B2").unsafe                          // natural size (XLResult; PNG/JPEG sniffed)
+sheet.addImage(image, ref"B2:D8")                              // stretched over a range — total
+val chart = Chart.bar(series, title = Some("Revenue")).unsafe  // XLResult: validated; also Chart.line/pie
+sheet.addChart(chart, ref"F2:K16")                             // anchored over the range — total
+sheet.pictures; sheet.charts                                   // typed views (unmodeled drawings preserved)
+
 sheet.withViewSettings(SheetView(showGridLines = false, zoomScale = Some(90)))
 
 // Print/PDF setup — all fields optional with Excel defaults

--- a/plugin/skills/xl-scripting/reference/RECIPES.md
+++ b/plugin/skills/xl-scripting/reference/RECIPES.md
@@ -10,7 +10,7 @@ Apply a 5% price increase to column C of every workbook in a directory, in place
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.11.3
+//> using dep com.tjclp::xl:0.12.0
 import com.tjclp.xl.scripting.{*, given}
 import java.nio.file.{Files, Paths}
 import scala.jdk.CollectionConverters.*
@@ -42,7 +42,7 @@ Read rows into case classes; collect per-cell validation failures into a new Iss
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.11.3
+//> using dep com.tjclp::xl:0.12.0
 import com.tjclp.xl.scripting.{*, given}
 
 final case class Order(id: Int, customer: String, amount: BigDecimal)
@@ -76,7 +76,7 @@ Three-year projection with growth formulas; fail the script if any formula error
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.11.3
+//> using dep com.tjclp::xl:0.12.0
 import com.tjclp.xl.scripting.{*, given}
 
 val header = CellStyle.default.bold.size(12.0).center
@@ -111,7 +111,7 @@ Stack the data rows of every input file under one header.
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.11.3
+//> using dep com.tjclp::xl:0.12.0
 import com.tjclp.xl.scripting.{*, given}
 import java.nio.file.{Files, Paths}
 import scala.jdk.CollectionConverters.*
@@ -147,7 +147,7 @@ println(s"combined ${files.size} files, ${combined.cells.size} cells")
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.11.3
+//> using dep com.tjclp::xl:0.12.0
 import com.tjclp.xl.scripting.{*, given}
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
@@ -176,7 +176,7 @@ println("✓ filtered (constant memory)")
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.11.3
+//> using dep com.tjclp::xl:0.12.0
 import com.tjclp.xl.scripting.{*, given}
 
 val before = Excel.read("before.xlsx")
@@ -204,7 +204,7 @@ else
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.11.3
+//> using dep com.tjclp::xl:0.12.0
 import com.tjclp.xl.scripting.{*, given}
 import java.nio.file.{Files, Paths}
 import scala.jdk.CollectionConverters.*

--- a/xl-core/src/com/tjclp/xl/workbooks/WorkbookMetadata.scala
+++ b/xl-core/src/com/tjclp/xl/workbooks/WorkbookMetadata.scala
@@ -21,7 +21,7 @@ final case class WorkbookMetadata(
   modified: Option[java.time.LocalDateTime] = None,
   lastModifiedBy: Option[String] = None,
   application: Option[String] = Some("XL - Pure Scala 3.8 Excel Library"),
-  appVersion: Option[String] = Some("0.11.3"),
+  appVersion: Option[String] = Some("0.12.0"),
   theme: ThemePalette = ThemePalette.office,
   definedNames: Vector[DefinedName] = Vector.empty,
   sheetStates: Map[SheetName, Option[String]] = Map.empty,


### PR DESCRIPTION
Release prep for **0.12.0 "Visual"** (wave 6: #317 + #318) — the final release of the six-wave backlog burn-down.

- All pins → 0.12.0; `build.mill`/`plugin.json`/`WorkbookMetadata.appVersion` bumped
- CHANGELOG: Unreleased → `[0.12.0] "Visual" - 2026-06-11`
- Roadmap: wave 6 marked released; current version 0.12.0
- Feature-doc cross-check: xl-cli SKILL.md gains the Images & Charts section; xl-scripting API.md gains the drawing/chart surface (signature-verified against the prelude probes — `ImageData.detect`, `XLResult` on `Chart.bar`, total range overloads); scripting guide gains the 0.12.0 paragraph

Gates green locally: snippets (17/17 against local build), compile, full suite, test-examples.sh, checkFormatAll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)