### PR TITLE
docs: refresh skills & docs for v0.12.2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ excel.read(path).flatMap(wb => excel.write(wb, outPath))
 
 ```bash
 ./mill __.compile          # Compile all
-./mill __.test             # Run all tests (3005+)
+./mill __.test             # Run all tests (3,858)
 ./mill xl-core.test        # Test specific module
 ./mill __.reformat         # Format (Scalafmt 3.10.1)
 ./mill __.checkFormat      # CI check
@@ -395,12 +395,12 @@ Styles deduplicated by `CellStyle.canonicalKey`. Build style index before emitti
 
 **Framework**: MUnit + ScalaCheck | **Generators**: `xl-core/test/src/com/tjclp/xl/Generators.scala`
 
-**3005+ tests** by module: xl-evaluator (1198), xl-core (971), xl-ooxml (381), xl-cli (308), xl-cats-effect (76), xl-agent (54), xl prelude probes (17). See `docs/reference/testing-guide.md` for suite structure and patterns.
+**3,858 tests** by module: xl-evaluator (1485), xl-core (1104), xl-ooxml (680), xl-cli (406), xl-cats-effect (110), xl-agent (54), xl prelude probes (19). See `docs/reference/testing-guide.md` for suite structure and patterns.
 
 ## Documentation
 
 - **Roadmap**: `docs/plan/roadmap.md` (single source of truth for work scheduling)
-- **Status**: `docs/STATUS.md` (current capabilities, 3005+ tests)
+- **Status**: `docs/STATUS.md` (current capabilities, 3,858 tests)
 - **Design**: `docs/design/*.md` (architecture, purity charter, domain model)
 - **Reference**: `docs/reference/*.md` (examples, scaffolds, performance guide)
 

--- a/docs/FAQ-AND-GLOSSARY.md
+++ b/docs/FAQ-AND-GLOSSARY.md
@@ -1,6 +1,6 @@
 # FAQ & Glossary
 
-**Last Updated**: 2026-06-10
+**Last Updated**: 2026-06-15
 
 ---
 
@@ -13,7 +13,7 @@ A: We want immutability, type safety, and compile-time guarantees; POI's design 
 A: One import — `import com.tjclp.xl.scripting.{*, given}` with scala-cli (since 0.11.0). See [reference/scripting.md](reference/scripting.md).
 
 **Q: Will charts look identical to Excel's?**
-A: Charts are not implemented yet; when added they will target ChartML with deterministic output.
+A: Typed bar/line/pie charts ship (0.12.0) and emit deterministic ChartML that Excel renders natively; Excel-authored charts round-trip byte-for-byte. Note: XL's own HTML/SVG/PNG export does not draw charts. See [LIMITATIONS §12](LIMITATIONS.md).
 
 **Q: Do you support `.xls`?**
 A: Not initially. Focus is `.xlsx`/`.xlsm`. BIFF can be a separate module later.

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -1,11 +1,11 @@
 # XL Current Limitations and Future Roadmap
 
-**Last Updated**: 2026-06-10
-**Current Phase**: Core domain + OOXML + streaming I/O complete; formula system complete (**107 functions** + cross-sheet support + dynamic arrays); structural editing (insert/delete rows & columns with formula rewriting); named-range & hyperlink authoring; tables + benchmarks complete; row/column serialization complete; **security hardening complete** (ZIP bomb detection, XXE prevention, formula injection guards in both in-memory and streaming writes); scripting prelude + whole-workbook recalculation + print setup authoring (0.11.0).
+**Last Updated**: 2026-06-15
+**Current Phase**: Core domain + OOXML + streaming I/O complete; formula system complete (**107 functions** + cross-sheet support + dynamic arrays); structural editing (insert/delete rows & columns with formula rewriting); named-range & hyperlink authoring; tables + benchmarks complete; row/column serialization complete; **security hardening complete** (ZIP bomb detection, XXE prevention, formula injection guards in both in-memory and streaming writes); scripting prelude + whole-workbook recalculation + print setup authoring (0.11.0); typed bar/line/pie charts + embedded pictures (0.12.0); conditional formatting (0.12.1); LibreOffice-edit interop fixes (0.12.2).
 
-> **Note (0.11.0):** Sections below largely predate the 0.10.0 "Trust & Author" and 0.11.0 "Scripting" releases and may understate current capabilities. Hyperlinks (#9) and named ranges (#15) are **supported**; inline worksheet elements like data validation (#11) are **preserved through edits** (authoring still pending); print setup is **partially supported** as of 0.11.0 (#16). 0.11.0 also added the scripting prelude (`com.tjclp.xl.scripting`), whole-workbook `recalculate` with per-cell errors, per-side borders/outlines, and sheet view settings — see the [CHANGELOG](../CHANGELOG.md). For the 0.10.0 rationale, see [archive/plan/v0.10.0-execution.md](archive/plan/v0.10.0-execution.md).
+> **Note (through 0.12.2):** Sections below largely predate the 0.10.0 "Trust & Author", 0.11.0 "Scripting", and 0.12.0–0.12.2 ("Visual"/"Clean Sweep"/"Interop") releases and may understate current capabilities. **Charts, drawings/pictures, and conditional formatting now ship** — see §12, §13, and §10 below. Hyperlinks (#9) and named ranges (#15) are **supported**; inline worksheet elements like data validation (#11) are **preserved through edits** (authoring still pending); print setup is **partially supported** as of 0.11.0 (#16). 0.11.0 also added the scripting prelude (`com.tjclp.xl.scripting`), whole-workbook `recalculate` with per-cell errors, per-side borders/outlines, and sheet view settings — see the [CHANGELOG](../CHANGELOG.md). For the 0.10.0 rationale, see [archive/plan/v0.10.0-execution.md](archive/plan/v0.10.0-execution.md).
 >
-> **Known open issues** (GitHub): leading `=+` formula prefix rejected (#271), trailing empty number-format sections (#262), quoting of cell-ref-shaped sheet names (#263), streaming StylePatcher indent (#264), SaxStax DirectSaxEmitter metadata gaps (#265), even/first page headers + fitToPage (#266), charts (#222), drawings (#221).
+> **Known open issues**: the issues previously listed here (#262–#266, #271) were closed in the v0.11.1 "Totality" wave, and charts (#222) / drawings (#221) shipped in 0.12.0. For the current open set, see [GitHub Issues](https://github.com/TJC-LP/xl/issues).
 
 This document provides a comprehensive overview of what XL can and cannot do today, with clear links to future implementation plans.
 
@@ -649,31 +649,22 @@ See: [plan/roadmap.md](plan/roadmap.md)
 
 ---
 
-### Phase 8: Drawings (Priority 4)
-**Effort**: 2-3 weeks
+### Phase 8: Drawings ✅ SHIPPED (0.12.0, #221)
 **Focus**: Images and shapes
 
-See: [plan/roadmap.md](plan/roadmap.md) (drawings tracked in #221)
-
-- [ ] Image embedding (5-7 days)
-- [ ] Shapes (3-4 days)
-- [ ] Drawing relationships (2-3 days)
+Embedded pictures are modeled, authored, and round-tripped (`Sheet.addImage`/`pictures`/`removeDrawing`, three anchor forms, 7-format classification, sha-deduped media); non-picture drawings (shapes, etc.) ride byte-preservation. See §13 below and [plan/roadmap.md](plan/roadmap.md) (#221). Shape *authoring* remains future.
 
 ---
 
-### Phase 9: Charts (Priority 5)
-**Effort**: 4-6 weeks
+### Phase 9: Charts ✅ TYPED BAR/LINE/PIE SHIPPED (0.12.0, #222)
 **Focus**: Chart generation
 
-See: [plan/roadmap.md](plan/roadmap.md) (charts tracked in #222)
-
-**Very complex**: 15+ chart types, each with custom XML structure
+Typed bar/line/pie charts are modeled, authored (`Chart.bar`/`line`/`pie` + `Sheet.addChart`, CLI `chart add`), and round-tripped; Excel-authored and out-of-fence charts stay byte-preserved. See §12 below and [plan/roadmap.md](plan/roadmap.md) (#222). Scatter/area/combo/3D and chart styling remain future.
 
 ---
 
 ### Phase 10: Tables & Advanced Features (Priority 6)
-**Effort**: 3-4 weeks
-**Focus**: Tables, pivots, conditional formatting
+**Focus**: Tables ✅ (shipped), conditional formatting ✅ (0.12.1, #136 — see §10), pivot tables ⏳ (still future)
 
 See: [plan/roadmap.md](plan/roadmap.md)
 
@@ -708,21 +699,23 @@ See: [plan/roadmap.md](plan/roadmap.md)
 | **Styles** | ✅ | ✅ | XL: Full in-memory; streaming uses minimal default styles |
 | **Formulas (eval)** | ✅ | ✅ | XL: 107 functions, dependency graph, cycle detection |
 | **Tables** | ✅ | ✅ | XL: Full table support with AutoFilter, structured refs |
-| **Charts** | ❌ | ✅ | POI: Full support |
-| **Drawings** | ❌ | ✅ | POI: Images/shapes |
+| **Charts** | ⚠️ | ✅ | XL: typed bar/line/pie (scoped, §12); POI: full |
+| **Drawings** | ⚠️ | ✅ | XL: embedded pictures (scoped, §13); POI: images/shapes |
 | **Memory (100k rows)** | ✅ 50MB | ❌ 800MB | XL: 16x better |
 | **Type Safety** | ✅ | ❌ | XL: Compile-time, POI: Runtime |
 | **Purity** | ✅ | ❌ | XL: Pure, POI: Mutable |
 | **Determinism** | ✅ | ❌ | XL: Stable diffs, POI: Non-deterministic |
 | **Security** | ✅ | ⚠️ | XL: ZIP bomb, XXE, formula injection protection |
 
-**Verdict**: XL is production-ready for data-heavy use cases (streaming, ETL). POI better for rich formatting/charts (for now).
+**Verdict**: XL is production-ready for data-heavy use cases (streaming, ETL) and now authors typed charts + embedded pictures (scoped — see §12/§13). POI still leads for advanced chart types, shapes, and pivot tables.
 
 ---
 
 ## Performance Benchmarks: XL vs Apache POI
 
 *See [design/performance-investigation.md](design/performance-investigation.md) for full analysis.*
+
+> ⚠️ **Benchmarks below were captured on an earlier release and have not been re-validated for 0.12.x — treat as indicative.** (0.12.1 additionally made codec put paths ~2.4x faster, #297.)
 
 ### Summary (Apple Silicon, JDK 21)
 
@@ -768,8 +761,8 @@ SAX parsing is inherently synchronous - the `parser.parse()` call blocks until t
 - Performance-critical workloads (benchmarked vs POI)
 
 **No/Not yet, if you need**:
-- Charts or drawings (planned)
-- Pivot tables/conditional formatting/data validation (planned)
+- Advanced chart types (scatter/area/combo/3D), shapes, or chart styling — typed bar/line/pie charts + embedded pictures **do** ship (scoped, §12/§13)
+- Pivot tables or data-validation authoring (planned)
 - Excel macros (not planned to execute; preservation planned)
 
 ---
@@ -830,8 +823,8 @@ SAX parsing is inherently synchronous - the `parser.parse()` call blocks until t
 
 ### If you hit a limitation today:
 
-1. **Need charts or drawings**: Use POI for chart/drawing *authoring* (#222, #221); XL preserves existing charts/drawings through edits
-2. **Unsupported formula function**: Store the formula as a string and let Excel recalculate on open (XL evaluates the 104 built-ins)
+1. **Need advanced charts/shapes**: XL authors typed bar/line/pie charts + embedded pictures (#222, #221; scoped — see §12/§13) and preserves everything else through edits; reach for POI only for chart types XL doesn't model yet (scatter/area/combo/3D, shapes)
+2. **Unsupported formula function**: Store the formula as a string and let Excel recalculate on open (XL evaluates the 107 built-ins)
 3. **Streaming update of one sheet in a huge workbook**: Use the in-memory read → modify → write path (surgical modification preserves untouched parts)
 
 ---
@@ -855,4 +848,4 @@ Want to help implement these features? See:
 
 ---
 
-*Last updated 2026-06-10 (0.11.0 doc-truth pass, GH-272: refreshed fixed/open status against the 0.10.0 and 0.11.0 releases, corrected the function registry breakdown, repointed retired plan links).*
+*Last updated 2026-06-15 (0.12.2 doc-truth pass: refreshed fixed/open status against the 0.12.0 "Visual" (charts/drawings), 0.12.1 "Clean Sweep" (conditional formatting), and 0.12.2 "Interop" releases; the earlier 0.11.0 pass is tracked under GH-272).*

--- a/docs/QUICK-START.md
+++ b/docs/QUICK-START.md
@@ -253,7 +253,7 @@ sheet.put(ref"A1" -> text)
 
 ### Export to HTML
 ```scala
-val html = sheet.toHtml(range"A1:B10")
+val html = sheet.toHtml(ref"A1:B10")
 println(html)  // <table>...</table> with inline CSS
 ```
 
@@ -307,7 +307,7 @@ cyclicSheet.evaluateWithDependencyCheck() match
   case Right(_) => // Won't happen
 ```
 
-**Available Functions** (104 total):
+**Available Functions** (107 total):
 - **Aggregate**: SUM, COUNT, COUNTA, COUNTBLANK, AVERAGE, MEDIAN, MIN, MAX, STDEV, STDEVP, VAR, VARP
 - **Statistical**: LARGE, SMALL, RANK, PERCENTILE, QUARTILE
 - **Conditional**: SUMIF, COUNTIF, SUMIFS, COUNTIFS, AVERAGEIF, AVERAGEIFS, MAXIFS, MINIFS, SUMPRODUCT
@@ -316,8 +316,9 @@ cyclicSheet.evaluateWithDependencyCheck() match
 - **Date**: TODAY, NOW, DATE, YEAR, MONTH, DAY, EOMONTH, EDATE, DATEDIF, NETWORKDAYS, WORKDAY, YEARFRAC
 - **Math**: ABS, ROUND, ROUNDUP, ROUNDDOWN, INT, MOD, POWER, SQRT, LOG, LN, EXP, FLOOR, CEILING, TRUNC, SIGN, PI
 - **Financial**: NPV, IRR, XNPV, XIRR, PMT, FV, PV, RATE, NPER
-- **Lookup / Reference**: VLOOKUP, HLOOKUP, XLOOKUP, INDEX, MATCH, OFFSET, ROW, COLUMN, ROWS, COLUMNS, ADDRESS
+- **Lookup / Reference**: VLOOKUP, HLOOKUP, XLOOKUP, INDEX, MATCH, OFFSET, INDIRECT, ROW, COLUMN, ROWS, COLUMNS, ADDRESS
 - **Dynamic Arrays**: TRANSPOSE, SEQUENCE, SORT, UNIQUE, FILTER
+- **Random**: RAND, RANDBETWEEN
 
 See CLAUDE.md for the complete list.
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,12 +1,19 @@
 # XL Project Status
 
-**Last Updated**: 2026-06-10
+**Last Updated**: 2026-06-15
 
 ## Current State
 
 > **For detailed phase completion status and roadmap, see [plan/roadmap.md](plan/roadmap.md)**
 
 ### What Works (Production-Ready)
+
+**New in 0.12.0–0.12.2** (2026-06-11):
+- ✅ **Typed charts** (0.12.0, #222) — bar/line/pie via `Chart.bar`/`line`/`pie` + `Sheet.addChart` (CLI `chart add`); typed-parse-or-Preserved hybrid read, structural-edit + rename reference tracking (see LIMITATIONS §12)
+- ✅ **Embedded pictures** (0.12.0, #221) — `Sheet.addImage`/`pictures`/`removeDrawing`, three anchor forms, 7-format sniffing, sha-deduped media; non-picture drawings preserved (see LIMITATIONS §13)
+- ✅ **Conditional formatting** (0.12.1, #136) — `Sheet.conditionalFormat` with cellIs/expression/colorScale/dataBar/top10/text rules + `Dxf` differential formats; joins the generative round-trip law (library API; see LIMITATIONS §10)
+- ✅ **LibreOffice interop** (0.12.2) — editing LibreOffice-produced workbooks no longer corrupts them; `[Content_Types]`/SST writer accounting hardened (#320–#323)
+- ✅ Codec `put` paths ~2.4x faster (0.12.1, #297)
 
 **New in 0.11.0 "Scripting"** (2026-06-10):
 - ✅ **Scripting prelude** `com.tjclp.xl.scripting.{*, given}` — ONE import for scripts: core API + DSL + compile-time literals + formula evaluation + sync `Excel` + streaming `ExcelIO` + smart detection (`String.toFormatted`) + `.unsafe` boundary
@@ -57,14 +64,14 @@
 - ✅ `readTyped[A]` for type-safe cell reading
 - ✅ **Optics** module (Lens, Optional, focus DSL)
 - ✅ RichText DSL: `"Bold".bold.red + " normal " + "Italic".italic.blue`
-- ✅ HTML export: `sheet.toHtml(range"A1:B10")`
+- ✅ HTML export: `sheet.toHtml(ref"A1:B10")`
 - ✅ **Formula Parsing** (WI-07 complete): TExpr GADT, FormulaParser, FormulaPrinter with round-trip verification and scientific notation
 - ✅ **Formula Evaluation** (WI-08 complete): Pure functional evaluator with total error handling, short-circuit semantics, and Excel-compatible behavior
 - ✅ **Function Library**: **107 built-in functions** (aggregate, conditional, logical, text, date, financial, lookup, math, statistical, dynamic arrays), extensible type class parser, evaluation API. 0.10.0 added IFS, SWITCH, CHOOSE, LARGE, SMALL, RANK, PERCENTILE, QUARTILE, HLOOKUP, MAXIFS, MINIFS, OFFSET, and the spill functions SEQUENCE/SORT/UNIQUE/FILTER (#76, #120, #122); 0.11.2 added INDIRECT (GH-274), RAND/RANDBETWEEN via the seeded Rng capability (GH-115), and LET lexical bindings (GH-193) (dynamic text-to-reference resolution with deferred-bucket recalculation).
 - ✅ **Dependency Graph** (WI-09d complete): Circular reference detection (Tarjan's SCC), topological sort (Kahn's algorithm), safe evaluation with cycle detection
 - ✅ **Cross-Sheet Formula References** (TJC-351): Single cell refs (`=Sales!A1`), range refs (`=SUM(Sales!A1:A10)`), arithmetic with cross-sheet refs, workbook-level cycle detection (`DependencyGraph.fromWorkbook`)
 
-**Performance** (JMH Benchmarked - WI-15):
+**Performance** (JMH Benchmarked - WI-15; figures captured on an earlier release, not re-validated for 0.12.x — treat as indicative):
 - ✅ **Streaming reads: 35% faster than POI for small files** (0.887ms vs 1.357ms @ 1k rows)
 - ✅ **Streaming reads: Competitive with POI for large files** (8.408ms vs 7.773ms @ 10k rows - within 8%)
 - ✅ **In-memory reads: 26% faster than POI for small files** (1.225ms vs 1.650ms @ 1k rows)
@@ -97,17 +104,17 @@
 
 ### Test Coverage
 
-**3005+ tests** (verified via `./mill __.test`, 2026-06-10):
+**3,858 tests** (verified via `./mill __.test`, 2026-06-15):
 
 | Module | Tests | Covers |
 |--------|-------|--------|
-| xl-evaluator | 1279 | parser, evaluator, 105-function library, dependency graph, cross-sheet formulas, recalculation, structural editing |
-| xl-core | 971 | addressing laws, Patch/StylePatch monoids, codecs, optics, RichText, interpolation, render (HTML/SVG), styles DSL |
-| xl-ooxml | 381 | round-trips (cells, styles, tables, comments, hyperlinks), compression, security (XXE, ZIP bomb), preservation |
-| xl-cli | 308 | command parsing, batch ops, view/eval/export, streaming mode |
-| xl-cats-effect | 76 | streaming I/O, O(1) memory verification, SAX/StAX write |
+| xl-evaluator | 1485 | parser, evaluator, 107-function library, dependency graph, cross-sheet formulas, recalculation, structural editing |
+| xl-core | 1104 | addressing laws, Patch/StylePatch monoids, codecs, optics, RichText, interpolation, render (HTML/SVG), styles DSL, charts, drawings, conditional formatting |
+| xl-ooxml | 680 | round-trips (cells, styles, tables, comments, hyperlinks, charts, drawings, conditional formatting), compression, security (XXE, ZIP bomb), preservation |
+| xl-cli | 406 | command parsing, batch ops, view/eval/export, streaming mode |
+| xl-cats-effect | 110 | streaming I/O, O(1) memory verification, SAX/StAX write |
 | xl-agent | 54 | benchmark engine, skill abstraction |
-| xl (prelude) | 17 | external-consumer probes (`xl/test/src/xlprelude/`) |
+| xl (prelude) | 19 | external-consumer probes (`xl/test/src/xlprelude/`) |
 | xl-testkit | 0 | placeholder (no sources yet) |
 
 See [reference/testing-guide.md](reference/testing-guide.md) for suite structure and testing patterns.
@@ -132,6 +139,7 @@ See [reference/testing-guide.md](reference/testing-guide.md) for suite structure
   - **Financial** (9): NPV, IRR, XNPV, XIRR, PMT, FV, PV, RATE, NPER
   - **Lookup / Reference** (12): VLOOKUP, HLOOKUP, XLOOKUP, INDEX, MATCH, OFFSET, INDIRECT, ROW, COLUMN, ROWS, COLUMNS, ADDRESS
   - **Dynamic Arrays** (5): TRANSPOSE, SEQUENCE, SORT, UNIQUE, FILTER
+  - **Random** (2): RAND, RANDBETWEEN
   - FunctionSpec registry: macro-collected specs with extensible registry
   - APIs: sheet.evaluateFormula(), sheet.evaluateCell(), sheet.evaluateAllFormulas()
   - Clock trait for pure date/time functions (deterministic testing)
@@ -158,8 +166,8 @@ See [reference/testing-guide.md](reference/testing-guide.md) for suite structure
 - ⚠️ xl/theme/theme1.xml (theme palette) — preserved from source on round-trip, not generated for new workbooks
 - ❌ xl/calcChain.xml (formula calculation order)
 - ✅ Worksheet relationships (`_rels/sheetN.xml.rels`) — written when a sheet has comments, tables, or hyperlinks
-- ⚠️ Print settings, page setup — partial as of 0.11.0: header/footer (odd), margins, print area, repeat rows (#259); even/first headers + fitToPage tracked in #266
-- ❌ Conditional formatting
+- ⚠️ Print settings, page setup — odd + even/first header/footer, margins, print area, repeat rows (#259, #266), and `fitToPage` tri-state (#284); shipped across 0.11.0–0.12.1
+- ✅ Conditional formatting (0.12.1, #136): typed `Sheet.conditionalFormat` rules (cellIs/expression/colorScale/dataBar/top10/text) + `Dxf` differential formats; library API (no CLI yet) — see LIMITATIONS §10
 - ❌ Data validation (preserved through edits, but no authoring API yet)
 - ✅ Named ranges (authoring shipped in 0.10.0: `DefinedName` serialization + CLI `name add/rm`)
 
@@ -217,11 +225,11 @@ See [reference/testing-guide.md](reference/testing-guide.md) for suite structure
 - ✅ **SAX Write** (WI-17): Fast SAX/StAX streaming write path
 - ✅ **Security Hardening** (WI-30): ZIP bomb detection, XXE prevention, formula injection guards
 
-**Not Started** (Future):
+**Future (and recently shipped)**:
 - ❌ P6b: Full case class codec derivation (Magnolia/Shapeless)
 - ❌ P9: Advanced macros (path macro, style literal)
-- ✅ P10: Drawings — embedded pictures (#221): `Sheet.addImage`/`pictures`/`removeDrawing`, three anchor forms, 7-format classification, sha-deduped media, hybrid byte-preservation of non-picture drawings (charts/shapes as `Drawing.Preserved`); shapes/charts typed model still future (#222). In-memory only — see LIMITATIONS §13
-- ❌ P11: Charts (existing charts preserved through edits; typed model is #222)
+- ✅ P10: Drawings — embedded pictures (#221): `Sheet.addImage`/`pictures`/`removeDrawing`, three anchor forms, 7-format classification, sha-deduped media, hybrid byte-preservation of non-picture drawings (shapes as `Drawing.Preserved`); shape *authoring* still future. In-memory only — see LIMITATIONS §13
+- ✅ P11: Charts (0.12.0, #222): typed bar/line/pie via `Chart.bar`/`line`/`pie` + `Sheet.addChart` (CLI `chart add`); out-of-fence/Excel-authored charts stay byte-preserved — see LIMITATIONS §12
 - ❌ Pivot Tables (remaining part of P12)
 
 ---
@@ -299,14 +307,14 @@ xl-cats-effect/src/com/tjclp/xl/io/
 
 ### Completed Modules (Additional)
 - `xl-evaluator/` ✅ **Complete** (WI-07/08/09 - formula parsing, evaluation, 107 functions, dependency graph, structural editing, recalculation)
-- `xl-cli/` ✅ **Complete** (stateless `xl` CLI: 40 subcommands, 21 batch ops, rendering, streaming mode)
+- `xl-cli/` ✅ **Complete** (stateless `xl` CLI: 45 subcommands, 21 batch ops, rendering, streaming mode)
 - `xl-agent/` ✅ **Complete** (AI agent benchmark runner)
 - `xl-benchmarks/` ✅ **Complete** (WI-15 - JMH performance benchmarks)
 
 ### Not Started (Future Phases)
-- `xl-testkit/` (law helpers, golden test framework)
-- `xl-drawings/` (P8 - images, shapes)
-- `xl-charts/` (P9 - chart generation)
+- `xl-testkit/` (law helpers, golden test framework) — still a placeholder
+
+> Drawings and charts shipped in 0.12.0 as `com.tjclp.xl.drawings` / `com.tjclp.xl.charts` **within `xl-core`**, not as separate modules.
 
 ---
 
@@ -327,6 +335,8 @@ xl-cats-effect/src/com/tjclp/xl/io/
 ---
 
 ## Performance Results (Actual)
+
+> ⚠️ **Captured on an earlier release (JDK 25, Apple Silicon); not re-validated for 0.12.x — treat as indicative.** 0.12.1 made codec `put` paths ~2.4x faster (#297), not reflected below.
 
 ### JMH Benchmark Results (WI-15) - XL vs Apache POI
 
@@ -379,7 +389,7 @@ xl-cats-effect/src/com/tjclp/xl/io/
 | **Read 100k** | 1.8s @ 10MB | ~8s @ 1GB | **4.4x faster, 100x less memory** ✅ |
 | **Read 500k** | ~9s @ 10MB | OOM @ 1GB+ | **Constant memory vs OOM** ✅ |
 
-**Note**: All performance claims now verified for both reads **and** writes. True O(1) streaming achieved.
+**Note**: The SXSSF comparison figures above are approximate (POI columns marked `~` are estimates); the JMH tables earlier in this section are the measured numbers. True O(1) streaming is verified by memory tests.
 
 **Result for Writes**: Exceeded goal of 3-5x throughput, achieved 80x memory improvement with constant memory.
 

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -36,7 +36,7 @@ graph TD
 
 Published (Maven Central):
 
-- `xl-core`: Pure domain model (`Cell`, `Sheet`, `Workbook`, styles, codecs, optics, macros).
+- `xl-core`: Pure domain model (`Cell`, `Sheet`, `Workbook`, styles, codecs, optics, macros, charts, drawings/pictures, conditional formatting).
 - `xl-ooxml`: Pure OOXML mapping layer (`XlsxReader` / `XlsxWriter`, `OoxmlWorkbook`, `OoxmlWorksheet`, `SharedStrings`, `Styles`).
 - `xl-cats-effect`: Effectful interpreters (`Excel[F]` / `ExcelIO`) and true streaming I/O built on Cats Effect, fs2, and fs2-data-xml.
 - `xl-evaluator`: Formula parser, printer, evaluator, function registry, dependency graph, cross-sheet formula support, and whole-workbook recalculation.
@@ -194,7 +194,7 @@ The evaluator implements: `Evaluator.eval: TExpr[A] => Sheet => Either[EvalError
 - Topological sort for evaluation order (Kahn's algorithm)
 - Short-circuit evaluation for And/Or
 - Division by zero handling (returns `CellError.Div0`)
-- 104 Excel functions: SUM, AVERAGE, IF, VLOOKUP, XLOOKUP, OFFSET, SUMIF, COUNTIF, NPV, IRR, dynamic arrays (SEQUENCE/SORT/UNIQUE/FILTER), and more
+- 107 Excel functions: SUM, AVERAGE, IF, VLOOKUP, XLOOKUP, OFFSET, SUMIF, COUNTIF, NPV, IRR, dynamic arrays (SEQUENCE/SORT/UNIQUE/FILTER), and more
 - Whole-workbook recalculation: `Workbook.recalculate(clock)` is total and returns `RecalcResult` (recached workbook + per-sheet values + per-cell `CellEvalError`s); cycle participants are isolated while the acyclic remainder still evaluates
 
 See `docs/STATUS.md` for the complete function list.

--- a/docs/design/io-modes.md
+++ b/docs/design/io-modes.md
@@ -325,7 +325,7 @@ test("streaming read uses constant memory"):
 
 ## Migration Path
 
-### Current State (As of 2026-06, v0.11.0)
+### Current State (As of 2026-06, v0.12.2)
 - In-memory: Production-ready for <100k rows
 - Streaming write: Production-ready for >100k rows (minimal styling)
 - Streaming read: Production-ready for >100k rows (O(1) memory)

--- a/docs/design/smart-streaming.md
+++ b/docs/design/smart-streaming.md
@@ -8,7 +8,7 @@ Make the XL CLI handle files of any size with optimal performance by automatical
 
 ---
 
-## Shipped (as of 0.11.0)
+## Shipped (as of 0.12.2)
 
 ### Manual Mode Selection
 - `--stream` flag opts into O(1) streaming for compatible commands
@@ -39,7 +39,7 @@ memory, but the write goes through the lower-allocation SAX/StAX backend
 
 ## Architecture Phases: Status
 
-Each phase below was designed when streaming was read-only (v0.8.0 era). Status as of 0.11.0:
+Each phase below was designed when streaming was read-only (v0.8.0 era). Status as of 0.12.2:
 
 | Phase | Status |
 |-------|--------|
@@ -257,7 +257,7 @@ ZIP File → Probe Metadata → Choose Mode → Execute Optimal Path → Output
 (The original plan pinned phases to v0.9.0/v1.0.0/v1.1.0; delivery diverged — range
 modifications shipped first, lazy metadata has not shipped. Restated against reality:)
 
-### Shipped (0.8.0 – 0.11.0)
+### Shipped (0.8.0 – 0.12.2)
 - [x] `--stream` flag for opt-in streaming
 - [x] `--max-size` flag for large file override
 - [x] Streaming reads: search, stats, bounds, view (md/csv/json), cell

--- a/docs/design/style-guide.md
+++ b/docs/design/style-guide.md
@@ -127,7 +127,7 @@ Tier rationale, suppression rules, and the process for adding warts are in
 ```bash
 ./mill __.checkFormat    # Scalafmt drift → CI failure
 ./mill __.compile        # WartRemover Tier 1 → compile error
-./mill __.test           # 3005+ tests
+./mill __.test           # 3,858 tests
 ```
 
 Pre-commit hooks (`.pre-commit-config.yaml`) run the same `checkFormat` and `compile` steps;

--- a/docs/plan/roadmap.md
+++ b/docs/plan/roadmap.md
@@ -2,7 +2,7 @@
 
 > **Track Progress**: [GitHub Issues](https://github.com/TJC-LP/xl/issues)
 
-**Last Updated**: 2026-06-10
+**Last Updated**: 2026-06-15
 
 > **Completed release records**: [archive/plan/v0.10.0-execution.md](../archive/plan/v0.10.0-execution.md) (0.10.0 tracker) and [archive/plan/v0.10.0-triage.md](../archive/plan/v0.10.0-triage.md) (rationale + per-issue verdicts).
 
@@ -10,7 +10,7 @@
 
 ## TL;DR
 
-**Current Status**: Production-ready with **104 formula functions** (incl. dynamic arrays SEQUENCE/SORT/UNIQUE/FILTER and OFFSET), **structural editing** (insert/delete rows & columns with formula rewriting), the **scripting prelude** (`com.tjclp.xl.scripting`), whole-workbook `recalculate`, named-range & hyperlink authoring, SAX streaming (36% faster than POI), Excel tables, and full OOXML round-trip. 3005+ tests passing.
+**Current Status**: Production-ready with **107 formula functions** (incl. dynamic arrays SEQUENCE/SORT/UNIQUE/FILTER and OFFSET), **structural editing** (insert/delete rows & columns with formula rewriting), the **scripting prelude** (`com.tjclp.xl.scripting`), whole-workbook `recalculate`, named-range & hyperlink authoring, **typed charts + embedded pictures** (0.12.0), **conditional formatting** (0.12.1), SAX streaming (36% faster than POI), Excel tables, and full OOXML round-trip. 3,858 tests passing.
 
 **Current Version**: **0.12.2 "Interop"** (released 2026-06-11)
 
@@ -56,6 +56,14 @@ All open bugs, one patch release (PR #276). Reviewer-discovered gaps filed as #2
 ### v0.12.0 "Visual" — wave 6 (Released 2026-06-11)
 
 Phased: (a) verbatim chart/drawing preservation proven by the wave-2 fixture corpus; (b) `Drawing`/`Image`/anchor domain model + image authoring ([#221](https://github.com/TJC-LP/xl/issues/221)); (c) typed chart AST (bar/line/pie) + authoring + `xl chart` CLI ([#222](https://github.com/TJC-LP/xl/issues/222)). Re-scoped by its own design panel when reached.
+
+### v0.12.1 "Clean Sweep" — wave 7 (Released 2026-06-11)
+
+Every remaining open issue closed in one wave. **Conditional formatting** ([#136](https://github.com/TJC-LP/xl/issues/136)) is the headline — typed cellIs/expression/colorScale/dataBar/top10/text rules + `dxf` differential formats, `sheet.conditionalFormat` authoring with auto-priority, structural-edit range shifting, unmodeled families preserved byte-faithfully — alongside twelve fidelity/writer fixes: openpyxl comment subdirectory dialect (#292), RichText SST keying (#303), exact surgical SST counts (#304), `[Content_Types]` preservation (#314), identity-keyed source mappings (#315), activeTab (#294), fitToPage tri-state (#284), `Cell.comment` deprecated→`Sheet.comments` (#295). Codec `put` paths 2.4x faster (#297).
+
+### v0.12.2 "Interop" — wave 9 (Released 2026-06-11)
+
+The LibreOffice edit-corruption fix and the writer follow-ups it surfaced: editing LO-produced workbooks no longer corrupts them ([#320](https://github.com/TJC-LP/xl/issues/320) — `workbook.xml.rels` regenerates in the same pass as `workbook.xml`, so sheet rIds stay consistent), comment content-type registration follows actual emitted paths (#321), no dangling `[Content_Types]` overrides for dropped writer-owned parts (#322), and new sheets join surgical SST accounting (#323).
 
 ### v0.11.0 "Scripting" (Released 2026-06-10)
 
@@ -106,9 +114,8 @@ Authoring and rendering features not yet shipped:
 | Feature | Status |
 |---------|--------|
 | XLSM macro preservation policy + tests (macros never executed) | Planned |
-| Data-validation / conditional-formatting **authoring** (currently preserved through edits, no write API) | Planned |
-| Drawing Layer (Images, Shapes) | Planned |
-| Chart Model | Planned |
+| Data-validation **authoring** (currently preserved through edits, no write API; conditional-formatting authoring shipped in 0.12.1) | Planned |
+| Drawing Layer — Shapes/connectors authoring (images shipped in 0.12.0) | Planned |
 | Two-phase streaming (SST + styles in row-stream write path) | Planned |
 | Merged Cells in row-stream Write | Backlog |
 | Query API | Backlog |
@@ -121,7 +128,7 @@ Authoring and rendering features not yet shipped:
 All completed phases are documented in git history. Key milestones:
 
 - **P0-P8**: Foundation, OOXML, streaming, codecs, macros
-- **WI-07/08/09**: Formula parser, evaluator (now **104 functions** after the 0.10.0 breadth pass)
+- **WI-07/08/09**: Formula parser, evaluator (**107 functions**; the 0.10.0 breadth pass took the registry 88→104, then 0.11.2 added INDIRECT/RAND/RANDBETWEEN/LET)
 - **TJC-1055** (closes GH-116): Text functions — TRIM, MID, FIND, SUBSTITUTE, VALUE, TEXT
 - **WI-10**: Excel table support
 - **WI-17**: SAX streaming write (36% faster than POI)

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -64,7 +64,7 @@ xl -f model.xlsx -s S1 eval "=B1*1.1" --with "B1=100"      # Evaluate with tempo
 
 # No file needed
 xl new report.xlsx --sheet Data --sheet Summary   # Create a blank workbook
-xl functions                                       # List all 104 supported functions
+xl functions                                       # List all 107 supported functions
 xl rasterizers                                     # List available PNG/PDF backends
 ```
 
@@ -88,7 +88,7 @@ xl rasterizers                                     # List available PNG/PDF back
 
 | Command | Arguments | Description |
 |---------|-----------|-------------|
-| `functions` | | List all 104 supported Excel functions (no `-f` needed) |
+| `functions` | | List all 107 supported Excel functions (no `-f` needed) |
 | `rasterizers` | | List available SVG-to-raster backends (no `-f` needed) |
 | `new` | `<output> [--sheet <name>]...` | Create a blank xlsx file (no `-f` needed) |
 | `sheets` | `[list\|hide <name> [--very]\|show <name>]` | List sheets (default) or hide/show one |

--- a/docs/reference/examples.md
+++ b/docs/reference/examples.md
@@ -119,7 +119,7 @@ parsedFormula.foreach { expr =>
 }
 ```
 
-**Note**: Evaluation is fully operational — 104 functions, whole-workbook `recalculate()`, dependency graphs with cycle detection. See the runnable scripts below.
+**Note**: Evaluation is fully operational — 107 functions, whole-workbook `recalculate()`, dependency graphs with cycle detection. See the runnable scripts below.
 
 ## 3) Example Scripts Catalog
 
@@ -210,19 +210,28 @@ scala-cli run examples/financial_model.sc
 
 CI compiles every script via `scripts/test-examples.sh` (and runs a curated subset), so the catalog cannot silently rot.
 
-## 4) Chart spec (Future — #222)
+## 4) Charts & pictures (shipped — 0.12.0, #222/#221)
 ```scala
-// Note: Chart support is a 0.12.0 candidate (GH #222, on the DrawingML layer #221).
-// This is a design preview only.
 import com.tjclp.xl.{*, given}
-// import com.tjclp.xl.chart.*  // Future module
+import com.tjclp.xl.unsafe.*       // .unsafe boundary (XLResult → value)
+import com.tjclp.xl.charts.*       // Chart, Series, DataRef, BarDirection, ...
+import com.tjclp.xl.drawings.*     // ImageData, Drawing, DrawingAnchor
+import scala.collection.immutable.ArraySeq
 
-// val revenue = ChartSpec(
-//   title  = Some("Revenue by Quarter"),
-//   series = Vector(Series(MarkType.Column(true, false), Encoding(Field.Range(ref"A2:A5"), Field.Range(ref"B2:B5")), Some("2025"))),
-//   xAxis  = Axis(AxisType.Category, Scale.Linear, Some("Quarter")),
-//   yAxis  = Axis(AxisType.Value, Scale.Linear, Some("USD (mm)")),
-//   legend = Legend(true, "right"),
-//   plotAreaFill = None
-// )
+// Typed bar chart: a values series (B2:B5) labelled by categories (A2:A5).
+val series = Series(
+  values     = DataRef(sheet.name, ref"B2:B5"),
+  categories = Some(DataRef(sheet.name, ref"A2:A5"))
+)
+val chart = Chart.bar(Vector(series), title = Some("Revenue by Quarter")).unsafe  // also Chart.line / Chart.pie
+val withChart = sheet.addChart(chart, ref"F2:K16")     // anchored over the range — total
+
+// Embedded picture (format sniffed from magic bytes; png/jpeg/gif/bmp natural-size):
+val imageBytes = ArraySeq.unsafeWrapArray(java.nio.file.Files.readAllBytes(java.nio.file.Path.of("logo.png")))
+val image      = ImageData.detect(imageBytes).unsafe
+val withImage  = sheet.addImage(image, ref"B2").unsafe
+
+withChart.charts    // typed chart views (unmodeled drawings are preserved byte-for-byte)
+withImage.pictures
 ```
+See [LIMITATIONS §12 (Charts)](../LIMITATIONS.md) and the scripting [API reference](../../plugin/skills/xl-scripting/reference/API.md) for the full surface and scoped limitations.

--- a/docs/reference/implementation-scaffolds.md
+++ b/docs/reference/implementation-scaffolds.md
@@ -1,9 +1,9 @@
 # Implementation Scaffolds: Idiomatic Scala 3 Code Examples
 
-> **Status (2026-06-10)**: historical scaffold record — several targets have since shipped (hyperlinks & named ranges in 0.10.0, page setup in 0.11.0) and the test scaffolds use ScalaTest while the project standardized on MUnit. Useful as design sketches, not as current API documentation.
+> **Status (2026-06-15)**: historical scaffold record — several targets have since shipped (hyperlinks & named ranges in 0.10.0, page setup in 0.11.0, **typed charts + embedded pictures in 0.12.0, conditional formatting in 0.12.1** — so the `OoxmlDrawing`/`OoxmlChartPart` scaffolds below still marked `// TODO` are obsolete; see [LIMITATIONS §12/§13](../LIMITATIONS.md)) and the test scaffolds use ScalaTest while the project standardized on MUnit. Useful as design sketches, not as current API documentation.
 
 **Purpose**: Complete, runnable code scaffolds for AI agents and developers
-**Last Updated**: 2026-01-23
+**Scaffold authored**: 2026-01-23 · **Status reviewed**: 2026-06-15 (see the Status note above)
 **Companion To**: [docs/plan/roadmap.md](../plan/roadmap.md)
 
 > **Note**: These are idiomatic Scala 3 scaffolds with enough structure for AI agents to expand. Assumes modules: `xl-core`, `xl-ooxml`, `xl-cats-effect`, `xl-benchmarks`.
@@ -1130,6 +1130,6 @@ object PartRegistry:
 
 ---
 
-**Last Updated**: 2026-01-23
+**Scaffold authored**: 2026-01-23 · **Status reviewed**: 2026-06-15 (see the Status note at the top)
 **Maintained By**: XL Core Team
 **For Strategic Context**: See [docs/plan/roadmap.md](../plan/roadmap.md)

--- a/docs/reference/migration-from-poi.md
+++ b/docs/reference/migration-from-poi.md
@@ -500,10 +500,10 @@ Memory: ~100MB (10x less)
 **A**: Not easily. They use different in-memory representations. You'd need to write to file and read back.
 
 ### Q: Does XL support all POI features?
-**A**: No. Still missing: charts, drawings, pivot tables, VBA. Formula **evaluation** is a point in XL's favor: 104 functions with whole-workbook recalculation (POI's evaluator exists but is partial and mutable). See [roadmap](../plan/roadmap.md) and [LIMITATIONS](../LIMITATIONS.md).
+**A**: Mostly. Now supported, with scoped limits (see [LIMITATIONS](../LIMITATIONS.md) §12/§13): typed bar/line/pie **charts** and embedded **pictures/drawings**. Still missing: pivot tables, data-validation authoring, VBA. Formula **evaluation** is a point in XL's favor: 107 functions with whole-workbook recalculation (POI's evaluator exists but is partial and mutable). See [roadmap](../plan/roadmap.md) and [LIMITATIONS](../LIMITATIONS.md).
 
 ### Q: Is XL production-ready?
-**A**: Yes for core features (read/write, styling, formulas, structural editing, streaming). No for visual features (charts, drawings).
+**A**: Yes for core features (read/write, styling, formulas, structural editing, streaming) and, as of 0.12.0, typed charts + embedded pictures (scoped — see [LIMITATIONS](../LIMITATIONS.md)). Pivot tables and data-validation authoring remain unsupported.
 
 ### Q: How do I handle errors in XL?
 **A**: XL uses Either[XLError, A]. Pattern match or use flatMap/map:

--- a/docs/reference/ooxml-research.md
+++ b/docs/reference/ooxml-research.md
@@ -1,6 +1,6 @@
 # OOXML Research & Quick Reference
 
-> **Status (2026-06-10)**: pre-implementation research record, kept for OOXML spec reference. Its design *recommendations* are historical — several were deliberately superseded (e.g. "don't ship a full evaluator in v1.0": xl now ships a 104-function evaluator with whole-workbook recalculation). Trust [STATUS.md](../STATUS.md) and the code for what xl does today; trust this file for OOXML part/relationship details.
+> **Status (2026-06-10)**: pre-implementation research record, kept for OOXML spec reference. Its design *recommendations* are historical — several were deliberately superseded (e.g. "don't ship a full evaluator in v1.0": xl now ships a 107-function evaluator with whole-workbook recalculation). Trust [STATUS.md](../STATUS.md) and the code for what xl does today; trust this file for OOXML part/relationship details.
 
 Comprehensive research on OOXML (Office Open XML) SpreadsheetML specification with concrete API sketches and implementation guidance.
 

--- a/docs/reference/performance-guide.md
+++ b/docs/reference/performance-guide.md
@@ -375,7 +375,9 @@ excel.read(largeFile)
 
 ## Performance Roadmap
 
-### Current (as of 0.11.0, 2026-06-10)
+### Current (as of 0.12.2)
+
+> ⚠️ Throughput figures here are indicative, captured on an earlier release; see [STATUS.md](../STATUS.md) for the benchmark tables and caveats.
 - ✅ Streaming write: O(1) memory, ~88k rows/sec
 - ✅ Streaming read: O(1) memory via `fs2.io.readInputStream` (+ SST materialized once)
 - ✅ Lazy optimizations: 30-75% speedup (memoized canonicalKey, single-pass usedRange)

--- a/docs/reference/testing-guide.md
+++ b/docs/reference/testing-guide.md
@@ -1,6 +1,6 @@
 # Testing & Laws — Property Suites, Round-Trips, and Coverage
 
-**Current Status**: CI runs the full Mill test graph across the library, evaluator, CLI, and support modules — **3005+ tests** as of 0.11.0. Use `./mill __.test` as the authoritative count.
+**Current Status**: CI runs the full Mill test graph across the library, evaluator, CLI, and support modules — **3,858 tests** as of 0.12.2. Use `./mill __.test` as the authoritative count.
 
 ## Test Infrastructure
 
@@ -211,18 +211,18 @@ GitHub Actions runs:
 
 ## Test Counts by Module
 
-As of 0.11.0 (`./mill show __.test`; macros are part of xl-core — there is no separate xl-macros module):
+As of 0.12.2 (per-module `./mill <module>.test`; macros are part of xl-core — there is no separate xl-macros module):
 
 | Module | Tests |
 |--------|-------|
-| xl-evaluator | 1198 |
-| xl-core | 971 |
-| xl-ooxml | 381 |
-| xl-cli | 308 |
-| xl-cats-effect | 76 |
+| xl-evaluator | 1485 |
+| xl-core | 1104 |
+| xl-ooxml | 680 |
+| xl-cli | 406 |
+| xl-cats-effect | 110 |
 | xl-agent | 54 |
-| xl (prelude probes, `xlprelude.ScriptingPreludeTest`) | 17 |
-| **Total** | **3005** (3004 passing + 1 ignored) |
+| xl (prelude probes, `xlprelude.ScriptingPreludeTest`) | 19 |
+| **Total** | **3,858** |
 
 ## Test Quality Metrics
 

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -9,7 +9,7 @@ library. The plugin packages two complementary skills.
 ### xl-cli — stateless CLI operations
 
 Drives the `xl` command-line binary: view ranges, read cells, search, evaluate formulas
-(104 supported functions), export to CSV/JSON/PNG/PDF, style cells, edit rows/columns, and apply
+(107 supported functions), export to CSV/JSON/PNG/PDF, style cells, edit rows/columns, and apply
 atomic batch operations. Every invocation reads the file, applies one change set, and writes the
 result — no session state. The skill auto-detects the latest released binary from the GitHub API,
 so it never needs a version bump. See [`skills/xl-cli/SKILL.md`](skills/xl-cli/SKILL.md).

--- a/plugin/skills/xl-scripting/SKILL.md
+++ b/plugin/skills/xl-scripting/SKILL.md
@@ -317,7 +317,7 @@ Switch to streaming above ~100k rows; `Excel.read` loads the whole workbook. Str
 
 ## Reference
 
-- `reference/API.md` — types, extension methods, style builders, all 105 formula functions, streaming API
+- `reference/API.md` — types, extension methods, style builders, all 107 formula functions, streaming API
 - `reference/RECIPES.md` — 7 complete, runnable scripts (bulk transform, typed extraction, model build, merge, streaming, diff, CSV ingest)
 - Repo examples: `examples/*.sc` in https://github.com/TJC-LP/xl (start with `scripting_tour.sc`)
 - The `xl-cli` skill for CLI operations (visual exports, quick inspection)


### PR DESCRIPTION
## Summary

Refreshes skills and documentation for content that went stale across the **0.12.0 "Visual"**, **0.12.1 "Clean Sweep"**, and **0.12.2 "Interop"** releases. Nearly every prose doc was stamped 2026-06-10 — one day before that feature wave — so large parts of `docs/` still described a pre-0.12.0 world (charts/drawings "missing", conditional formatting "❌", function count 104/105, "current state" framing frozen at 0.11.0).

The skills were already nearly current; the rot was concentrated in `docs/`.

## Changes (19 files)

- **Function count** `104`/`105` → **107** (verified via `xl functions`) across docs + the `xl-scripting` skill + `plugin/README.md`; completed the QUICK-START/STATUS category breakdowns (INDIRECT, RAND, RANDBETWEEN). The historical "88→104" progression in the roadmap is left intact.
- **Test count** "3005+" → **3,858** with a refreshed per-module table, from an actual `./mill __.test` run.
- **Charts / drawings / conditional formatting** reconciled from "missing/future/❌" to shipped across STATUS, LIMITATIONS (internal contradiction resolved), migration-from-poi, FAQ, architecture, and a new live `examples.md` sample.
- **Version framing**: added the missing **v0.12.1 / v0.12.2 roadmap entries**; re-stamped 0.11.0-era "current state" sections to 0.12.2.
- **API drift**: `range"A1:B10"` → `ref"A1:B10"` (the former doesn't compile).
- **Performance claims** caveated as not re-validated for 0.12.x (no fabricated numbers); noted the 0.12.1 codec 2.4x speedup.
- **Misc**: `40 → 45` subcommands; removed closed issues (#262–#266, #271) from the LIMITATIONS "open issues" note; timestamps bumped; implementation-scaffolds flagged historical.

## Verification

- Consistency greps clean — no stale 104/105-function or "3005" counts remain (only the intentional historical roadmap references).
- Function count **107** confirmed directly from `xl functions` (CLI v0.12.2).
- The new `examples.md` chart/picture snippet was **compile-tested against `com.tjclp::xl:0.12.2`** — which caught and fixed two real bugs (missing `unsafe` import; `ImageData.detect` takes `ArraySeq[Byte]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
