### PR TITLE
Wave 9: LibreOffice edit corruption fixed + Content_Types/SST follow-ups (0.12.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed (wave 9)
+
+- **Editing LibreOffice-produced workbooks no longer corrupts them** (#320):
+  `workbook.xml.rels` regenerates in the same pass as `workbook.xml` — sheet rIds stay
+  consistent with their rels (LO maps rId1 to the theme; any edit previously made the first
+  sheet resolve to `theme1.xml`), preserved workbook-level elements survive the regeneration,
+  and multi-add/multi-rename allocates distinct sheetIds. Verified end-to-end: xl and
+  openpyxl both read edited LO files correctly; the wave-7 CfPreservationSpec workaround is
+  undone (full re-reads assert directly).
+- **Comment content-type registration follows actual emitted paths** (#321 — proven already
+  fixed by the GH-315 rework; falsifiability-tested regression guard committed).
+- **No dangling [Content_Types] overrides for dropped writer-owned parts** (#322): deleted
+  sheets' worksheet/comment/VML overrides are pruned from the preserved merge; exotic
+  non-writer-owned overrides still survive.
+- **New sheets join surgical SST accounting** (#323): `Workbook.put` of a fresh sheet on a
+  source-backed workbook references the combined SST (`t="s"`) with exact counts instead of
+  re-inlining its strings.
+
 ## [0.12.1] "Clean Sweep" - 2026-06-11
 
 Wave 7: every remaining open issue closed in one wave — conditional formatting lands as

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/ContentTypes.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/ContentTypes.scala
@@ -183,16 +183,49 @@ object ContentTypes extends XmlReadable[ContentTypes]:
    * which worksheets/styles/sharedStrings/comments/tables ship — EXCEPT `/xl/workbook.xml`, whose
    * content type encodes the package dialect (macro-enabled, template) that the domain model does
    * not track.
+   *
+   * GH-322: a preserved override of a WRITER-OWNED part class whose part no longer ships — e.g. a
+   * deleted sheet's `/xl/worksheets/sheetN.xml` — must not survive the union as a dangling entry.
+   * Such an override is kept only when the model registers the part or it rides the verbatim copy
+   * loop (`verbatimParts`, zip paths without the leading slash). Non-writer-owned registrations
+   * (pivots, customXml, macro payloads, themes) always survive.
    */
-  def reconcile(preserved: ContentTypes, model: ContentTypes): ContentTypes =
+  def reconcile(
+    preserved: ContentTypes,
+    model: ContentTypes,
+    verbatimParts: Set[String] = Set.empty
+  ): ContentTypes =
+    val verbatimPartNames = verbatimParts.map(p => s"/$p")
+    val livePreserved = preserved.overrides.filter { case (partName, ct) =>
+      !writerOwnedContentTypes.contains(ct) ||
+      model.overrides.contains(partName) ||
+      verbatimPartNames.contains(partName)
+    }
     val workbookDialect =
       preserved.overrides.get(workbookPartName).map(workbookPartName -> _)
     ContentTypes(
       defaults = preserved.defaults ++ model.defaults,
-      overrides = preserved.overrides ++ model.overrides ++ workbookDialect
+      overrides = livePreserved ++ model.overrides ++ workbookDialect
     )
 
   private val workbookPartName = "/xl/workbook.xml"
+
+  /**
+   * Content types of the part classes the writer fully owns (GH-322): every shipping part of these
+   * classes is registered by the model (worksheets, comments, tables, styles, sharedStrings,
+   * drawings, charts) or named in the verbatim set handed to [[reconcile]], so a preserved override
+   * of one of these types covering neither is a dangling registration.
+   */
+  private val writerOwnedContentTypes: Set[String] = Set(
+    ctWorksheet,
+    ctComments,
+    ctVmlDrawing,
+    ctDrawing,
+    ctChart,
+    ctTable,
+    ctSharedStrings,
+    ctStyles
+  )
 
   def fromXml(elem: Elem): Either[String, ContentTypes] =
     val defaults = getChildren(elem, "Default").map { e =>

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/Relationships.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/Relationships.scala
@@ -1,5 +1,7 @@
 package com.tjclp.xl.ooxml
 
+import java.nio.file.Paths
+
 import scala.xml.*
 import XmlUtil.*
 
@@ -131,6 +133,103 @@ object Relationships extends XmlReadable[Relationships]:
       else Seq.empty
 
     Relationships(sheets ++ styles ++ sst)
+
+  /**
+   * Resolve a workbook-rels target to a package path against the xl/ base. A leading slash is
+   * package-absolute (openpyxl writes `/xl/worksheets/sheet1.xml`); anything else resolves relative
+   * to xl/. Single source of truth shared by the reader's sheet resolution and the writer's rels
+   * reconciliation (GH-320) — they must never disagree on what a target names.
+   */
+  def resolveWorkbookTarget(target: String): String =
+    val cleaned = if target.startsWith("/") then target.drop(1) else target
+    val resolvedPath =
+      if cleaned.startsWith("xl/") || cleaned.startsWith("xl\\") then Paths.get(cleaned)
+      else Paths.get("xl").resolve(cleaned)
+    resolvedPath.normalize().toString.replace('\\', '/')
+
+  /** A package path as a workbook-rels target (relative to xl/). */
+  private def workbookTargetOf(packagePath: String): String =
+    packagePath.stripPrefix("xl/")
+
+  /**
+   * Regenerate workbook.xml.rels in the same pass as workbook.xml (GH-320).
+   *
+   * Sheet rIds are REUSED from the preserved rels — each live sheet matched by its
+   * identity-resolved source part path — and never renumbered: LibreOffice numbers its rels
+   * theme-first (rId1 = theme, sheets from rId3), so renumbering sheets rId1..N against a verbatim
+   * rels copy made the first sheet resolve to the theme part. Non-sheet rels (theme, styles,
+   * sharedStrings, calcChain, externalLinks, pivotCache, ...) ride through untouched — their ids
+   * stay stable, so `r:id` references inside preserved workbook elements (pivotCaches,
+   * externalReferences) keep resolving. Worksheet rels not claimed by any live sheet are dropped
+   * (deleted sheets); new sheets allocate ids ABOVE every preserved numeric id, in sheet order
+   * (deterministic). The styles/sharedStrings rels are ensured by type with the same allocation
+   * (presence follows what the writer actually emits — the withDocProps precedent).
+   *
+   * @param preserved
+   *   the source workbook.xml.rels
+   * @param sheetSourcePaths
+   *   per live sheet, its identity-resolved SOURCE part path (None = new sheet)
+   * @param sheetOutputPaths
+   *   per live sheet, the package path the writer emits the worksheet at
+   * @param ensureSharedStrings
+   *   true when the output ships xl/sharedStrings.xml
+   * @return
+   *   (rId per sheet index — these MUST feed the workbook.xml `<sheet r:id>` emission, so every
+   *   reference resolves by construction; the regenerated relationships)
+   */
+  def reconcileWorkbook(
+    preserved: Relationships,
+    sheetSourcePaths: Vector[Option[String]],
+    sheetOutputPaths: Vector[String],
+    ensureSharedStrings: Boolean
+  ): (Vector[String], Relationships) =
+    val worksheetRelByPath: Map[String, Relationship] =
+      preserved.relationships.iterator
+        .filter(_.`type` == relTypeWorksheet)
+        .map(rel => resolveWorkbookTarget(rel.target) -> rel)
+        .toMap
+    val maxNumericId: Int = preserved.relationships
+      .flatMap(_.id.stripPrefix("rId").toIntOption)
+      .maxOption
+      .getOrElse(0)
+
+    // Per sheet: keep the matched rel verbatim when its target already names the output part
+    // (byte-stable for untouched dialects), re-target it when the sheet moved, or allocate fresh.
+    val (sheetRels, afterSheets) = sheetSourcePaths
+      .zip(sheetOutputPaths)
+      .foldLeft((Vector.empty[Relationship], maxNumericId)) {
+        case ((acc, maxId), (sourcePath, outputPath)) =>
+          sourcePath.flatMap(worksheetRelByPath.get) match
+            case Some(rel) if resolveWorkbookTarget(rel.target) == outputPath =>
+              (acc :+ rel, maxId)
+            case Some(rel) =>
+              (acc :+ rel.copy(target = workbookTargetOf(outputPath)), maxId)
+            case None =>
+              val fresh =
+                Relationship(s"rId${maxId + 1}", relTypeWorksheet, workbookTargetOf(outputPath))
+              (acc :+ fresh, maxId + 1)
+      }
+
+    val nonSheet = preserved.relationships.filterNot(_.`type` == relTypeWorksheet)
+
+    def ensure(
+      state: (Seq[Relationship], Int),
+      present: Boolean,
+      relType: String,
+      target: String
+    ): (Seq[Relationship], Int) =
+      val (rels, maxId) = state
+      if present then
+        if rels.exists(_.`type` == relType) then state
+        else (rels :+ Relationship(s"rId${maxId + 1}", relType, target), maxId + 1)
+      else (rels.filterNot(_.`type` == relType), maxId)
+
+    val base = (nonSheet ++ sheetRels, afterSheets)
+    val withStyles = ensure(base, present = true, relTypeStyles, "styles.xml")
+    val (finalRels, _) =
+      ensure(withStyles, ensureSharedStrings, relTypeSharedStrings, "sharedStrings.xml")
+
+    (sheetRels.map(_.id), Relationships(finalRels))
 
   def fromXml(elem: Elem): Either[String, Relationships] =
     val rels = getChildren(elem, "Relationship").map { e =>

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/Workbook.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/Workbook.scala
@@ -117,23 +117,29 @@ case class OoxmlWorkbook(
     stateOverrides: Map[SheetName, Option[String]],
     relationshipIds: Seq[String]
   ): OoxmlWorkbook =
-    val updatedRefs = newSheets.zipWithIndex.map { case (sheet, idx) =>
-      val relId = relationshipIds.lift(idx).getOrElse(s"rId${idx + 1}")
-      // Check for explicit state override from domain metadata
-      val overriddenState = stateOverrides.get(sheet.name)
+    // Fresh sheetId allocation threads through the pass (seeded with the preserved max, which
+    // already covers every matched sheet's id) so multiple unmatched sheets in one session —
+    // multi-add, multi-rename — get DISTINCT ids; ECMA-376 requires sheetId uniqueness. Mirrors
+    // the rId counter in Relationships.reconcileWorkbook.
+    val seedMaxId = sheets.map(_.sheetId).maxOption.getOrElse(0)
+    val (updatedRefs, _) = newSheets.zipWithIndex
+      .foldLeft((Vector.empty[SheetRef], seedMaxId)) { case ((acc, maxId), (sheet, idx)) =>
+        val relId = relationshipIds.lift(idx).getOrElse(s"rId${idx + 1}")
+        // Check for explicit state override from domain metadata
+        val overriddenState = stateOverrides.get(sheet.name)
 
-      // Try to find original SheetRef to preserve sheetId
-      sheets.find(_.name == sheet.name) match
-        case Some(original) =>
-          // Use override if present, otherwise preserve original state
-          val finalState = overriddenState.getOrElse(original.state)
-          original.copy(relationshipId = relId, state = finalState)
-        case None =>
-          // New sheet - generate new ID, use override or default to visible
-          val newId = sheets.map(_.sheetId).maxOption.getOrElse(0) + 1
-          val finalState = overriddenState.getOrElse(None)
-          SheetRef(sheet.name, newId, relId, finalState)
-    }
+        // Try to find original SheetRef to preserve sheetId
+        sheets.find(_.name == sheet.name) match
+          case Some(original) =>
+            // Use override if present, otherwise preserve original state
+            val finalState = overriddenState.getOrElse(original.state)
+            (acc :+ original.copy(relationshipId = relId, state = finalState), maxId)
+          case None =>
+            // New sheet - allocate above every id seen so far, use override or default to visible
+            val newId = maxId + 1
+            val finalState = overriddenState.getOrElse(None)
+            (acc :+ SheetRef(sheet.name, newId, relId, finalState), newId)
+      }
     copy(sheets = updatedRefs)
 
   def toXml: Elem =

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/Workbook.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/Workbook.scala
@@ -104,7 +104,21 @@ case class OoxmlWorkbook(
     newSheets: Vector[com.tjclp.xl.api.Sheet],
     stateOverrides: Map[SheetName, Option[String]] = Map.empty
   ): OoxmlWorkbook =
+    updateSheets(newSheets, stateOverrides, OoxmlWorkbook.sequentialRelIds(newSheets.size))
+
+  /**
+   * Update sheets with EXPLICIT relationship ids (GH-320). The ids must come from the same
+   * reconciliation pass that regenerates workbook.xml.rels — renumbering them independently
+   * (rId1..N) corrupted foreign files whose preserved rels number sheets after the theme part
+   * (LibreOffice maps rId1 to the theme, so the first sheet resolved to xl/theme/theme1.xml).
+   */
+  def updateSheets(
+    newSheets: Vector[com.tjclp.xl.api.Sheet],
+    stateOverrides: Map[SheetName, Option[String]],
+    relationshipIds: Seq[String]
+  ): OoxmlWorkbook =
     val updatedRefs = newSheets.zipWithIndex.map { case (sheet, idx) =>
+      val relId = relationshipIds.lift(idx).getOrElse(s"rId${idx + 1}")
       // Check for explicit state override from domain metadata
       val overriddenState = stateOverrides.get(sheet.name)
 
@@ -113,12 +127,12 @@ case class OoxmlWorkbook(
         case Some(original) =>
           // Use override if present, otherwise preserve original state
           val finalState = overriddenState.getOrElse(original.state)
-          original.copy(relationshipId = s"rId${idx + 1}", state = finalState)
+          original.copy(relationshipId = relId, state = finalState)
         case None =>
           // New sheet - generate new ID, use override or default to visible
           val newId = sheets.map(_.sheetId).maxOption.getOrElse(0) + 1
           val finalState = overriddenState.getOrElse(None)
-          SheetRef(sheet.name, newId, s"rId${idx + 1}", finalState)
+          SheetRef(sheet.name, newId, relId, finalState)
     }
     copy(sheets = updatedRefs)
 
@@ -215,26 +229,86 @@ object OoxmlWorkbook extends XmlReadable[OoxmlWorkbook]:
   def minimal(sheetName: String = "Sheet1"): OoxmlWorkbook =
     OoxmlWorkbook(Seq(SheetRef(SheetName.unsafe(sheetName), 1, "rId1")))
 
+  /** Sequential rId1..N — the fresh-workbook id scheme (matches Relationships.workbook). */
+  private[ooxml] def sequentialRelIds(count: Int): Vector[String] =
+    (1 to count).map(idx => s"rId$idx").toVector
+
   /** Create workbook from domain model */
   def fromDomain(wb: Workbook): OoxmlWorkbook =
-    val sheetRefs = wb.sheets.zipWithIndex.map { case (sheet, idx) =>
-      val state = wb.metadata.sheetStates.get(sheet.name).flatten
-      SheetRef(sheet.name, idx + 1, s"rId${idx + 1}", state)
-    }
-    // GH-243: preserve-the-system — declare the 1904 date system when the model says so, so the
-    // raw serials riding through (and DateTime cells serialized with the 1904 epoch) stay correct.
-    val workbookPr =
-      if wb.metadata.date1904 then Some(elem("workbookPr", "date1904" -> "1")()) else None
-    // GH-236: serialize named ranges from the typed model (previously dropped on write).
-    // GH-259: print area / repeat rows live on Sheet.pageSetup and are appended here as
-    // sheet-scoped _xlnm.Print_Area / _xlnm.Print_Titles names.
-    OoxmlWorkbook(
-      sheetRefs,
-      workbookPr = workbookPr,
-      // GH-294: fresh workbooks always ship bookViews/activeTab (Excel always writes bookViews)
-      bookViews = buildBookViews(None, clampActiveTab(wb.activeSheetIndex, wb.sheets.size)),
-      definedNames = buildDefinedNames(PrintNames.effective(wb))
-    )
+    fromDomain(wb, None, sequentialRelIds(wb.sheets.size))
+
+  /**
+   * Create workbook.xml from the domain model, carrying preserved workbook-level elements through
+   * when the source structure is available (GH-320 — the metadata-modified path).
+   *
+   * The model wins for everything it represents — sheets (names/order/visibility), activeTab,
+   * definedNames, date1904 — while unmodeled preserved elements ride through in schema order:
+   * fileVersion, workbookPr attributes, mc:AlternateContent, xr:revisionPtr, bookViews siblings,
+   * calcPr, extLst, and otherElements (workbookProtection, pivotCaches, externalReferences, ...) —
+   * the worksheet-level preserved-metadata machinery applied at workbook level. The relationship
+   * ids come from the rels reconciliation pass (see [[Relationships.reconcileWorkbook]]) so every
+   * emitted `r:id` resolves.
+   */
+  def fromDomain(
+    wb: Workbook,
+    preserved: Option[OoxmlWorkbook],
+    relationshipIds: Seq[String]
+  ): OoxmlWorkbook =
+    preserved match
+      case Some(p) =>
+        p.updateSheets(wb.sheets, wb.metadata.sheetStates, relationshipIds)
+          // GH-294: model activeTab overlaid on the preserved bookViews (siblings ride through)
+          .withActiveTab(clampActiveTab(wb.activeSheetIndex, wb.sheets.size))
+          .copy(
+            workbookPr = reconcileDate1904(p.workbookPr, wb.metadata.date1904),
+            definedNames = reconcileDefinedNames(p.definedNames, PrintNames.effective(wb))
+          )
+      case None =>
+        val sheetRefs = wb.sheets.zipWithIndex.map { case (sheet, idx) =>
+          val state = wb.metadata.sheetStates.get(sheet.name).flatten
+          val relId = relationshipIds.lift(idx).getOrElse(s"rId${idx + 1}")
+          SheetRef(sheet.name, idx + 1, relId, state)
+        }
+        // GH-243: preserve-the-system — declare the 1904 date system when the model says so, so the
+        // raw serials riding through (and DateTime cells serialized with the 1904 epoch) stay
+        // correct.
+        val workbookPr =
+          if wb.metadata.date1904 then Some(elem("workbookPr", "date1904" -> "1")()) else None
+        // GH-236: serialize named ranges from the typed model (previously dropped on write).
+        // GH-259: print area / repeat rows live on Sheet.pageSetup and are appended here as
+        // sheet-scoped _xlnm.Print_Area / _xlnm.Print_Titles names.
+        OoxmlWorkbook(
+          sheetRefs,
+          workbookPr = workbookPr,
+          // GH-294: fresh workbooks always ship bookViews/activeTab (Excel always writes bookViews)
+          bookViews = buildBookViews(None, clampActiveTab(wb.activeSheetIndex, wb.sheets.size)),
+          definedNames = buildDefinedNames(PrintNames.effective(wb))
+        )
+
+  /**
+   * Keep the preserved `<definedNames>` bytes when the model agrees with them; regenerate the
+   * element from the model otherwise (the GH-259 reconcile, shared by both writer branches).
+   */
+  def reconcileDefinedNames(
+    preservedElem: Option[Elem],
+    expected: Vector[DefinedName]
+  ): Option[Elem] =
+    if parseDefinedNames(preservedElem).toSet == expected.toSet then preservedElem
+    else buildDefinedNames(expected)
+
+  /**
+   * Reconcile the date1904 declaration with the model (model wins, GH-243) while every other
+   * preserved workbookPr attribute (codeName, defaultThemeVersion, ...) rides through.
+   * Byte-identical when the model agrees with the preserved spelling.
+   */
+  def reconcileDate1904(preservedPr: Option[Elem], date1904: Boolean): Option[Elem] =
+    if parseDate1904(preservedPr) == date1904 then preservedPr
+    else
+      (preservedPr, date1904) match
+        case (Some(pr), true) => Some(pr % new UnprefixedAttribute("date1904", "1", Null))
+        case (Some(pr), false) => Some(pr.copy(attributes = pr.attributes.remove("date1904")))
+        case (None, true) => Some(elem("workbookPr", "date1904" -> "1")())
+        case (None, false) => None
 
   /** Clamp an active-tab index into [0, sheetCount-1] (write side; the reader clamps too). */
   def clampActiveTab(index: Int, sheetCount: Int): Int =

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/XlsxReader.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/XlsxReader.scala
@@ -970,12 +970,10 @@ object XlsxReader:
 
   private def defaultSheetPath(sheetId: Int): String = s"xl/worksheets/sheet$sheetId.xml"
 
+  // GH-320: single source of truth with the writer's rels reconciliation — reader and writer
+  // must never disagree on what a workbook-rels target names.
   private def resolveSheetPath(target: String): String =
-    val cleaned = if target.startsWith("/") then target.drop(1) else target
-    val resolvedPath =
-      if cleaned.startsWith("xl/") || cleaned.startsWith("xl\\") then Paths.get(cleaned)
-      else Paths.get("xl").resolve(cleaned)
-    resolvedPath.normalize().toString.replace('\\', '/')
+    Relationships.resolveWorkbookTarget(target)
 
   /**
    * Convert OoxmlWorksheet to domain Sheet.

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/XlsxWriter.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/XlsxWriter.scala
@@ -1694,52 +1694,85 @@ object XlsxWriter:
     // GH-221: drawing-layer plan — snapshot-equality dirty test, media dedup, first-drawing wiring
     val drawingPlan = planDrawingWrites(workbook, sourceContext, sheetsToRegenerate)
 
-    // Preserve structural parts from source (or fallback to minimal)
-    // IMPORTANT: When metadata is modified (add/remove/rename/reorder sheets),
-    // we MUST regenerate the structural parts since sheet count/order changed.
-    val (preservedContentTypes, preservedRootRels, preservedWorkbookRels, preservedWorkbook) =
+    // Preserve structural parts from source (or fallback to minimal). Parsed UNGATED (GH-320):
+    // the metadata-modified path needs the preserved workbook element (carry-through) and the
+    // preserved rels (sheet-rId reconciliation) too, not just the byte-stable path.
+    val (preservedStructCt, preservedStructRootRels, preservedStructWbRels, preservedStructWb) =
       sourceContext match
-        case Some(ctx) if !tracker.modifiedMetadata => parsePreservedStructure(ctx.sourcePath)
-        case _ => (None, None, None, None)
+        case Some(ctx) => parsePreservedStructure(ctx.sourcePath)
+        case None => (None, None, None, None)
+
+    // IMPORTANT: When metadata is modified (add/remove/rename/reorder sheets), the workbook
+    // skeleton MUST be regenerated from the domain — these gated views feed the byte-stable
+    // preservation branches only.
+    val metadataStable = !tracker.modifiedMetadata
+    val preservedContentTypes = preservedStructCt.filter(_ => metadataStable)
+    val preservedWorkbook = preservedStructWb.filter(_ => metadataStable)
 
     // GH-314: the preserved [Content_Types].xml matters even when metadata changed — exotic
     // preserved parts (pivots, custom XML, macro payloads) still ride the verbatim copy loop and
-    // must stay registered. Parsed here so the regenerate-from-minimal branch below can reconcile
-    // instead of dropping their overrides.
-    val preservedContentTypesForReconcile: Option[ContentTypes] =
-      preservedContentTypes.orElse {
-        sourceContext.flatMap { ctx =>
-          withZipFile(ctx.sourcePath) { zip =>
-            parseOptionalEntry(zip, "[Content_Types].xml")(ContentTypes.fromXml)
-          }
-        }
+    // must stay registered, so the regenerate-from-minimal branch below reconciles instead of
+    // dropping their overrides.
+    val preservedContentTypesForReconcile: Option[ContentTypes] = preservedStructCt
+
+    // GH-320: workbook.xml.rels is regenerated IN THE SAME PASS as workbook.xml. Sheet rIds are
+    // reused from the source rels (matched by identity-resolved source part) and never renumbered;
+    // non-sheet rels ride through with stable ids; fresh sheets allocate above the max id. The
+    // resulting ids feed the <sheet r:id> emission below, so every reference resolves by
+    // construction. (LibreOffice numbers rels theme-first — renumbering sheets rId1..N against the
+    // verbatim rels made the first sheet resolve to xl/theme/theme1.xml: a data-corruption class.)
+    val sheetSourcePaths: Vector[Option[String]] =
+      workbook.sheets.indices.toVector.map(idx => sourceContext.flatMap(sourceSheetPath(_, idx)))
+    val sheetOutputPaths: Vector[String] =
+      workbook.sheets.indices.toVector.map { idx =>
+        if sheetsToRegenerate.contains(idx) then s"xl/worksheets/sheet${idx + 1}.xml"
+        else sheetSourcePaths(idx).getOrElse(s"xl/worksheets/sheet${idx + 1}.xml")
       }
+    val (sheetRelIds, workbookRels) = preservedStructWbRels match
+      case Some(preservedRels) =>
+        Relationships.reconcileWorkbook(
+          preservedRels,
+          sheetSourcePaths,
+          sheetOutputPaths,
+          ensureSharedStrings = sharedStringsInOutput
+        )
+      case None =>
+        (
+          OoxmlWorkbook.sequentialRelIds(workbook.sheets.size),
+          Relationships.workbook(
+            sheetCount = workbook.sheets.size,
+            hasStyles = true,
+            hasSharedStrings = sharedStringsInOutput
+          )
+        )
 
     // Use preserved workbook structure if available, otherwise create minimal
     val ooxmlWb = preservedWorkbook match
       case Some(preserved) =>
-        // Update sheets in preserved structure (names/order/visibility may have changed).
-        // Named ranges (definedNames) ride through verbatim here (byte-identical). Authoring a
-        // name marks metadata modified, which routes to the fromDomain branch below (GH-236).
+        // Update sheets in preserved structure (names/order/visibility may have changed) with
+        // the reconciled rIds. Named ranges (definedNames) ride through verbatim here
+        // (byte-identical). Authoring a name marks metadata modified, which routes to the
+        // fromDomain branch below (GH-236).
         // GH-294: the model's activeSheetIndex is overlaid on the preserved bookViews (model
         // wins; unmodeled view attributes ride through), clamped like the fromDomain path.
         val updated = preserved
-          .updateSheets(workbook.sheets, workbook.metadata.sheetStates)
+          .updateSheets(workbook.sheets, workbook.metadata.sheetStates, sheetRelIds)
           .withActiveTab(
             OoxmlWorkbook.clampActiveTab(workbook.activeSheetIndex, workbook.sheets.size)
           )
         // GH-259: print names (_xlnm.Print_Area/_xlnm.Print_Titles) are modeled on Sheet.pageSetup,
         // so a sheet edit can change them WITHOUT marking metadata modified. Reconcile: keep the
         // preserved definedNames bytes when the model agrees, otherwise regenerate the element.
-        val expected = PrintNames.effective(workbook)
-        if OoxmlWorkbook.parseDefinedNames(updated.definedNames).toSet == expected.toSet then
-          updated
-        else updated.copy(definedNames = OoxmlWorkbook.buildDefinedNames(expected))
+        updated.copy(definedNames =
+          OoxmlWorkbook
+            .reconcileDefinedNames(updated.definedNames, PrintNames.effective(workbook))
+        )
       case None =>
         // Fallback for programmatically created workbooks OR when metadata was modified — fresh
-        // workbook structure; fromDomain serializes wb.metadata.definedNames (GH-236) plus the
-        // PageSetup-derived print names (GH-259).
-        OoxmlWorkbook.fromDomain(workbook)
+        // sheets/definedNames from the domain (GH-236/GH-259) with preserved workbook-level
+        // elements (fileVersion, calcPr, workbookProtection, bookViews siblings, extLst, ...)
+        // carried through when a source exists (GH-320).
+        OoxmlWorkbook.fromDomain(workbook, preservedStructWb, sheetRelIds)
 
     // GH-242: document properties are model-driven. The reader parses docProps/core.xml and
     // app.xml into WorkbookMetadata (and marks them parsed, so they are never copied verbatim);
@@ -1805,26 +1838,11 @@ object XlsxWriter:
               .withDocPropsOverrides(corePropsXml.isDefined, appPropsXml.isDefined)
           case None => model
 
-    val rootRels = preservedRootRels
+    // GH-320: ungated like the content types (GH-314) — a metadata-modified write must keep the
+    // preserved package-level rels (docProps/custom.xml and friends ride the verbatim copy loop).
+    val rootRels = preservedStructRootRels
       .getOrElse(Relationships.root())
       .withDocProps(corePropsXml.isDefined, appPropsXml.isDefined)
-
-    val workbookRels = preservedWorkbookRels match
-      case Some(preserved) =>
-        // Add sharedStrings relationship if we're generating it but source didn't have it
-        if sharedStringsInOutput && !sourceHasSharedStrings then
-          val nextId = preserved.relationships.size + 1
-          preserved.copy(relationships =
-            preserved.relationships :+
-              Relationship(s"rId$nextId", XmlUtil.relTypeSharedStrings, "sharedStrings.xml")
-          )
-        else preserved
-      case None =>
-        Relationships.workbook(
-          sheetCount = workbook.sheets.size,
-          hasStyles = true,
-          hasSharedStrings = sharedStringsInOutput
-        )
 
     // Open output ZIP
     val zip = target match

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/XlsxWriter.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/XlsxWriter.scala
@@ -1656,6 +1656,25 @@ object XlsxWriter:
       )
     }
 
+    // VML parts the regeneration supersedes, excluded from the verbatim copy loop (GH-292/GH-315):
+    // each regenerated sheet's source-numbered VML (comment removal must drop it) AND the emission
+    // target from the SAME per-write assignment the emission consumes. Hoisted so the content-type
+    // reconciliation below (GH-322) and the copy loop share one definition.
+    val vmlPathsToSkip: Set[String] = sourceContext match
+      case None => Set.empty
+      case Some(ctx) =>
+        sheetsToRegenerate.flatMap { idx =>
+          workbook.sheets.lift(idx) match
+            case None => Set.empty[String]
+            case Some(sheet) =>
+              val sourceRels = sourceSheetRelsPath(ctx, idx)
+              val mapped = ctx.commentPathMapping.get(sheet.name)
+              val emitted = commentPathBySheet.get(idx)
+              (mapped.toList ++ emitted.toList)
+                .toSet[String]
+                .map(cp => vmlPathForSheet(Some(ctx), sourceRels, idx, cp))
+        }
+
     // Build table data
     val (tablesBySheet, totalTableCount, tableIdMap) = buildTablesData(workbook)
 
@@ -1758,10 +1777,18 @@ object XlsxWriter:
         // content types so exotic parts riding the copy loop keep their registrations. docProps
         // reconciliation is re-applied AFTER the merge: it removes stale preserved overrides for
         // docProps the model no longer emits (GH-242), which a plain union would resurrect.
+        // GH-322: the verbatim set names the writer-owned parts that ship WITHOUT a model
+        // registration — the copy loop's survivors plus the re-emitted VML (Default-covered) —
+        // so preserved overrides of writer-owned classes that ship neither way (a deleted
+        // sheet's worksheet part) are pruned instead of surviving as dangling entries.
         preservedContentTypesForReconcile match
           case Some(preserved) =>
             ContentTypes
-              .reconcile(preserved, model)
+              .reconcile(
+                preserved,
+                model,
+                verbatimParts = preservableParts -- vmlPathsToSkip ++ vmlPathBySheet.values
+              )
               .withDocPropsOverrides(corePropsXml.isDefined, appPropsXml.isDefined)
           case None => model
 
@@ -2024,23 +2051,8 @@ object XlsxWriter:
       // Copy preserved parts (charts, drawings, images, etc.) if source available
       // Skip VML drawings for regenerated sheets - we regenerate VML from domain model
       // (or omit it if comments were removed); skip drawing parts superseded by same-path
-      // regeneration (GH-221)
+      // regeneration (GH-221). vmlPathsToSkip is hoisted above (shared with GH-322).
       sourceContext.foreach { ctx =>
-        val vmlPathsToSkip: Set[String] = sheetsToRegenerate.flatMap { idx =>
-          workbook.sheets.lift(idx) match
-            case None => Set.empty[String]
-            case Some(sheet) =>
-              val sourceRels = sourceSheetRelsPath(ctx, idx)
-              val mapped = ctx.commentPathMapping.get(sheet.name)
-              // GH-292/GH-315: mirror the regeneration paths EXACTLY, or the preserved copy
-              // ships too — the sheet's source-numbered VML (comment removal must drop it) AND
-              // the emission target from the SAME per-write assignment the emission consumed.
-              val emitted = commentPathBySheet.get(idx)
-              (mapped.toList ++ emitted.toList)
-                .toSet[String]
-                .map(cp => vmlPathForSheet(Some(ctx), sourceRels, idx, cp))
-        }
-
         preservableParts.foreach { path =>
           // vmlPathsToSkip holds the exact regeneration targets — including foreign-named VML
           // parts like openpyxl's commentsDrawing1.vml (GH-292), so no filename-prefix guard

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/XlsxWriter.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/XlsxWriter.scala
@@ -1472,12 +1472,25 @@ object XlsxWriter:
         // Parse preserved SST (sourceContext guaranteed to exist if sourceHasSharedStrings is true)
         val parsedSST = sourceContext.map(ctx => parsePreservedSST(ctx.sourcePath)).getOrElse(None)
 
+        // GH-323: a NEW sheet (no source counterpart by identity, GH-315) never enters
+        // tracker.modifiedSheets — Workbook.put of an unseen name marks only metadata — yet its
+        // regenerated part encodes text through whatever SST ships. It joins the modified-sheet
+        // set for SST accounting: its strings enter the combined SST and the per-reference count
+        // (its pre-edit contribution is naturally 0 — there is no source part to subtract).
+        val sstAccountedSheets: Vector[Int] = sourceContext match
+          case Some(ctx) =>
+            (tracker.modifiedSheets ++
+              workbook.sheets.indices.filter(idx =>
+                sourceSheetPath(ctx, idx).isEmpty
+              )).toVector.sorted
+          case None => tracker.modifiedSheets.toVector.sorted
+
         // Check if modified sheets contain NEW strings not in the preserved SST.
         // Entries are collected PER REFERENCE (one per text cell, GH-277: the SST count attribute
         // counts references) in deterministic ref order, and compared EXACTLY — no Unicode
         // normalization, byte-different spellings are different strings (GH-277/GH-289).
         val modifiedSheetRefEntries: Vector[Either[String, RichText]] =
-          tracker.modifiedSheets.toVector.sorted.flatMap { idx =>
+          sstAccountedSheets.flatMap { idx =>
             workbook.sheets.lift(idx).toList.flatMap { sheet =>
               sheet.cells.toVector.sortBy(_._1.toA1).flatMap { case (_, cell) =>
                 cell.value match
@@ -1505,7 +1518,7 @@ object XlsxWriter:
         // current index no longer names the right source part.
         val preEditModifiedRefs = sourceContext
           .map { ctx =>
-            tracker.modifiedSheets.toVector.sorted
+            sstAccountedSheets
               .map(idx =>
                 sourceSheetPath(ctx, idx).fold(0)(countSourceSstReferences(ctx.sourcePath, _))
               )

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/CfPreservationSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/CfPreservationSpec.scala
@@ -240,30 +240,11 @@ class CfPreservationSpec extends FunSuite:
     // ...and stays paired with the worksheet-level x14:conditionalFormattings (same rule id,
     // once in the cfRule's <x14:id>, once in the worksheet extLst pairing)
     assertEquals(count("{26C9BFD7-9A20-468E-9236-D82474454A88}"), 2)
-    // Re-read the cf model through the reader's own per-part pipeline (OoxmlWorksheet routes
-    // through WorksheetReader's rebind; CfCodec.parseAll with the output's dxfs — exactly what
-    // XlsxReader.convertToDomainSheet does). Full-workbook reread of a MODIFIED LibreOffice file
-    // is blocked by a pre-existing cf-UNRELATED writer bug: workbook.xml is regenerated with
-    // renumbered sheet rIds (rId1) while the preserved workbook.xml.rels keeps LO's layout
-    // (rId1 = theme), so sheet resolution lands on theme1.xml. Reproduces at the parent commit
-    // on small-values-lo.xlsx with a plain cell edit; tracked separately.
-    def cfModelOf(p: Path): Vector[ConditionalFormat] =
-      val ws = worksheet.OoxmlWorksheet
-        .fromXml(
-          XmlSecurity
-            .parseSafe(entryText(p, "xl/worksheets/sheet1.xml"), "ws")
-            .fold(e => fail(e.message), identity)
-        )
-        .fold(e => fail(e), identity)
-      val styles = style.WorkbookStyles
-        .fromXml(
-          XmlSecurity
-            .parseSafe(entryText(p, "xl/styles.xml"), "styles")
-            .fold(e => fail(e.message), identity)
-        )
-        .fold(e => fail(e), identity)
-      worksheet.CfCodec.parseAll(ws.conditionalFormatting, styles.dxfs)
-    val after = cfModelOf(out)
+    // Full-workbook re-read of the MODIFIED LibreOffice file — the assertion this test always
+    // wanted. It was blocked by GH-320 (workbook.xml regenerated with renumbered sheet rIds
+    // against LO's verbatim rels, where rId1 = theme, so sheet resolution landed on theme1.xml)
+    // and went through the reader's per-part pipeline instead; GH-320 fixed, workaround undone.
+    val after = reread(out).sheets(0).conditionalFormats
     assertEquals(after.size, before.size + 1)
     assertEquals(after.take(before.size), before, "preserved blocks must ride through unchanged")
     after.lastOption match

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/ContentTypesReconcileSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/ContentTypesReconcileSpec.scala
@@ -3,6 +3,8 @@ package com.tjclp.xl.ooxml
 import java.nio.file.{Files, Path}
 import java.util.zip.{ZipEntry, ZipFile, ZipOutputStream}
 
+import scala.jdk.CollectionConverters.*
+
 import com.tjclp.xl.api.*
 import com.tjclp.xl.codec.CellCodec.given
 import com.tjclp.xl.macros.ref
@@ -111,6 +113,57 @@ class ContentTypesReconcileSpec extends FunSuite:
     Files.deleteIfExists(output)
   }
 
+  // ========== GH-321: comment overrides follow EMITTED paths on metadata-modified writes ==========
+
+  test("GH-321: metadata-only write of a foreign-dialect comments file has no dangling overrides") {
+    val source = TestFixtures.copyToTemp("comments-hyperlinks.xlsx")
+    val wb = XlsxReader.read(source).fold(err => fail(s"Read failed: $err"), identity)
+
+    // Metadata-only edit: no sheet content touched → the regenerate-from-minimal CT branch
+    val modified = wb.withDefinedName("Answer", "Notes!$A$1")
+
+    val output = Files.createTempFile("gh321-metadata", ".xlsx")
+    XlsxWriter.write(modified, output).fold(err => fail(s"Write failed: $err"), identity)
+
+    val entries = zipEntryNames(output)
+    // The openpyxl-dialect comment + VML parts ship at their SOURCE paths (identity-mapped,
+    // GH-315/GH-292), never at the legacy index paths
+    assert(
+      entries.contains("xl/comments/comment1.xml"),
+      s"foreign-dialect comment part missing from output: $entries"
+    )
+    assert(
+      entries.contains("xl/drawings/commentsDrawing1.vml"),
+      s"foreign-dialect VML part missing from output: $entries"
+    )
+    assert(!entries.contains("xl/comments1.xml"), "comment part emitted at the legacy index path")
+
+    val ct = parseContentTypes(output)
+    // The shipped comment part is registered at its ACTUAL path...
+    assertEquals(
+      ct.overrides.get("/xl/comments/comment1.xml"),
+      Some(XmlUtil.ctComments),
+      s"shipped comment part unregistered. Overrides: ${ct.overrides}"
+    )
+    // ...the shipped VML part is covered by the vml extension Default...
+    assert(
+      ct.defaults.keysIterator.exists(_.equalsIgnoreCase("vml")),
+      s"vml Default missing. Defaults: ${ct.defaults}"
+    )
+    // ...and NO override points at a part that does not ship (index-derived registration would
+    // leave /xl/comments1.xml + /xl/drawings/vmlDrawing1.vml dangling here)
+    val dangling = ct.overrides.keys.filterNot(p => entries.contains(p.stripPrefix("/")))
+    assert(dangling.isEmpty, s"overrides point at parts that do not ship: ${dangling.mkString(", ")}")
+
+    // The comment itself round-trips
+    val reloaded = XlsxReader.read(output).fold(err => fail(s"Reload failed: $err"), identity)
+    val sheet = reloaded("Notes").fold(err => fail(s"Sheet missing: $err"), identity)
+    assert(sheet.comments.contains(ref"A1"), "comment lost on metadata-only write")
+
+    Files.deleteIfExists(source)
+    Files.deleteIfExists(output)
+  }
+
   // ========== pure reconcile law: preserved ∪ model, model wins except workbook dialect ==========
 
   test("ContentTypes.reconcile: union with model-wins, preserved workbook dialect kept") {
@@ -146,6 +199,15 @@ class ContentTypesReconcileSpec extends FunSuite:
     val zip = new ZipFile(path.toFile)
     try zip.getEntry(entryName) != null
     finally zip.close()
+
+  private def zipEntryNames(path: Path): Set[String] =
+    val zip = new ZipFile(path.toFile)
+    try zip.entries().asScala.map(_.getName).toSet
+    finally zip.close()
+
+  private def parseContentTypes(path: Path): ContentTypes =
+    val xml = scala.xml.XML.loadString(new String(readEntry(path, "[Content_Types].xml"), "UTF-8"))
+    ContentTypes.fromXml(xml).fold(err => fail(s"Content types parse failed: $err"), identity)
 
   private def readEntry(path: Path, entryName: String): Array[Byte] =
     val zip = new ZipFile(path.toFile)

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/ContentTypesReconcileSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/ContentTypesReconcileSpec.scala
@@ -164,6 +164,66 @@ class ContentTypesReconcileSpec extends FunSuite:
     Files.deleteIfExists(output)
   }
 
+  // ========== GH-322: writer-owned overrides for parts that no longer ship are pruned ==========
+
+  test("GH-322: deleting a sheet leaves no dangling worksheet override; exotic override survives") {
+    val source = createExoticFixture(sheetCount = 2)
+    val wb = XlsxReader.read(source).fold(err => fail(s"Read failed: $err"), identity)
+
+    val modified = wb.remove("Sheet2").fold(err => fail(s"Remove failed: $err"), identity)
+
+    val output = Files.createTempFile("gh322-delete", ".xlsx")
+    XlsxWriter.write(modified, output).fold(err => fail(s"Write failed: $err"), identity)
+
+    val entries = zipEntryNames(output)
+    assert(!entries.contains("xl/worksheets/sheet2.xml"), "deleted sheet part must not ship")
+
+    val ct = parseContentTypes(output)
+    // The deleted sheet's preserved override must not survive the merge as a dangling entry
+    assertEquals(
+      ct.overrides.get("/xl/worksheets/sheet2.xml"),
+      None,
+      s"deleted sheet's worksheet override survived as a dangling entry. Overrides: ${ct.overrides}"
+    )
+    // The surviving sheet stays registered; non-writer-owned preserved overrides ride through
+    assertEquals(ct.overrides.get("/xl/worksheets/sheet1.xml"), Some(XmlUtil.ctWorksheet))
+    assertEquals(ct.overrides.get(customXmlOverride), Some("application/xml"))
+    assert(entryExists(output, "customXml/item1.xml"), "preserved customXml part should ship")
+    // ...and no override anywhere points at a part that does not ship
+    val dangling = ct.overrides.keys.filterNot(p => entries.contains(p.stripPrefix("/")))
+    assert(dangling.isEmpty, s"overrides point at parts that do not ship: ${dangling.mkString(", ")}")
+
+    val reloaded = XlsxReader.read(output).fold(err => fail(s"Reload failed: $err"), identity)
+    assertEquals(reloaded.sheetNames.map(_.value), Vector("Sheet1"))
+
+    Files.deleteIfExists(source)
+    Files.deleteIfExists(output)
+  }
+
+  test("ContentTypes.reconcile: prunes writer-owned overrides absent from model and verbatim set") {
+    val preserved = ContentTypes(
+      defaults = Map("rels" -> XmlUtil.ctRelationships, "xml" -> "application/xml"),
+      overrides = Map(
+        "/xl/workbook.xml" -> XmlUtil.ctWorkbook,
+        "/xl/worksheets/sheet1.xml" -> XmlUtil.ctWorksheet,
+        "/xl/worksheets/sheet3.xml" -> XmlUtil.ctWorksheet, // deleted sheet → dangling
+        "/xl/comments9.xml" -> XmlUtil.ctComments, // removed comments → dangling
+        "/xl/drawings/drawing7.xml" -> XmlUtil.ctDrawing, // ships verbatim → kept
+        customXmlOverride -> "application/xml" // not writer-owned → kept
+      )
+    )
+    val model = ContentTypes.minimal(hasStyles = true, hasSharedStrings = false, sheetCount = 1)
+
+    val merged =
+      ContentTypes.reconcile(preserved, model, verbatimParts = Set("xl/drawings/drawing7.xml"))
+
+    assertEquals(merged.overrides.get("/xl/worksheets/sheet3.xml"), None, "dangling sheet kept")
+    assertEquals(merged.overrides.get("/xl/comments9.xml"), None, "dangling comments kept")
+    assertEquals(merged.overrides.get("/xl/drawings/drawing7.xml"), Some(XmlUtil.ctDrawing))
+    assertEquals(merged.overrides.get(customXmlOverride), Some("application/xml"))
+    assertEquals(merged.overrides.get("/xl/worksheets/sheet1.xml"), Some(XmlUtil.ctWorksheet))
+  }
+
   // ========== pure reconcile law: preserved ∪ model, model wins except workbook dialect ==========
 
   test("ContentTypes.reconcile: union with model-wins, preserved workbook dialect kept") {
@@ -228,9 +288,10 @@ class ContentTypesReconcileSpec extends FunSuite:
    * Excel-shaped raw fixture carrying an exotic part: customXml/item1.xml registered via an
    * Override the writer's domain model knows nothing about. With `macroEnabled` the workbook main
    * part uses the macro dialect content type and a vbaProject.bin payload rides along (bin
-   * Default), mirroring a real .xlsm.
+   * Default), mirroring a real .xlsm. `sheetCount` controls the number of worksheets (GH-322
+   * deletion coverage needs at least two).
    */
-  private def createExoticFixture(macroEnabled: Boolean = false): Path =
+  private def createExoticFixture(macroEnabled: Boolean = false, sheetCount: Int = 1): Path =
     val path = Files.createTempFile("gh314-fixture", if macroEnabled then ".xlsm" else ".xlsx")
     val workbookCt =
       if macroEnabled then macroWorkbookCt
@@ -238,6 +299,19 @@ class ContentTypesReconcileSpec extends FunSuite:
     val macroDefault =
       if macroEnabled then s"""  <Default Extension="bin" ContentType="$vbaProjectCt"/>\n"""
       else ""
+    val sheetOverrides = (1 to sheetCount)
+      .map { i =>
+        s"""  <Override PartName="/xl/worksheets/sheet$i.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>"""
+      }
+      .mkString("\n")
+    val sheetElems = (1 to sheetCount)
+      .map(i => s"""    <sheet name="Sheet$i" sheetId="$i" r:id="rId$i"/>""")
+      .mkString("\n")
+    val sheetRels = (1 to sheetCount)
+      .map { i =>
+        s"""  <Relationship Id="rId$i" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet$i.xml"/>"""
+      }
+      .mkString("\n")
     val out = new ZipOutputStream(Files.newOutputStream(path))
     out.setLevel(1)
     try
@@ -249,7 +323,7 @@ class ContentTypesReconcileSpec extends FunSuite:
   <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
   <Default Extension="xml" ContentType="application/xml"/>
 $macroDefault  <Override PartName="/xl/workbook.xml" ContentType="$workbookCt"/>
-  <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+$sheetOverrides
   <Override PartName="/xl/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"/>
   <Override PartName="$customXmlOverride" ContentType="application/xml"/>
 </Types>"""
@@ -265,20 +339,20 @@ $macroDefault  <Override PartName="/xl/workbook.xml" ContentType="$workbookCt"/>
       writeEntry(
         out,
         "xl/workbook.xml",
-        """<?xml version="1.0"?>
+        s"""<?xml version="1.0"?>
 <workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
   <sheets>
-    <sheet name="Sheet1" sheetId="1" r:id="rId1"/>
+$sheetElems
   </sheets>
 </workbook>"""
       )
       writeEntry(
         out,
         "xl/_rels/workbook.xml.rels",
-        """<?xml version="1.0"?>
+        s"""<?xml version="1.0"?>
 <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
-  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
-  <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/>
+$sheetRels
+  <Relationship Id="rId${sheetCount + 1}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/>
 </Relationships>"""
       )
       writeEntry(
@@ -292,16 +366,18 @@ $macroDefault  <Override PartName="/xl/workbook.xml" ContentType="$workbookCt"/>
   <cellXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0"/></cellXfs>
 </styleSheet>"""
       )
-      writeEntry(
-        out,
-        "xl/worksheets/sheet1.xml",
-        """<?xml version="1.0"?>
+      (1 to sheetCount).foreach { i =>
+        writeEntry(
+          out,
+          s"xl/worksheets/sheet$i.xml",
+          s"""<?xml version="1.0"?>
 <worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
   <sheetData>
-    <row r="1"><c r="A1"><v>1</v></c></row>
+    <row r="1"><c r="A1"><v>$i</v></c></row>
   </sheetData>
 </worksheet>"""
-      )
+        )
+      }
       writeEntry(
         out,
         "customXml/item1.xml",

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/ContentTypesReconcileSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/ContentTypesReconcileSpec.scala
@@ -153,7 +153,10 @@ class ContentTypesReconcileSpec extends FunSuite:
     // ...and NO override points at a part that does not ship (index-derived registration would
     // leave /xl/comments1.xml + /xl/drawings/vmlDrawing1.vml dangling here)
     val dangling = ct.overrides.keys.filterNot(p => entries.contains(p.stripPrefix("/")))
-    assert(dangling.isEmpty, s"overrides point at parts that do not ship: ${dangling.mkString(", ")}")
+    assert(
+      dangling.isEmpty,
+      s"overrides point at parts that do not ship: ${dangling.mkString(", ")}"
+    )
 
     // The comment itself round-trips
     val reloaded = XlsxReader.read(output).fold(err => fail(s"Reload failed: $err"), identity)
@@ -191,7 +194,10 @@ class ContentTypesReconcileSpec extends FunSuite:
     assert(entryExists(output, "customXml/item1.xml"), "preserved customXml part should ship")
     // ...and no override anywhere points at a part that does not ship
     val dangling = ct.overrides.keys.filterNot(p => entries.contains(p.stripPrefix("/")))
-    assert(dangling.isEmpty, s"overrides point at parts that do not ship: ${dangling.mkString(", ")}")
+    assert(
+      dangling.isEmpty,
+      s"overrides point at parts that do not ship: ${dangling.mkString(", ")}"
+    )
 
     val reloaded = XlsxReader.read(output).fold(err => fail(s"Reload failed: $err"), identity)
     assertEquals(reloaded.sheetNames.map(_.value), Vector("Sheet1"))

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/SurgicalSstCombineSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/SurgicalSstCombineSpec.scala
@@ -246,6 +246,60 @@ class SurgicalSstCombineSpec extends FunSuite:
     Files.deleteIfExists(output)
   }
 
+  // ========== GH-323: a NEW sheet's text joins the surgical SST accounting ==========
+
+  test("GH-323: Workbook.put of a NEW sheet encodes text via the combined SST, counts exact") {
+    // Source: Sheet1 references Alpha/Beta/Gamma (A1..A3) → count=3, uniqueCount=3
+    val source = createRawSstFixture()
+    val wb = XlsxReader.read(source).fold(err => fail(s"Read failed: $err"), identity)
+
+    // NEW sheet (no source counterpart): one existing string + one new string referenced twice.
+    // Workbook.put of an unseen name marks metadata modified but NOT sheet-modified.
+    val added = Sheet("Added").put(ref"A1" -> "Alpha", ref"A2" -> "Delta", ref"A3" -> "Delta")
+    val modified = wb.put(added)
+
+    val output = Files.createTempFile("gh323-newsheet", ".xlsx")
+    XlsxWriter.write(modified, output).fold(err => fail(s"Write failed: $err"), identity)
+
+    // The new sheet's text cells must reference the combined SST, not re-inline
+    val sheetXml = new String(readEntry(output, "xl/worksheets/sheet2.xml"), "UTF-8")
+    assert(
+      !sheetXml.contains("inlineStr"),
+      s"new sheet re-inlined its strings while the preserved SST ships:\n$sheetXml"
+    )
+    assert(
+      sheetXml.contains("t=\"s\""),
+      s"new sheet should reference SST entries via t=\"s\":\n$sheetXml"
+    )
+
+    val sstXml = new String(readEntry(output, "xl/sharedStrings.xml"), "UTF-8")
+    // 3 source refs + 3 new-sheet refs (Alpha, Delta, Delta) = 6; Delta appends → uniqueCount=4
+    assert(
+      sstXml.contains("count=\"6\""),
+      s"SST count must include the NEW sheet's references. SST:\n$sstXml"
+    )
+    assert(
+      sstXml.contains("uniqueCount=\"4\""),
+      s"SST uniqueCount should be 3 preserved + 1 new (Delta). SST:\n$sstXml"
+    )
+    assert(
+      sstXml.contains("<t>Delta</t>"),
+      s"the new sheet's new string must join the combined SST. SST:\n$sstXml"
+    )
+
+    // And everything reads back from both sheets
+    val reloaded = XlsxReader.read(output).fold(err => fail(s"Reload failed: $err"), identity)
+    assertEquals(textAtIn(reloaded, "Added", ref"A1"), Some("Alpha"))
+    assertEquals(textAtIn(reloaded, "Added", ref"A2"), Some("Delta"))
+    assertEquals(textAtIn(reloaded, "Added", ref"A3"), Some("Delta"))
+    List(ref"A1", ref"A2", ref"A3").zip(existingStrings).foreach { case (r, s) =>
+      assertEquals(textAt(reloaded, r), Some(s))
+    }
+
+    Files.deleteIfExists(source)
+    Files.deleteIfExists(output)
+  }
+
   // ========== helpers ==========
 
   private def textAtIn(wb: Workbook, sheet: String, r: ARef): Option[String] =

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/WorkbookRelsRegenerationSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/WorkbookRelsRegenerationSpec.scala
@@ -81,6 +81,13 @@ class WorkbookRelsRegenerationSpec extends FunSuite:
       (e \@ "name") -> rId
     }.toVector
 
+  /** name -> sheetId for every `<sheet>` in workbook.xml, in declaration order. */
+  private def sheetIdsByName(path: Path): Vector[(String, String)] =
+    val wb = parseEntry(path, "xl/workbook.xml")
+    (wb \ "sheets" \ "sheet").collect { case e: scala.xml.Elem =>
+      (e \@ "name") -> (e \@ "sheetId")
+    }.toVector
+
   /** Id -> (Type, Target, TargetMode) for every relationship in workbook.xml.rels. */
   private def workbookRels(path: Path): Map[String, (String, String, Option[String])] =
     val ids = relIdList(path)
@@ -277,6 +284,59 @@ class WorkbookRelsRegenerationSpec extends FunSuite:
     assertEquals(back.sheetNames.map(_.value), Vector("Values", "Extra"))
     assertEquals(back.sheets(1)(ref"A1").value, CellValue.Number(BigDecimal(42)))
     assertEquals(back.sheets(0)(ref"A2").value, CellValue.Text("héllo wörld"))
+  }
+
+  test("GH-320: adding two sheets in one session allocates distinct sheetIds") {
+    // ECMA-376 requires unique sheetId; allocation must thread through the pass, not recompute
+    // max(preserved)+1 per sheet (which hands every new sheet in the session the same id).
+    Seq("small-values.xlsx", "small-values-lo.xlsx").foreach { fixture =>
+      val (_, wb) = readFixture(fixture)
+      val extra1 = Sheet(SheetName.unsafe("Extra1")).put(ref"A1", CellValue.Number(BigDecimal(1)))
+      val extra2 = Sheet(SheetName.unsafe("Extra2")).put(ref"A1", CellValue.Number(BigDecimal(2)))
+      val added = wb
+        .insertAt(1, extra1)
+        .flatMap(_.insertAt(2, extra2))
+        .fold(err => fail(s"$fixture: insertAt failed: $err"), identity)
+      val out = writeTo(added, "multi-add")
+      val ids = sheetIdsByName(out)
+      assertEquals(ids.map(_._1), Vector("Values", "Extra1", "Extra2"), fixture)
+      val sheetIds = ids.map(_._2)
+      assertEquals(
+        sheetIds.distinct.size,
+        sheetIds.size,
+        s"$fixture: duplicate sheetId in workbook.xml: $ids"
+      )
+      // deterministic: preserved sheet keeps its id, fresh sheets allocate max+1 in sheet order
+      assertEquals(sheetIds, Vector("1", "2", "3"), fixture)
+      val back = reread(out)
+      assertEquals(back.sheetNames.map(_.value), Vector("Values", "Extra1", "Extra2"), fixture)
+      assertEquals(back.sheets(1)(ref"A1").value, CellValue.Number(BigDecimal(1)), fixture)
+      assertEquals(back.sheets(2)(ref"A1").value, CellValue.Number(BigDecimal(2)), fixture)
+    }
+  }
+
+  test("GH-320: renaming both sheets of formulas-lo.xlsx keeps sheetIds distinct") {
+    val (_, wb) = readFixture("formulas-lo.xlsx")
+    val renamed = wb
+      .rename(SheetName.unsafe("Data"), SheetName.unsafe("D2"))
+      .flatMap(_.rename(SheetName.unsafe("Calc"), SheetName.unsafe("C2")))
+      .fold(err => fail(s"rename failed: $err"), identity)
+    val out = writeTo(renamed, "multi-rename")
+    val ids = sheetIdsByName(out)
+    assertEquals(ids.map(_._1), Vector("D2", "C2"))
+    val sheetIds = ids.map(_._2)
+    assertEquals(
+      sheetIds.distinct.size,
+      sheetIds.size,
+      s"duplicate sheetId in workbook.xml: $ids"
+    )
+    // renamed sheets miss the name match, so each allocates a fresh id above the preserved max
+    assertEquals(sheetIds, Vector("3", "4"))
+    // their rIds still ride through (identity-resolved part match is rename-stable, GH-315)
+    assertEquals(sheetRelIds(out), Vector("D2" -> "rId3", "C2" -> "rId4"))
+    val back = reread(out)
+    assertEquals(back.sheetNames.map(_.value), Vector("D2", "C2"))
+    assertEquals(back.sheets(0)(ref"A5").value, CellValue.Number(BigDecimal(50)))
   }
 
   test("GH-320: deleting a sheet from formulas-lo.xlsx drops its rel and keeps the rest") {

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/WorkbookRelsRegenerationSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/WorkbookRelsRegenerationSpec.scala
@@ -1,0 +1,355 @@
+package com.tjclp.xl.ooxml
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path}
+import java.util.zip.ZipFile
+
+import scala.jdk.CollectionConverters.*
+
+import munit.FunSuite
+import com.tjclp.xl.api.*
+import com.tjclp.xl.cells.CellValue
+import com.tjclp.xl.macros.ref
+
+/**
+ * GH-320: regenerating workbook.xml must never desync from workbook.xml.rels.
+ *
+ * LibreOffice numbers its workbook rels theme-first (rId1 = theme, rId3 = first worksheet), so a
+ * writer that renumbers sheet rIds to rId1..N while copying the preserved rels verbatim makes the
+ * first sheet resolve to xl/theme/theme1.xml — xl's own reader fails ("Missing required child
+ * element: sheetData") and openpyxl reads an empty sheet. Excel/openpyxl files survived only
+ * because their rels happen to number sheets first.
+ *
+ * Contract pinned here:
+ *   - sheet rIds are REUSED from the source rels (matched by worksheet target), never renumbered
+ *   - non-sheet rels (theme, styles, sharedStrings, calcChain, ...) ride through with their ids
+ *   - new sheets allocate ids ABOVE every preserved numeric id (no collision)
+ *   - every r:id in the regenerated workbook.xml resolves in the regenerated rels, and every
+ *     internal rel target resolves to a zip entry
+ *   - the metadata-modified (fromDomain) path carries preserved workbook-level elements through:
+ *     fileVersion, workbookPr, workbookProtection, bookViews siblings, calcPr, extLst
+ */
+class WorkbookRelsRegenerationSpec extends FunSuite:
+
+  private val relTypeWorksheetUri =
+    "http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"
+  private val relTypeThemeUri =
+    "http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme"
+
+  private def readFixture(name: String): (Path, Workbook) =
+    val path = TestFixtures.copyToTemp(name)
+    val wb = XlsxReader
+      .read(path)
+      .fold(err => fail(s"$name failed to read: ${err.message}"), identity)
+    (path, wb)
+
+  private def writeTo(wb: Workbook, label: String): Path =
+    val out = Files.createTempFile(s"xl-rels-$label-", ".xlsx")
+    out.toFile.deleteOnExit()
+    XlsxWriter
+      .write(wb, out)
+      .fold(err => fail(s"$label write failed: ${err.message}"), _ => ())
+    out
+
+  private def reread(path: Path): Workbook =
+    XlsxReader.read(path).fold(err => fail(s"re-read failed: ${err.message}"), identity)
+
+  private def entryText(path: Path, name: String): String =
+    val zip = new ZipFile(path.toFile)
+    try
+      Option(zip.getEntry(name)) match
+        case Some(e) => new String(zip.getInputStream(e).readAllBytes(), StandardCharsets.UTF_8)
+        case None => fail(s"zip entry $name not found in $path")
+    finally zip.close()
+
+  private def zipEntryNames(path: Path): Set[String] =
+    val zip = new ZipFile(path.toFile)
+    try zip.entries().asScala.map(_.getName).toSet
+    finally zip.close()
+
+  private def parseEntry(path: Path, name: String): scala.xml.Elem =
+    XmlSecurity.parseSafe(entryText(path, name), name).fold(e => fail(e.message), identity)
+
+  /** name -> r:id for every `<sheet>` in workbook.xml. */
+  private def sheetRelIds(path: Path): Vector[(String, String)] =
+    val wb = parseEntry(path, "xl/workbook.xml")
+    (wb \ "sheets" \ "sheet").collect { case e: scala.xml.Elem =>
+      val rId = e
+        .attribute(XmlUtil.nsRelationships, "id")
+        .map(_.text)
+        .getOrElse(fail(s"sheet missing r:id: $e"))
+      (e \@ "name") -> rId
+    }.toVector
+
+  /** Id -> (Type, Target, TargetMode) for every relationship in workbook.xml.rels. */
+  private def workbookRels(path: Path): Map[String, (String, String, Option[String])] =
+    val ids = relIdList(path)
+    assertEquals(ids.distinct, ids, s"duplicate relationship ids in $path: $ids")
+    val rels = parseEntry(path, "xl/_rels/workbook.xml.rels")
+    (rels \ "Relationship").collect { case e: scala.xml.Elem =>
+      (e \@ "Id") -> ((e \@ "Type", e \@ "Target", Option(e \@ "TargetMode").filter(_.nonEmpty)))
+    }.toMap
+
+  /** Every relationship Id in declaration order (duplicates visible, unlike the Map view). */
+  private def relIdList(path: Path): Vector[String] =
+    val rels = parseEntry(path, "xl/_rels/workbook.xml.rels")
+    (rels \ "Relationship").collect { case e: scala.xml.Elem => e \@ "Id" }.toVector
+
+  /** Resolve a workbook-rels target against the xl/ base (leading slash = package-absolute). */
+  private def resolveTarget(target: String): String =
+    val cleaned = if target.startsWith("/") then target.drop(1) else target
+    val resolved =
+      if cleaned.startsWith("xl/") then java.nio.file.Paths.get(cleaned)
+      else java.nio.file.Paths.get("xl").resolve(cleaned)
+    resolved.normalize().toString.replace('\\', '/')
+
+  private def edit(wb: Workbook, value: CellValue): Workbook =
+    wb.update(wb.sheets(0).name, _.put(ref"Z99", value))
+      .fold(err => fail(s"edit failed: $err"), identity)
+
+  // ===== (i) the wave-7 blocked test: full re-read of an edited LibreOffice file =====
+
+  test("GH-320: one-cell edit on small-values-lo.xlsx re-reads fully with values intact") {
+    val (_, wb) = readFixture("small-values-lo.xlsx")
+    val edited = edit(wb, CellValue.Text("edited"))
+    val out = writeTo(edited, "lo-edit")
+    val back = reread(out)
+    assertEquals(back.sheets(0).name.value, "Values")
+    assertEquals(back.sheets(0)(ref"A2").value, CellValue.Text("héllo wörld"))
+    assertEquals(back.sheets(0)(ref"A5").value, CellValue.Text("  leading and trailing  "))
+    assertEquals(back.sheets(0)(ref"Z99").value, CellValue.Text("edited"))
+  }
+
+  test("GH-320: edited LO workbook keeps the source sheet rId and the theme rel") {
+    val (_, wb) = readFixture("small-values-lo.xlsx")
+    val out = writeTo(edit(wb, CellValue.Number(BigDecimal(7))), "lo-ids")
+    // LibreOffice numbered the sheet rId3 (rId1 = theme); the source ids must ride through
+    assertEquals(sheetRelIds(out), Vector("Values" -> "rId3"))
+    val rels = workbookRels(out)
+    val (sheetType, sheetTarget, _) = rels.getOrElse("rId3", fail(s"rId3 missing: $rels"))
+    assertEquals(sheetType, relTypeWorksheetUri)
+    assertEquals(resolveTarget(sheetTarget), "xl/worksheets/sheet1.xml")
+    val (themeType, themeTarget, _) = rels.getOrElse("rId1", fail(s"rId1 missing: $rels"))
+    assertEquals(themeType, relTypeThemeUri)
+    assertEquals(resolveTarget(themeTarget), "xl/theme/theme1.xml")
+  }
+
+  test("GH-320: openpyxl reads the edited LibreOffice file (subprocess smoke)") {
+    assume(pythonWithOpenpyxl, "python3 with openpyxl not available")
+    val (_, wb) = readFixture("small-values-lo.xlsx")
+    val out = writeTo(edit(wb, CellValue.Text("edited")), "lo-openpyxl")
+    val script =
+      s"""import openpyxl
+         |wb = openpyxl.load_workbook(${pyString(out.toString)})
+         |ws = wb["Values"]
+         |print(ws["A2"].value)
+         |print(ws["Z99"].value)
+         |""".stripMargin
+    val output = runPython(script)
+    assert(output.contains("héllo wörld"), s"openpyxl lost A2 (empty sheet?): $output")
+    assert(output.contains("edited"), s"openpyxl lost the edit: $output")
+  }
+
+  test("GH-320: openpyxl reads the setActiveSheet output (metadata-modified path smoke)") {
+    assume(pythonWithOpenpyxl, "python3 with openpyxl not available")
+    val (_, wb) = readFixture("formulas-lo.xlsx")
+    val activated = wb.setActiveSheet(1).fold(err => fail(s"setActiveSheet failed: $err"), identity)
+    val out = writeTo(activated, "lo-active-openpyxl")
+    val script =
+      s"""import openpyxl
+         |wb = openpyxl.load_workbook(${pyString(out.toString)})
+         |print(wb.sheetnames)
+         |print(wb["Data"]["A5"].value)
+         |""".stripMargin
+    val output = runPython(script)
+    assert(output.contains("['Data', 'Calc']"), s"openpyxl lost the sheets: $output")
+    assert(output.contains("50"), s"openpyxl lost Data!A5: $output")
+  }
+
+  // ===== the resolution law, every fixture =====
+
+  test("GH-320 LAW: a cell edit keeps every workbook.xml r:id resolving to its part") {
+    TestFixtures.all.foreach { fixture =>
+      val (_, wb) = readFixture(fixture)
+      val out = writeTo(edit(wb, CellValue.Number(BigDecimal(1))), "law")
+      val rels = workbookRels(out)
+      val entries = zipEntryNames(out)
+      // every <sheet r:id> resolves to a worksheet-type rel whose target part exists
+      sheetRelIds(out).foreach { case (name, rId) =>
+        val (relType, target, _) =
+          rels.getOrElse(rId, fail(s"$fixture: sheet '$name' r:id=$rId missing from rels: $rels"))
+        assertEquals(
+          relType,
+          relTypeWorksheetUri,
+          s"$fixture: sheet '$name' r:id=$rId resolves to a non-worksheet part ($target)"
+        )
+        assert(
+          entries.contains(resolveTarget(target)),
+          s"$fixture: sheet '$name' target $target missing from zip"
+        )
+      }
+      // no duplicate ids, and every internal rel target resolves to a zip entry
+      rels.foreach { case (id, (_, target, targetMode)) =>
+        if !targetMode.contains("External") then
+          assert(
+            entries.contains(resolveTarget(target)),
+            s"$fixture: rel $id target $target missing from zip"
+          )
+      }
+    }
+  }
+
+  // ===== (iii) metadata-modified path: preserved workbook-level elements survive =====
+
+  test("GH-320: setActiveSheet on formulas-lo.xlsx keeps calcPr/fileVersion/protection/extLst") {
+    val (_, wb) = readFixture("formulas-lo.xlsx")
+    val activated = wb.setActiveSheet(1).fold(err => fail(s"setActiveSheet failed: $err"), identity)
+    val out = writeTo(activated, "lo-active")
+
+    val workbookElem = parseEntry(out, "xl/workbook.xml")
+    val calcPr = (workbookElem \ "calcPr").headOption.getOrElse(fail("calcPr dropped"))
+    assertEquals(calcPr \@ "iterateCount", "100", "calcPr attributes dropped")
+    val fileVersion = (workbookElem \ "fileVersion").headOption.getOrElse(fail("fileVersion lost"))
+    assertEquals(fileVersion \@ "appName", "Calc")
+    assert((workbookElem \ "workbookProtection").nonEmpty, "workbookProtection dropped")
+    assert(
+      (workbookElem \ "extLst").exists(_.toString.contains("extCalcPr")),
+      "loext extLst dropped"
+    )
+    val workbookPr = (workbookElem \ "workbookPr").headOption.getOrElse(fail("workbookPr lost"))
+    assertEquals(workbookPr \@ "backupFile", "false", "unmodeled workbookPr attrs dropped")
+    // bookViews: the model's activeTab overlays while sibling attributes ride through (GH-294)
+    val view = (workbookElem \ "bookViews" \ "workbookView").headOption
+      .getOrElse(fail("workbookView lost"))
+    assertEquals(view \@ "activeTab", "1")
+    assertEquals(view \@ "showHorizontalScroll", "true", "unmodeled bookViews attrs dropped")
+    // schema order: fileVersion < workbookPr < bookViews < sheets < calcPr
+    val xml = entryText(out, "xl/workbook.xml")
+    val order = List("<fileVersion", "<workbookPr", "<bookViews", "<sheets", "<calcPr")
+      .map(tag => tag -> xml.indexOf(tag))
+    order.foreach((tag, idx) => assert(idx >= 0, s"$tag missing: $xml"))
+    assertEquals(order.map(_._2).sorted, order.map(_._2), s"schema order violated: $order")
+
+    // sheet rIds preserved, theme rel intact, everything resolves
+    assertEquals(sheetRelIds(out), Vector("Data" -> "rId3", "Calc" -> "rId4"))
+    val rels = workbookRels(out)
+    assertEquals(rels.get("rId1").map(_._1), Some(relTypeThemeUri))
+
+    val back = reread(out)
+    assertEquals(back.activeSheetIndex, 1)
+    assertEquals(
+      back.sheets(1)(ref"A1").value,
+      CellValue.Formula("SUM(Data!A1:A5)", Some(CellValue.Number(BigDecimal(150))))
+    )
+  }
+
+  test("GH-320: authored defined name on small-values-lo.xlsx keeps preserved elements") {
+    val (_, wb) = readFixture("small-values-lo.xlsx")
+    val named = wb.withDefinedName("MyRange", "Values!$A$1:$A$3")
+    val out = writeTo(named, "lo-name")
+    val workbookElem = parseEntry(out, "xl/workbook.xml")
+    assert((workbookElem \ "calcPr").nonEmpty, "calcPr dropped on metadata write")
+    assert((workbookElem \ "fileVersion").nonEmpty, "fileVersion dropped on metadata write")
+    val dn = (workbookElem \ "definedNames" \ "definedName").headOption
+      .getOrElse(fail("authored definedName missing"))
+    assertEquals(dn \@ "name", "MyRange")
+    assertEquals(sheetRelIds(out), Vector("Values" -> "rId3"))
+    val back = reread(out)
+    assertEquals(back.metadata.definedNames.map(_.name), Vector("MyRange"))
+    assertEquals(back.sheets(0)(ref"A2").value, CellValue.Text("héllo wörld"))
+  }
+
+  // ===== new sheets allocate fresh non-colliding ids =====
+
+  test("GH-320: adding a sheet to small-values-lo.xlsx allocates a fresh rId above the max") {
+    val (_, wb) = readFixture("small-values-lo.xlsx")
+    val extra = Sheet(SheetName.unsafe("Extra")).put(ref"A1", CellValue.Number(BigDecimal(42)))
+    val added = wb.insertAt(1, extra).fold(err => fail(s"insertAt failed: $err"), identity)
+    val out = writeTo(added, "lo-add")
+    val ids = sheetRelIds(out)
+    assertEquals(ids.map(_._1), Vector("Values", "Extra"))
+    assertEquals(ids.headOption.map(_._2), Some("rId3"), "surviving sheet must keep its source id")
+    // LO's rels claim rId1..rId4 — the fresh sheet must allocate above them
+    assertEquals(ids.lift(1).map(_._2), Some("rId5"), "fresh sheet id must not collide")
+    val rels = workbookRels(out)
+    assertEquals(rels.get("rId1").map(_._1), Some(relTypeThemeUri), "theme rel dropped")
+    val back = reread(out)
+    assertEquals(back.sheetNames.map(_.value), Vector("Values", "Extra"))
+    assertEquals(back.sheets(1)(ref"A1").value, CellValue.Number(BigDecimal(42)))
+    assertEquals(back.sheets(0)(ref"A2").value, CellValue.Text("héllo wörld"))
+  }
+
+  test("GH-320: deleting a sheet from formulas-lo.xlsx drops its rel and keeps the rest") {
+    val (_, wb) = readFixture("formulas-lo.xlsx")
+    val without = wb.removeAt(1).fold(err => fail(s"removeAt failed: $err"), identity)
+    val out = writeTo(without, "lo-delete")
+    // the surviving sheet keeps its source id; the deleted sheet's rel does not dangle
+    assertEquals(sheetRelIds(out), Vector("Data" -> "rId3"))
+    val rels = workbookRels(out)
+    val worksheetTargets = rels.values.collect {
+      case (relType, target, _) if relType == relTypeWorksheetUri => resolveTarget(target)
+    }
+    assertEquals(worksheetTargets.toSet, Set("xl/worksheets/sheet1.xml"))
+    assertEquals(rels.get("rId1").map(_._1), Some(relTypeThemeUri), "theme rel dropped")
+    val entries = zipEntryNames(out)
+    rels.foreach { case (id, (_, target, targetMode)) =>
+      if !targetMode.contains("External") then
+        assert(entries.contains(resolveTarget(target)), s"rel $id dangling: $target")
+    }
+    val back = reread(out)
+    assertEquals(back.sheetNames.map(_.value), Vector("Data"))
+    assertEquals(back.sheets(0)(ref"A5").value, CellValue.Number(BigDecimal(50)))
+  }
+
+  // ===== stability: the regenerated output is itself a valid surgical source =====
+
+  test("GH-320: a second edit→write cycle on the LO file is stable (fixpoint)") {
+    val (_, wb) = readFixture("small-values-lo.xlsx")
+    val out1 = writeTo(edit(wb, CellValue.Number(BigDecimal(1))), "lo-cycle1")
+    val firstIds = sheetRelIds(out1)
+    val wb2 = reread(out1)
+    val edited2 = wb2
+      .update(wb2.sheets(0).name, _.put(ref"Y98", CellValue.Number(BigDecimal(2))))
+      .fold(err => fail(s"second edit failed: $err"), identity)
+    val out2 = writeTo(edited2, "lo-cycle2")
+    assertEquals(sheetRelIds(out2), firstIds, "sheet rIds must be stable across cycles")
+    val back = reread(out2)
+    assertEquals(back.sheets(0)(ref"Z99").value, CellValue.Number(BigDecimal(1)))
+    assertEquals(back.sheets(0)(ref"Y98").value, CellValue.Number(BigDecimal(2)))
+    assertEquals(back.sheets(0)(ref"A2").value, CellValue.Text("héllo wörld"))
+  }
+
+  // ===== (iv) Excel-dialect guard: well-ordered rels ride through unchanged =====
+
+  test("GH-320: numeric edit on small-values.xlsx keeps workbook rels semantically identical") {
+    val (in, wb) = readFixture("small-values.xlsx")
+    val out = writeTo(edit(wb, CellValue.Number(BigDecimal(7))), "openpyxl-edit")
+    assertEquals(sheetRelIds(out), Vector("Values" -> "rId1"))
+    assertEquals(workbookRels(out), workbookRels(in), "openpyxl rels must ride through unchanged")
+    val back = reread(out)
+    assertEquals(back.sheets(0)(ref"Z99").value, CellValue.Number(BigDecimal(7)))
+  }
+
+  // ===== helpers: openpyxl subprocess (the wave-6b smoke precedent) =====
+
+  private lazy val pythonWithOpenpyxl: Boolean =
+    scala.util
+      .Try {
+        val p = new ProcessBuilder("python3", "-c", "import openpyxl")
+          .redirectErrorStream(true)
+          .start()
+        p.waitFor() == 0
+      }
+      .getOrElse(false)
+
+  private def pyString(s: String): String =
+    "\"" + s.replace("\\", "\\\\").replace("\"", "\\\"") + "\""
+
+  private def runPython(script: String): String =
+    val pb = new ProcessBuilder("python3", "-c", script).redirectErrorStream(true)
+    pb.environment().put("PYTHONIOENCODING", "utf-8")
+    val p = pb.start()
+    val output = new String(p.getInputStream.readAllBytes(), StandardCharsets.UTF_8)
+    val exit = p.waitFor()
+    assertEquals(exit, 0, s"python exited $exit:\n$output")
+    output


### PR DESCRIPTION
## Summary

Wave 9 via `issue-wave.js`: 2 clusters, both approved (one rework round — the reviewer caught a duplicate-sheetId regression the rels fix itself introduced on multi-add/multi-rename, fixed with allocation threading).

### The corruption fix (#320)
`workbook.xml.rels` now regenerates **in the same pass** as `workbook.xml`: sheet rIds consistent with their rels (LibreOffice maps rId1 to the theme — previously any edit made the first sheet resolve to `theme1.xml`), preserved workbook-level elements (calcPr, bookViews siblings) survive regeneration, sheetIds allocate distinctly. **Verified end-to-end by the reviewer**: the original CLI repro (one-cell edit on an LO file) now reads back correctly in xl AND openpyxl; 8 adversarial probes across all 15 corpus fixtures held (every r:id resolves, no dangling rels, full rereads). The wave-7 `CfPreservationSpec` workaround is undone — full-workbook re-reads assert directly.

### Follow-ups
- **#321 proven not-reproducible**: the GH-315 rework already registers comment content types from actual emitted paths; falsifiability-tested regression guard committed (re-broke the registration, watched the guard bite, restored).
- **#322**: deleted sheets' writer-owned overrides pruned from the preserved Content_Types merge (exotic overrides still survive).
- **#323**: new sheets on source-backed workbooks join surgical SST accounting — combined-SST references with exact counts, no re-inlining.

### Discovered and filed
#327 (zip-name collision on Excel-reordered sources — fails loudly, pre-existing), #328 (comments-removed danglers in the preserved-CT branch — #322's sibling).

## Verification
Baseline 3842 green. Integrated: full suite green, law at 500 green, checkFormatAll green. TDD + revert-and-rerun refutation both clusters; external openpyxl validation on the corruption fix.

Closes #320
Closes #321
Closes #322
Closes #323

🤖 Generated with [Claude Code](https://claude.com/claude-code)