### PR TITLE
Wave 10: Excel comparison semantics, array-aware IF, benchmark failure diagnostics

### DIFF
--- a/xl-agent/src/com/tjclp/xl/agent/benchmark/reporting/ReportWriter.scala
+++ b/xl-agent/src/com/tjclp/xl/agent/benchmark/reporting/ReportWriter.scala
@@ -32,6 +32,12 @@ object ReportWriter:
   /** Max cell refs to show in failed case summary */
   private[reporting] val MaxCellRefsInSummary: Int = 5
 
+  /**
+   * Max characters for error messages in report output. Deliberately generous: when a case dies
+   * mid-run the error string is often the only surviving diagnostic (issue #334).
+   */
+  private[reporting] val MaxErrorLength: Int = 200
+
   // --------------------------------------------------------------------------
   // Public API
   // --------------------------------------------------------------------------
@@ -102,6 +108,7 @@ object ReportWriter:
       sb.append("## Failed Tasks Details\n\n")
       failedTasks.foreach { result =>
         sb.append(s"### Task ${result.taskId} (${result.skill})\n\n")
+        result.error.foreach(e => sb.append(s"**Error:** ${sanitizeError(e)}\n\n"))
         result.gradeDetails.reasoning.foreach(r => sb.append(s"**Reason:** $r\n\n"))
         if result.gradeDetails.mismatches.nonEmpty then
           sb.append("**Mismatches:**\n\n")
@@ -182,6 +189,10 @@ object ReportWriter:
 
   private def escapeMarkdown(s: String): String =
     s.replace("|", "\\|").replace("\n", " ").take(MaxMarkdownCellLength)
+
+  /** Flatten an error message to one line, keeping enough of it to be diagnosable */
+  private[reporting] def sanitizeError(s: String): String =
+    s.replace("\n", " ").take(MaxErrorLength)
 
 /** Paths to generated report files */
 case class ReportPaths(
@@ -301,14 +312,17 @@ object UnifiedReportWriter:
           }
           .getOrElse(Json.Null)
 
-        // Per-case results with mismatches
+        // Per-case results with mismatches and failure diagnostics (issue #334)
         val caseResultsJson = Json.arr(r.caseResults.map { cr =>
           val mismatchRefs = cr.mismatches.take(ReportWriter.MaxCellRefsInSummary).map(_.ref)
           Json.obj(
             "caseNum" -> Json.fromInt(cr.caseNum),
             "passed" -> Json.fromBoolean(cr.passed),
+            "latencyMs" -> Json.fromLong(cr.latencyMs),
             "mismatches" -> (if mismatchRefs.isEmpty then Json.Null
-                             else Json.arr(mismatchRefs.map(Json.fromString)*))
+                             else Json.arr(mismatchRefs.map(Json.fromString)*)),
+            "error" -> cr.error.map(Json.fromString).getOrElse(Json.Null),
+            "tracePath" -> cr.tracePath.map(p => Json.fromString(p.toString)).getOrElse(Json.Null)
           )
         }*)
 
@@ -455,7 +469,7 @@ object UnifiedReportWriter:
                 cr.mismatches.take(ReportWriter.MaxMismatchesPerCase).map(_.ref).mkString(", ")
               val refsDisplay = if refs.nonEmpty then s": $refs" else ""
               val errorDisplay = cr.error
-                .map(e => s" - Error: ${e.take(ReportWriter.MaxReasoningLength)}")
+                .map(e => s" - Error: ${ReportWriter.sanitizeError(e)}")
                 .getOrElse("")
               sb.append(s"- Case ${cr.caseNum}$refsDisplay$errorDisplay\n")
             }
@@ -505,7 +519,9 @@ object UnifiedReportWriter:
             Json.obj(
               "caseNum" -> Json.fromInt(cr.caseNum),
               "passed" -> Json.fromBoolean(cr.passed),
-              "latencyMs" -> Json.fromLong(cr.latencyMs)
+              "latencyMs" -> Json.fromLong(cr.latencyMs),
+              "error" -> cr.error.map(Json.fromString).getOrElse(Json.Null),
+              "tracePath" -> cr.tracePath.map(p => Json.fromString(p.toString)).getOrElse(Json.Null)
             )
           }*)
         )

--- a/xl-agent/src/com/tjclp/xl/agent/benchmark/runner/UnifiedRunner.scala
+++ b/xl-agent/src/com/tjclp/xl/agent/benchmark/runner/UnifiedRunner.scala
@@ -99,16 +99,26 @@ object UnifiedRunner extends IOApp:
       yield benchmarkRun
     }
 
+  /** Max characters of an error message shown on the streaming console line */
+  private val MaxStreamedErrorLength = 200
+
   /** Format an ExecutionResult for streaming output */
-  private def formatExecutionResult(result: ExecutionResult): String =
+  private[runner] def formatExecutionResult(result: ExecutionResult): String =
     val status =
       if result.passed then Console.GREEN + "✓" + Console.RESET
       else if result.error.isDefined then Console.RED + "✗" + Console.RESET
       else Console.YELLOW + "○" + Console.RESET
 
-    f"$status ${result.skill}%-8s ${result.taskIdValue}%-12s " +
+    val base = f"$status ${result.skill}%-8s ${result.taskIdValue}%-12s " +
       f"${result.passedCases}/${result.totalCases} cases " +
       f"tokens=${result.totalTokens}%6d latency=${result.latencyMs}%5dms"
+
+    // Surface the first error (task-level or per-case) so failed cases are diagnosable
+    // from the console without digging through result files (issue #334)
+    val firstError = result.error.orElse(result.caseResults.flatMap(_.error).headOption)
+    firstError.fold(base) { e =>
+      s"$base error=${e.replace("\n", " ").take(MaxStreamedErrorLength)}"
+    }
 
   /** Print summary after benchmark completion */
   private def printSummary(run: BenchmarkRun): IO[Unit] =
@@ -178,7 +188,10 @@ ${"=" * 60}
   // --------------------------------------------------------------------------
 
   /** Build a BenchmarkReport from a BenchmarkRun (for legacy compatibility) */
-  private def buildReportFromRun(config: UnifiedConfig, run: BenchmarkRun): IO[BenchmarkReport] =
+  private[runner] def buildReportFromRun(
+    config: UnifiedConfig,
+    run: BenchmarkRun
+  ): IO[BenchmarkReport] =
     IO {
       // Convert ExecutionResults to TaskResultEntries
       val entries = run.allResults.flatMap { result =>
@@ -204,7 +217,7 @@ ${"=" * 60}
               outputTokens = caseResult.usage.outputTokens
             ),
             latencyMs = caseResult.latencyMs,
-            error = result.error
+            error = caseResult.error.orElse(result.error)
           )
         }
       }.toList

--- a/xl-agent/src/com/tjclp/xl/agent/benchmark/skills/CaseFailure.scala
+++ b/xl-agent/src/com/tjclp/xl/agent/benchmark/skills/CaseFailure.scala
@@ -1,0 +1,60 @@
+package com.tjclp.xl.agent.benchmark.skills
+
+import cats.effect.{Clock, IO}
+import com.tjclp.xl.agent.TokenUsage as AgentTokenUsage
+import com.tjclp.xl.agent.benchmark.execution.{CaseDetails, CaseResult, TokenUsage}
+import com.tjclp.xl.agent.benchmark.tracing.ConversationTracer
+
+/**
+ * Total failure handlers for benchmark case execution (issue #334).
+ *
+ * When a case dies mid-run the conversation trace collected so far is the primary diagnostic, so
+ * these handlers save it best-effort before returning the failing CaseResult. They never raise:
+ * tracer completion/save failures are swallowed (the trace is lost but the error is preserved).
+ */
+object CaseFailure:
+
+  /** One-line description of a failure, total even for exceptions without a message */
+  def describe(e: Throwable): String =
+    val message = Option(e.getMessage).getOrElse("(no message)")
+    s"${e.getClass.getSimpleName}: $message"
+
+  /**
+   * Build the failing CaseResult for a case that raised after its tracer was created.
+   *
+   * Completes the tracer with the error and saves the partial trace; a successfully saved path is
+   * wired into the CaseResult so reports can point at the surviving trace.
+   */
+  def withPartialTrace(
+    tracer: ConversationTracer,
+    caseNum: Int,
+    startTimeMs: Long,
+    error: Throwable
+  ): IO[CaseResult] =
+    val message = describe(error)
+    for
+      endTimeMs <- Clock[IO].monotonic.map(_.toMillis)
+      _ <- tracer.complete(AgentTokenUsage.zero, passed = false, error = Some(message)).attempt
+      saved <- tracer.save().attempt
+    yield CaseResult(
+      caseNum = caseNum,
+      passed = false,
+      usage = TokenUsage.zero,
+      latencyMs = math.max(0L, endTimeMs - startTimeMs),
+      details = CaseDetails.NoDetails,
+      tracePath = saved.toOption,
+      error = Some(message)
+    )
+
+  /** Fallback for failures before a tracer exists (there is no trace to save) */
+  def withoutTrace(caseNum: Int, error: Throwable): IO[CaseResult] =
+    IO.pure(
+      CaseResult(
+        caseNum = caseNum,
+        passed = false,
+        usage = TokenUsage.zero,
+        latencyMs = 0,
+        details = CaseDetails.NoDetails,
+        error = Some(describe(error))
+      )
+    )

--- a/xl-agent/src/com/tjclp/xl/agent/benchmark/skills/builtin/XlSkill.scala
+++ b/xl-agent/src/com/tjclp/xl/agent/benchmark/skills/builtin/XlSkill.scala
@@ -9,7 +9,7 @@ import com.tjclp.xl.agent.benchmark.{Evaluator, RangeResult}
 import com.tjclp.xl.agent.benchmark.common.FileManager
 import com.tjclp.xl.agent.benchmark.execution.*
 import com.tjclp.xl.agent.benchmark.grading.{CellMismatch, Score}
-import com.tjclp.xl.agent.benchmark.skills.{Skill, SkillContext, SkillRegistry}
+import com.tjclp.xl.agent.benchmark.skills.{CaseFailure, Skill, SkillContext, SkillRegistry}
 import com.tjclp.xl.agent.benchmark.task.*
 import com.tjclp.xl.agent.benchmark.tracing.ConversationTracer
 
@@ -117,11 +117,60 @@ object XlSkill extends Skill:
       engineConfig.outputDir.resolve("outputs").resolve(task.taskIdValue).resolve(name)
     val outputPath = outputDir.resolve(s"${testCase.caseNum}_output.xlsx")
 
+    // The fallible section: everything after the tracer exists, so a failure anywhere in
+    // here can still save the partial conversation trace (issue #334)
+    def runCase(tracer: ConversationTracer, startTime: Long): IO[CaseResult] =
+      val agentTask = AgentTask(
+        instruction = task.instruction,
+        inputFile = testCase.inputPath,
+        outputFile = outputPath,
+        answerPosition = task.evaluation.answerPosition
+      )
+      for
+        // Run agent with streaming to capture conversation
+        result <- agent.runStreaming(agentTask, tracer.onEvent)
+
+        // Evaluate output against answer
+        rangeResults <- result.outputPath match
+          case Some(path) =>
+            val answerPos = task.evaluation.answerPosition.getOrElse("A1")
+            Evaluator.compare(path, testCase.answerPath, answerPos, engineConfig.xlCliPath)
+          case None =>
+            IO.pure(List(RangeResult("N/A", false, Nil)))
+
+        passed = rangeResults.forall(_.passed)
+
+        endTime <- Clock[IO].monotonic.map(_.toMillis)
+        latencyMs = endTime - startTime
+
+        // Complete and save tracer
+        _ <- tracer.complete(result.usage, passed, result.error)
+        tracePath <- tracer.save()
+
+        // Convert mismatches to grading format
+        mismatches = rangeResults.flatMap(_.mismatches).map { m =>
+          CellMismatch(
+            ref = m.ref,
+            expected = m.expected.toString,
+            actual = m.actual.toString
+          )
+        }
+
+        details =
+          if passed then CaseDetails.filePass
+          else CaseDetails.fileFail(mismatches)
+      yield CaseResult(
+        caseNum = testCase.caseNum,
+        passed = passed,
+        usage = TokenUsage.fromAgentUsage(result.usage),
+        latencyMs = latencyMs,
+        details = details,
+        tracePath = Some(tracePath)
+      )
+
     (for
       _ <- IO.blocking(Files.createDirectories(outputDir))
       startTime <- Clock[IO].monotonic.map(_.toMillis)
-
-      // Create tracer for conversation logs
       tracer <- ConversationTracer.create(
         outputDir = engineConfig.outputDir,
         taskId = task.taskIdValue,
@@ -130,66 +179,10 @@ object XlSkill extends Skill:
         streaming = engineConfig.stream,
         model = Some(agentConfig.model)
       )
-
-      // Create agent task
-      agentTask = AgentTask(
-        instruction = task.instruction,
-        inputFile = testCase.inputPath,
-        outputFile = outputPath,
-        answerPosition = task.evaluation.answerPosition
-      )
-
-      // Run agent with streaming to capture conversation
-      result <- agent.runStreaming(agentTask, tracer.onEvent)
-
-      // Evaluate output against answer
-      rangeResults <- result.outputPath match
-        case Some(path) =>
-          val answerPos = task.evaluation.answerPosition.getOrElse("A1")
-          Evaluator.compare(path, testCase.answerPath, answerPos, engineConfig.xlCliPath)
-        case None =>
-          IO.pure(List(RangeResult("N/A", false, Nil)))
-
-      passed = rangeResults.forall(_.passed)
-
-      endTime <- Clock[IO].monotonic.map(_.toMillis)
-      latencyMs = endTime - startTime
-
-      // Complete and save tracer
-      _ <- tracer.complete(result.usage, passed, result.error)
-      tracePath <- tracer.save()
-
-      // Convert mismatches to grading format
-      mismatches = rangeResults.flatMap(_.mismatches).map { m =>
-        CellMismatch(
-          ref = m.ref,
-          expected = m.expected.toString,
-          actual = m.actual.toString
-        )
+      result <- runCase(tracer, startTime).handleErrorWith { e =>
+        CaseFailure.withPartialTrace(tracer, testCase.caseNum, startTime, e)
       }
-
-      details =
-        if passed then CaseDetails.filePass
-        else CaseDetails.fileFail(mismatches)
-    yield CaseResult(
-      caseNum = testCase.caseNum,
-      passed = passed,
-      usage = TokenUsage.fromAgentUsage(result.usage),
-      latencyMs = latencyMs,
-      details = details,
-      tracePath = Some(tracePath)
-    )).handleErrorWith { e =>
-      IO.pure(
-        CaseResult(
-          caseNum = testCase.caseNum,
-          passed = false,
-          usage = TokenUsage.zero,
-          latencyMs = 0,
-          details = CaseDetails.NoDetails,
-          error = Some(s"${e.getClass.getSimpleName}: ${e.getMessage}")
-        )
-      )
-    }
+    yield result).handleErrorWith(e => CaseFailure.withoutTrace(testCase.caseNum, e))
 
   /** Run a token comparison test case (TokenBenchmark/analysis style) */
   private def runTokenComparisonCase(
@@ -205,11 +198,46 @@ object XlSkill extends Skill:
       engineConfig.outputDir.resolve("outputs").resolve(task.taskIdValue).resolve(name)
     val outputPath = outputDir.resolve(s"${testCase.caseNum}_output.xlsx")
 
+    // The fallible section: everything after the tracer exists, so a failure anywhere in
+    // here can still save the partial conversation trace (issue #334)
+    def runCase(tracer: ConversationTracer, startTime: Long): IO[CaseResult] =
+      val agentTask = AgentTask(
+        instruction = task.instruction,
+        inputFile = testCase.inputPath,
+        outputFile = outputPath,
+        answerPosition = task.evaluation.answerPosition
+      )
+      for
+        // Run agent with streaming to capture conversation
+        result <- agent.runStreaming(agentTask, tracer.onEvent)
+
+        endTime <- Clock[IO].monotonic.map(_.toMillis)
+        latencyMs = endTime - startTime
+
+        usage = TokenUsage.fromAgentUsage(result.usage)
+
+        // For analysis tasks, "success" means agent ran without error.
+        // Actual correctness is determined by LLM grading (via CaseDetails.TokenComparison).
+        agentSucceeded = result.error.isEmpty
+
+        // Complete and save tracer
+        _ <- tracer.complete(result.usage, agentSucceeded, result.error)
+        tracePath <- tracer.save()
+      yield CaseResult(
+        caseNum = testCase.caseNum,
+        passed = agentSucceeded, // Agent ran without error; grading determines correctness
+        usage = usage,
+        latencyMs = latencyMs,
+        details = CaseDetails.token(
+          result.responseText.getOrElse(""),
+          task.evaluation.expectedAnswer
+        ),
+        tracePath = Some(tracePath)
+      )
+
     (for
       _ <- IO.blocking(Files.createDirectories(outputDir))
       startTime <- Clock[IO].monotonic.map(_.toMillis)
-
-      // Create tracer for conversation logs
       tracer <- ConversationTracer.create(
         outputDir = engineConfig.outputDir,
         taskId = task.taskIdValue,
@@ -218,48 +246,7 @@ object XlSkill extends Skill:
         streaming = engineConfig.stream,
         model = Some(agentConfig.model)
       )
-
-      agentTask = AgentTask(
-        instruction = task.instruction,
-        inputFile = testCase.inputPath,
-        outputFile = outputPath,
-        answerPosition = task.evaluation.answerPosition
-      )
-
-      // Run agent with streaming to capture conversation
-      result <- agent.runStreaming(agentTask, tracer.onEvent)
-
-      endTime <- Clock[IO].monotonic.map(_.toMillis)
-      latencyMs = endTime - startTime
-
-      usage = TokenUsage.fromAgentUsage(result.usage)
-
-      // For analysis tasks, "success" means agent ran without error.
-      // Actual correctness is determined by LLM grading (via CaseDetails.TokenComparison).
-      agentSucceeded = result.error.isEmpty
-
-      // Complete and save tracer
-      _ <- tracer.complete(result.usage, agentSucceeded, result.error)
-      tracePath <- tracer.save()
-    yield CaseResult(
-      caseNum = testCase.caseNum,
-      passed = agentSucceeded, // Agent ran without error; grading determines correctness
-      usage = usage,
-      latencyMs = latencyMs,
-      details = CaseDetails.token(
-        result.responseText.getOrElse(""),
-        task.evaluation.expectedAnswer
-      ),
-      tracePath = Some(tracePath)
-    )).handleErrorWith { e =>
-      IO.pure(
-        CaseResult(
-          caseNum = testCase.caseNum,
-          passed = false,
-          usage = TokenUsage.zero,
-          latencyMs = 0,
-          details = CaseDetails.NoDetails,
-          error = Some(s"${e.getClass.getSimpleName}: ${e.getMessage}")
-        )
-      )
-    }
+      result <- runCase(tracer, startTime).handleErrorWith { e =>
+        CaseFailure.withPartialTrace(tracer, testCase.caseNum, startTime, e)
+      }
+    yield result).handleErrorWith(e => CaseFailure.withoutTrace(testCase.caseNum, e))

--- a/xl-agent/src/com/tjclp/xl/agent/benchmark/skills/builtin/XlsxSkill.scala
+++ b/xl-agent/src/com/tjclp/xl/agent/benchmark/skills/builtin/XlsxSkill.scala
@@ -8,7 +8,7 @@ import com.tjclp.xl.agent.approach.XlsxApproachStrategy
 import com.tjclp.xl.agent.benchmark.{Evaluator, RangeResult}
 import com.tjclp.xl.agent.benchmark.execution.*
 import com.tjclp.xl.agent.benchmark.grading.{CellMismatch, Score}
-import com.tjclp.xl.agent.benchmark.skills.{Skill, SkillContext, SkillRegistry}
+import com.tjclp.xl.agent.benchmark.skills.{CaseFailure, Skill, SkillContext, SkillRegistry}
 import com.tjclp.xl.agent.benchmark.task.*
 import com.tjclp.xl.agent.benchmark.tracing.ConversationTracer
 
@@ -93,11 +93,58 @@ object XlsxSkill extends Skill:
       engineConfig.outputDir.resolve("outputs").resolve(task.taskIdValue).resolve(name)
     val outputPath = outputDir.resolve(s"${testCase.caseNum}_output.xlsx")
 
+    // The fallible section: everything after the tracer exists, so a failure anywhere in
+    // here can still save the partial conversation trace (issue #334)
+    def runCase(tracer: ConversationTracer, startTime: Long): IO[CaseResult] =
+      val agentTask = AgentTask(
+        instruction = task.instruction,
+        inputFile = testCase.inputPath,
+        outputFile = outputPath,
+        answerPosition = task.evaluation.answerPosition
+      )
+      for
+        // Run agent with streaming to capture conversation
+        result <- agent.runStreaming(agentTask, tracer.onEvent)
+
+        rangeResults <- result.outputPath match
+          case Some(path) =>
+            val answerPos = task.evaluation.answerPosition.getOrElse("A1")
+            Evaluator.compare(path, testCase.answerPath, answerPos, engineConfig.xlCliPath)
+          case None =>
+            IO.pure(List(RangeResult("N/A", false, Nil)))
+
+        passed = rangeResults.forall(_.passed)
+
+        endTime <- Clock[IO].monotonic.map(_.toMillis)
+        latencyMs = endTime - startTime
+
+        // Complete and save tracer
+        _ <- tracer.complete(result.usage, passed, result.error)
+        tracePath <- tracer.save()
+
+        mismatches = rangeResults.flatMap(_.mismatches).map { m =>
+          CellMismatch(
+            ref = m.ref,
+            expected = m.expected.toString,
+            actual = m.actual.toString
+          )
+        }
+
+        details =
+          if passed then CaseDetails.filePass
+          else CaseDetails.fileFail(mismatches)
+      yield CaseResult(
+        caseNum = testCase.caseNum,
+        passed = passed,
+        usage = TokenUsage.fromAgentUsage(result.usage),
+        latencyMs = latencyMs,
+        details = details,
+        tracePath = Some(tracePath)
+      )
+
     (for
       _ <- IO.blocking(Files.createDirectories(outputDir))
       startTime <- Clock[IO].monotonic.map(_.toMillis)
-
-      // Create tracer for conversation logs
       tracer <- ConversationTracer.create(
         outputDir = engineConfig.outputDir,
         taskId = task.taskIdValue,
@@ -106,63 +153,10 @@ object XlsxSkill extends Skill:
         streaming = engineConfig.stream,
         model = Some(agentConfig.model)
       )
-
-      agentTask = AgentTask(
-        instruction = task.instruction,
-        inputFile = testCase.inputPath,
-        outputFile = outputPath,
-        answerPosition = task.evaluation.answerPosition
-      )
-
-      // Run agent with streaming to capture conversation
-      result <- agent.runStreaming(agentTask, tracer.onEvent)
-
-      rangeResults <- result.outputPath match
-        case Some(path) =>
-          val answerPos = task.evaluation.answerPosition.getOrElse("A1")
-          Evaluator.compare(path, testCase.answerPath, answerPos, engineConfig.xlCliPath)
-        case None =>
-          IO.pure(List(RangeResult("N/A", false, Nil)))
-
-      passed = rangeResults.forall(_.passed)
-
-      endTime <- Clock[IO].monotonic.map(_.toMillis)
-      latencyMs = endTime - startTime
-
-      // Complete and save tracer
-      _ <- tracer.complete(result.usage, passed, result.error)
-      tracePath <- tracer.save()
-
-      mismatches = rangeResults.flatMap(_.mismatches).map { m =>
-        CellMismatch(
-          ref = m.ref,
-          expected = m.expected.toString,
-          actual = m.actual.toString
-        )
+      result <- runCase(tracer, startTime).handleErrorWith { e =>
+        CaseFailure.withPartialTrace(tracer, testCase.caseNum, startTime, e)
       }
-
-      details =
-        if passed then CaseDetails.filePass
-        else CaseDetails.fileFail(mismatches)
-    yield CaseResult(
-      caseNum = testCase.caseNum,
-      passed = passed,
-      usage = TokenUsage.fromAgentUsage(result.usage),
-      latencyMs = latencyMs,
-      details = details,
-      tracePath = Some(tracePath)
-    )).handleErrorWith { e =>
-      IO.pure(
-        CaseResult(
-          caseNum = testCase.caseNum,
-          passed = false,
-          usage = TokenUsage.zero,
-          latencyMs = 0,
-          details = CaseDetails.NoDetails,
-          error = Some(s"${e.getClass.getSimpleName}: ${e.getMessage}")
-        )
-      )
-    }
+    yield result).handleErrorWith(e => CaseFailure.withoutTrace(testCase.caseNum, e))
 
   /** Run a token comparison test case (TokenBenchmark/analysis style) */
   private def runTokenComparisonCase(
@@ -178,11 +172,46 @@ object XlsxSkill extends Skill:
       engineConfig.outputDir.resolve("outputs").resolve(task.taskIdValue).resolve(name)
     val outputPath = outputDir.resolve(s"${testCase.caseNum}_output.xlsx")
 
+    // The fallible section: everything after the tracer exists, so a failure anywhere in
+    // here can still save the partial conversation trace (issue #334)
+    def runCase(tracer: ConversationTracer, startTime: Long): IO[CaseResult] =
+      val agentTask = AgentTask(
+        instruction = task.instruction,
+        inputFile = testCase.inputPath,
+        outputFile = outputPath,
+        answerPosition = task.evaluation.answerPosition
+      )
+      for
+        // Run agent with streaming to capture conversation
+        result <- agent.runStreaming(agentTask, tracer.onEvent)
+
+        endTime <- Clock[IO].monotonic.map(_.toMillis)
+        latencyMs = endTime - startTime
+
+        usage = TokenUsage.fromAgentUsage(result.usage)
+
+        // For analysis tasks, "success" means agent ran without error.
+        // Actual correctness is determined by LLM grading (via CaseDetails.TokenComparison).
+        agentSucceeded = result.error.isEmpty
+
+        // Complete and save tracer
+        _ <- tracer.complete(result.usage, agentSucceeded, result.error)
+        tracePath <- tracer.save()
+      yield CaseResult(
+        caseNum = testCase.caseNum,
+        passed = agentSucceeded, // Agent ran without error; grading determines correctness
+        usage = usage,
+        latencyMs = latencyMs,
+        details = CaseDetails.token(
+          result.responseText.getOrElse(""),
+          task.evaluation.expectedAnswer
+        ),
+        tracePath = Some(tracePath)
+      )
+
     (for
       _ <- IO.blocking(Files.createDirectories(outputDir))
       startTime <- Clock[IO].monotonic.map(_.toMillis)
-
-      // Create tracer for conversation logs
       tracer <- ConversationTracer.create(
         outputDir = engineConfig.outputDir,
         taskId = task.taskIdValue,
@@ -191,48 +220,7 @@ object XlsxSkill extends Skill:
         streaming = engineConfig.stream,
         model = Some(agentConfig.model)
       )
-
-      agentTask = AgentTask(
-        instruction = task.instruction,
-        inputFile = testCase.inputPath,
-        outputFile = outputPath,
-        answerPosition = task.evaluation.answerPosition
-      )
-
-      // Run agent with streaming to capture conversation
-      result <- agent.runStreaming(agentTask, tracer.onEvent)
-
-      endTime <- Clock[IO].monotonic.map(_.toMillis)
-      latencyMs = endTime - startTime
-
-      usage = TokenUsage.fromAgentUsage(result.usage)
-
-      // For analysis tasks, "success" means agent ran without error.
-      // Actual correctness is determined by LLM grading (via CaseDetails.TokenComparison).
-      agentSucceeded = result.error.isEmpty
-
-      // Complete and save tracer
-      _ <- tracer.complete(result.usage, agentSucceeded, result.error)
-      tracePath <- tracer.save()
-    yield CaseResult(
-      caseNum = testCase.caseNum,
-      passed = agentSucceeded, // Agent ran without error; grading determines correctness
-      usage = usage,
-      latencyMs = latencyMs,
-      details = CaseDetails.token(
-        result.responseText.getOrElse(""),
-        task.evaluation.expectedAnswer
-      ),
-      tracePath = Some(tracePath)
-    )).handleErrorWith { e =>
-      IO.pure(
-        CaseResult(
-          caseNum = testCase.caseNum,
-          passed = false,
-          usage = TokenUsage.zero,
-          latencyMs = 0,
-          details = CaseDetails.NoDetails,
-          error = Some(s"${e.getClass.getSimpleName}: ${e.getMessage}")
-        )
-      )
-    }
+      result <- runCase(tracer, startTime).handleErrorWith { e =>
+        CaseFailure.withPartialTrace(tracer, testCase.caseNum, startTime, e)
+      }
+    yield result).handleErrorWith(e => CaseFailure.withoutTrace(testCase.caseNum, e))

--- a/xl-agent/src/com/tjclp/xl/agent/benchmark/tracing/ConversationTracer.scala
+++ b/xl-agent/src/com/tjclp/xl/agent/benchmark/tracing/ConversationTracer.scala
@@ -180,7 +180,7 @@ class ConversationTracer private (
         )
       )
       _ <- IO.whenA(streaming)(
-        StreamingConsole.enqueueCaseComplete(streamContext, passed, durationMs)
+        StreamingConsole.enqueueCaseComplete(streamContext, passed, durationMs, error)
       )
     yield ()
 

--- a/xl-agent/src/com/tjclp/xl/agent/benchmark/tracing/StreamingConsole.scala
+++ b/xl-agent/src/com/tjclp/xl/agent/benchmark/tracing/StreamingConsole.scala
@@ -16,8 +16,12 @@ object StreamingConsole:
   private sealed trait StreamItem
   private object StreamItem:
     case class CaseStart(ctx: StreamContext) extends StreamItem
-    case class CaseComplete(ctx: StreamContext, passed: Boolean, durationMs: Long)
-        extends StreamItem
+    case class CaseComplete(
+      ctx: StreamContext,
+      passed: Boolean,
+      durationMs: Long,
+      error: Option[String]
+    ) extends StreamItem
     case class Event(ctx: StreamContext, traced: TracedEvent) extends StreamItem
     case object Shutdown extends StreamItem
 
@@ -30,6 +34,7 @@ object StreamingConsole:
 
   private val DefaultQueueSize = 2048
   private val DefaultMaxTextChars = 4096
+  private val MaxErrorChars = 200
 
   // ANSI color codes
   private val Reset = "\u001b[0m"
@@ -67,8 +72,13 @@ object StreamingConsole:
   def enqueueCaseStart(ctx: StreamContext): IO[Unit] =
     enqueue(StreamItem.CaseStart(ctx))
 
-  def enqueueCaseComplete(ctx: StreamContext, passed: Boolean, durationMs: Long): IO[Unit] =
-    enqueue(StreamItem.CaseComplete(ctx, passed, durationMs))
+  def enqueueCaseComplete(
+    ctx: StreamContext,
+    passed: Boolean,
+    durationMs: Long,
+    error: Option[String] = None
+  ): IO[Unit] =
+    enqueue(StreamItem.CaseComplete(ctx, passed, durationMs, error))
 
   def enqueueEvent(ctx: StreamContext, traced: TracedEvent): IO[Unit] =
     enqueue(StreamItem.Event(ctx, traced))
@@ -95,9 +105,10 @@ object StreamingConsole:
         case StreamItem.CaseStart(ctx) =>
           pending.fold(IO.unit) { case (pctx, buffer) => flushText(pctx, buffer) } *>
             printCaseHeader(ctx) *> loop(None)
-        case StreamItem.CaseComplete(ctx, passed, durationMs) =>
+        case StreamItem.CaseComplete(ctx, passed, durationMs, error) =>
           pending.fold(IO.unit) { case (pctx, buffer) => flushText(pctx, buffer) } *>
-            printComplete(ctx.skillName, ctx.taskId, ctx.caseNum, passed, durationMs) *> loop(None)
+            printComplete(ctx.skillName, ctx.taskId, ctx.caseNum, passed, durationMs, error) *>
+            loop(None)
         case StreamItem.Event(ctx, traced) =>
           traced.event match
             case AgentEvent.TextOutput(text, _) =>
@@ -216,13 +227,27 @@ object StreamingConsole:
     taskId: String,
     caseNum: Int,
     passed: Boolean,
-    durationMs: Long
+    durationMs: Long,
+    error: Option[String] = None
   ): IO[Unit] =
     IO.blocking {
-      val status = if passed then s"${Green}PASSED" else s"${Red}FAILED"
-      val duration = f"${durationMs / 1000.0}%.1fs"
-      Console.println(s"\n$status$Reset Task $taskId:$caseNum ($duration)")
+      Console.println("\n" + formatCompleteLine(taskId, caseNum, passed, durationMs, error))
     }
+
+  /** Completion line, with the error surfaced on failure so crashes are visible live */
+  private[tracing] def formatCompleteLine(
+    taskId: String,
+    caseNum: Int,
+    passed: Boolean,
+    durationMs: Long,
+    error: Option[String]
+  ): String =
+    val status = if passed then s"${Green}PASSED" else s"${Red}FAILED"
+    val duration = f"${durationMs / 1000.0}%.1fs"
+    val errorSuffix = error.fold("") { e =>
+      s" $Red${e.replace("\n", " ").take(MaxErrorChars)}$Reset"
+    }
+    s"$status$Reset Task $taskId:$caseNum ($duration)$errorSuffix"
 
   private def truncateLines(s: String, maxLines: Int): String =
     val lines = s.split("\n")

--- a/xl-agent/test/src/com/tjclp/xl/agent/benchmark/reporting/ReportWriterSpec.scala
+++ b/xl-agent/test/src/com/tjclp/xl/agent/benchmark/reporting/ReportWriterSpec.scala
@@ -1,6 +1,7 @@
 package com.tjclp.xl.agent.benchmark.reporting
 
 import munit.FunSuite
+import com.tjclp.xl.agent.benchmark.grading.{GradeDetails, Score}
 
 class ReportWriterSpec extends FunSuite:
 
@@ -70,6 +71,34 @@ class ReportWriterSpec extends FunSuite:
 
   test("escapeMarkdown handles combined escaping") {
     assertEquals(escapeMarkdown("a|b\nc"), "a\\|b c")
+  }
+
+  // --------------------------------------------------------------------------
+  // Error surfacing (issue #334)
+  // --------------------------------------------------------------------------
+
+  test("formatMarkdown surfaces the per-entry error in Failed Tasks Details") {
+    val error = "RuntimeException: agent connection dropped mid-run"
+    val entry = TaskResultEntry(
+      taskId = "13894",
+      skill = "xl",
+      caseNum = Some(3),
+      instruction = "Fill the summary table",
+      category = "cell_level",
+      score = Score.BinaryScore.Fail,
+      gradeDetails = GradeDetails.fail("Case failed"),
+      usage = TokenSummary.zero,
+      latencyMs = 570_000L,
+      error = Some(error)
+    )
+    val report = ReportBuilder()
+      .withTitle("Test Report")
+      .withSkills(List("xl"))
+      .addResult(entry)
+      .build()
+
+    val md = ReportWriter.formatMarkdown(report)
+    assert(md.contains(error), s"markdown must contain the entry error:\n$md")
   }
 
   // --------------------------------------------------------------------------

--- a/xl-agent/test/src/com/tjclp/xl/agent/benchmark/reporting/UnifiedReportWriterSpec.scala
+++ b/xl-agent/test/src/com/tjclp/xl/agent/benchmark/reporting/UnifiedReportWriterSpec.scala
@@ -1,0 +1,139 @@
+package com.tjclp.xl.agent.benchmark.reporting
+
+import munit.CatsEffectSuite
+import com.tjclp.xl.agent.benchmark.execution.{
+  BenchmarkRun,
+  CaseDetails,
+  CaseResult,
+  EngineConfig,
+  ExecutionResult,
+  SkillRunResult,
+  TokenUsage
+}
+import com.tjclp.xl.agent.benchmark.execution.SkillSummary as ExecSkillSummary
+import com.tjclp.xl.agent.benchmark.task.*
+import io.circe.Json
+
+import java.nio.file.{Files, Path}
+import java.time.Instant
+
+/**
+ * Pins per-case error diagnostics in report output (issue #334): a case that dies mid-run must
+ * leave its error string in summary.json, the per-skill summary.json, and summary.md.
+ */
+class UnifiedReportWriterSpec extends CatsEffectSuite:
+
+  private val tempDir = FunFixture[Path](
+    setup = _ => Files.createTempDirectory("unified-report-spec"),
+    teardown = { dir =>
+      import scala.jdk.CollectionConverters.*
+      import scala.util.Using
+      Using.resource(Files.walk(dir)) { stream =>
+        stream.iterator().asScala.toList.reverse.foreach(p => Files.deleteIfExists(p))
+      }
+    }
+  )
+
+  // Distinctive error longer than the 40-char reasoning truncation: the tail must survive
+  // into the markdown so a failed 9-minute case is diagnosable from the report alone.
+  private val caseError =
+    "IllegalStateException: connection reset during sub-turn 20 (partial trace saved)"
+
+  private val savedTracePath = Path.of("results", "tasks", "13894", "xl", "case3")
+
+  private def sampleRun: BenchmarkRun =
+    val okCase = CaseResult.passed(1, TokenUsage(100, 50), latencyMs = 1000)
+    val failedCase = CaseResult(
+      caseNum = 3,
+      passed = false,
+      usage = TokenUsage.zero,
+      latencyMs = 570_000L,
+      details = CaseDetails.NoDetails,
+      tracePath = Some(savedTracePath),
+      error = Some(caseError)
+    )
+    val result = ExecutionResult.fromCases(
+      taskId = TaskId("13894"),
+      skill = "xl",
+      caseResults = Vector(okCase, failedCase),
+      usage = TokenUsage(100, 50),
+      latencyMs = 571_000L
+    )
+    val task = BenchmarkTask(
+      id = TaskId("13894"),
+      instruction = "Fill the summary table",
+      category = TaskCategory.CellLevel,
+      inputSource = InputSource.NoInput,
+      evaluation = EvaluationSpec.fileOnly
+    )
+    val start = Instant.parse("2026-07-08T00:00:00Z")
+    BenchmarkRun(
+      startTime = start,
+      endTime = start.plusSeconds(600),
+      config = EngineConfig.default,
+      skillResults = Map(
+        "xl" -> SkillRunResult(
+          skill = "xl",
+          displayName = "xl-cli",
+          results = Vector(result),
+          summary = ExecSkillSummary.fromResults(Vector(result))
+        )
+      ),
+      tasks = List(task)
+    )
+
+  private def parseJson(path: Path): Json =
+    io.circe.parser
+      .parse(Files.readString(path))
+      .getOrElse(fail(s"unparseable JSON at $path"))
+
+  private def caseEntries(resultJson: Json): Vector[Json] =
+    resultJson.hcursor
+      .downField("caseResults")
+      .focus
+      .flatMap(_.asArray)
+      .getOrElse(fail(s"no caseResults array in $resultJson"))
+
+  private def firstResult(json: Json): Json =
+    json.hcursor
+      .downField("results")
+      .focus
+      .flatMap(_.asArray)
+      .flatMap(_.headOption)
+      .getOrElse(fail(s"no results array in $json"))
+
+  private def entryFor(entries: Vector[Json], caseNum: Int): Json =
+    entries
+      .find(_.hcursor.get[Int]("caseNum").contains(caseNum))
+      .getOrElse(fail(s"no caseResults entry for case $caseNum"))
+
+  tempDir.test("summary.json caseResults entries carry error and tracePath") { dir =>
+    UnifiedReportWriter.write(sampleRun, dir).map { _ =>
+      val json = parseJson(dir.resolve("summary.json"))
+      val entries = caseEntries(firstResult(json))
+
+      val failed = entryFor(entries, 3)
+      assertEquals(failed.hcursor.get[String]("error"), Right(caseError))
+      assertEquals(failed.hcursor.get[String]("tracePath"), Right(savedTracePath.toString))
+      assertEquals(failed.hcursor.get[Long]("latencyMs"), Right(570_000L))
+
+      val ok = entryFor(entries, 1)
+      assert(ok.hcursor.downField("error").focus.exists(_.isNull), s"expected null error: $ok")
+    }
+  }
+
+  tempDir.test("per-skill summary.json caseResults entries carry error") { dir =>
+    UnifiedReportWriter.write(sampleRun, dir).map { _ =>
+      val json = parseJson(dir.resolve("xl").resolve("summary.json"))
+      val entries = caseEntries(firstResult(json))
+      val failed = entryFor(entries, 3)
+      assertEquals(failed.hcursor.get[String]("error"), Right(caseError))
+    }
+  }
+
+  tempDir.test("summary.md records the full per-case error") { dir =>
+    UnifiedReportWriter.write(sampleRun, dir).map { _ =>
+      val md = Files.readString(dir.resolve("summary.md"))
+      assert(md.contains(caseError), s"markdown must contain the case error:\n$md")
+    }
+  }

--- a/xl-agent/test/src/com/tjclp/xl/agent/benchmark/runner/UnifiedRunnerSpec.scala
+++ b/xl-agent/test/src/com/tjclp/xl/agent/benchmark/runner/UnifiedRunnerSpec.scala
@@ -90,7 +90,12 @@ class UnifiedRunnerSpec extends CatsEffectSuite:
       endTime = start.plusSeconds(600),
       config = EngineConfig.default,
       skillResults = Map(
-        "xl" -> SkillRunResult("xl", "xl-cli", Vector(result), ExecSkillSummary.fromResults(Vector(result)))
+        "xl" -> SkillRunResult(
+          "xl",
+          "xl-cli",
+          Vector(result),
+          ExecSkillSummary.fromResults(Vector(result))
+        )
       ),
       tasks = List(task)
     )

--- a/xl-agent/test/src/com/tjclp/xl/agent/benchmark/runner/UnifiedRunnerSpec.scala
+++ b/xl-agent/test/src/com/tjclp/xl/agent/benchmark/runner/UnifiedRunnerSpec.scala
@@ -1,0 +1,104 @@
+package com.tjclp.xl.agent.benchmark.runner
+
+import munit.CatsEffectSuite
+import com.tjclp.xl.agent.benchmark.execution.{
+  BenchmarkRun,
+  CaseDetails,
+  CaseResult,
+  EngineConfig,
+  ExecutionResult,
+  SkillRunResult,
+  TokenUsage
+}
+import com.tjclp.xl.agent.benchmark.execution.SkillSummary as ExecSkillSummary
+import com.tjclp.xl.agent.benchmark.task.*
+
+import java.time.Instant
+
+/** Pins error surfacing in the streaming console line and legacy report entries (issue #334) */
+class UnifiedRunnerSpec extends CatsEffectSuite:
+
+  private val caseError = "RuntimeException: boom mid-run"
+
+  private def failedCase(caseNum: Int): CaseResult =
+    CaseResult(
+      caseNum = caseNum,
+      passed = false,
+      usage = TokenUsage.zero,
+      latencyMs = 570_000L,
+      details = CaseDetails.NoDetails,
+      tracePath = None,
+      error = Some(caseError)
+    )
+
+  test("streaming console line surfaces the first per-case error") {
+    val result = ExecutionResult.fromCases(
+      TaskId("13894"),
+      "xl",
+      Vector(CaseResult.passed(1, TokenUsage.zero, 1000), failedCase(3)),
+      TokenUsage.zero,
+      571_000L
+    )
+    val line = UnifiedRunner.formatExecutionResult(result)
+    assert(line.contains(caseError), line)
+  }
+
+  test("streaming console line surfaces a task-level error") {
+    val result = ExecutionResult.failed(TaskId("2768"), "xl", "Skill setup exploded")
+    val line = UnifiedRunner.formatExecutionResult(result)
+    assert(line.contains("Skill setup exploded"), line)
+  }
+
+  test("streaming console line omits the error suffix when there is none") {
+    val result = ExecutionResult.fromCases(
+      TaskId("2768"),
+      "xl",
+      Vector(CaseResult.passed(1, TokenUsage.zero, 1000)),
+      TokenUsage.zero,
+      1000L
+    )
+    val line = UnifiedRunner.formatExecutionResult(result)
+    assert(!line.contains("error="), line)
+  }
+
+  test("streaming console line keeps errors single-line and bounded") {
+    val messy = "X" * 500 + "\nsecond line"
+    val result = ExecutionResult.failed(TaskId("2768"), "xl", messy)
+    val line = UnifiedRunner.formatExecutionResult(result)
+    assert(!line.contains("\n"), "console line must stay a single line")
+    assert(!line.contains("X" * 201), "long errors must be truncated")
+  }
+
+  test("legacy report entries carry the per-case error") {
+    val result = ExecutionResult.fromCases(
+      TaskId("13894"),
+      "xl",
+      Vector(failedCase(3)),
+      TokenUsage.zero,
+      570_000L
+    )
+    val task = BenchmarkTask(
+      id = TaskId("13894"),
+      instruction = "Fill the summary table",
+      category = TaskCategory.CellLevel,
+      inputSource = InputSource.NoInput,
+      evaluation = EvaluationSpec.fileOnly
+    )
+    val start = Instant.parse("2026-07-08T00:00:00Z")
+    val run = BenchmarkRun(
+      startTime = start,
+      endTime = start.plusSeconds(600),
+      config = EngineConfig.default,
+      skillResults = Map(
+        "xl" -> SkillRunResult("xl", "xl-cli", Vector(result), ExecSkillSummary.fromResults(Vector(result)))
+      ),
+      tasks = List(task)
+    )
+
+    UnifiedRunner.buildReportFromRun(UnifiedConfig(), run).map { report =>
+      val entry = report.taskResults
+        .find(e => e.taskId == "13894" && e.caseNum.contains(3))
+        .getOrElse(fail("missing entry for case 3"))
+      assertEquals(entry.error, Some(caseError))
+    }
+  }

--- a/xl-agent/test/src/com/tjclp/xl/agent/benchmark/skills/CaseFailureSpec.scala
+++ b/xl-agent/test/src/com/tjclp/xl/agent/benchmark/skills/CaseFailureSpec.scala
@@ -1,0 +1,108 @@
+package com.tjclp.xl.agent.benchmark.skills
+
+import cats.effect.{Clock, IO}
+import munit.CatsEffectSuite
+import com.tjclp.xl.agent.AgentEvent
+import com.tjclp.xl.agent.benchmark.tracing.ConversationTracer
+
+import java.nio.file.{Files, Path}
+
+/**
+ * Pins the trace-on-failure path (issue #334): when a case dies mid-run, the conversation trace
+ * collected up to the failure must land on disk with passed=false and the error recorded, and the
+ * handler must be total (never raise, even when saving the trace itself fails).
+ */
+class CaseFailureSpec extends CatsEffectSuite:
+
+  private val tempDir = FunFixture[Path](
+    setup = _ => Files.createTempDirectory("case-failure-spec"),
+    teardown = { dir =>
+      import scala.jdk.CollectionConverters.*
+      import scala.util.Using
+      Using.resource(Files.walk(dir)) { stream =>
+        stream.iterator().asScala.toList.reverse.foreach(p => Files.deleteIfExists(p))
+      }
+    }
+  )
+
+  tempDir.test("withPartialTrace saves the partial trace with passed=false and the error") { dir =>
+    for
+      tracer <- ConversationTracer.create(
+        outputDir = dir,
+        taskId = "13894",
+        skillName = "xl",
+        caseNum = 3,
+        streaming = false,
+        model = Some("claude-test")
+      )
+      _ <- tracer.onEvent(AgentEvent.TextOutput("partial progress before the crash"))
+      start <- Clock[IO].monotonic.map(_.toMillis)
+      result <- CaseFailure.withPartialTrace(
+        tracer,
+        caseNum = 3,
+        startTimeMs = start - 1234,
+        error = new RuntimeException("boom mid-run")
+      )
+      traceJson <- IO.blocking {
+        val traceDir = result.tracePath.getOrElse(fail("expected a saved trace path"))
+        Files.readString(traceDir.resolve("conversation.json"))
+      }
+    yield
+      assertEquals(result.caseNum, 3)
+      assertEquals(result.passed, false)
+      assertEquals(result.error, Some("RuntimeException: boom mid-run"))
+      assert(result.latencyMs >= 1234, s"latency should cover the run so far: ${result.latencyMs}")
+
+      val parsed = io.circe.parser.parse(traceJson).getOrElse(fail("unparseable trace JSON"))
+      val meta = parsed.hcursor.downField("metadata")
+      assertEquals(meta.get[Boolean]("passed"), Right(false))
+      assertEquals(meta.get[String]("error"), Right("RuntimeException: boom mid-run"))
+      assert(
+        traceJson.contains("partial progress before the crash"),
+        "events collected before the failure must survive in the trace"
+      )
+  }
+
+  tempDir.test("withPartialTrace is total when the trace cannot be saved") { dir =>
+    val blocker = dir.resolve("blocker")
+    for
+      // A regular file where save() needs a directory makes the save fail deterministically
+      _ <- IO.blocking(Files.createFile(blocker))
+      tracer <- ConversationTracer.create(
+        outputDir = blocker,
+        taskId = "13894",
+        skillName = "xl",
+        caseNum = 1
+      )
+      start <- Clock[IO].monotonic.map(_.toMillis)
+      result <- CaseFailure.withPartialTrace(
+        tracer,
+        caseNum = 1,
+        startTimeMs = start,
+        error = new IllegalStateException("kaput")
+      )
+    yield
+      assertEquals(result.passed, false)
+      assertEquals(result.error, Some("IllegalStateException: kaput"))
+      assertEquals(result.tracePath, None)
+  }
+
+  test("withoutTrace records the error when no tracer exists") {
+    CaseFailure.withoutTrace(2, new IllegalArgumentException("no tracer yet")).map { result =>
+      assertEquals(result.caseNum, 2)
+      assertEquals(result.passed, false)
+      assertEquals(result.error, Some("IllegalArgumentException: no tracer yet"))
+      assertEquals(result.tracePath, None)
+    }
+  }
+
+  test("describe is total for exceptions without a message") {
+    assertEquals(CaseFailure.describe(new RuntimeException()), "RuntimeException: (no message)")
+  }
+
+  test("describe includes exception class and message") {
+    assertEquals(
+      CaseFailure.describe(new IllegalStateException("oops")),
+      "IllegalStateException: oops"
+    )
+  }

--- a/xl-agent/test/src/com/tjclp/xl/agent/benchmark/skills/builtin/SkillFailurePathSpec.scala
+++ b/xl-agent/test/src/com/tjclp/xl/agent/benchmark/skills/builtin/SkillFailurePathSpec.scala
@@ -14,8 +14,8 @@ import java.nio.file.{Files, Path}
  * must return a total CaseResult carrying the error AND leave the partial conversation trace on
  * disk.
  *
- * Runs fully offline: the dummy-key client never reaches the network because the missing input
- * file makes the upload raise first.
+ * Runs fully offline: the dummy-key client never reaches the network because the missing input file
+ * makes the upload raise first.
  */
 class SkillFailurePathSpec extends CatsEffectSuite:
 

--- a/xl-agent/test/src/com/tjclp/xl/agent/benchmark/skills/builtin/SkillFailurePathSpec.scala
+++ b/xl-agent/test/src/com/tjclp/xl/agent/benchmark/skills/builtin/SkillFailurePathSpec.scala
@@ -1,0 +1,71 @@
+package com.tjclp.xl.agent.benchmark.skills.builtin
+
+import munit.CatsEffectSuite
+import com.tjclp.xl.agent.AgentConfig
+import com.tjclp.xl.agent.anthropic.AnthropicClientIO
+import com.tjclp.xl.agent.benchmark.execution.EngineConfig
+import com.tjclp.xl.agent.benchmark.skills.SkillContext
+import com.tjclp.xl.agent.benchmark.task.*
+
+import java.nio.file.{Files, Path}
+
+/**
+ * End-to-end wiring check for the case failure path (issue #334): a real executeCase that raises
+ * must return a total CaseResult carrying the error AND leave the partial conversation trace on
+ * disk.
+ *
+ * Runs fully offline: the dummy-key client never reaches the network because the missing input
+ * file makes the upload raise first.
+ */
+class SkillFailurePathSpec extends CatsEffectSuite:
+
+  private val tempDir = FunFixture[Path](
+    setup = _ => Files.createTempDirectory("skill-failure-path-spec"),
+    teardown = { dir =>
+      import scala.jdk.CollectionConverters.*
+      import scala.util.Using
+      Using.resource(Files.walk(dir)) { stream =>
+        stream.iterator().asScala.toList.reverse.foreach(p => Files.deleteIfExists(p))
+      }
+    }
+  )
+
+  tempDir.test("a failing executeCase records the error and saves the partial trace") { dir =>
+    val missingInput = dir.resolve("does-not-exist.xlsx")
+    val testCase = TestCaseFile(3, missingInput, dir.resolve("answer.xlsx"))
+    val task = BenchmarkTask(
+      id = TaskId("13894"),
+      instruction = "test instruction",
+      category = TaskCategory.CellLevel,
+      inputSource = InputSource.TestCases(Vector(testCase)),
+      evaluation = EvaluationSpec.fileOnly
+    )
+    AnthropicClientIO.resource("dummy-key-never-used").use { client =>
+      XlsxSkill
+        .executeCase(
+          testCase,
+          task,
+          SkillContext.empty,
+          client,
+          AgentConfig(model = "claude-test"),
+          EngineConfig.default.copy(outputDir = dir, stream = false)
+        )
+        .map { result =>
+          assertEquals(result.caseNum, 3)
+          assertEquals(result.passed, false)
+          assert(
+            result.error.exists(_.contains("FileUploadFailed")),
+            s"error must be recorded: ${result.error}"
+          )
+          val traceDir = result.tracePath.getOrElse(fail("partial trace was not saved"))
+          val traceJson = Files.readString(traceDir.resolve("conversation.json"))
+          val parsed = io.circe.parser.parse(traceJson).getOrElse(fail("unparseable trace JSON"))
+          val meta = parsed.hcursor.downField("metadata")
+          assertEquals(meta.get[Boolean]("passed"), Right(false))
+          assert(
+            meta.get[String]("error").exists(_.contains("FileUploadFailed")),
+            s"trace metadata must carry the error: $traceJson"
+          )
+        }
+    }
+  }

--- a/xl-agent/test/src/com/tjclp/xl/agent/benchmark/tracing/StreamingConsoleSpec.scala
+++ b/xl-agent/test/src/com/tjclp/xl/agent/benchmark/tracing/StreamingConsoleSpec.scala
@@ -1,0 +1,32 @@
+package com.tjclp.xl.agent.benchmark.tracing
+
+import munit.FunSuite
+
+/** Pins the live console completion line, including error surfacing on failure (issue #334) */
+class StreamingConsoleSpec extends FunSuite:
+
+  test("completion line shows PASSED without an error suffix") {
+    val line = StreamingConsole.formatCompleteLine("13894", 3, passed = true, 9_500L, None)
+    assert(line.contains("PASSED"), line)
+    assert(line.contains("13894:3"), line)
+    assert(line.contains("9.5s"), line)
+  }
+
+  test("completion line shows FAILED with the error message") {
+    val line = StreamingConsole.formatCompleteLine(
+      "13894",
+      3,
+      passed = false,
+      570_000L,
+      Some("RuntimeException: boom mid-run")
+    )
+    assert(line.contains("FAILED"), line)
+    assert(line.contains("RuntimeException: boom mid-run"), line)
+  }
+
+  test("completion line keeps errors single-line and bounded") {
+    val messy = "Y" * 500 + "\nsecond line"
+    val line = StreamingConsole.formatCompleteLine("t", 1, passed = false, 100L, Some(messy))
+    assert(!line.contains("\n"), "completion line must stay a single line")
+    assert(!line.contains("Y" * 201), "long errors must be truncated")
+  }

--- a/xl-evaluator/src/com/tjclp/xl/formula/ast/TExpr.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/ast/TExpr.scala
@@ -193,24 +193,28 @@ enum TExpr[A] derives CanEqual:
   case Neq[A](x: TExpr[A], y: TExpr[A]) extends TExpr[Boolean]
 
   /**
-   * Less than: x < y (numeric comparison)
+   * Less than: x < y.
+   *
+   * GH-335: polymorphic like Eq — Excel's ordered comparison ranks number < text < logical,
+   * compares text case-insensitively/lexicographically, and coerces empty cells to the other
+   * operand's zero value (0 / "" / FALSE). See ArrayArithmetic.compareCellValues.
    */
-  case Lt(x: TExpr[BigDecimal], y: TExpr[BigDecimal]) extends TExpr[Boolean]
+  case Lt[A](x: TExpr[A], y: TExpr[A]) extends TExpr[Boolean]
 
   /**
-   * Less than or equal: x <= y
+   * Less than or equal: x <= y (Excel ordering — see Lt)
    */
-  case Lte(x: TExpr[BigDecimal], y: TExpr[BigDecimal]) extends TExpr[Boolean]
+  case Lte[A](x: TExpr[A], y: TExpr[A]) extends TExpr[Boolean]
 
   /**
-   * Greater than: x > y
+   * Greater than: x > y (Excel ordering — see Lt)
    */
-  case Gt(x: TExpr[BigDecimal], y: TExpr[BigDecimal]) extends TExpr[Boolean]
+  case Gt[A](x: TExpr[A], y: TExpr[A]) extends TExpr[Boolean]
 
   /**
-   * Greater than or equal: x >= y
+   * Greater than or equal: x >= y (Excel ordering — see Lt)
    */
-  case Gte(x: TExpr[BigDecimal], y: TExpr[BigDecimal]) extends TExpr[Boolean]
+  case Gte[A](x: TExpr[A], y: TExpr[A]) extends TExpr[Boolean]
 
   // Type conversions
 

--- a/xl-evaluator/src/com/tjclp/xl/formula/ast/TExprCoercions.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/ast/TExprCoercions.scala
@@ -22,8 +22,8 @@ trait TExprCoercions:
     case _: TExpr.Call[?] | _: TExpr.Let[?] | _: TExpr.Aggregate | _: TExpr.Coerced[?] => true
     case _: TExpr.Add | _: TExpr.Sub | _: TExpr.Mul | _: TExpr.Div | _: TExpr.Pow => true
     case _: TExpr.Concat => true
-    case _: TExpr.Eq[?] | _: TExpr.Neq[?] | _: TExpr.Lt | _: TExpr.Lte | _: TExpr.Gt |
-        _: TExpr.Gte =>
+    case _: TExpr.Eq[?] | _: TExpr.Neq[?] | _: TExpr.Lt[?] | _: TExpr.Lte[?] | _: TExpr.Gt[?] |
+        _: TExpr.Gte[?] =>
       true
     case _: TExpr.ToInt | _: TExpr.DateToSerial | _: TExpr.DateTimeToSerial => true
     case _ => false
@@ -177,10 +177,11 @@ trait TExprCoercions:
     // truthiness; text is a clean error); boolean literals keep their shape
     case TExpr.Lit(_: BigDecimal) | TExpr.Lit(_: String) =>
       coerced[Boolean](expr, BindingCoercion.Bool)
-    // Comparisons are the statically boolean-typed operators — keep their shape
-    case _: TExpr.Eq[?] | _: TExpr.Neq[?] | _: TExpr.Lt | _: TExpr.Lte | _: TExpr.Gt |
-        _: TExpr.Gte =>
-      expr.asInstanceOf[TExpr[Boolean]]
+    // GH-333: comparisons are statically Boolean but runtime-polymorphic — over a range operand
+    // in array mode they yield an ArrayResult of booleans. Coerce at evaluation time so scalar
+    // boolean positions (IFS/AND/OR/NOT conditions) collapse-and-coerce totally instead of
+    // deferring a ClassCastException; array/operand positions still pass the array through.
+    // (No dedicated case: isRuntimePolymorphic already includes the comparison operators.)
     // GH-306: numeric call results use Excel truthiness (=IF(SUM(A1:A2), 1, 2), 0 = FALSE);
     // uncoercible results (text) are a clean error instead of a ClassCastException
     case other if isRuntimePolymorphic(other) => coerced[Boolean](other, BindingCoercion.Bool)
@@ -210,5 +211,19 @@ trait TExprCoercions:
   def asResolvedValueExpr(expr: TExpr[?]): TExpr[CellValue] = expr match
     case PolyRef(at, anchor) => Ref(at, anchor, decodeResolvedValue)
     case SheetPolyRef(sheet, at, anchor) => SheetRef(sheet, at, anchor, decodeResolvedValue)
+    case other =>
+      other.asInstanceOf[TExpr[CellValue]] // Safe: non-PolyRef already has correct type
+
+  /**
+   * Convert any TExpr to a comparison operand (GH-335).
+   *
+   * Like asResolvedValueExpr but cell references PRESERVE emptiness (decodeComparableValue) so
+   * ArrayArithmetic.compareCellValues can coerce an empty cell relative to the other operand (0 vs
+   * numbers, "" vs text, FALSE vs booleans) — the Excel comparison semantics for = <> < <= > >=.
+   */
+  @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+  def asComparableValueExpr(expr: TExpr[?]): TExpr[CellValue] = expr match
+    case PolyRef(at, anchor) => Ref(at, anchor, decodeComparableValue)
+    case SheetPolyRef(sheet, at, anchor) => SheetRef(sheet, at, anchor, decodeComparableValue)
     case other =>
       other.asInstanceOf[TExpr[CellValue]] // Safe: non-PolyRef already has correct type

--- a/xl-evaluator/src/com/tjclp/xl/formula/ast/TExprDecoders.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/ast/TExprDecoders.scala
@@ -94,6 +94,22 @@ trait TExprDecoders:
     scala.util.Right(cell.value)
 
   /**
+   * Decode cell for comparison operands (GH-335): extracts cached formula values but PRESERVES
+   * emptiness, unlike decodeResolvedValue's Empty -> 0.
+   *
+   * Excel coerces an empty cell relative to the OTHER comparison operand (0 against numbers, ""
+   * against text, FALSE against booleans) — that coercion lives in
+   * ArrayArithmetic.compareCellValues and needs to see the Empty. An uncached formula value keeps
+   * the decodeResolvedValue zero convention.
+   */
+  def decodeComparableValue(cell: Cell): Either[CodecError, CellValue] =
+    val resolved = cell.value match
+      case CellValue.Formula(_, Some(cached)) => cached
+      case CellValue.Formula(_, None) => CellValue.Number(BigDecimal(0))
+      case other => other
+    scala.util.Right(resolved)
+
+  /**
    * Decode cell as resolved CellValue (extracts cached values, converts empty to 0).
    *
    * Used for standalone cell references (e.g., =A1, =Sheet1!B2) where the formula returns the

--- a/xl-evaluator/src/com/tjclp/xl/formula/eval/ArrayArithmetic.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/eval/ArrayArithmetic.scala
@@ -131,78 +131,95 @@ object ArrayArithmetic:
       case (ArrayOperand.Array(l), ArrayOperand.Array(r)) =>
         broadcastArrays(l, r, op).map(ArrayOperand.Array(_))
 
-  /** Comparison operation type (returns Boolean, not Either) */
-  type CompareOp = (BigDecimal, BigDecimal) => Boolean
+  /**
+   * GH-335: Excel's total order for the comparison operators, shared by the scalar and
+   * array/broadcast paths so `A1<B1` and `(A1:A10<B1)` agree elementwise.
+   *
+   * Within a type: numbers compare numerically (dates ARE numbers via their Excel serial), text
+   * case-insensitively and lexicographically, booleans FALSE < TRUE. Across types Excel ranks
+   * number < text < logical — text never parses as a number under comparison (unlike arithmetic).
+   * Empty cells coerce to the other operand's zero value (0 against numbers, "" against text, FALSE
+   * against booleans; two empties are equal). Error values refuse to compare with a clean Left
+   * naming the Excel error code.
+   *
+   * @return
+   *   the comparison sign (negative, zero, positive), or Left for incomparable values
+   */
+  def compareCellValues(a: CellValue, b: CellValue): Either[EvalError, Int] =
+    (normalizeForCompare(a), normalizeForCompare(b)) match
+      case (CellValue.Error(err), _) =>
+        Left(EvalError.EvalFailed(s"comparison: cannot compare ${err.toExcel} error value", None))
+      case (_, CellValue.Error(err)) =>
+        Left(EvalError.EvalFailed(s"comparison: cannot compare ${err.toExcel} error value", None))
+      case (CellValue.Number(x), CellValue.Number(y)) => Right(x.compare(y))
+      case (CellValue.Text(x), CellValue.Text(y)) => Right(x.compareToIgnoreCase(y))
+      case (CellValue.Bool(x), CellValue.Bool(y)) => Right(java.lang.Boolean.compare(x, y))
+      case (CellValue.Empty, CellValue.Empty) => Right(0)
+      // Empty coerces to the other operand's zero value
+      case (CellValue.Empty, CellValue.Number(y)) => Right(BigDecimal(0).compare(y))
+      case (CellValue.Number(x), CellValue.Empty) => Right(x.compare(BigDecimal(0)))
+      case (CellValue.Empty, CellValue.Text(y)) => Right("".compareToIgnoreCase(y))
+      case (CellValue.Text(x), CellValue.Empty) => Right(x.compareToIgnoreCase(""))
+      case (CellValue.Empty, CellValue.Bool(y)) => Right(java.lang.Boolean.compare(false, y))
+      case (CellValue.Bool(x), CellValue.Empty) => Right(java.lang.Boolean.compare(x, false))
+      // Cross-type: number < text < logical
+      case (x, y) =>
+        for
+          rx <- typeRank(x)
+          ry <- typeRank(y)
+        yield Integer.compare(rx, ry)
+
+  /** Excel's cross-type comparison rank: number < text < logical. */
+  private def typeRank(cv: CellValue): Either[EvalError, Int] = cv match
+    case CellValue.Number(_) => Right(0)
+    case CellValue.Text(_) => Right(1)
+    case CellValue.Bool(_) => Right(2)
+    case other => Left(EvalError.TypeMismatch("comparison", "comparable value", other.toString))
 
   /**
-   * GH-197: Perform broadcasting comparison operation.
+   * Normalize a CellValue for comparison: cached formula values extract, dates become their Excel
+   * serial number, rich text flattens to its plain text.
+   */
+  private def normalizeForCompare(cv: CellValue): CellValue = cv match
+    case CellValue.Formula(_, Some(cached)) => normalizeForCompare(cached)
+    case CellValue.DateTime(dt) =>
+      CellValue.Number(BigDecimal(CellValue.dateTimeToExcelSerial(dt)))
+    case CellValue.RichText(rt) => CellValue.Text(rt.toPlainText)
+    case other => other
+
+  /**
+   * GH-335: broadcast an ordered comparison over two arrays elementwise (scalar operands wrap as
+   * 1x1 arrays and broadcast like any other dimension-1 axis).
    *
-   * Like `broadcast`, but for comparison operators (>, <, =, etc.). Returns ArrayResult of
-   * booleans.
-   *
-   * @param left
-   *   Left operand (scalar or array)
-   * @param right
-   *   Right operand (scalar or array)
    * @param op
-   *   Comparison operation to apply element-wise
+   *   interprets the comparison sign from [[compareCellValues]] (e.g. `_ < 0` for Lt)
    * @return
    *   ArrayResult of CellValue.Bool values
    */
-  def broadcastCompare(
-    left: ArrayOperand,
-    right: ArrayOperand,
-    op: CompareOp
-  ): Either[EvalError, ArrayResult] =
-    (left, right) match
-      // scalar vs scalar -> 1x1 boolean array
-      case (ArrayOperand.Scalar(l), ArrayOperand.Scalar(r)) =>
-        Right(ArrayResult.single(CellValue.Bool(op(l, r))))
-
-      // scalar vs array -> broadcast scalar to all elements
-      case (ArrayOperand.Scalar(s), ArrayOperand.Array(arr)) =>
-        arrayToNumeric(arr).map { nums =>
-          ArrayResult(nums.map(_.map(v => CellValue.Bool(op(s, v)))))
-        }
-
-      // array vs scalar -> broadcast scalar to all elements
-      case (ArrayOperand.Array(arr), ArrayOperand.Scalar(s)) =>
-        arrayToNumeric(arr).map { nums =>
-          ArrayResult(nums.map(_.map(v => CellValue.Bool(op(v, s)))))
-        }
-
-      // array vs array -> broadcast with dimension matching
-      case (ArrayOperand.Array(l), ArrayOperand.Array(r)) =>
-        broadcastCompareArrays(l, r, op)
-
-  /**
-   * GH-197: Broadcast compare two arrays together.
-   */
-  private def broadcastCompareArrays(
+  def broadcastOrderedCompare(
     left: ArrayResult,
     right: ArrayResult,
-    op: CompareOp
+    op: Int => Boolean
   ): Either[EvalError, ArrayResult] =
     for
       outRows <- broadcastDim(left.rows, right.rows, "rows")
       outCols <- broadcastDim(left.cols, right.cols, "columns")
-      leftNums <- arrayToNumeric(left)
-      rightNums <- arrayToNumeric(right)
-    yield
-      val result = (0 until outRows).toVector.map { row =>
-        (0 until outCols).toVector.map { col =>
-          val lVal = getWithBroadcast(leftNums, row, col, left.rows, left.cols)
-          val rVal = getWithBroadcast(rightNums, row, col, right.rows, right.cols)
-          CellValue.Bool(op(lVal, rVal))
+      result <- traverseVV(
+        (0 until outRows).toVector.map { row =>
+          (0 until outCols).toVector.map { col =>
+            val lVal = getWithBroadcastCV(left.values, row, col, left.rows, left.cols)
+            val rVal = getWithBroadcastCV(right.values, row, col, right.rows, right.cols)
+            (lVal, rVal)
+          }
         }
-      }
-      ArrayResult(result)
+      ) { case (l, r) => compareCellValues(l, r).map(c => CellValue.Bool(op(c))) }
+    yield ArrayResult(result)
 
   /**
    * GH-197: Element-wise equality/inequality comparison with broadcasting.
    *
-   * Unlike `broadcastCompare`, this works on CellValue directly for polymorphic equality (strings,
-   * numbers, booleans). Used by Eq/Neq operators.
+   * Works on CellValue directly for polymorphic equality (strings, numbers, booleans). Used by
+   * Eq/Neq operators.
    */
   def broadcastEqualityCompare(
     left: ArrayResult,
@@ -245,6 +262,53 @@ object ArrayArithmetic:
     val c = if arrCols == 1 then 0 else col
     arr(r)(c)
 
+  /**
+   * GH-333: elementwise IF over an array condition (Excel CSE semantics).
+   *
+   * The condition broadcasts against both branch arrays (scalar branches arrive as 1x1 arrays and
+   * repeat like any dimension-1 axis): out(i)(j) = if cond(i)(j) then ifTrue(i)(j) else
+   * ifFalse(i)(j). This is the classic MIN(IF(...))/MAX(IF(...)) shape — the aggregate then folds
+   * the resulting array.
+   *
+   * Condition elements follow Excel truthiness (booleans as-is, numbers zero/non-zero, empty is
+   * FALSE); text or error elements refuse with a clean Left.
+   */
+  def broadcastIf(
+    cond: ArrayResult,
+    ifTrue: ArrayResult,
+    ifFalse: ArrayResult
+  ): Either[EvalError, ArrayResult] =
+    for
+      rowsCT <- broadcastDim(cond.rows, ifTrue.rows, "rows")
+      outRows <- broadcastDim(rowsCT, ifFalse.rows, "rows")
+      colsCT <- broadcastDim(cond.cols, ifTrue.cols, "columns")
+      outCols <- broadcastDim(colsCT, ifFalse.cols, "columns")
+      result <- traverseVV(
+        (0 until outRows).toVector.map { row =>
+          (0 until outCols).toVector.map(col => (row, col))
+        }
+      ) { case (row, col) =>
+        val condCV = getWithBroadcastCV(cond.values, row, col, cond.rows, cond.cols)
+        cellValueTruthy(condCV).map { truthy =>
+          if truthy then getWithBroadcastCV(ifTrue.values, row, col, ifTrue.rows, ifTrue.cols)
+          else getWithBroadcastCV(ifFalse.values, row, col, ifFalse.rows, ifFalse.cols)
+        }
+      }
+    yield ArrayResult(result)
+
+  /**
+   * Excel truthiness for an IF-condition element: booleans as-is, numbers zero/non-zero, empty is
+   * FALSE (the ScalarCoercion Bool conventions); text and errors refuse cleanly.
+   */
+  private def cellValueTruthy(cv: CellValue): Either[EvalError, Boolean] = cv match
+    case CellValue.Bool(b) => Right(b)
+    case CellValue.Number(n) => Right(n.signum != 0)
+    case CellValue.Empty => Right(false)
+    case CellValue.Formula(_, Some(cached)) => cellValueTruthy(cached)
+    case CellValue.Error(err) =>
+      Left(EvalError.EvalFailed(s"IF condition: cannot coerce ${err.toExcel} error value", None))
+    case other => Left(EvalError.TypeMismatch("IF condition", "boolean", other.toString))
+
   /** Convert any value to CellValue for comparison. */
   def anyToCellValue(v: Any): CellValue = v match
     case cv: CellValue => cv
@@ -254,31 +318,22 @@ object ArrayArithmetic:
     case n: Long => CellValue.Number(BigDecimal(n))
     case n: Double => CellValue.Number(BigDecimal(n))
     case b: Boolean => CellValue.Bool(b)
+    // GH-335: date-returning calls (TODAY, DATE, ...) compare as dates, not as their toString
+    case ld: java.time.LocalDate => CellValue.DateTime(ld.atStartOfDay())
+    case ldt: java.time.LocalDateTime => CellValue.DateTime(ldt)
     case _ => CellValue.Text(v.toString)
 
   /**
    * Compare CellValues for equality (case-insensitive for text), matching Excel.
    *
    * Shared with the scalar equality fast path in Evaluator (GH-234) so scalar `=A1=B1` and array
-   * `=A1:A3=B1:B3` equality use identical semantics.
+   * `=A1:A3=B1:B3` equality use identical semantics. GH-335: defined via [[compareCellValues]] so
+   * = and < agree — empty cells equal 0 / "" / FALSE, dates equal their serial number, and
+   * cross-type values (which never coerce under comparison) are simply unequal. Error values
+   * equal nothing.
    */
-  def cellValueEquals(a: CellValue, b: CellValue): Boolean = (a, b) match
-    case (CellValue.Text(t1), CellValue.Text(t2)) =>
-      t1.equalsIgnoreCase(t2)
-    case (CellValue.Number(n1), CellValue.Number(n2)) =>
-      n1 == n2
-    case (CellValue.Bool(b1), CellValue.Bool(b2)) =>
-      b1 == b2
-    case (CellValue.DateTime(d1), CellValue.DateTime(d2)) =>
-      d1.isEqual(d2)
-    case (CellValue.Empty, CellValue.Empty) =>
-      true
-    case (CellValue.Formula(_, Some(c1)), other) =>
-      cellValueEquals(c1, other)
-    case (other, CellValue.Formula(_, Some(c2))) =>
-      cellValueEquals(other, c2)
-    case _ =>
-      false
+  def cellValueEquals(a: CellValue, b: CellValue): Boolean =
+    compareCellValues(a, b).fold(_ => false, _ == 0)
 
   /**
    * Broadcast two arrays together.

--- a/xl-evaluator/src/com/tjclp/xl/formula/eval/Evaluator.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/eval/Evaluator.scala
@@ -388,24 +388,22 @@ private class EvaluatorImpl(
 
       // ===== Comparison Operators =====
       // GH-197: Use evalComparison for array-aware comparisons
+      // GH-335: polymorphic Excel ordering (number < text < logical, case-insensitive text,
+      // empty coerces) — op interprets the comparison sign from compareCellValues
       case TExpr.Lt(x, y) =>
-        // Less than: numeric comparison (array-aware)
-        evalComparison(x, y, _ < _, sheet, clock, workbook, currentCell)
+        evalComparison(x, y, _ < 0, sheet, clock, workbook, currentCell)
           .asInstanceOf[Either[EvalError, A]]
 
       case TExpr.Lte(x, y) =>
-        // Less than or equal: numeric comparison (array-aware)
-        evalComparison(x, y, _ <= _, sheet, clock, workbook, currentCell)
+        evalComparison(x, y, _ <= 0, sheet, clock, workbook, currentCell)
           .asInstanceOf[Either[EvalError, A]]
 
       case TExpr.Gt(x, y) =>
-        // Greater than: numeric comparison (array-aware)
-        evalComparison(x, y, _ > _, sheet, clock, workbook, currentCell)
+        evalComparison(x, y, _ > 0, sheet, clock, workbook, currentCell)
           .asInstanceOf[Either[EvalError, A]]
 
       case TExpr.Gte(x, y) =>
-        // Greater than or equal: numeric comparison (array-aware)
-        evalComparison(x, y, _ >= _, sheet, clock, workbook, currentCell)
+        evalComparison(x, y, _ >= 0, sheet, clock, workbook, currentCell)
           .asInstanceOf[Either[EvalError, A]]
 
       case TExpr.Eq(x, y) =>
@@ -795,40 +793,49 @@ private class EvaluatorImpl(
     yield output
 
   /**
-   * GH-197: Evaluate comparison with array support.
+   * GH-197/GH-335: Evaluate an ordered comparison (< <= > >=) with array support.
    *
-   * When either operand is a range or array:
-   *   - Convert to arrays and perform element-wise comparison
-   *   - Return ArrayResult of booleans
+   * Operands evaluate polymorphically and compare with Excel's total order
+   * (ArrayArithmetic.compareCellValues): text lexicographic/case-insensitive, number < text <
+   * logical across types, empty coercing to the other operand's zero value. When either operand is
+   * a range or array the comparison broadcasts elementwise into an ArrayResult of booleans; two
+   * scalars return a plain Boolean.
    *
-   * When both operands are scalars:
-   *   - Return plain Boolean (fast path)
+   * @param op
+   *   interprets the comparison sign (e.g. `_ < 0` for Lt)
    */
   @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
   private def evalComparison(
-    xExpr: TExpr[BigDecimal],
-    yExpr: TExpr[BigDecimal],
-    op: ArrayArithmetic.CompareOp,
+    xExpr: TExpr[?],
+    yExpr: TExpr[?],
+    op: Int => Boolean,
     sheet: Sheet,
     clock: Clock,
     workbook: Option[Workbook],
     currentCell: Option[ARef]
   ): Either[EvalError, Any] =
+    def broadcastToBool(left: ArrayResult, right: ArrayResult): Either[EvalError, Any] =
+      ArrayArithmetic
+        .broadcastOrderedCompare(left, right, op)
+        .flatMap(collapseUnlessArrayMode("comparison", BindingCoercion.Bool))
+    def single(scalar: Any): ArrayResult =
+      ArrayResult.single(ArrayArithmetic.anyToCellValue(scalar))
     for
       xVal <- evalMaybeArray(xExpr, sheet, clock, workbook, currentCell)
       yVal <- evalMaybeArray(yExpr, sheet, clock, workbook, currentCell)
       result <- (xVal, yVal) match
+        // At least one array -> element-wise comparison with broadcasting
+        case (lArr: ArrayResult, rArr: ArrayResult) => broadcastToBool(lArr, rArr)
+        case (lArr: ArrayResult, scalar) => broadcastToBool(lArr, single(scalar))
+        case (scalar, rArr: ArrayResult) => broadcastToBool(single(scalar), rArr)
         // Both scalars -> plain boolean (fast path)
-        case (x: BigDecimal, y: BigDecimal) =>
-          Right(op(x, y))
-        // At least one array -> element-wise comparison
-        case _ =>
-          for
-            xOp <- toOperand(xVal, sheet)
-            yOp <- toOperand(yVal, sheet)
-            compared <- ArrayArithmetic.broadcastCompare(xOp, yOp, op)
-            output <- collapseUnlessArrayMode("comparison", BindingCoercion.Bool)(compared)
-          yield output
+        case (x, y) =>
+          ArrayArithmetic
+            .compareCellValues(
+              ArrayArithmetic.anyToCellValue(x),
+              ArrayArithmetic.anyToCellValue(y)
+            )
+            .map(op)
     yield result
 
   /**

--- a/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpecsBase.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpecsBase.scala
@@ -1,7 +1,13 @@
 package com.tjclp.xl.formula.functions
 
 import com.tjclp.xl.formula.ast.{TExpr, ExprValue, BindingCoercion}
-import com.tjclp.xl.formula.eval.{EvalError, Evaluator, ArrayArithmetic, ScalarCoercion}
+import com.tjclp.xl.formula.eval.{
+  EvalError,
+  Evaluator,
+  ArrayArithmetic,
+  ArrayResult,
+  ScalarCoercion
+}
 import com.tjclp.xl.formula.parser.ParseError
 import com.tjclp.xl.formula.{Clock, Arity}
 
@@ -144,6 +150,36 @@ trait FunctionSpecsBase:
       case _: TExpr.PolyRef | _: TExpr.SheetPolyRef => TExpr.asResolvedValueExpr(expr)
       case other => other
     ctx.evalExpr[Any](resolved.asInstanceOf[TExpr[Any]])
+
+  /**
+   * GH-333: evaluate an argument array-aware, materializing bare ranges.
+   *
+   * Unlike evalAny (whose scalar boundary collapses arrays and rejects bare RangeRefs), this yields
+   * ArrayResults for range-shaped arguments and array-producing expressions — the IF
+   * branch/condition convention, mirroring the evaluator's own evalMaybeArray operand handling.
+   */
+  @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+  protected def evalMaybeArrayArg(ctx: EvalContext, expr: TExpr[?]): Either[EvalError, Any] =
+    expr match
+      case TExpr.RangeRef(range) =>
+        Right(ArrayArithmetic.rangeToArray(range, ctx.sheet))
+      case TExpr.SheetRange(sheetName, range) =>
+        Evaluator
+          .resolveRangeLocation(
+            TExpr.RangeLocation.CrossSheet(sheetName, range),
+            ctx.sheet,
+            ctx.workbook
+          )
+          .map(targetSheet => ArrayArithmetic.rangeToArray(range, targetSheet))
+      case _: TExpr.PolyRef | _: TExpr.SheetPolyRef =>
+        ctx.evalArrayExpr(TExpr.asResolvedValueExpr(expr).asInstanceOf[TExpr[Any]])
+      case other =>
+        ctx.evalArrayExpr(other.asInstanceOf[TExpr[Any]])
+
+  /** Normalize an evaluated value to an ArrayResult (scalars become 1x1). */
+  protected def toCellArray(value: Any): ArrayResult = value match
+    case arr: ArrayResult => arr
+    case scalar => ArrayResult.single(ArrayArithmetic.anyToCellValue(scalar))
 
   protected def evalValue(ctx: EvalContext, expr: TExpr[?]): Either[EvalError, ExprValue] =
     evalAny(ctx, expr).map(ExprValue.from)

--- a/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpecsConditional.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpecsConditional.scala
@@ -1,7 +1,13 @@
 package com.tjclp.xl.formula.functions
 
-import com.tjclp.xl.formula.ast.{TExpr, ExprValue}
-import com.tjclp.xl.formula.eval.{EvalError, Evaluator, ArrayArithmetic}
+import com.tjclp.xl.formula.ast.{TExpr, ExprValue, BindingCoercion}
+import com.tjclp.xl.formula.eval.{
+  EvalError,
+  Evaluator,
+  ArrayArithmetic,
+  ArrayResult,
+  ScalarCoercion
+}
 import com.tjclp.xl.formula.parser.ParseError
 import com.tjclp.xl.formula.{Clock, Arity}
 import com.tjclp.xl.cells.{CellError, CellValue}
@@ -10,10 +16,32 @@ trait FunctionSpecsConditional extends FunctionSpecsBase:
   val ifFn: FunctionSpec[Any] { type Args = IfArgs } =
     FunctionSpec.simple[Any, IfArgs]("IF", Arity.three) { (args, ctx) =>
       val (condExpr, ifTrueExpr, ifFalseExpr) = args
-      for
-        cond <- ctx.evalExpr(condExpr)
-        result <- if cond then evalAny(ctx, ifTrueExpr) else evalAny(ctx, ifFalseExpr)
-      yield result
+      // GH-333: evaluate the condition array-aware. A range-shaped condition (the classic
+      // MIN(IF(A1:A10>0,…)) CSE idiom) yields an ArrayResult that must broadcast elementwise —
+      // collapsing it to a scalar (the old ctx.evalExpr path) delivered a CellValue.Bool into a
+      // Boolean position and crashed with a ClassCastException.
+      evalMaybeArrayArg(ctx, condExpr).flatMap {
+        case condArr: ArrayResult =>
+          // CSE semantics: both branches evaluate (they broadcast elementwise against the
+          // condition), so branch laziness only applies to the scalar path below.
+          for
+            ifTrueVal <- evalMaybeArrayArg(ctx, ifTrueExpr)
+            ifFalseVal <- evalMaybeArrayArg(ctx, ifFalseExpr)
+            result <- ArrayArithmetic.broadcastIf(
+              condArr,
+              toCellArray(ifTrueVal),
+              toCellArray(ifFalseVal)
+            )
+          yield result
+        case scalarCond =>
+          // Scalar condition: coerce totally (Excel truthiness) and keep lazy branch selection.
+          ScalarCoercion.coerce("IF condition", scalarCond, BindingCoercion.Bool).flatMap {
+            case cond: Boolean =>
+              if cond then evalAny(ctx, ifTrueExpr) else evalAny(ctx, ifFalseExpr)
+            case other =>
+              Left(EvalError.TypeMismatch("IF condition", "boolean", other.toString))
+          }
+      }
     }
 
   // GH-76 (tier 1): variadic conditional / selection functions. Args are a flat List[TExpr[Any]].

--- a/xl-evaluator/src/com/tjclp/xl/formula/parser/FormulaParser.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/parser/FormulaParser.scala
@@ -270,12 +270,11 @@ object FormulaParser:
           val s3 = skipWhitespace(s2.advance())
           descend(s3).flatMap { sd =>
             parseComparison(sd).map { case (right, s4) =>
-              // GH-233: resolve PolyRef operands polymorphically (like the inequality
-              // branches use asNumericExpr) so =A1=B1 / =IF(A1=B1,…) evaluate instead of
-              // erroring with "Unresolved PolyRef". asResolvedValueExpr preserves
-              // text/number/bool/date equality (unlike numeric-only asNumericExpr).
+              // GH-233: resolve PolyRef operands polymorphically so =A1=B1 / =IF(A1=B1,…)
+              // evaluate instead of erroring with "Unresolved PolyRef". GH-335: the comparable
+              // decoder preserves emptiness so empty cells equal 0 / "" / FALSE like Excel.
               (
-                TExpr.Eq(TExpr.asResolvedValueExpr(left), TExpr.asResolvedValueExpr(right)),
+                TExpr.Eq(TExpr.asComparableValueExpr(left), TExpr.asComparableValueExpr(right)),
                 s4.copy(depth = s3.depth)
               )
             }
@@ -286,9 +285,10 @@ object FormulaParser:
               val s3 = skipWhitespace(s2.advance(2))
               descend(s3).flatMap { sd =>
                 parseComparison(sd).map { case (right, s4) =>
-                  // GH-233: resolve PolyRef operands so =A1<>B1 evaluates (see Eq above).
+                  // GH-233/GH-335: resolve PolyRef operands so =A1<>B1 evaluates (see Eq above).
                   (
-                    TExpr.Neq(TExpr.asResolvedValueExpr(left), TExpr.asResolvedValueExpr(right)),
+                    TExpr
+                      .Neq(TExpr.asComparableValueExpr(left), TExpr.asComparableValueExpr(right)),
                     s4.copy(depth = s3.depth)
                   )
                 }
@@ -297,10 +297,13 @@ object FormulaParser:
               val s3 = skipWhitespace(s2.advance(2))
               descend(s3).flatMap { sd =>
                 parseComparison(sd).map { case (right, s4) =>
+                  // GH-335: resolve operands polymorphically (like Eq) — Excel compares text
+                  // lexicographically and ranks number < text < logical, so numeric-only
+                  // coercion would reject text operands.
                   (
                     TExpr.Lte(
-                      TExpr.asNumericExpr(left), // Convert PolyRef to typed Ref
-                      TExpr.asNumericExpr(right)
+                      TExpr.asComparableValueExpr(left),
+                      TExpr.asComparableValueExpr(right)
                     ),
                     s4.copy(depth = s3.depth)
                   )
@@ -310,11 +313,9 @@ object FormulaParser:
               val s3 = skipWhitespace(s2.advance())
               descend(s3).flatMap { sd =>
                 parseComparison(sd).map { case (right, s4) =>
+                  // GH-335: polymorphic operands (see Lte above)
                   (
-                    TExpr.Lt(
-                      TExpr.asNumericExpr(left), // Convert PolyRef to typed Ref
-                      TExpr.asNumericExpr(right)
-                    ),
+                    TExpr.Lt(TExpr.asComparableValueExpr(left), TExpr.asComparableValueExpr(right)),
                     s4.copy(depth = s3.depth)
                   )
                 }
@@ -325,10 +326,11 @@ object FormulaParser:
               val s3 = skipWhitespace(s2.advance(2))
               descend(s3).flatMap { sd =>
                 parseComparison(sd).map { case (right, s4) =>
+                  // GH-335: polymorphic operands (see Lte above)
                   (
                     TExpr.Gte(
-                      TExpr.asNumericExpr(left), // Convert PolyRef to typed Ref
-                      TExpr.asNumericExpr(right)
+                      TExpr.asComparableValueExpr(left),
+                      TExpr.asComparableValueExpr(right)
                     ),
                     s4.copy(depth = s3.depth)
                   )
@@ -338,11 +340,9 @@ object FormulaParser:
               val s3 = skipWhitespace(s2.advance())
               descend(s3).flatMap { sd =>
                 parseComparison(sd).map { case (right, s4) =>
+                  // GH-335: polymorphic operands (see Lte above)
                   (
-                    TExpr.Gt(
-                      TExpr.asNumericExpr(left), // Convert PolyRef to typed Ref
-                      TExpr.asNumericExpr(right)
-                    ),
+                    TExpr.Gt(TExpr.asComparableValueExpr(left), TExpr.asComparableValueExpr(right)),
                     s4.copy(depth = s3.depth)
                   )
                 }

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/ArrayArithmeticSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/ArrayArithmeticSpec.scala
@@ -409,3 +409,91 @@ class ArrayArithmeticSpec extends FunSuite:
     assertEquals(updatedSheet(ref"C2").value, CellValue.Number(9)) // 3^2
     assertEquals(updatedSheet(ref"C3").value, CellValue.Number(16)) // 4^2
   }
+
+  // ========== GH-333: IF over array conditions (CSE semantics) ==========
+  //
+  // MIN(IF(cond_array, values, fallback)) is the classic pre-MINIFS idiom. IF must broadcast
+  // the condition elementwise (Excel CSE) so aggregators receive the resulting array — never
+  // an uncaught exception escaping the total-function boundary.
+
+  test("GH-333: MIN(IF(...)) on an empty sheet evaluates to the fallback") {
+    // The exact issue shape: even an empty sheet crashed with an uncaught exception.
+    val sheet = Sheet("Test")
+    val result = sheet.evaluateArrayFormula("=MIN(IF(A1:A2>0,A1:A2,99))", ref"D1")
+    assert(result.isRight, s"Expected Right, got $result")
+    val (updatedSheet, _) = result.toOption.get
+    assertEquals(updatedSheet(ref"D1").value, CellValue.Number(99))
+  }
+
+  test("GH-333: MIN(IF(...)) selects elementwise over data") {
+    val sheet = Sheet("Test")
+      .put(ref"A1", CellValue.Number(5))
+      .put(ref"A2", CellValue.Number(-3))
+
+    // cond [TRUE, FALSE] -> [5, 99] -> MIN = 5
+    val result = sheet.evaluateArrayFormula("=MIN(IF(A1:A2>0,A1:A2,99))", ref"D1")
+    assert(result.isRight, s"Expected Right, got $result")
+    val (updatedSheet, _) = result.toOption.get
+    assertEquals(updatedSheet(ref"D1").value, CellValue.Number(5))
+  }
+
+  test("GH-333: MAX(IF(...)) and SUM(IF(...)) aggregate the broadcast array") {
+    val sheet = Sheet("Test")
+      .put(ref"A1", CellValue.Number(5))
+      .put(ref"A2", CellValue.Number(-3))
+      .put(ref"A3", CellValue.Number(7))
+
+    val maxResult = sheet.evaluateArrayFormula("=MAX(IF(A1:A3>0,A1:A3,0))", ref"D1")
+    assert(maxResult.isRight, s"Expected Right, got $maxResult")
+    assertEquals(maxResult.toOption.get._1(ref"D1").value, CellValue.Number(7))
+
+    val sumResult = sheet.evaluateArrayFormula("=SUM(IF(A1:A3>0,A1:A3,0))", ref"E1")
+    assert(sumResult.isRight, s"Expected Right, got $sumResult")
+    assertEquals(sumResult.toOption.get._1(ref"E1").value, CellValue.Number(12))
+  }
+
+  test("GH-333: MIN(IF(...)) via scalar evaluateFormula also evaluates") {
+    // The aggregate evaluates its argument array-aware even under scalar entry.
+    val sheet = Sheet("Test")
+      .put(ref"A1", CellValue.Number(5))
+      .put(ref"A2", CellValue.Number(-3))
+
+    val result = sheet.evaluateFormula("=MIN(IF(A1:A2>0,A1:A2,99))")
+    assert(result.isRight, s"Expected Right, got $result")
+    assertEquals(result.toOption.get, CellValue.Number(5))
+  }
+
+  test("GH-333: standalone IF over array condition spills") {
+    val sheet = Sheet("Test")
+      .put(ref"A1", CellValue.Number(5))
+      .put(ref"A2", CellValue.Number(-3))
+
+    val result = sheet.evaluateArrayFormula("=IF(A1:A2>0,A1:A2,99)", ref"C1")
+    assert(result.isRight, s"Expected Right, got $result")
+    val (updatedSheet, spillRange) = result.toOption.get
+    assertEquals(spillRange.height, 2)
+    assertEquals(updatedSheet(ref"C1").value, CellValue.Number(5))
+    assertEquals(updatedSheet(ref"C2").value, CellValue.Number(99))
+  }
+
+  test("GH-333: IF broadcasts scalar branches over the condition array") {
+    val sheet = Sheet("Test")
+      .put(ref"A1", CellValue.Number(5))
+      .put(ref"A2", CellValue.Number(-3))
+
+    // cond [TRUE, FALSE] -> [1, 0] -> MIN = 0
+    val result = sheet.evaluateArrayFormula("=MIN(IF(A1:A2>0,1,0))", ref"D1")
+    assert(result.isRight, s"Expected Right, got $result")
+    assertEquals(result.toOption.get._1(ref"D1").value, CellValue.Number(0))
+  }
+
+  test("GH-333: scalar IF is unchanged (lazy branch selection)") {
+    val sheet = Sheet("Test")
+      .put(ref"A1", CellValue.Number(5))
+      .put(ref"B1", CellValue.Number(0))
+
+    // The untaken branch would divide by zero; scalar IF must not evaluate it.
+    val result = sheet.evaluateFormula("=IF(A1>0,42,A1/B1)")
+    assert(result.isRight, s"Expected Right, got $result")
+    assertEquals(result.toOption.get, CellValue.Number(42))
+  }

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/ComparisonSemanticsSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/ComparisonSemanticsSpec.scala
@@ -14,11 +14,10 @@ import com.tjclp.xl.sheets.Sheet
  *   - number vs number: numeric order (dates ARE numbers via their Excel serial)
  *   - boolean vs boolean: FALSE < TRUE
  *   - cross-type: number < text < logical (no numeric parsing of text under comparison)
- *   - empty cells coerce relative to the other operand: 0 vs numbers, "" vs text, FALSE vs
- *     booleans
+ *   - empty cells coerce relative to the other operand: 0 vs numbers, "" vs text, FALSE vs booleans
  *
- * The dogfooding repro: SUMPRODUCT over a text column raised
- * TypeMismatch(numeric argument,number,z) instead of comparing lexicographically.
+ * The dogfooding repro: SUMPRODUCT over a text column raised TypeMismatch(numeric
+ * argument,number,z) instead of comparing lexicographically.
  */
 @SuppressWarnings(Array("org.wartremover.warts.OptionPartial"))
 class ComparisonSemanticsSpec extends FunSuite:

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/ComparisonSemanticsSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/ComparisonSemanticsSpec.scala
@@ -1,0 +1,193 @@
+package com.tjclp.xl.formula
+
+import munit.FunSuite
+import com.tjclp.xl.*
+import com.tjclp.xl.unsafe.*
+import com.tjclp.xl.cells.CellValue
+import com.tjclp.xl.sheets.Sheet
+
+/**
+ * GH-335: Excel semantics for the ordered comparison operators (< <= > >=).
+ *
+ * Excel compares polymorphically, in both scalar and array/broadcast positions:
+ *   - text vs text: case-insensitive, lexicographic
+ *   - number vs number: numeric order (dates ARE numbers via their Excel serial)
+ *   - boolean vs boolean: FALSE < TRUE
+ *   - cross-type: number < text < logical (no numeric parsing of text under comparison)
+ *   - empty cells coerce relative to the other operand: 0 vs numbers, "" vs text, FALSE vs
+ *     booleans
+ *
+ * The dogfooding repro: SUMPRODUCT over a text column raised
+ * TypeMismatch(numeric argument,number,z) instead of comparing lexicographically.
+ */
+@SuppressWarnings(Array("org.wartremover.warts.OptionPartial"))
+class ComparisonSemanticsSpec extends FunSuite:
+
+  private def sheetWith(entries: (ARef, Any)*): Sheet =
+    entries.foldLeft(Sheet("Test")) { case (s, (ref, value)) =>
+      val cv = value match
+        case cv: CellValue => cv
+        case str: String => CellValue.Text(str)
+        case n: Int => CellValue.Number(BigDecimal(n))
+        case n: BigDecimal => CellValue.Number(n)
+        case b: Boolean => CellValue.Bool(b)
+        case d: java.time.LocalDate => CellValue.DateTime(d.atStartOfDay())
+        case _ => CellValue.Text(value.toString)
+      s.put(ref, cv).unsafe
+    }
+
+  private def evalAs[A](formula: String, sheet: Sheet): Either[String, A] =
+    FormulaParser.parse(formula) match
+      case Right(expr) =>
+        Evaluator.eval(expr, sheet) match
+          case Right(value) => Right(value.asInstanceOf[A])
+          case Left(err) => Left(s"Eval error: $err")
+      case Left(err) => Left(s"Parse error: $err")
+
+  private def assertBool(formula: String, expected: Boolean, sheet: Sheet = Sheet("Test"))(implicit
+    loc: munit.Location
+  ): Unit =
+    evalAs[Any](formula, sheet) match
+      case Right(b: Boolean) => assertEquals(b, expected, s"$formula")
+      case Right(other) => fail(s"$formula: expected Boolean, got $other")
+      case Left(err) => fail(s"$formula failed: $err")
+
+  private def assertNum(formula: String, expected: Int, sheet: Sheet)(implicit
+    loc: munit.Location
+  ): Unit =
+    evalAs[Any](formula, sheet) match
+      case Right(n: BigDecimal) => assertEquals(n, BigDecimal(expected), s"$formula")
+      case Right(other) => fail(s"$formula: expected BigDecimal, got $other")
+      case Left(err) => fail(s"$formula failed: $err")
+
+  // ===== Issue repro (a): text range < text literal inside SUMPRODUCT =====
+
+  test("GH-335: SUMPRODUCT((B1:B2<\"z\")*1) counts text below z") {
+    val sheet = sheetWith(ref"B1" -> "apple", ref"B2" -> "banana")
+    assertNum("=SUMPRODUCT((B1:B2<\"z\")*1)", 2, sheet)
+  }
+
+  // ===== Issue repro (b): dates-as-text column compared to a text anchor =====
+
+  test("GH-335: SUMPRODUCT over dates-as-text compares lexicographically") {
+    val sheet = sheetWith(
+      ref"F2" -> "15/07/20",
+      ref"F3" -> "05/08/20",
+      ref"F4" -> "01/01/21",
+      ref"F5" -> "20/06/20"
+    )
+    // Lexicographic: only "01/01/21" < "05/08/20"
+    assertNum("=SUMPRODUCT(($F$2:$F$5<$F$3)*1)", 1, sheet)
+  }
+
+  // ===== Scalar text comparisons =====
+
+  test("text vs text compares case-insensitively, lexicographically") {
+    assertBool("=\"apple\"<\"BANANA\"", true)
+    assertBool("=\"B\">\"a\"", true)
+    assertBool("=\"apple\"<=\"APPLE\"", true)
+    assertBool("=\"apple\">=\"APPLE\"", true)
+    assertBool("=\"zebra\"<\"apple\"", false)
+  }
+
+  test("text cell vs text cell comparison") {
+    val sheet = sheetWith(ref"A1" -> "apple", ref"A2" -> "Banana")
+    assertBool("=A1<A2", true, sheet)
+    assertBool("=A2<A1", false, sheet)
+  }
+
+  // ===== Cross-type ordering: number < text < logical =====
+
+  test("number < text (even numeric-looking text)") {
+    assertBool("=5<\"5\"", true)
+    assertBool("=\"2\">100", true)
+    assertBool("=100<\"2\"", true)
+  }
+
+  test("text < logical") {
+    assertBool("=\"zzz\"<TRUE", true)
+    assertBool("=\"zzz\"<FALSE", true)
+    assertBool("=FALSE>\"zzz\"", true)
+  }
+
+  test("number < logical, FALSE < TRUE") {
+    assertBool("=TRUE>100", true)
+    assertBool("=FALSE>100", true)
+    assertBool("=FALSE<TRUE", true)
+    assertBool("=TRUE<=TRUE", true)
+    assertBool("=TRUE<FALSE", false)
+  }
+
+  // ===== Empty-cell coercion =====
+
+  test("empty cell compares as 0 against numbers") {
+    val sheet = Sheet("Test")
+    assertBool("=A1<5", true, sheet)
+    assertBool("=A1>-1", true, sheet)
+    assertBool("=A1>0", false, sheet)
+  }
+
+  test("empty cell compares as empty string against text") {
+    val sheet = Sheet("Test")
+    assertBool("=A1<\"a\"", true, sheet)
+    assertBool("=A1>\"a\"", false, sheet)
+  }
+
+  test("empty cell compares as FALSE against booleans") {
+    val sheet = Sheet("Test")
+    assertBool("=A1<TRUE", true, sheet)
+    assertBool("=A1<FALSE", false, sheet)
+    assertBool("=A1>=FALSE", true, sheet)
+  }
+
+  test("empty cell equals 0 and empty string (scalar and array)") {
+    val sheet = sheetWith(ref"A2" -> 5)
+    assertBool("=A1=0", true, sheet)
+    assertBool("=A1=\"\"", true, sheet)
+    assertNum("=SUMPRODUCT((A1:A2=0)*1)", 1, sheet)
+  }
+
+  // ===== Numbers and dates =====
+
+  test("numeric comparisons unchanged") {
+    assertBool("=1<2", true)
+    assertBool("=2<=2", true)
+    assertBool("=3>4", false)
+  }
+
+  test("date cells compare as serial numbers") {
+    val sheet = sheetWith(
+      ref"A1" -> java.time.LocalDate.of(2020, 1, 1),
+      ref"A2" -> java.time.LocalDate.of(2021, 1, 1)
+    )
+    assertBool("=A1<A2", true, sheet)
+    assertBool("=A1<DATE(2020,6,1)", true, sheet)
+    assertBool("=A2<DATE(2020,6,1)", false, sheet)
+    assertNum("=SUMPRODUCT((A1:A2<DATE(2020,6,1))*1)", 1, sheet)
+  }
+
+  // ===== Array/broadcast paths =====
+
+  test("mixed-type array vs number scalar uses type ranks elementwise") {
+    val sheet = sheetWith(ref"A1" -> 1, ref"A2" -> "apple", ref"A3" -> true)
+    // 1>100 FALSE; "apple">100 TRUE (text>number); TRUE>100 TRUE (logical>number)
+    assertNum("=SUMPRODUCT((A1:A3>100)*1)", 2, sheet)
+  }
+
+  test("text array vs text cell anchor broadcasts") {
+    val sheet = sheetWith(ref"A1" -> "apple", ref"A2" -> "banana", ref"B1" -> "b")
+    // case-insensitive lexicographic: "apple"<"b" TRUE, "banana">"b" (prefix) -> not < "b"
+    assertNum("=SUMPRODUCT((A1:A2<B1)*1)", 1, sheet)
+  }
+
+  test("empty cells in range compare as 0 against numeric scalar") {
+    val sheet = sheetWith(ref"A2" -> 5)
+    // A1 empty -> 0<3 TRUE; 5<3 FALSE
+    assertNum("=SUMPRODUCT((A1:A2<3)*1)", 1, sheet)
+  }
+
+  test("array comparison feeds boolean arithmetic (issue shape)") {
+    val sheet = sheetWith(ref"A1" -> "x", ref"A2" -> "y", ref"B1" -> 10, ref"B2" -> 20)
+    // (text<"y") -> [TRUE, FALSE]; * B gives [10, 0]
+    assertNum("=SUMPRODUCT((A1:A2<\"y\")*B1:B2)", 10, sheet)
+  }

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/FormulaParserSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/FormulaParserSpec.scala
@@ -78,10 +78,10 @@ class FormulaParserSpec extends ScalaCheckSuite:
         op <- Gen.oneOf[
           (TExpr[BigDecimal], TExpr[BigDecimal]) => TExpr[Boolean]
         ](
-          TExpr.Lt.apply,
-          TExpr.Lte.apply,
-          TExpr.Gt.apply,
-          TExpr.Gte.apply
+          TExpr.Lt(_, _),
+          TExpr.Lte(_, _),
+          TExpr.Gt(_, _),
+          TExpr.Gte(_, _)
         )
       yield op(x, y)
 


### PR DESCRIPTION
## Summary

Ultracode wave over the three issues found by the live SpreadsheetBench runs (see #332's benchmark session). Two worktree-isolated TDD implementers, each adversarially reviewed (revert-and-rerun refutation, edge probes, full-suite verification) — both clusters approved on first review.

### fix(evaluator): Excel comparison semantics + array-aware IF — Closes #335. Closes #333.

**#335** — ordered comparisons (`< <= > >=`) were parsed through numeric coercion, so any text operand raised `TypeMismatch`. Now:
- `TExpr.Lt/Lte/Gt/Gte` are polymorphic GADT cases (like `Eq/Neq`); operands resolve via a comparable-value decoder that preserves emptiness
- New `ArrayArithmetic.compareCellValues` implements Excel's total order: case-insensitive lexicographic text, cross-type rank `number < text < logical`, `FALSE < TRUE`, dates by Excel serial, `Empty` coerces to the other operand's zero (`0` / `""` / `FALSE`), errors refuse with a clean `Left`
- `=`/`<>`/`SWITCH` share the same semantics via `cellValueEquals`
- Scalar and array/broadcast paths are uniform: `=SUMPRODUCT((B1:B2<"z")*1)` → 2; dates-as-text count lexicographically

**#333** — root cause (JVM trace, not guessed): in array mode, IF's condition collapsed an `ArrayResult` into an erasure-cast `Boolean` → `ClassCastException` escaping the total-function boundary (the raw GraalVM trace in the native CLI). Now IF evaluates its condition array-aware and broadcasts elementwise per Excel CSE (`=MIN(IF(A1:A2>0,A1:A2,99))` on empties → 99); the same crash family in other boolean positions (`AND/OR/NOT/IFS` over array conditions) collapses totally (`=AND(A1:A2>0)` → clean `FALSE`, was a crash).

Review evidence: 24 new specs, 21 fail verbatim with pre-fix sources restored (the other 3 pin adjacent already-correct behavior); 42 edge probes Excel-correct or documented-total; hand-verified lexicographic counts; full CLI pipeline runs all three issue repros correctly.

### fix(xl-agent): preserve per-case diagnostics on mid-run failure — Closes #334.

- `CaseResult.error` and `tracePath` now serialize into `summary.json`/`summary.md`; streaming console lines append the first error
- New `CaseFailure` helper: the error path does best-effort `tracer.complete(...) → save()` so the partial conversation trace survives exactly when it matters; last-resort no-trace fallback stays total
- Reviewer verified with a real failure E2E (stubbed client), reverted-source red runs, and probes across both XlSkill paths not covered by the E2E

### Behavior changes worth a release-note line
- Equality (`=`, `<>`, SWITCH) now equates `Empty` with `0`/`""`/`FALSE` and dates with their Excel serial (Excel-correct; previously type-strict)
- Numeric-looking text no longer parses as a number under ordered comparison (`="2">100` → TRUE, Excel-correct)
- Documented-total divergences (candidates for follow-up issues): comparing against an Error-valued cell yields a whole-formula error rather than Excel's elementwise propagation (consistent with existing arithmetic convention); `AND/OR` over array conditions use top-left implicit intersection, not CSE aggregation; array-path IF evaluates both branches eagerly

## Test plan
- [x] Baseline gate before implementation: 3,865 tests green on the wave branch
- [x] Full suite on the integrated branch: `__.compile` + `__.test` + `__.checkFormat` all green (xl-evaluator 1509 incl. 24 new; xl-agent 60 incl. new failure-path/report specs)
- [x] `make install` + original issue repros through the installed CLI: `SUMPRODUCT((B1:B2<"z")*1)` → 2, `MIN(IF(...))` → 99, `AND(range>0)` → FALSE
- [x] The real benchmark formula from SpreadsheetBench 2768 case 2 (previously unevaluable) now computes every cell; remaining diffs are the model's allocation-priority interpretation, identical to openpyxl's miss

🤖 Generated with [Claude Code](https://claude.com/claude-code)