### PR TITLE
refactor(xl-agent): refresh for Claude 5 family, SDK 2.48.0, current API surface

### DIFF
--- a/xl-agent/package.mill
+++ b/xl-agent/package.mill
@@ -12,12 +12,12 @@ object `package` extends build.XLInternalModule {
   )
 
   override def mvnDeps = Seq(
-    mvn"com.anthropic:anthropic-java:2.11.1",
-    mvn"io.circe::circe-core:0.14.10",
-    mvn"io.circe::circe-generic:0.14.10",
-    mvn"io.circe::circe-parser:0.14.10",
-    mvn"io.github.cdimascio:dotenv-java:3.1.0",
-    mvn"org.apache.commons:commons-compress:1.27.1",
+    mvn"com.anthropic:anthropic-java:2.48.0",
+    mvn"io.circe::circe-core:0.14.13",
+    mvn"io.circe::circe-generic:0.14.13",
+    mvn"io.circe::circe-parser:0.14.13",
+    mvn"io.github.cdimascio:dotenv-java:3.2.0",
+    mvn"org.apache.commons:commons-compress:1.28.0",
     mvn"com.squareup.okhttp3:okhttp:4.12.0"
   )
 

--- a/xl-agent/src/com/tjclp/xl/agent/Agent.scala
+++ b/xl-agent/src/com/tjclp/xl/agent/Agent.scala
@@ -5,10 +5,12 @@ import cats.effect.std.Queue
 import cats.syntax.all.*
 import com.tjclp.xl.agent.anthropic.{AnthropicClientIO, CodeExecution, SkillsApi}
 import com.tjclp.xl.agent.approach.{ApproachStrategy, XlApproachStrategy}
+import com.tjclp.xl.agent.benchmark.common.FileManager
 import com.tjclp.xl.agent.error.AgentError
 
 import java.nio.file.{Files, Path}
 import java.util.concurrent.TimeUnit
+import scala.jdk.OptionConverters.*
 
 /** A task for the agent to execute */
 case class AgentTask(
@@ -79,7 +81,14 @@ object Agent:
         // Extract response info
         responseText = CodeExecution.extractResponseText(response)
         outputFileId = CodeExecution.extractOutputFileId(response, config.verbose)
-        usage = TokenUsage(response.usage().inputTokens(), response.usage().outputTokens())
+        usage = TokenUsage(
+          inputTokens = response.usage().inputTokens(),
+          outputTokens = response.usage().outputTokens(),
+          cacheCreationTokens =
+            response.usage().cacheCreationInputTokens().toScala.map(Long.unbox).getOrElse(0L),
+          cacheReadTokens =
+            response.usage().cacheReadInputTokens().toScala.map(Long.unbox).getOrElse(0L)
+        )
 
         // Download output file if found
         outputPath <- outputFileId match
@@ -129,9 +138,9 @@ object Agent:
     for
       client <- AnthropicClientIO.fromEnv
 
-      // Resolve binary and skill paths
-      binaryPath <- Resource.eval(resolveBinaryPath(config))
-      skillPath <- Resource.eval(resolveSkillPath(config))
+      // Resolve binary and skill paths (version-agnostic, auto-downloads latest release)
+      binaryPath <- Resource.eval(FileManager.resolveBinaryPath(config.xlBinaryPath))
+      skillPath <- Resource.eval(FileManager.resolveSkillPath(config.xlSkillPath))
 
       // Upload binary file
       binaryFile <- Resource.make(client.uploadFile(binaryPath))(f =>
@@ -145,30 +154,3 @@ object Agent:
       // Create xl-cli approach strategy with skill ID
       strategy = XlApproachStrategy(binaryFile, skillId)
     yield create(client, config, strategy)
-
-  private def resolveBinaryPath(config: AgentConfig): IO[Path] =
-    config.xlBinaryPath match
-      case Some(p) => IO.pure(p)
-      case None =>
-        findFile(
-          "xl-0.9.0-linux-amd64",
-          List("../benchmark", "examples/anthropic-sdk/benchmark", ".")
-        )
-
-  private def resolveSkillPath(config: AgentConfig): IO[Path] =
-    config.xlSkillPath match
-      case Some(p) => IO.pure(p)
-      case None =>
-        findFile(
-          "xl-skill-0.9.0.zip",
-          List("../benchmark", "examples/anthropic-sdk/benchmark", ".")
-        )
-
-  private def findFile(name: String, dirs: List[String]): IO[Path] =
-    IO.blocking {
-      import java.nio.file.Paths
-      dirs.view
-        .map(d => Paths.get(d, name))
-        .find(p => Files.exists(p))
-        .getOrElse(Paths.get(dirs.head, name))
-    }

--- a/xl-agent/src/com/tjclp/xl/agent/Models.scala
+++ b/xl-agent/src/com/tjclp/xl/agent/Models.scala
@@ -11,26 +11,43 @@ import java.nio.file.Path
 /** Configuration for the agent */
 case class AgentConfig(
   model: String = benchmark.Models.DefaultAgent,
-  maxTokens: Int = 8192,
+  // Claude 5 models run adaptive thinking by default; thinking tokens count
+  // against maxTokens, so leave headroom beyond the expected response size.
+  maxTokens: Int = 16384,
   verbose: Boolean = false,
   xlBinaryPath: Option[Path] = None,
   xlSkillPath: Option[Path] = None,
   forceUpload: Boolean = false
 )
 
-/** Token usage from API */
+/** Token usage from API (cache fields track prompt-caching activity) */
 case class TokenUsage(
   inputTokens: Long,
-  outputTokens: Long
+  outputTokens: Long,
+  cacheCreationTokens: Long = 0,
+  cacheReadTokens: Long = 0
 ):
   def totalTokens: Long = inputTokens + outputTokens
   def +(other: TokenUsage): TokenUsage =
-    TokenUsage(inputTokens + other.inputTokens, outputTokens + other.outputTokens)
+    TokenUsage(
+      inputTokens + other.inputTokens,
+      outputTokens + other.outputTokens,
+      cacheCreationTokens + other.cacheCreationTokens,
+      cacheReadTokens + other.cacheReadTokens
+    )
 
 object TokenUsage:
   val zero: TokenUsage = TokenUsage(0, 0)
   given Encoder[TokenUsage] = deriveEncoder
-  given Decoder[TokenUsage] = deriveDecoder
+  // Custom decoder: cache fields default to 0 so pre-existing traces still decode
+  given Decoder[TokenUsage] = Decoder.instance { c =>
+    for
+      input <- c.get[Long]("inputTokens")
+      output <- c.get[Long]("outputTokens")
+      cacheCreate <- c.getOrElse[Long]("cacheCreationTokens")(0L)
+      cacheRead <- c.getOrElse[Long]("cacheReadTokens")(0L)
+    yield TokenUsage(input, output, cacheCreate, cacheRead)
+  }
 
 /** Per-turn token usage tracking */
 case class TurnUsage(

--- a/xl-agent/src/com/tjclp/xl/agent/anthropic/CodeExecution.scala
+++ b/xl-agent/src/com/tjclp/xl/agent/anthropic/CodeExecution.scala
@@ -40,6 +40,18 @@ object CodeExecution:
         streamProcessor <- StreamEventProcessor.create(eventQueue, onEvent, config.verbose)
         result <- IO
           .blocking {
+            // Prompt caching (5m TTL): the code-execution loop re-samples the
+            // conversation on every server-side sub-turn, and a task's cases
+            // share tools + system + skill context — both re-read from cache.
+            val cacheMarker = BetaCacheControlEphemeral.builder().build()
+
+            // System block breakpoint: shared read point across a task's cases
+            val systemBlock = BetaTextBlockParam
+              .builder()
+              .text(systemPrompt)
+              .cacheControl(cacheMarker)
+              .build()
+
             // Build content blocks: text + container uploads
             val contentBlocks = new java.util.ArrayList[BetaContentBlockParam]()
             contentBlocks.add(
@@ -57,8 +69,11 @@ object CodeExecution:
               .builder()
               .model(config.model)
               .maxTokens(config.maxTokens.toLong)
-              .system(systemPrompt)
+              .systemOfBetaTextBlockParams(java.util.List.of(systemBlock))
               .addUserMessageOfBetaContentBlockParams(contentBlocks)
+              // Top-level cache_control auto-places on the last cacheable
+              // block, covering the whole initial prompt for the loop
+              .cacheControl(cacheMarker)
 
             // Apply strategy-specific configuration (tools, betas, container)
             val params = configureRequest(baseBuilder).build()

--- a/xl-agent/src/com/tjclp/xl/agent/anthropic/CodeExecution.scala
+++ b/xl-agent/src/com/tjclp/xl/agent/anthropic/CodeExecution.scala
@@ -4,7 +4,6 @@ import cats.effect.{IO, Ref}
 import cats.effect.std.{Dispatcher, Queue}
 import cats.syntax.all.*
 import com.anthropic.client.AnthropicClient as JAnthropicClient
-import com.anthropic.core.JsonValue
 import com.anthropic.helpers.BetaMessageAccumulator
 import com.anthropic.models.beta.messages.*
 import com.tjclp.xl.agent.{AgentConfig, AgentEvent, TokenUsage, UploadedFile}
@@ -41,13 +40,17 @@ object CodeExecution:
         streamProcessor <- StreamEventProcessor.create(eventQueue, onEvent, config.verbose)
         result <- IO
           .blocking {
-            import java.util.{List as JList, Map as JMap}
-
             // Build content blocks: text + container uploads
-            val contentBlocks = new java.util.ArrayList[JMap[String, Any]]()
-            contentBlocks.add(JMap.of("type", "text", "text", userPrompt))
+            val contentBlocks = new java.util.ArrayList[BetaContentBlockParam]()
+            contentBlocks.add(
+              BetaContentBlockParam.ofText(BetaTextBlockParam.builder().text(userPrompt).build())
+            )
             containerUploads.foreach { fileId =>
-              contentBlocks.add(JMap.of("type", "container_upload", "file_id", fileId))
+              contentBlocks.add(
+                BetaContentBlockParam.ofContainerUpload(
+                  BetaContainerUploadBlockParam.builder().fileId(fileId).build()
+                )
+              )
             }
 
             val baseBuilder = MessageCreateParams
@@ -55,21 +58,7 @@ object CodeExecution:
               .model(config.model)
               .maxTokens(config.maxTokens.toLong)
               .system(systemPrompt)
-              .addUserMessage("placeholder")
-              // Override messages to include container_upload blocks
-              .putAdditionalBodyProperty(
-                "messages",
-                JsonValue.from(
-                  JList.of(
-                    JMap.of(
-                      "role",
-                      "user",
-                      "content",
-                      contentBlocks
-                    )
-                  )
-                )
-              )
+              .addUserMessageOfBetaContentBlockParams(contentBlocks)
 
             // Apply strategy-specific configuration (tools, betas, container)
             val params = configureRequest(baseBuilder).build()

--- a/xl-agent/src/com/tjclp/xl/agent/anthropic/SkillsApi.scala
+++ b/xl-agent/src/com/tjclp/xl/agent/anthropic/SkillsApi.scala
@@ -59,8 +59,13 @@ object SkillsApi:
   def listCustomSkills(apiKey: String): IO[List[SkillMetadata]] =
     IO.blocking {
       val client = new OkHttpClient()
+      // limit=1000: the default page is 20 and the endpoint's has_more/next_page
+      // have been observed reporting no-more-data while more exists, so request
+      // one page large enough to cover the org's custom skills. Without this,
+      // an existing xl-cli skill outside the first page triggers a duplicate
+      // display_title error on create.
       val request = new Request.Builder()
-        .url(s"$ApiBase/skills?source=custom")
+        .url(s"$ApiBase/skills?source=custom&limit=1000")
         .addHeader("x-api-key", apiKey)
         .addHeader("anthropic-version", "2023-06-01")
         .addHeader("anthropic-beta", SkillsBeta)
@@ -96,10 +101,10 @@ object SkillsApi:
         .setType(MultipartBody.FORM)
         .addFormDataPart("display_title", displayTitle)
 
-      // Add each file
+      // Add each file (API requires files[] array notation)
       files.foreach { case (filename, content) =>
         bodyBuilder.addFormDataPart(
-          "files",
+          "files[]",
           filename,
           RequestBody.create(content, OctetMediaType)
         )
@@ -245,22 +250,26 @@ object SkillsApi:
     yield skillId
 
   /**
-   * Extract files from a zip archive.
+   * Extract files from a zip archive, normalized for the Skills API.
    *
-   * The zip should have xl-cli/ as the top-level folder with SKILL.md at the root. This matches the
-   * Skills API requirement.
+   * The Skills API requires every file inside exactly one top-level folder with SKILL.md at that
+   * folder's root (e.g. xl-cli/SKILL.md). Release zips ship flat (SKILL.md at the archive root), so
+   * flat archives are wrapped in `rootFolder`; already-rooted archives pass through unchanged.
    */
-  private def extractZipFiles(zipPath: Path): IO[List[(String, Array[Byte])]] =
+  private def extractZipFiles(
+    zipPath: Path,
+    rootFolder: String = "xl-cli"
+  ): IO[List[(String, Array[Byte])]] =
     IO.blocking {
       Using.resource(new ZipFile(zipPath.toFile)) { zip =>
-        zip.entries().asScala.toList.flatMap { entry =>
-          if entry.isDirectory then None
-          else
-            val content = Using.resource(zip.getInputStream(entry)) { is =>
-              is.readAllBytes()
-            }
-            // Use the path as-is from the zip (should already be xl-cli/...)
-            Some((entry.getName, content))
+        val entries = zip.entries().asScala.toList.filterNot(_.isDirectory)
+        val isFlat = entries.exists(_.getName == "SKILL.md")
+        entries.map { entry =>
+          val content = Using.resource(zip.getInputStream(entry)) { is =>
+            is.readAllBytes()
+          }
+          val name = if isFlat then s"$rootFolder/${entry.getName}" else entry.getName
+          (name, content)
         }
       }
     }

--- a/xl-agent/src/com/tjclp/xl/agent/approach/XlApproachStrategy.scala
+++ b/xl-agent/src/com/tjclp/xl/agent/approach/XlApproachStrategy.scala
@@ -2,7 +2,7 @@ package com.tjclp.xl.agent.approach
 
 import com.anthropic.models.beta.AnthropicBeta
 import com.anthropic.models.beta.messages.{
-  BetaCodeExecutionTool20250825,
+  BetaCodeExecutionTool20260521,
   BetaContainerParams,
   BetaSkillParams,
   MessageCreateParams
@@ -61,7 +61,7 @@ INPUT="$$INPUT_DIR/$inputFilename"
 
     builder
       .container(container)
-      .addTool(BetaCodeExecutionTool20250825.builder().build())
+      .addTool(BetaCodeExecutionTool20260521.builder().build())
       .addBeta(AnthropicBeta.of("code-execution-2025-08-25"))
       .addBeta(AnthropicBeta.SKILLS_2025_10_02)
       .addBeta(AnthropicBeta.FILES_API_2025_04_14)

--- a/xl-agent/src/com/tjclp/xl/agent/approach/XlsxApproachStrategy.scala
+++ b/xl-agent/src/com/tjclp/xl/agent/approach/XlsxApproachStrategy.scala
@@ -2,7 +2,7 @@ package com.tjclp.xl.agent.approach
 
 import com.anthropic.models.beta.AnthropicBeta
 import com.anthropic.models.beta.messages.{
-  BetaCodeExecutionTool20250825,
+  BetaCodeExecutionTool20260521,
   BetaContainerParams,
   BetaSkillParams,
   MessageCreateParams
@@ -58,7 +58,7 @@ ws = wb.active
 
     builder
       .container(container)
-      .addTool(BetaCodeExecutionTool20250825.builder().build())
+      .addTool(BetaCodeExecutionTool20260521.builder().build())
       .addBeta(AnthropicBeta.of("code-execution-2025-08-25"))
       .addBeta(AnthropicBeta.SKILLS_2025_10_02)
       .addBeta(AnthropicBeta.FILES_API_2025_04_14)

--- a/xl-agent/src/com/tjclp/xl/agent/benchmark/Models.scala
+++ b/xl-agent/src/com/tjclp/xl/agent/benchmark/Models.scala
@@ -18,23 +18,28 @@ package com.tjclp.xl.agent.benchmark
 object Models:
 
   // --------------------------------------------------------------------------
-  // Model Identifiers (Claude 4.5 Series)
+  // Model Identifiers (Claude 5 family + current Opus/Haiku)
+  //
+  // Aliases (not dated snapshots) so new snapshots are picked up automatically.
   // --------------------------------------------------------------------------
 
-  /** Claude Opus 4.5 - highest capability, best for grading */
-  val Opus45: String = "claude-opus-4-5-20251101"
+  /** Claude Fable 5 - most capable model, for the hardest tasks (premium pricing) */
+  val Fable5: String = "claude-fable-5"
 
-  /** Claude Sonnet 4.5 - balanced capability and cost, good default for agents */
-  val Sonnet45: String = "claude-sonnet-4-5-20250929"
+  /** Claude Opus 4.8 - highest-capability Opus tier, best for grading */
+  val Opus48: String = "claude-opus-4-8"
+
+  /** Claude Sonnet 5 - near-Opus coding/agentic quality at Sonnet cost, default for agents */
+  val Sonnet5: String = "claude-sonnet-5"
 
   /** Claude Haiku 4.5 - fastest and cheapest, good for simple tasks */
-  val Haiku45: String = "claude-haiku-4-5-20251001"
+  val Haiku45: String = "claude-haiku-4-5"
 
   /** Default model for agent execution */
-  val DefaultAgent: String = Sonnet45
+  val DefaultAgent: String = Sonnet5
 
   /** Default model for grading (uses Opus for accuracy) */
-  val DefaultGrader: String = Opus45
+  val DefaultGrader: String = Opus48
 
   // --------------------------------------------------------------------------
   // Pricing
@@ -76,7 +81,15 @@ object Models:
         (BigDecimal(cacheCreateTokens) * cacheWritePerMillion / 1_000_000) +
         (BigDecimal(cacheReadTokens) * cacheReadPerMillion / 1_000_000)
 
-  /** Claude Opus 4.5 pricing (as of Feb 2026) */
+  /** Claude Fable 5 / Mythos 5 pricing (as of Jun 2026) */
+  val FablePricing: Pricing = Pricing(
+    inputPerMillion = BigDecimal("10.00"),
+    outputPerMillion = BigDecimal("50.00"),
+    cacheWritePerMillion = BigDecimal("12.50"),
+    cacheReadPerMillion = BigDecimal("1.00")
+  )
+
+  /** Claude Opus 4.x pricing (as of Jun 2026) */
   val OpusPricing: Pricing = Pricing(
     inputPerMillion = BigDecimal("5.00"),
     outputPerMillion = BigDecimal("25.00"),
@@ -84,7 +97,7 @@ object Models:
     cacheReadPerMillion = BigDecimal("0.50")
   )
 
-  /** Claude Sonnet 4.5 pricing (as of Feb 2026) */
+  /** Claude Sonnet pricing (standard rate; Sonnet 5 has intro $2/$10 through 2026-08-31) */
   val SonnetPricing: Pricing = Pricing(
     inputPerMillion = BigDecimal("3.00"),
     outputPerMillion = BigDecimal("15.00"),
@@ -92,7 +105,7 @@ object Models:
     cacheReadPerMillion = BigDecimal("0.30")
   )
 
-  /** Claude Haiku 4.5 pricing (as of Feb 2026) */
+  /** Claude Haiku 4.5 pricing (as of Jun 2026) */
   val HaikuPricing: Pricing = Pricing(
     inputPerMillion = BigDecimal("1.00"),
     outputPerMillion = BigDecimal("5.00"),
@@ -100,12 +113,13 @@ object Models:
     cacheReadPerMillion = BigDecimal("0.10")
   )
 
-  /** Default pricing (Sonnet 4.5) */
+  /** Default pricing (Sonnet) */
   val DefaultPricing: Pricing = SonnetPricing
 
   /** Get pricing for a model by name */
   def pricingFor(model: String): Pricing =
     model.toLowerCase match
+      case m if m.contains("fable") || m.contains("mythos") => FablePricing
       case m if m.contains("opus") => OpusPricing
       case m if m.contains("haiku") => HaikuPricing
       case _ => SonnetPricing

--- a/xl-agent/src/com/tjclp/xl/agent/benchmark/common/ComparisonModels.scala
+++ b/xl-agent/src/com/tjclp/xl/agent/benchmark/common/ComparisonModels.scala
@@ -59,14 +59,17 @@ object ModelPricing:
       cacheReadPerMillion = p.cacheReadPerMillion.toDouble
     )
 
-  // Claude Opus 4.5 pricing (delegates to Models)
-  val Opus45: ModelPricing = fromModels(Models.OpusPricing)
+  // Claude Fable 5 pricing (delegates to Models)
+  val Fable: ModelPricing = fromModels(Models.FablePricing)
 
-  // Claude Sonnet 4.5 pricing (delegates to Models)
-  val Sonnet45: ModelPricing = fromModels(Models.SonnetPricing)
+  // Claude Opus pricing (delegates to Models)
+  val Opus: ModelPricing = fromModels(Models.OpusPricing)
 
-  // Claude Haiku 4.5 pricing (delegates to Models)
-  val Haiku45: ModelPricing = fromModels(Models.HaikuPricing)
+  // Claude Sonnet pricing (delegates to Models)
+  val Sonnet: ModelPricing = fromModels(Models.SonnetPricing)
+
+  // Claude Haiku pricing (delegates to Models)
+  val Haiku: ModelPricing = fromModels(Models.HaikuPricing)
 
   def forModel(modelName: String): ModelPricing =
     fromModels(Models.pricingFor(modelName))

--- a/xl-agent/src/com/tjclp/xl/agent/benchmark/common/FileManager.scala
+++ b/xl-agent/src/com/tjclp/xl/agent/benchmark/common/FileManager.scala
@@ -5,16 +5,18 @@ import cats.syntax.all.*
 import com.tjclp.xl.agent.error.AgentError
 
 import java.nio.file.{Files, Path, Paths}
-import scala.jdk.OptionConverters.*
+import scala.jdk.CollectionConverters.*
 import scala.sys.process.*
+import scala.util.Using
 
 /** Shared file management utilities for benchmarks */
 object FileManager:
 
-  // Default binary/skill versions
-  private val DefaultBinaryVersion = "0.9.0"
-  private val DefaultBinaryName = s"xl-$DefaultBinaryVersion-linux-amd64"
-  private val DefaultSkillName = s"xl-skill-$DefaultBinaryVersion.zip"
+  // Release asset patterns. Version-agnostic on purpose: resolution picks the
+  // highest version present, and auto-download always fetches the latest
+  // release, so there is no pinned version to keep in sync with releases.
+  private val BinaryPattern = "xl-*-linux-amd64"
+  private val SkillPattern = "xl-skill-*.zip"
 
   // Default search directories
   private val DefaultSearchDirs = List(
@@ -23,62 +25,50 @@ object FileManager:
     "."
   )
 
-  /** Resolve path to xl binary, optionally downloading from GitHub */
+  /** Resolve path to xl binary, optionally downloading the latest release from GitHub */
   def resolveBinaryPath(
     pathOverride: Option[Path] = None,
     searchDirs: List[String] = DefaultSearchDirs,
     autoDownload: Boolean = true
   ): IO[Path] =
-    pathOverride match
-      case Some(p) => IO.pure(p)
-      case None =>
-        findExistingFile(DefaultBinaryName, searchDirs).flatMap {
-          case Some(p) => IO.pure(p)
-          case None if autoDownload =>
-            for
-              targetDir <- IO.pure(searchDirs.lastOption.getOrElse("."))
-              _ <- downloadFromGitHub("xl-*-linux-amd64", targetDir)
-              path <- findExistingFile(DefaultBinaryName, searchDirs)
-                .flatMap(
-                  _.liftTo[IO](
-                    AgentError.ConfigError(s"Binary not found after download: $DefaultBinaryName")
-                  )
-                )
-            yield path
-          case None =>
-            IO.raiseError(
-              AgentError.ConfigError(
-                s"Binary not found: $DefaultBinaryName. Use --xl-binary or place in ${searchDirs.mkString(", ")}"
-              )
-            )
-        }
+    resolveAsset("Binary", BinaryPattern, "--xl-binary", pathOverride, searchDirs, autoDownload)
 
-  /** Resolve path to xl skill zip, optionally downloading from GitHub */
+  /** Resolve path to xl skill zip, optionally downloading the latest release from GitHub */
   def resolveSkillPath(
     pathOverride: Option[Path] = None,
     searchDirs: List[String] = DefaultSearchDirs,
     autoDownload: Boolean = true
   ): IO[Path] =
+    resolveAsset("Skill", SkillPattern, "--xl-skill", pathOverride, searchDirs, autoDownload)
+
+  private def resolveAsset(
+    label: String,
+    pattern: String,
+    overrideFlag: String,
+    pathOverride: Option[Path],
+    searchDirs: List[String],
+    autoDownload: Boolean
+  ): IO[Path] =
     pathOverride match
       case Some(p) => IO.pure(p)
       case None =>
-        findExistingFile(DefaultSkillName, searchDirs).flatMap {
+        findByPattern(pattern, searchDirs).flatMap {
           case Some(p) => IO.pure(p)
           case None if autoDownload =>
             for
               targetDir <- IO.pure(searchDirs.lastOption.getOrElse("."))
-              _ <- downloadFromGitHub("xl-skill-*.zip", targetDir)
-              path <- findExistingFile(DefaultSkillName, searchDirs)
+              _ <- downloadFromGitHub(pattern, targetDir)
+              path <- findByPattern(pattern, searchDirs)
                 .flatMap(
                   _.liftTo[IO](
-                    AgentError.ConfigError(s"Skill not found after download: $DefaultSkillName")
+                    AgentError.ConfigError(s"$label not found after download: $pattern")
                   )
                 )
             yield path
           case None =>
             IO.raiseError(
               AgentError.ConfigError(
-                s"Skill not found: $DefaultSkillName. Use --xl-skill or place in ${searchDirs.mkString(", ")}"
+                s"$label not found: $pattern. Use $overrideFlag or place in ${searchDirs.mkString(", ")}"
               )
             )
         }
@@ -91,23 +81,38 @@ object FileManager:
         .find(p => Files.exists(p))
     }
 
-  /** Find a file by pattern (glob) in the given directories */
+  /**
+   * Find a file by pattern (glob) in the given directories.
+   *
+   * When several files match (e.g. binaries from multiple releases side by side), the one with the
+   * highest embedded semantic version wins.
+   */
   def findByPattern(pattern: String, dirs: List[String]): IO[Option[Path]] =
     IO.blocking {
       import java.nio.file.FileSystems
       val matcher = FileSystems.getDefault.getPathMatcher(s"glob:$pattern")
+      val versionRegex = """(\d+)\.(\d+)\.(\d+)""".r
 
-      dirs.view.flatMap { dir =>
-        val dirPath = Paths.get(dir)
-        if Files.isDirectory(dirPath) then
-          Files
-            .list(dirPath)
-            .filter(p => matcher.matches(p.getFileName))
-            .findFirst()
-            .map(_.toAbsolutePath)
-            .toScala
-        else None
-      }.headOption
+      def versionKey(p: Path): (Int, Int, Int) =
+        versionRegex.findFirstMatchIn(p.getFileName.toString) match
+          case Some(m) => (m.group(1).toInt, m.group(2).toInt, m.group(3).toInt)
+          case None => (-1, -1, -1)
+
+      dirs
+        .flatMap { dir =>
+          val dirPath = Paths.get(dir)
+          if Files.isDirectory(dirPath) then
+            Using.resource(Files.list(dirPath)) { stream =>
+              stream
+                .iterator()
+                .asScala
+                .filter(p => matcher.matches(p.getFileName))
+                .map(_.toAbsolutePath)
+                .toList
+            }
+          else Nil
+        }
+        .maxByOption(versionKey)
     }
 
   /** Download assets from GitHub release using gh CLI */

--- a/xl-agent/src/com/tjclp/xl/agent/benchmark/execution/TokenUsage.scala
+++ b/xl-agent/src/com/tjclp/xl/agent/benchmark/execution/TokenUsage.scala
@@ -71,7 +71,12 @@ object TokenUsage:
 
   /** Create from the agent's TokenUsage type */
   def fromAgentUsage(usage: com.tjclp.xl.agent.TokenUsage): TokenUsage =
-    TokenUsage(usage.inputTokens, usage.outputTokens, 0, 0)
+    TokenUsage(
+      usage.inputTokens,
+      usage.outputTokens,
+      usage.cacheCreationTokens,
+      usage.cacheReadTokens
+    )
 
   /** Monoid instance for combining token usage */
   given Monoid[TokenUsage] with
@@ -100,16 +105,19 @@ object TokenUsage:
 type ModelPricing = Models.Pricing
 
 object ModelPricing:
-  /** Claude Opus 4.5 pricing */
-  val opus45: ModelPricing = Models.OpusPricing
+  /** Claude Fable 5 pricing */
+  val fable: ModelPricing = Models.FablePricing
 
-  /** Claude Sonnet 4 pricing */
-  val sonnet4: ModelPricing = Models.SonnetPricing
+  /** Claude Opus pricing */
+  val opus: ModelPricing = Models.OpusPricing
 
-  /** Claude Haiku 3.5 pricing */
-  val haiku35: ModelPricing = Models.HaikuPricing
+  /** Claude Sonnet pricing */
+  val sonnet: ModelPricing = Models.SonnetPricing
 
-  /** Default pricing (Sonnet 4) */
+  /** Claude Haiku pricing */
+  val haiku: ModelPricing = Models.HaikuPricing
+
+  /** Default pricing (Sonnet) */
   val default: ModelPricing = Models.DefaultPricing
 
   /** Get pricing for a model by name */

--- a/xl-agent/src/com/tjclp/xl/agent/benchmark/grading/LLMGrader.scala
+++ b/xl-agent/src/com/tjclp/xl/agent/benchmark/grading/LLMGrader.scala
@@ -6,7 +6,11 @@ import cats.syntax.all.*
 import com.anthropic.client.AnthropicClient as JAnthropicClient
 import com.anthropic.core.JsonValue
 import com.anthropic.models.beta.AnthropicBeta
-import com.anthropic.models.beta.messages.{BetaJsonOutputFormat, MessageCreateParams}
+import com.anthropic.models.beta.messages.{
+  BetaJsonOutputFormat,
+  BetaOutputConfig,
+  MessageCreateParams
+}
 import com.tjclp.xl.agent.benchmark.Models
 import io.circe.*
 import io.circe.parser.*
@@ -15,11 +19,11 @@ import scala.jdk.CollectionConverters.*
 import scala.jdk.OptionConverters.*
 
 // ============================================================================
-// LLM-Based Grader (Opus 4.5 as Judge)
+// LLM-Based Grader (Opus as Judge)
 // ============================================================================
 
 /**
- * Grader that uses Opus 4.5 with structured outputs for evaluation.
+ * Grader that uses an Opus-tier model with structured outputs for evaluation.
  *
  * Supports parallel grading via `gradeAll` with configurable concurrency.
  */
@@ -88,9 +92,9 @@ class OpusLLMGrader(
         .putAdditionalProperty("additionalProperties", JsonValue.from(false))
         .build()
 
-      val outputFormat = BetaJsonOutputFormat
+      val outputConfig = BetaOutputConfig
         .builder()
-        .schema(gradeSchema)
+        .format(BetaJsonOutputFormat.builder().schema(gradeSchema).build())
         .build()
 
       val params = MessageCreateParams
@@ -98,7 +102,7 @@ class OpusLLMGrader(
         .model(model)
         .maxTokens(256L)
         .addUserMessage(prompt)
-        .outputFormat(outputFormat)
+        .outputConfig(outputConfig)
         .addBeta(AnthropicBeta.of("structured-outputs-2025-11-13"))
         .build()
 
@@ -283,7 +287,7 @@ class SonnetLLMGrader(client: JAnthropicClient, parallelism: Int = OpusLLMGrader
   override val name: String = "llm-sonnet"
 
 object SonnetLLMGrader:
-  val Model: String = "claude-sonnet-4-20250514"
+  val Model: String = Models.Sonnet5
 
   def apply(client: JAnthropicClient): SonnetLLMGrader =
     new SonnetLLMGrader(client)

--- a/xl-agent/src/com/tjclp/xl/agent/benchmark/runner/UnifiedRunner.scala
+++ b/xl-agent/src/com/tjclp/xl/agent/benchmark/runner/UnifiedRunner.scala
@@ -25,15 +25,22 @@ import java.time.{Duration, Instant}
 /** Single entry point for all benchmark types */
 object UnifiedRunner extends IOApp:
 
+  /** Raised by parseArgs after printing help; mapped to a clean successful exit */
+  private object HelpRequested extends RuntimeException("Help requested")
+
   override def run(args: List[String]): IO[ExitCode] =
-    for
-      config <- parseArgs(args)
-      _ <- config.listSkills.fold(IO.unit)(listSkillsAndExit)
-      _ <- IO.println(s"${Console.BOLD}Unified Benchmark Runner${Console.RESET}")
-      _ <- IO(SkillRegistry.initialize())
-      benchmarkRun <- runBenchmarkWithEngine(config)
-      _ <- writeUnifiedReport(config, benchmarkRun)
-    yield ExitCode.Success
+    parseArgs(args)
+      .flatMap { config =>
+        if config.listSkills.isDefined then printSkillsList
+        else
+          for
+            _ <- IO.println(s"${Console.BOLD}Unified Benchmark Runner${Console.RESET}")
+            _ <- IO(SkillRegistry.initialize())
+            benchmarkRun <- runBenchmarkWithEngine(config)
+            _ <- writeUnifiedReport(config, benchmarkRun)
+          yield ExitCode.Success
+      }
+      .recover { case HelpRequested => ExitCode.Success }
 
   /** Run the benchmark using BenchmarkEngine */
   def runBenchmarkWithEngine(config: UnifiedConfig): IO[BenchmarkRun] =
@@ -293,7 +300,7 @@ ${"=" * 60}
             parse(rest, config.copy(forceUpload = true))
           case ("--help" | "-h") :: _ =>
             printHelp()
-            throw new RuntimeException("Help requested")
+            throw HelpRequested
           case arg :: _ if arg.startsWith("-") =>
             throw new IllegalArgumentException(s"Unknown argument: $arg")
           case _ :: rest => parse(rest, config) // Skip positional args
@@ -302,7 +309,7 @@ ${"=" * 60}
     }
 
   private def printHelp(): Unit =
-    println("""
+    println(s"""
       |Unified Benchmark Runner
       |
       |Usage: UnifiedRunner [options]
@@ -335,7 +342,7 @@ ${"=" * 60}
       |  --stream               Real-time streaming output
       |
       |Execution:
-      |  --model <name>         Model to use (default: claude-sonnet-4-20250514)
+      |  --model <name>         Model to use (default: ${Models.DefaultAgent})
       |  --parallelism <n>      Number of parallel tasks (default: 4)
       |  --xl-cli <path>        Path to xl CLI for local grading (default: xl)
       |  --xl-binary <path>     Path to xl binary for upload (default: auto-download)
@@ -343,13 +350,13 @@ ${"=" * 60}
       |  --force-upload         Force re-upload of binary and skill (bypass cache)
       |""".stripMargin)
 
-  private def listSkillsAndExit(unit: Unit): IO[Nothing] =
+  private def printSkillsList: IO[ExitCode] =
     for
       _ <- IO(SkillRegistry.initialize())
       skills <- IO(SkillRegistry.all)
       _ <- IO.println("Available skills:")
       _ <- skills.traverse_(s => IO.println(s"  ${s.name}: ${s.description}"))
-    yield throw new RuntimeException("Listed skills")
+    yield ExitCode.Success
 
 // ============================================================================
 // Configuration

--- a/xl-agent/src/com/tjclp/xl/agent/benchmark/skills/builtin/XlSkill.scala
+++ b/xl-agent/src/com/tjclp/xl/agent/benchmark/skills/builtin/XlSkill.scala
@@ -127,7 +127,8 @@ object XlSkill extends Skill:
         taskId = task.taskIdValue,
         skillName = name,
         caseNum = testCase.caseNum,
-        streaming = engineConfig.stream
+        streaming = engineConfig.stream,
+        model = Some(agentConfig.model)
       )
 
       // Create agent task
@@ -214,7 +215,8 @@ object XlSkill extends Skill:
         taskId = task.taskIdValue,
         skillName = name,
         caseNum = testCase.caseNum,
-        streaming = engineConfig.stream
+        streaming = engineConfig.stream,
+        model = Some(agentConfig.model)
       )
 
       agentTask = AgentTask(

--- a/xl-agent/src/com/tjclp/xl/agent/benchmark/skills/builtin/XlsxSkill.scala
+++ b/xl-agent/src/com/tjclp/xl/agent/benchmark/skills/builtin/XlsxSkill.scala
@@ -103,7 +103,8 @@ object XlsxSkill extends Skill:
         taskId = task.taskIdValue,
         skillName = name,
         caseNum = testCase.caseNum,
-        streaming = engineConfig.stream
+        streaming = engineConfig.stream,
+        model = Some(agentConfig.model)
       )
 
       agentTask = AgentTask(
@@ -187,7 +188,8 @@ object XlsxSkill extends Skill:
         taskId = task.taskIdValue,
         skillName = name,
         caseNum = testCase.caseNum,
-        streaming = engineConfig.stream
+        streaming = engineConfig.stream,
+        model = Some(agentConfig.model)
       )
 
       agentTask = AgentTask(

--- a/xl-agent/src/com/tjclp/xl/agent/benchmark/token/TokenGrader.scala
+++ b/xl-agent/src/com/tjclp/xl/agent/benchmark/token/TokenGrader.scala
@@ -5,7 +5,11 @@ import cats.syntax.all.*
 import com.anthropic.client.AnthropicClient as JAnthropicClient
 import com.anthropic.core.JsonValue
 import com.anthropic.models.beta.AnthropicBeta
-import com.anthropic.models.beta.messages.{BetaJsonOutputFormat, MessageCreateParams}
+import com.anthropic.models.beta.messages.{
+  BetaJsonOutputFormat,
+  BetaOutputConfig,
+  MessageCreateParams
+}
 import com.tjclp.xl.agent.benchmark.Models
 import com.tjclp.xl.agent.error.AgentError
 import io.circe.*
@@ -14,7 +18,7 @@ import io.circe.parser.*
 import scala.jdk.CollectionConverters.*
 import scala.jdk.OptionConverters.*
 
-/** Grading result from Opus 4.5 */
+/** Grading result from the grader model */
 case class GradeResult(
   grade: Grade,
   reason: String
@@ -29,7 +33,7 @@ object GradeResult:
     yield GradeResult(grade, reason)
   }
 
-/** Grades task responses using Opus 4.5 with structured outputs */
+/** Grades task responses using the default grader model with structured outputs */
 object TokenGrader:
 
   private val Model = Models.DefaultGrader
@@ -74,9 +78,9 @@ object TokenGrader:
         .putAdditionalProperty("additionalProperties", JsonValue.from(false))
         .build()
 
-      val outputFormat = BetaJsonOutputFormat
+      val outputConfig = BetaOutputConfig
         .builder()
-        .schema(gradeSchema)
+        .format(BetaJsonOutputFormat.builder().schema(gradeSchema).build())
         .build()
 
       val params = MessageCreateParams
@@ -84,7 +88,7 @@ object TokenGrader:
         .model(Model)
         .maxTokens(256L)
         .addUserMessage(prompt)
-        .outputFormat(outputFormat)
+        .outputConfig(outputConfig)
         .addBeta(AnthropicBeta.of("structured-outputs-2025-11-13"))
         .build()
 

--- a/xl-agent/src/com/tjclp/xl/agent/benchmark/tracing/ConversationTracer.scala
+++ b/xl-agent/src/com/tjclp/xl/agent/benchmark/tracing/ConversationTracer.scala
@@ -31,6 +31,7 @@ case class ConversationMetadata(
   skillName: String,
   caseNum: Int,
   startTime: Instant,
+  model: Option[String] = None,
   endTime: Option[Instant] = None,
   usage: Option[TokenUsage] = None,
   passed: Option[Boolean] = None,
@@ -45,6 +46,7 @@ object ConversationMetadata:
       "taskId" -> m.taskId.asJson,
       "skillName" -> m.skillName.asJson,
       "caseNum" -> m.caseNum.asJson,
+      "model" -> m.model.asJson,
       "startTime" -> m.startTime.toString.asJson,
       "endTime" -> m.endTime.map(_.toString).asJson,
       "durationMs" -> m.durationMs.asJson,
@@ -218,11 +220,12 @@ object ConversationTracer:
     taskId: String,
     skillName: String,
     caseNum: Int,
-    streaming: Boolean = false
+    streaming: Boolean = false,
+    model: Option[String] = None
   ): IO[ConversationTracer] =
     for
       now <- IO.realTimeInstant
-      initialMeta = ConversationMetadata(taskId, skillName, caseNum, now)
+      initialMeta = ConversationMetadata(taskId, skillName, caseNum, now, model = model)
       eventsRef <- Ref.of[IO, Vector[TracedEvent]](Vector.empty)
       metaRef <- Ref.of[IO, ConversationMetadata](initialMeta)
       streamContext = StreamingConsole.StreamContext(taskId, skillName, caseNum)

--- a/xl-agent/src/com/tjclp/xl/agent/benchmark/tracing/TraceFormat.scala
+++ b/xl-agent/src/com/tjclp/xl/agent/benchmark/tracing/TraceFormat.scala
@@ -28,9 +28,13 @@ object TraceFormat:
       .getOrElse("")
     val costStr = meta.usage
       .map { u =>
-        val pricing = ModelPricing.Opus45
+        // Price by the model that actually ran (Sonnet-tier fallback if unknown)
+        val pricing = ModelPricing.forModel(meta.model.getOrElse(""))
         val cost =
-          (u.inputTokens * pricing.inputPerMillion + u.outputTokens * pricing.outputPerMillion) / 1_000_000.0
+          (u.inputTokens * pricing.inputPerMillion +
+            u.outputTokens * pricing.outputPerMillion +
+            u.cacheCreationTokens * pricing.cacheWritePerMillion +
+            u.cacheReadTokens * pricing.cacheReadPerMillion) / 1_000_000.0
         f"**Cost:** $$$cost%.2f"
       }
       .getOrElse("")

--- a/xl-agent/test/src/com/tjclp/xl/agent/ModelsSpec.scala
+++ b/xl-agent/test/src/com/tjclp/xl/agent/ModelsSpec.scala
@@ -14,9 +14,27 @@ class ModelsSpec extends CatsEffectSuite:
     assertEquals(result.totalTokens, 450L)
   }
 
+  test("TokenUsage addition combines cache tokens") {
+    val a = TokenUsage(100, 50, cacheCreationTokens = 10, cacheReadTokens = 5)
+    val b = TokenUsage(200, 100, cacheCreationTokens = 20, cacheReadTokens = 15)
+    val result = a + b
+    assertEquals(result.cacheCreationTokens, 30L)
+    assertEquals(result.cacheReadTokens, 20L)
+  }
+
   test("TokenUsage.zero") {
     assertEquals(TokenUsage.zero.inputTokens, 0L)
     assertEquals(TokenUsage.zero.outputTokens, 0L)
+    assertEquals(TokenUsage.zero.cacheCreationTokens, 0L)
+    assertEquals(TokenUsage.zero.cacheReadTokens, 0L)
+  }
+
+  test("TokenUsage decodes legacy JSON without cache fields") {
+    val json = io.circe.Json.obj(
+      "inputTokens" -> io.circe.Json.fromLong(100),
+      "outputTokens" -> io.circe.Json.fromLong(50)
+    )
+    assertEquals(json.as[TokenUsage], Right(TokenUsage(100, 50)))
   }
 
   test("AgentEvent JSON encoding") {
@@ -41,8 +59,8 @@ class ModelsSpec extends CatsEffectSuite:
 
   test("AgentConfig defaults") {
     val config = AgentConfig()
-    // Default is Sonnet 4.5 (balanced capability and cost)
-    assertEquals(config.model, "claude-sonnet-4-5-20250929")
-    assertEquals(config.maxTokens, 8192)
+    // Default is Sonnet 5 (near-Opus coding/agentic quality at Sonnet cost)
+    assertEquals(config.model, "claude-sonnet-5")
+    assertEquals(config.maxTokens, 16384)
     assertEquals(config.verbose, false)
   }

--- a/xl-agent/test/src/com/tjclp/xl/agent/benchmark/common/FileManagerSpec.scala
+++ b/xl-agent/test/src/com/tjclp/xl/agent/benchmark/common/FileManagerSpec.scala
@@ -1,0 +1,49 @@
+package com.tjclp.xl.agent.benchmark.common
+
+import munit.CatsEffectSuite
+
+import java.nio.file.{Files, Path}
+
+class FileManagerSpec extends CatsEffectSuite:
+
+  private val tempDir = FunFixture[Path](
+    setup = _ => Files.createTempDirectory("filemanager-spec"),
+    teardown = { dir =>
+      import scala.jdk.CollectionConverters.*
+      import scala.util.Using
+      Using.resource(Files.walk(dir)) { stream =>
+        stream.iterator().asScala.toList.reverse.foreach(p => Files.deleteIfExists(p))
+      }
+    }
+  )
+
+  tempDir.test("findByPattern picks the highest version among matches") { dir =>
+    Files.createFile(dir.resolve("xl-0.9.0-linux-amd64"))
+    Files.createFile(dir.resolve("xl-0.12.2-linux-amd64"))
+    Files.createFile(dir.resolve("xl-0.10.1-linux-amd64"))
+
+    FileManager
+      .findByPattern("xl-*-linux-amd64", List(dir.toString))
+      .map(found => assertEquals(found.map(_.getFileName.toString), Some("xl-0.12.2-linux-amd64")))
+  }
+
+  tempDir.test("findByPattern compares versions numerically, not lexicographically") { dir =>
+    Files.createFile(dir.resolve("xl-skill-0.9.0.zip"))
+    Files.createFile(dir.resolve("xl-skill-0.10.0.zip"))
+
+    FileManager
+      .findByPattern("xl-skill-*.zip", List(dir.toString))
+      .map(found => assertEquals(found.map(_.getFileName.toString), Some("xl-skill-0.10.0.zip")))
+  }
+
+  tempDir.test("findByPattern returns None when nothing matches") { dir =>
+    FileManager
+      .findByPattern("xl-*-linux-amd64", List(dir.toString))
+      .map(found => assertEquals(found, None))
+  }
+
+  test("findByPattern tolerates missing directories") {
+    FileManager
+      .findByPattern("xl-*-linux-amd64", List("/nonexistent/path/for/spec"))
+      .map(found => assertEquals(found, None))
+  }


### PR DESCRIPTION
## Summary

Full staleness sweep of `xl-agent/` — models, SDK, API surface, five latent bugs (two found by audit, three by live run), plus prompt caching.

### Models → Claude 5 family
- Registry now uses aliases: `claude-sonnet-5` (default agent), `claude-opus-4-8` (default grader), `claude-fable-5`, `claude-haiku-4-5`; adds the Fable/Mythos pricing tier and matches it in `pricingFor`
- `SonnetLLMGrader` was pinned to `claude-sonnet-4-20250514` (deprecated, retirement scheduled) → now `Models.Sonnet5`
- `--help` shows the real default model instead of a stale hardcoded one

### SDK & API surface
- `anthropic-java` **2.11.1 → 2.48.0** (+ circe 0.14.13, dotenv-java 3.2.0, commons-compress 1.28.0)
- Code execution tool `20250825` → `20260521` (current generation; beta headers unchanged)
- `container_upload` blocks now use typed `BetaContainerUploadBlockParam` instead of the `putAdditionalBodyProperty` raw-JSON override the old SDK required
- Graders migrate deprecated `.outputFormat(...)` → `.outputConfig(format)`

### Prompt caching (−52…59% cost per task)
- System-block breakpoint (shared tools+system read point across a task's cases) + top-level `cache_control` (auto-places on the last cacheable block, covering the initial prompt for the code-execution loop's sub-turns)
- Measured on task 59196: xl $0.65 → **$0.27**, xlsx $0.35 → **$0.17**; uncached input drops from ~200K to ~10 tokens/case

### Bug fixes found by audit
- **Auto-download could never work**: `FileManager` pinned `xl-0.9.0-*` filenames while `gh release download` fetches the latest (0.12.2) — resolution is now version-agnostic (glob + numeric semver sort, covered by new `FileManagerSpec`); `Agent.resource` reuses it instead of duplicating the stale logic
- **Trace costs were always priced at Opus rates**: traces now record the model and price by it, including cache tokens
- Cache tokens (`cache_creation/read_input_tokens`) are now captured end-to-end instead of dropped
- `AgentConfig.maxTokens` 8192 → 16384 (adaptive thinking counts against `max_tokens` on Claude 5 models)
- `--list-skills` / `--help` exit cleanly instead of via a thrown stack trace

### Bug fixes found by live smoke run (Skills API drift)
- `createSkill` must send `files[]` (array notation) — bare `files` now 400s
- `listCustomSkills` requests `limit=1000` — default page is 20 and `has_more`/`next_page` report no-more-data while more exists, so an existing `xl-cli` skill outside page 1 caused a duplicate `display_title` 400
- `extractZipFiles` normalizes flat release zips (SKILL.md at archive root) into the `xl-cli/` top-level folder the Skills API requires

## Test plan
- [x] `./mill xl-agent.test` — 341/341 green (new: cache-token math, legacy-JSON decode, FileManager version sort)
- [x] `./mill xl-agent.checkFormat`
- [x] Zero deprecation warnings on clean compile against 2.48.0
- [x] Smoke: `--list-skills` and `--help` run and exit 0
- [x] **Live benchmark, uncached baseline** — SpreadsheetBench 59196, `--skills xl,xlsx` on `claude-sonnet-5`: **6/6 cases pass**, 67s wall, ~$1.00. Verified: binary+skill auto-download from v0.12.2 release, skill version registration from flat zip, `code_execution_20260521` + typed container uploads, model-stamped traces with per-model cost lines, file-grading via local `xl` CLI
- [x] **Live benchmark, cached** — same task 6/6 pass at **$0.44 total (−56%)**; re-verified 3/3 after switching to top-level auto-placement; upload/skill reuse paths exercised (no `--force-upload`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)