### PR TITLE
fix(evaluator): AND/OR aggregate over array conditions; NOT and IFS broadcast elementwise

### DIFF
--- a/xl-evaluator/src/com/tjclp/xl/formula/eval/ArrayArithmetic.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/eval/ArrayArithmetic.scala
@@ -289,7 +289,7 @@ object ArrayArithmetic:
         }
       ) { case (row, col) =>
         val condCV = getWithBroadcastCV(cond.values, row, col, cond.rows, cond.cols)
-        cellValueTruthy(condCV).map { truthy =>
+        conditionTruthy("IF condition", condCV).map { truthy =>
           if truthy then getWithBroadcastCV(ifTrue.values, row, col, ifTrue.rows, ifTrue.cols)
           else getWithBroadcastCV(ifFalse.values, row, col, ifFalse.rows, ifFalse.cols)
         }
@@ -297,17 +297,35 @@ object ArrayArithmetic:
     yield ArrayResult(result)
 
   /**
-   * Excel truthiness for an IF-condition element: booleans as-is, numbers zero/non-zero, empty is
-   * FALSE (the ScalarCoercion Bool conventions); text and errors refuse cleanly.
+   * GH-333/GH-338: Excel truthiness for a condition element, shared by broadcastIf (IF over an
+   * array condition) and the logical functions' array paths (AND/OR aggregation, NOT broadcast):
+   * booleans as-is, numbers zero/non-zero, empty is FALSE (the ScalarCoercion Bool conventions);
+   * text and errors refuse cleanly with a Left naming the position via `label`.
    */
-  private def cellValueTruthy(cv: CellValue): Either[EvalError, Boolean] = cv match
+  def conditionTruthy(label: String, cv: CellValue): Either[EvalError, Boolean] = cv match
     case CellValue.Bool(b) => Right(b)
     case CellValue.Number(n) => Right(n.signum != 0)
     case CellValue.Empty => Right(false)
-    case CellValue.Formula(_, Some(cached)) => cellValueTruthy(cached)
+    case CellValue.Formula(_, Some(cached)) => conditionTruthy(label, cached)
     case CellValue.Error(err) =>
-      Left(EvalError.EvalFailed(s"IF condition: cannot coerce ${err.toExcel} error value", None))
-    case other => Left(EvalError.TypeMismatch("IF condition", "boolean", other.toString))
+      Left(EvalError.EvalFailed(s"$label: cannot coerce ${err.toExcel} error value", None))
+    case other => Left(EvalError.TypeMismatch(label, "boolean", other.toString))
+
+  /**
+   * GH-338: truthiness of every element (row-major), for the AND/OR aggregation folds (AND =
+   * forall, OR = exists). The first refusing element (text/error) short-circuits with its Left,
+   * consistent with broadcastIf's whole-array traversal.
+   */
+  def truthyElements(label: String, arr: ArrayResult): Either[EvalError, Vector[Boolean]] =
+    traverseV(arr.values.flatten)(cv => conditionTruthy(label, cv))
+
+  /**
+   * GH-338: elementwise NOT over an array condition, preserving shape (Excel broadcasts NOT rather
+   * than aggregating). Elements follow the conditionTruthy conventions.
+   */
+  def broadcastNot(label: String, arr: ArrayResult): Either[EvalError, ArrayResult] =
+    traverseVV(arr.values)(cv => conditionTruthy(label, cv).map(b => CellValue.Bool(!b)))
+      .map(ArrayResult(_))
 
   /** Convert any value to CellValue for comparison. */
   def anyToCellValue(v: Any): CellValue = v match

--- a/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpecsConditional.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpecsConditional.scala
@@ -49,14 +49,32 @@ trait FunctionSpecsConditional extends FunctionSpecsBase:
   /** IFS(cond1, val1, cond2, val2, ...) — first TRUE condition's value, else #N/A. */
   val ifs: FunctionSpec[Any] { type Args = List[TExpr[Any]] } =
     FunctionSpec.simple[Any, List[TExpr[Any]]]("IFS", Arity.AtLeast(2)) { (args, ctx) =>
-      @annotation.tailrec
+      // GH-338: condition slots evaluate array-aware like IF (GH-333). A scalar condition keeps
+      // the lazy pair walk; an array condition switches to CSE semantics — its value and the
+      // remaining pairs all evaluate, chaining elementwise through broadcastIf with the no-match
+      // #N/A as the final fallback: IFS(c1,v1,c2,v2) = if c1 then v1 else (if c2 then v2 else NA).
       def loop(pairs: List[TExpr[Any]]): Either[EvalError, Any] =
         pairs match
           case cond :: value :: rest =>
-            ctx.evalExpr(TExpr.asBooleanExpr(cond)) match
-              case Left(err) => Left(err)
-              case Right(true) => evalAny(ctx, value)
-              case Right(false) => loop(rest)
+            evalMaybeArrayArg(ctx, cond).flatMap {
+              case condArr: ArrayResult =>
+                for
+                  valueVal <- evalMaybeArrayArg(ctx, value)
+                  restVal <- loop(rest)
+                  result <- ArrayArithmetic.broadcastIf(
+                    condArr,
+                    toCellArray(valueVal),
+                    toCellArray(restVal)
+                  )
+                yield result
+              case scalarCond =>
+                ScalarCoercion.coerce("IFS condition", scalarCond, BindingCoercion.Bool).flatMap {
+                  case condBool: Boolean =>
+                    if condBool then evalAny(ctx, value) else loop(rest)
+                  case other =>
+                    Left(EvalError.TypeMismatch("IFS condition", "boolean", other.toString))
+                }
+            }
           case _ => Right(CellValue.Error(CellError.NA))
       loop(args)
     }

--- a/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpecsLogical.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpecsLogical.scala
@@ -1,42 +1,88 @@
 package com.tjclp.xl.formula.functions
 
-import com.tjclp.xl.formula.ast.{TExpr, ExprValue}
-import com.tjclp.xl.formula.eval.{EvalError, Evaluator}
-import com.tjclp.xl.formula.parser.ParseError
-import com.tjclp.xl.formula.{Clock, Arity}
+import com.tjclp.xl.formula.ast.{TExpr, BindingCoercion}
+import com.tjclp.xl.formula.eval.{EvalError, ArrayArithmetic, ArrayResult, ScalarCoercion}
+import com.tjclp.xl.formula.Arity
 
 trait FunctionSpecsLogical extends FunctionSpecsBase:
+
+  /**
+   * GH-338: evaluate one AND/OR argument to its boolean contribution.
+   *
+   * Array-shaped arguments (range comparisons like A1:A10>0, array-returning calls, NOT over an
+   * array) fold elementwise with `foldElems` (AND = forall, OR = exists) using the broadcastIf
+   * condition conventions — text or error elements refuse with a clean Left. Scalars follow the
+   * shared Excel-truthiness table (numbers zero/non-zero, empty FALSE, text refuses). Bare ranges
+   * keep their pre-existing "must be used within a function" error: raw-range coercion parity
+   * (Excel skips text/blanks over untyped ranges) is documented out of scope in GH-338.
+   */
+  private def conditionArg(fnName: String, ctx: EvalContext, expr: TExpr[?])(
+    foldElems: Vector[Boolean] => Boolean
+  ): Either[EvalError, Boolean] =
+    val label = s"$fnName condition"
+    val evaluated = expr match
+      case _: TExpr.RangeRef | _: TExpr.SheetRange => evalAny(ctx, expr)
+      case other => evalMaybeArrayArg(ctx, other)
+    evaluated.flatMap {
+      case arr: ArrayResult => ArrayArithmetic.truthyElements(label, arr).map(foldElems)
+      case scalar =>
+        ScalarCoercion.coerce(label, scalar, BindingCoercion.Bool).flatMap {
+          case b: Boolean => Right(b)
+          case other => Left(EvalError.TypeMismatch(label, "boolean", other.toString))
+        }
+    }
+
   val and: FunctionSpec[Boolean] { type Args = BooleanList } =
     FunctionSpec.simple[Boolean, BooleanList]("AND", Arity.atLeastOne) { (args, ctx) =>
+      // GH-338: array arguments aggregate across every element (Excel AND is n-ary over
+      // arrays); a decisive FALSE still short-circuits the remaining arguments.
       @annotation.tailrec
       def loop(remaining: List[TExpr[Boolean]]): Either[EvalError, Boolean] =
         remaining match
           case Nil => Right(true)
           case head :: tail =>
-            ctx.evalExpr(head) match
+            conditionArg("AND", ctx, head)(_.forall(identity)) match
               case Left(err) => Left(err)
-              case Right(value) =>
-                if !value then Right(false)
-                else loop(tail)
+              case Right(false) => Right(false)
+              case Right(true) => loop(tail)
       loop(args)
     }
 
   val or: FunctionSpec[Boolean] { type Args = BooleanList } =
     FunctionSpec.simple[Boolean, BooleanList]("OR", Arity.atLeastOne) { (args, ctx) =>
+      // GH-338: array arguments aggregate across every element (Excel OR is n-ary over
+      // arrays); a decisive TRUE still short-circuits the remaining arguments.
       @annotation.tailrec
       def loop(remaining: List[TExpr[Boolean]]): Either[EvalError, Boolean] =
         remaining match
           case Nil => Right(false)
           case head :: tail =>
-            ctx.evalExpr(head) match
+            conditionArg("OR", ctx, head)(_.exists(identity)) match
               case Left(err) => Left(err)
-              case Right(value) =>
-                if value then Right(true)
-                else loop(tail)
+              case Right(true) => Right(true)
+              case Right(false) => loop(tail)
       loop(args)
     }
 
+  @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
   val not: FunctionSpec[Boolean] { type Args = UnaryBoolean } =
     FunctionSpec.simple[Boolean, UnaryBoolean]("NOT", Arity.one) { (expr, ctx) =>
-      ctx.evalExpr(expr).map(value => !value)
+      // GH-338: an array condition broadcasts elementwise (Excel NOT is elementwise, not an
+      // aggregate); the ArrayResult travels through the erased Boolean slot exactly like
+      // comparison results do — cast the Either container, not the value. Scalar conditions
+      // keep Excel truthiness; bare ranges keep their pre-existing error (see conditionArg).
+      val evaluated = expr match
+        case _: TExpr.RangeRef | _: TExpr.SheetRange => evalAny(ctx, expr)
+        case other => evalMaybeArrayArg(ctx, other)
+      evaluated.flatMap {
+        case arr: ArrayResult =>
+          ArrayArithmetic
+            .broadcastNot("NOT condition", arr)
+            .asInstanceOf[Either[EvalError, Boolean]]
+        case scalar =>
+          ScalarCoercion.coerce("NOT condition", scalar, BindingCoercion.Bool).flatMap {
+            case b: Boolean => Right(!b)
+            case other => Left(EvalError.TypeMismatch("NOT condition", "boolean", other.toString))
+          }
+      }
     }

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/LogicalArrayFoldSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/LogicalArrayFoldSpec.scala
@@ -1,0 +1,211 @@
+package com.tjclp.xl.formula
+
+import munit.FunSuite
+
+import com.tjclp.xl.addressing.ARef
+import com.tjclp.xl.cells.{CellError, CellValue}
+import com.tjclp.xl.formula.eval.SheetEvaluator.*
+import com.tjclp.xl.sheets.Sheet
+import com.tjclp.xl.syntax.*
+
+/**
+ * GH-338: AND/OR aggregate over array conditions; NOT broadcasts elementwise.
+ *
+ * Post-GH-333 the logical functions no longer crashed on array conditions, but the Coerced(Bool)
+ * scalar boundary collapsed them by top-left implicit intersection — a plausible-but-wrong answer.
+ * Excel's AND/OR natively accept array arguments and aggregate across EVERY element (no CSE entry
+ * required); NOT broadcasts elementwise like the fixed IF. Condition elements follow the
+ * broadcastIf conventions: booleans as-is, numbers zero/non-zero, empty is FALSE; text and error
+ * elements refuse with a clean Left.
+ */
+@SuppressWarnings(Array("org.wartremover.warts.OptionPartial"))
+class LogicalArrayFoldSpec extends FunSuite:
+
+  // The GH-338 repro data: mixed signs, truthy element FIRST (collapse used to answer TRUE).
+  private val mixedTF = Sheet("Test")
+    .put(ref"A1", CellValue.Number(5))
+    .put(ref"A2", CellValue.Number(-1))
+
+  // Mirror image: falsy element first (collapse used to answer FALSE for OR).
+  private val mixedFT = Sheet("Test")
+    .put(ref"A1", CellValue.Number(-1))
+    .put(ref"A2", CellValue.Number(5))
+
+  private val allNegative = Sheet("Test")
+    .put(ref"A1", CellValue.Number(-5))
+    .put(ref"A2", CellValue.Number(-1))
+
+  private def assertScalar(sheet: Sheet, formula: String, expected: CellValue)(implicit
+    loc: munit.Location
+  ): Unit =
+    assertEquals(sheet.evaluateFormula(formula), Right(expected), formula)
+
+  private def assertArrayEntry(sheet: Sheet, formula: String, expected: CellValue)(implicit
+    loc: munit.Location
+  ): Unit =
+    val result = sheet.evaluateArrayFormula(formula, ref"D1")
+    assert(result.isRight, s"$formula: expected Right, got $result")
+    val (updated, spill) = result.toOption.get
+    assertEquals(spill.height, 1, s"$formula spill height")
+    assertEquals(spill.width, 1, s"$formula spill width")
+    assertEquals(updated(ref"D1").value, expected, formula)
+
+  // ===== The exact GH-338 repro, via BOTH evaluation entries =====
+
+  test("GH-338: AND over a mixed array comparison aggregates to FALSE (array entry)") {
+    assertArrayEntry(mixedTF, "=AND(A1:A2>0)", CellValue.Bool(false))
+  }
+
+  test("GH-338: OR over a mixed array comparison aggregates to TRUE (array entry)") {
+    assertArrayEntry(mixedFT, "=OR(A1:A2>0)", CellValue.Bool(true))
+  }
+
+  test("GH-338: AND aggregates via plain scalar evaluateFormula too") {
+    assertScalar(mixedTF, "=AND(A1:A2>0)", CellValue.Bool(false))
+  }
+
+  test("GH-338: OR aggregates via plain scalar evaluateFormula too") {
+    assertScalar(mixedFT, "=OR(A1:A2>0)", CellValue.Bool(true))
+  }
+
+  // ===== Element order must not matter =====
+
+  test("GH-338: AND/OR aggregation is order-independent") {
+    assertScalar(mixedFT, "=AND(A1:A2>0)", CellValue.Bool(false))
+    assertScalar(mixedTF, "=OR(A1:A2>0)", CellValue.Bool(true))
+  }
+
+  // ===== Multi-argument mixes (scalars and arrays fold together) =====
+
+  test("GH-338: mixed scalar and array arguments fold together") {
+    assertScalar(mixedTF, "=AND(TRUE, A1:A2>0)", CellValue.Bool(false))
+    assertScalar(mixedTF, "=AND(A1:A2>-10, TRUE)", CellValue.Bool(true))
+    assertScalar(mixedTF, "=OR(FALSE, A1:A2>0)", CellValue.Bool(true))
+    // A1=5, A2=-1: no element exceeds 5, and B1 is empty (decodes FALSE)
+    assertScalar(mixedTF, "=OR(A1:A2>5, B1)", CellValue.Bool(false))
+    val withB1 = mixedTF.put(ref"B1", CellValue.Bool(true))
+    assertScalar(withB1, "=OR(A1:A2>5, B1)", CellValue.Bool(true))
+  }
+
+  test("GH-338: two array arguments both aggregate") {
+    // {T,F} and {T,T}: AND folds both to FALSE && TRUE = FALSE; OR to TRUE
+    assertScalar(mixedTF, "=AND(A1:A2>0, A1:A2>-10)", CellValue.Bool(false))
+    assertScalar(mixedTF, "=OR(A1:A2>100, A1:A2>0)", CellValue.Bool(true))
+  }
+
+  // ===== All-TRUE / all-FALSE arrays =====
+
+  test("GH-338: all-TRUE and all-FALSE arrays") {
+    assertScalar(mixedTF, "=AND(A1:A2>-10)", CellValue.Bool(true))
+    assertScalar(mixedTF, "=OR(A1:A2>100)", CellValue.Bool(false))
+    assertScalar(allNegative, "=AND(A1:A2<0)", CellValue.Bool(true))
+    assertScalar(allNegative, "=OR(A1:A2>0)", CellValue.Bool(false))
+  }
+
+  // ===== Empty cells =====
+
+  test("GH-338: empty cells in the compared range coerce as 0") {
+    val sparse = Sheet("Test").put(ref"A1", CellValue.Number(5)) // A2 empty
+    assertScalar(sparse, "=AND(A1:A2>0)", CellValue.Bool(false)) // 0>0 is FALSE
+    assertScalar(sparse, "=OR(A1:A2>0)", CellValue.Bool(true))
+    assertScalar(sparse, "=AND(A1:A2>=0)", CellValue.Bool(true)) // 0>=0 is TRUE
+  }
+
+  test("GH-338: empty condition elements are FALSE (broadcastIf convention)") {
+    // IF selects from an empty range, so the condition array AND/OR folds is all Empty
+    assertScalar(mixedTF, "=OR(IF(A1:A2>0,C1:C2,C1:C2))", CellValue.Bool(false))
+    assertScalar(mixedTF, "=OR(IF(A1:A2>0,C1:C2,C1:C2), TRUE)", CellValue.Bool(true))
+    assertScalar(mixedTF, "=AND(IF(A1:A2>0,C1:C2,C1:C2))", CellValue.Bool(false))
+  }
+
+  // ===== NOT broadcasts elementwise =====
+
+  test("GH-338: NOT broadcasts elementwise over an array condition (2x1 shape)") {
+    val result = mixedTF.evaluateArrayFormula("=NOT(A1:A2>0)", ref"C1")
+    assert(result.isRight, s"Expected Right, got $result")
+    val (updated, spill) = result.toOption.get
+    assertEquals(spill.height, 2)
+    assertEquals(spill.width, 1)
+    assertEquals(updated(ref"C1").value, CellValue.Bool(false))
+    assertEquals(updated(ref"C2").value, CellValue.Bool(true))
+  }
+
+  test("GH-338: AND(NOT(...)) and OR(NOT(...)) compose end-to-end") {
+    // mixedFT: NOT({F,T}) = {T,F} — collapse used to answer TRUE
+    assertScalar(mixedFT, "=AND(NOT(A1:A2>0))", CellValue.Bool(false))
+    assertScalar(mixedTF, "=AND(NOT(A1:A2>0))", CellValue.Bool(false))
+    assertScalar(mixedTF, "=OR(NOT(A1:A2>0))", CellValue.Bool(true))
+    assertScalar(allNegative, "=AND(NOT(A1:A2>0))", CellValue.Bool(true))
+    assertScalar(allNegative, "=OR(NOT(A1:A2<0))", CellValue.Bool(false))
+  }
+
+  test("GH-338: scalar NOT keeps current behavior (including scalar-entry collapse)") {
+    assertScalar(mixedTF, "=NOT(TRUE)", CellValue.Bool(false))
+    assertScalar(mixedTF, "=NOT(0)", CellValue.Bool(true))
+    assertScalar(mixedTF, "=NOT(A1)", CellValue.Bool(false)) // 5 is truthy
+    // Scalar entry collapses the broadcast array to its top-left element (implicit intersection)
+    assertScalar(mixedTF, "=NOT(A1:A2>0)", CellValue.Bool(false))
+    assertScalar(mixedFT, "=NOT(A1:A2>0)", CellValue.Bool(true))
+  }
+
+  // ===== Text in a condition position refuses cleanly (total, no throw) =====
+
+  test("GH-338: text condition elements refuse with a clean Left") {
+    assert(mixedTF.evaluateFormula("=AND(IF(A1:A2>0,\"x\",\"y\"))").isLeft)
+    assert(mixedTF.evaluateFormula("=OR(IF(A1:A2>0,\"x\",\"y\"))").isLeft)
+    assert(mixedTF.evaluateFormula("=NOT(IF(A1:A2>0,\"x\",\"y\"))").isLeft)
+    assert(mixedTF.evaluateArrayFormula("=AND(IF(A1:A2>0,\"x\",\"y\"))", ref"D1").isLeft)
+    assert(mixedTF.evaluateFormula("=OR(\"abc\")").isLeft)
+  }
+
+  // ===== Pre-existing semantics stay frozen =====
+
+  test("GH-338: cross-argument short-circuit is preserved") {
+    // The second argument would divide by zero; a decisive first argument must skip it
+    assertScalar(mixedTF, "=AND(1>2, 1/0>0)", CellValue.Bool(false))
+    assertScalar(mixedTF, "=OR(1<2, 1/0>0)", CellValue.Bool(true))
+  }
+
+  test("GH-338: bare-range arguments keep their pre-existing error (out of scope)") {
+    // Raw-range coercion parity (Excel skips text/blanks) is documented out of scope in GH-338
+    val andResult = mixedTF.evaluateFormula("=AND(A1:A2)")
+    assert(andResult.isLeft, s"Expected Left, got $andResult")
+    assert(
+      andResult.left.toOption.get.message.contains("must be used within a function"),
+      s"unexpected error: $andResult"
+    )
+    assert(mixedTF.evaluateFormula("=OR(A1:A2)").isLeft)
+    assert(mixedTF.evaluateFormula("=NOT(A1:A2)").isLeft)
+  }
+
+  // ===== IFS condition slots evaluate array-aware like IF =====
+
+  test("GH-338: IFS over an array condition broadcasts elementwise (CSE semantics)") {
+    val result = mixedTF.evaluateArrayFormula("=IFS(A1:A2>0, 1, TRUE, 0)", ref"D1")
+    assert(result.isRight, s"Expected Right, got $result")
+    val (updated, spill) = result.toOption.get
+    assertEquals(spill.height, 2)
+    assertEquals(updated(ref"D1").value, CellValue.Number(1))
+    assertEquals(updated(ref"D2").value, CellValue.Number(0))
+  }
+
+  test("GH-338: SUM(IFS(...)) aggregates the broadcast array via scalar entry") {
+    // {5>0, -1>0} selects {5, 0} elementwise
+    assertScalar(mixedTF, "=SUM(IFS(A1:A2>0, A1:A2, TRUE, 0))", CellValue.Number(5))
+  }
+
+  test("GH-338: IFS with no matching pair yields elementwise #N/A") {
+    val result = mixedTF.evaluateArrayFormula("=IFS(A1:A2>100, 1)", ref"D1")
+    assert(result.isRight, s"Expected Right, got $result")
+    val (updated, spill) = result.toOption.get
+    assertEquals(spill.height, 2)
+    assertEquals(updated(ref"D1").value, CellValue.Error(CellError.NA))
+    assertEquals(updated(ref"D2").value, CellValue.Error(CellError.NA))
+  }
+
+  test("GH-338: scalar IFS keeps lazy pair selection") {
+    // First TRUE condition wins without evaluating later pairs (which would divide by zero)
+    assertScalar(mixedTF, "=IFS(TRUE, 42, 1/0>0, 99)", CellValue.Number(42))
+    assertScalar(mixedTF, "=IFS(1>2, 1, 2>1, 7)", CellValue.Number(7))
+    assertScalar(mixedTF, "=IFS(1>2, 1)", CellValue.Error(CellError.NA))
+  }


### PR DESCRIPTION
## Summary

Closes #338. Pre-0.12.3 fix for the silent-wrong-answer path left by wave 10: logical functions stopped crashing on array conditions (#333) but collapsed them by top-left implicit intersection — `=AND(A1:A2>0)` with A1=5, A2=-1 returned TRUE.

- **AND/OR** now evaluate every argument array-aware (`evalMaybeArrayArg`, the wave-10 seam) *before* boolean coercion and fold elementwise — AND=forall, OR=exists — using the exact `broadcastIf` condition truthiness (bool as-is, number zero/non-zero, empty=FALSE, text/error refuse with a total `Left`). Mixed scalar+array argument lists work; cross-argument short-circuit on decisive values is preserved (pinned).
- **NOT** broadcasts shape-preservingly over array conditions (`=NOT(A1:A2>0)` → 2×1 spill); scalar behavior unchanged (pinned).
- **IFS** (the brief's SHOULD item — it fell out of the same seam): array conditions chain `broadcastIf` per CSE semantics with elementwise `#N/A` when no pair matches; scalar IFS keeps lazy pair selection (pinned by `=IFS(TRUE,42,1/0>0,99)` → 42).
- **Out of scope, unchanged by design**: bare-range coercion (`AND(A1:A10)` keeps its pre-existing error — Excel's text/blank-skipping parity is a separate follow-up), elementwise error propagation (#337).

Single-cluster ultracode wave (TDD implementer + adversarial reviewer, approved first review). 20-spec `LogicalArrayFoldSpec`: 12 fail verbatim pre-fix (aggregation/broadcast), 8 pin unchanged semantics pre- and post-fix.

## Test plan
- [x] TDD red evidence: 12/20 new specs fail on pre-fix sources with the issue's exact wrong values
- [x] `xl-evaluator.test` 1529/1529 (+20); full `__.test` green; **global** `checkFormatAll __.sources` green (the wave-10 CI lesson)
- [x] `make install` + installed-CLI verification on A1=5/A2=-1: `AND(A1:A2>0)` → FALSE, `OR(A1:A2>0)` → TRUE, `NOT(A1:A2>0)` → {FALSE;TRUE}; compositions `IF(NOT(...))`, `SUMPRODUCT(NOT(...)*1)` correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)