### PR TITLE
Wave 11: elementwise error carriage, array-IF branch errors, benchmark stop_reason + diagnostics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,6 +147,7 @@ The `xl-agent` module runs AI agent benchmarks comparing different Excel manipul
 | `--task <id>` | Run specific task ID (can repeat) |
 | `--skills <list>` | Comma-separated: `xl`, `xlsx`, or `xl,xlsx` |
 | `--parallelism <n>` | Number of parallel work units (default: 4) |
+| `--max-tokens <n>` | Per-iteration output cap for agent turns (default: 32768; thinking counts against it) |
 | `--stream` | Real-time colored console output |
 | `--force-upload` | Bypass file cache, re-upload skill |
 | `--output-dir <path>` | Results directory (default: `results/`) |

--- a/xl-agent/src/com/tjclp/xl/agent/Agent.scala
+++ b/xl-agent/src/com/tjclp/xl/agent/Agent.scala
@@ -81,6 +81,9 @@ object Agent:
         // Extract response info
         responseText = CodeExecution.extractResponseText(response)
         outputFileId = CodeExecution.extractOutputFileId(response, config.verbose)
+        // Final stop_reason of the accumulated message: max_tokens/refusal/pause_turn
+        // silently end the code-execution loop and must not read as clean completions
+        stopReason = response.stopReason().toScala.map(_.asString)
         usage = TokenUsage(
           inputTokens = response.usage().inputTokens(),
           outputTokens = response.usage().outputTokens(),
@@ -107,7 +110,8 @@ object Agent:
         latencyMs = endTime - startTime
       // For file modification tasks, success = output file created.
       // For analysis tasks (no expected output), success = agent completed.
-      // Don't set error for missing output files - let grading layer handle this.
+      // Don't set error for missing output files - let grading layer handle this;
+      // error only reports non-clean stops (truncation/refusal), issue #340.
       yield AgentResult(
         success = outputPath.isDefined || responseText.nonEmpty,
         outputFileId = outputFileId,
@@ -116,7 +120,8 @@ object Agent:
         latencyMs = latencyMs,
         transcript = collectedEvents,
         responseText = Some(responseText),
-        error = None // Grading determines correctness, not output file presence
+        error = StopReasonPolicy.errorFor(stopReason),
+        stopReason = stopReason
       )
 
     private def drainQueue(

--- a/xl-agent/src/com/tjclp/xl/agent/Models.scala
+++ b/xl-agent/src/com/tjclp/xl/agent/Models.scala
@@ -12,13 +12,18 @@ import java.nio.file.Path
 case class AgentConfig(
   model: String = benchmark.Models.DefaultAgent,
   // Claude 5 models run adaptive thinking by default; thinking tokens count
-  // against maxTokens, so leave headroom beyond the expected response size.
-  maxTokens: Int = 16384,
+  // against maxTokens, so leave generous headroom beyond the expected response
+  // size (a 16K cap truncated a real thinking-heavy benchmark turn, issue #340).
+  maxTokens: Int = AgentConfig.DefaultMaxTokens,
   verbose: Boolean = false,
   xlBinaryPath: Option[Path] = None,
   xlSkillPath: Option[Path] = None,
   forceUpload: Boolean = false
 )
+
+object AgentConfig:
+  /** Default per-iteration token budget, shared with the CLI's --max-tokens flag */
+  val DefaultMaxTokens: Int = 32768
 
 /** Token usage from API (cache fields track prompt-caching activity) */
 case class TokenUsage(
@@ -205,7 +210,9 @@ case class AgentResult(
   latencyMs: Long,
   transcript: Vector[AgentEvent],
   responseText: Option[String] = None,
-  error: Option[String] = None
+  error: Option[String] = None,
+  /** Final API stop_reason (wire value, e.g. "end_turn", "max_tokens"); see StopReasonPolicy */
+  stopReason: Option[String] = None
 )
 
 object AgentResult:
@@ -217,7 +224,8 @@ object AgentResult:
       "usage" -> Encoder[TokenUsage].apply(r.usage),
       "latencyMs" -> Json.fromLong(r.latencyMs),
       "responseText" -> r.responseText.fold(Json.Null)(Json.fromString),
-      "error" -> r.error.fold(Json.Null)(Json.fromString)
+      "error" -> r.error.fold(Json.Null)(Json.fromString),
+      "stopReason" -> r.stopReason.fold(Json.Null)(Json.fromString)
     )
   }
 

--- a/xl-agent/src/com/tjclp/xl/agent/StopReasonPolicy.scala
+++ b/xl-agent/src/com/tjclp/xl/agent/StopReasonPolicy.scala
@@ -1,0 +1,28 @@
+package com.tjclp.xl.agent
+
+/**
+ * Pure mapping from the API's final `stop_reason` to an agent-level error (issue #340).
+ *
+ * A sampling iteration that ends with `max_tokens` (or `refusal`) silently terminates the
+ * code-execution loop and previously looked like a clean completion: the run xl/13894 case 3 hit
+ * the 16K cap at 16,819 output tokens, produced no file, and recorded no error. Deriving
+ * `AgentResult.error` from the stop reason makes every non-clean stop loud through the existing
+ * failure plumbing (trace metadata, console lines, reports).
+ */
+object StopReasonPolicy:
+
+  /** Stop reasons that mark a cleanly finished turn (wire values from `BetaStopReason`) */
+  private val CleanStops: Set[String] = Set("end_turn", "tool_use", "stop_sequence")
+
+  /**
+   * Error text for a final stop reason; None when the turn finished cleanly.
+   *
+   * Unknown reasons are flagged rather than ignored: a stop reason this policy has never seen is by
+   * definition not a known-clean completion, and a false alarm is cheaper than a silent truncation.
+   */
+  def errorFor(stopReason: Option[String]): Option[String] =
+    stopReason.filterNot(CleanStops.contains).map {
+      case "max_tokens" => "turn truncated: stop_reason=max_tokens (raise --max-tokens)"
+      case "refusal" => "model refused: stop_reason=refusal"
+      case other => s"turn incomplete: stop_reason=$other"
+    }

--- a/xl-agent/src/com/tjclp/xl/agent/anthropic/CodeExecution.scala
+++ b/xl-agent/src/com/tjclp/xl/agent/anthropic/CodeExecution.scala
@@ -101,6 +101,15 @@ object CodeExecution:
               accumulator.message()
             finally streamResponse.close()
           }
+          .onError { case _ =>
+            // Best-effort recovery of the open turn's token usage when the stream dies
+            // mid-turn (issue #340). Routed through the same sequential dispatcher so it
+            // runs after every already-submitted stream event (a pending message_stop
+            // must close the turn first, or its usage would be double-counted).
+            IO.fromFuture(IO(dispatcher.unsafeToFuture(streamProcessor.flushPartialTurn)))
+              .attempt
+              .void
+          }
           .adaptError { case e: Exception =>
             AgentError.StreamingError(e.getMessage)
           }

--- a/xl-agent/src/com/tjclp/xl/agent/anthropic/Streaming.scala
+++ b/xl-agent/src/com/tjclp/xl/agent/anthropic/Streaming.scala
@@ -20,12 +20,34 @@ case class ProcessorState(
   prevCumulativeOutput: Long = 0L,
   lastCumulativeInput: Long = 0L,
   lastCumulativeOutput: Long = 0L,
+  // True between message_start and message_stop: the turn's usage has not been
+  // reported by a TurnComplete yet (truncated-stream recovery, issue #340)
+  turnOpen: Boolean = false,
   // Sub-turn tracking for code execution (assistant → tool → result cycles)
   subTurnNum: Int = 0,
   subTurnStartTime: Option[Instant] = None,
   subTurnAnchorTime: Option[Instant] = None,
   pendingToolCall: Boolean = false
-)
+):
+  /**
+   * Usage accrued in the currently open turn, or None once message_stop reported it.
+   *
+   * Pure decision behind [[StreamEventProcessor.flushPartialTurn]]: only an open turn may emit a
+   * synthetic TurnComplete, otherwise the last completed turn would be double-counted.
+   */
+  def openTurnUsage(now: Instant): Option[TurnUsage] =
+    Option.when(turnOpen) {
+      TurnUsage(
+        turnNum = turnNum,
+        inputTokens = lastCumulativeInput - prevCumulativeInput,
+        outputTokens = lastCumulativeOutput - prevCumulativeOutput,
+        cumulativeInputTokens = lastCumulativeInput,
+        cumulativeOutputTokens = lastCumulativeOutput,
+        durationMs = turnStartTime
+          .map(start => java.time.Duration.between(start, now).toMillis)
+          .getOrElse(0L)
+      )
+    }
 
 /** Processes streaming events from the Anthropic API and emits AgentEvents */
 class StreamEventProcessor private (
@@ -95,6 +117,25 @@ class StreamEventProcessor private (
     val messageStopIO = processMessageStop(event)
     textIO *> toolStartIO *> toolResultIO *> toolStopIO *>
       messageStartIO *> messageDeltaIO *> messageStopIO
+
+  /**
+   * Emit a synthetic TurnComplete carrying the usage accrued in a turn cut off mid-stream.
+   *
+   * TurnComplete normally fires only on message_stop, so a stream that dies mid-turn loses all
+   * token accounting for the open turn (issue #340). Called best-effort when the SSE stream fails;
+   * a no-op when no turn is open, so completed turns are never double-counted.
+   */
+  def flushPartialTurn: IO[Unit] =
+    for
+      now <- IO.realTimeInstant
+      partial <- state.modify { s =>
+        (s.copy(turnOpen = false), s.openTurnUsage(now))
+      }
+      _ <- partial.fold(IO.unit) { usage =>
+        val turnEvent = AgentEvent.TurnComplete(usage)
+        eventQueue.offer(turnEvent) *> onEvent(turnEvent)
+      }
+    yield ()
 
   private def processTextDelta(event: BetaRawMessageStreamEvent): IO[Unit] =
     event.contentBlockDelta().toScala match
@@ -328,6 +369,7 @@ class StreamEventProcessor private (
               prevCumulativeInput = s.lastCumulativeInput,
               prevCumulativeOutput = s.lastCumulativeOutput,
               lastCumulativeInput = usage.inputTokens(),
+              turnOpen = true,
               subTurnStartTime = None,
               subTurnAnchorTime = Some(now),
               pendingToolCall = false
@@ -381,6 +423,8 @@ class StreamEventProcessor private (
           turnEvent = AgentEvent.TurnComplete(usage)
           _ <- eventQueue.offer(turnEvent)
           _ <- onEvent(turnEvent)
+          // The turn's usage is reported; a later flushPartialTurn must not repeat it
+          _ <- state.update(_.copy(turnOpen = false))
           _ <- IO.whenA(verbose) {
             IO {
               println(

--- a/xl-agent/src/com/tjclp/xl/agent/benchmark/execution/BenchmarkEngine.scala
+++ b/xl-agent/src/com/tjclp/xl/agent/benchmark/execution/BenchmarkEngine.scala
@@ -3,12 +3,13 @@ package com.tjclp.xl.agent.benchmark.execution
 import cats.effect.{Clock, IO}
 import cats.effect.syntax.concurrent.*
 import cats.syntax.all.*
-import com.tjclp.xl.agent.AgentConfig
+import com.tjclp.xl.agent.{AgentConfig, TokenUsage as AgentTokenUsage}
 import com.tjclp.xl.agent.anthropic.AnthropicClientIO
 import com.tjclp.xl.agent.benchmark.grading.*
 import com.tjclp.xl.agent.benchmark.reporting.TokenSummary
-import com.tjclp.xl.agent.benchmark.skills.{Skill, SkillContext}
+import com.tjclp.xl.agent.benchmark.skills.{CaseFailure, Skill, SkillContext}
 import com.tjclp.xl.agent.benchmark.task.*
+import com.tjclp.xl.agent.benchmark.tracing.ConversationTracer
 
 import java.nio.file.Path
 import java.time.{Duration, Instant}
@@ -324,6 +325,10 @@ private class DefaultBenchmarkEngine(
 
   /**
    * Execute a single work unit (one case for one skill on one task).
+   *
+   * Skills own their failure paths and save partial traces themselves (see CaseFailure); this
+   * engine-level handler is a last resort for Skill implementations that raise outside their own
+   * guarded sections. No tracer exists here, so it records a metadata-only failure trace.
    */
   private def executeWorkUnit(
     unit: WorkUnit,
@@ -336,21 +341,49 @@ private class DefaultBenchmarkEngine(
         WorkUnitResult(unit.taskId, unit.skillName, caseResult)
       }
       .handleErrorWith { e =>
-        IO.pure(
-          WorkUnitResult(
-            unit.taskId,
-            unit.skillName,
-            CaseResult(
-              caseNum = unit.testCase.caseNum,
-              passed = false,
-              usage = TokenUsage.zero,
-              latencyMs = 0,
-              details = CaseDetails.NoDetails,
-              error = Some(s"Execution failed: ${e.getClass.getSimpleName}: ${e.getMessage}")
-            )
-          )
-        )
+        lastResortFailure(unit, agentConfig, config, e)
       }
+
+  /**
+   * Total fallback for a work unit whose Skill raised: best-effort save of a metadata-only trace
+   * (error + model, zero events) so even third-party skill crashes leave forensics on disk (issue
+   * #340).
+   */
+  private def lastResortFailure(
+    unit: WorkUnit,
+    agentConfig: AgentConfig,
+    config: EngineConfig,
+    error: Throwable
+  ): IO[WorkUnitResult] =
+    val message = s"Execution failed: ${CaseFailure.describe(error)}"
+    val saveTrace = for
+      tracer <- ConversationTracer.create(
+        outputDir = config.outputDir,
+        taskId = unit.task.taskIdValue,
+        skillName = unit.skillName,
+        caseNum = unit.testCase.caseNum,
+        streaming = false,
+        model = Some(agentConfig.model)
+      )
+      _ <- tracer.complete(AgentTokenUsage.zero, passed = false, error = Some(message)).attempt
+      saved <- tracer.save().attempt
+    yield saved.toOption
+
+    saveTrace.handleError(_ => None).map { tracePath =>
+      WorkUnitResult(
+        unit.taskId,
+        unit.skillName,
+        CaseResult(
+          caseNum = unit.testCase.caseNum,
+          passed = false,
+          usage = TokenUsage.zero,
+          latencyMs = 0,
+          details = CaseDetails.NoDetails,
+          tracePath = tracePath,
+          error = Some(message)
+        )
+      )
+    }
 
   /**
    * Aggregate work unit results by (task, skill) and apply grading.

--- a/xl-agent/src/com/tjclp/xl/agent/benchmark/execution/ExecutionResult.scala
+++ b/xl-agent/src/com/tjclp/xl/agent/benchmark/execution/ExecutionResult.scala
@@ -146,13 +146,21 @@ object ExecutionResult:
     latencyMs: Long
   ): ExecutionResult =
     val passed = caseResults.count(_.passed)
+    // Every case errored: an execution failure, not a graded fail — surface the first
+    // error at task level so the console renders red ✗ (issue #340). Partial errors
+    // stay case-level only (the task remains a graded result).
+    val error =
+      if caseResults.nonEmpty && caseResults.forall(_.error.isDefined) then
+        caseResults.flatMap(_.error).headOption
+      else None
     ExecutionResult(
       taskId = taskId,
       skill = skill,
       caseResults = caseResults,
       aggregateScore = Score.FractionalScore(passed, caseResults.length),
       usage = usage,
-      latencyMs = latencyMs
+      latencyMs = latencyMs,
+      error = error
     )
 
 // ============================================================================

--- a/xl-agent/src/com/tjclp/xl/agent/benchmark/runner/UnifiedRunner.scala
+++ b/xl-agent/src/com/tjclp/xl/agent/benchmark/runner/UnifiedRunner.scala
@@ -65,6 +65,7 @@ object UnifiedRunner extends IOApp:
 
         agentConfig = AgentConfig(
           model = config.model,
+          maxTokens = config.maxTokens,
           verbose = false,
           xlBinaryPath = config.xlBinaryPath,
           xlSkillPath = config.xlSkillPath,
@@ -260,7 +261,7 @@ ${"=" * 60}
   // CLI Argument Parsing
   // --------------------------------------------------------------------------
 
-  private def parseArgs(args: List[String]): IO[UnifiedConfig] =
+  private[runner] def parseArgs(args: List[String]): IO[UnifiedConfig] =
     IO {
       @annotation.tailrec
       def parse(remaining: List[String], config: UnifiedConfig): UnifiedConfig =
@@ -293,6 +294,8 @@ ${"=" * 60}
             parse(rest, config.copy(tasksFile = Some(Path.of(value))))
           case "--model" :: value :: rest =>
             parse(rest, config.copy(model = value))
+          case "--max-tokens" :: value :: rest =>
+            parse(rest, config.copy(maxTokens = value.toInt))
           case "--stream" :: rest =>
             parse(rest, config.copy(stream = true))
           case "--no-grade" :: rest =>
@@ -356,6 +359,8 @@ ${"=" * 60}
       |
       |Execution:
       |  --model <name>         Model to use (default: ${Models.DefaultAgent})
+      |  --max-tokens <n>       Per-iteration token budget; adaptive thinking counts
+      |                         against it (default: ${AgentConfig.DefaultMaxTokens})
       |  --parallelism <n>      Number of parallel tasks (default: 4)
       |  --xl-cli <path>        Path to xl CLI for local grading (default: xl)
       |  --xl-binary <path>     Path to xl binary for upload (default: auto-download)
@@ -392,6 +397,7 @@ case class UnifiedConfig(
   tasksFile: Option[Path] = None,
   outputDir: Path = Path.of("results", BenchmarkUtils.formatTimestamp),
   model: String = Models.DefaultAgent,
+  maxTokens: Int = AgentConfig.DefaultMaxTokens,
   parallelism: Int = 4,
   stream: Boolean = false,
   enableGrading: Boolean = true,

--- a/xl-agent/src/com/tjclp/xl/agent/benchmark/skills/CaseFailure.scala
+++ b/xl-agent/src/com/tjclp/xl/agent/benchmark/skills/CaseFailure.scala
@@ -23,7 +23,9 @@ object CaseFailure:
    * Build the failing CaseResult for a case that raised after its tracer was created.
    *
    * Completes the tracer with the error and saves the partial trace; a successfully saved path is
-   * wired into the CaseResult so reports can point at the surviving trace.
+   * wired into the CaseResult so reports can point at the surviving trace. Token usage is recovered
+   * by summing the per-turn deltas of the TurnComplete events collected before the failure (issue
+   * #340) — recording zero undercounted the real cost of failed cases.
    */
   def withPartialTrace(
     tracer: ConversationTracer,
@@ -34,12 +36,16 @@ object CaseFailure:
     val message = describe(error)
     for
       endTimeMs <- Clock[IO].monotonic.map(_.toMillis)
-      _ <- tracer.complete(AgentTokenUsage.zero, passed = false, error = Some(message)).attempt
+      trace <- tracer.getTrace
+      partialUsage = trace.turnUsages.foldLeft(AgentTokenUsage.zero) { (acc, turn) =>
+        acc + AgentTokenUsage(turn.inputTokens, turn.outputTokens)
+      }
+      _ <- tracer.complete(partialUsage, passed = false, error = Some(message)).attempt
       saved <- tracer.save().attempt
     yield CaseResult(
       caseNum = caseNum,
       passed = false,
-      usage = TokenUsage.zero,
+      usage = TokenUsage.fromAgentUsage(partialUsage),
       latencyMs = math.max(0L, endTimeMs - startTimeMs),
       details = CaseDetails.NoDetails,
       tracePath = saved.toOption,

--- a/xl-agent/src/com/tjclp/xl/agent/benchmark/skills/Skill.scala
+++ b/xl-agent/src/com/tjclp/xl/agent/benchmark/skills/Skill.scala
@@ -138,6 +138,11 @@ trait Skill:
    * single-case execution. The default implementation delegates to the full execute() method for
    * backward compatibility, but skills should override this for better efficiency.
    *
+   * Failure contract: implementations should handle their own failures and return a failing
+   * CaseResult with the conversation trace saved (see [[CaseFailure]] for total handlers). If an
+   * implementation raises instead, the engine's last-resort fallback only records a metadata-only
+   * failure trace — the conversation collected before the crash is lost.
+   *
    * @param testCase
    *   The specific test case to execute
    * @param task

--- a/xl-agent/src/com/tjclp/xl/agent/benchmark/skills/builtin/XlSkill.scala
+++ b/xl-agent/src/com/tjclp/xl/agent/benchmark/skills/builtin/XlSkill.scala
@@ -144,7 +144,7 @@ object XlSkill extends Skill:
         latencyMs = endTime - startTime
 
         // Complete and save tracer
-        _ <- tracer.complete(result.usage, passed, result.error)
+        _ <- tracer.complete(result.usage, passed, result.error, result.stopReason)
         tracePath <- tracer.save()
 
         // Convert mismatches to grading format
@@ -165,7 +165,8 @@ object XlSkill extends Skill:
         usage = TokenUsage.fromAgentUsage(result.usage),
         latencyMs = latencyMs,
         details = details,
-        tracePath = Some(tracePath)
+        tracePath = Some(tracePath),
+        error = result.error // Non-clean stop (truncation/refusal) is a case error (issue #340)
       )
 
     (for
@@ -221,7 +222,7 @@ object XlSkill extends Skill:
         agentSucceeded = result.error.isEmpty
 
         // Complete and save tracer
-        _ <- tracer.complete(result.usage, agentSucceeded, result.error)
+        _ <- tracer.complete(result.usage, agentSucceeded, result.error, result.stopReason)
         tracePath <- tracer.save()
       yield CaseResult(
         caseNum = testCase.caseNum,
@@ -232,7 +233,8 @@ object XlSkill extends Skill:
           result.responseText.getOrElse(""),
           task.evaluation.expectedAnswer
         ),
-        tracePath = Some(tracePath)
+        tracePath = Some(tracePath),
+        error = result.error // Non-clean stop (truncation/refusal) is a case error (issue #340)
       )
 
     (for

--- a/xl-agent/src/com/tjclp/xl/agent/benchmark/skills/builtin/XlsxSkill.scala
+++ b/xl-agent/src/com/tjclp/xl/agent/benchmark/skills/builtin/XlsxSkill.scala
@@ -119,7 +119,7 @@ object XlsxSkill extends Skill:
         latencyMs = endTime - startTime
 
         // Complete and save tracer
-        _ <- tracer.complete(result.usage, passed, result.error)
+        _ <- tracer.complete(result.usage, passed, result.error, result.stopReason)
         tracePath <- tracer.save()
 
         mismatches = rangeResults.flatMap(_.mismatches).map { m =>
@@ -139,7 +139,8 @@ object XlsxSkill extends Skill:
         usage = TokenUsage.fromAgentUsage(result.usage),
         latencyMs = latencyMs,
         details = details,
-        tracePath = Some(tracePath)
+        tracePath = Some(tracePath),
+        error = result.error // Non-clean stop (truncation/refusal) is a case error (issue #340)
       )
 
     (for
@@ -195,7 +196,7 @@ object XlsxSkill extends Skill:
         agentSucceeded = result.error.isEmpty
 
         // Complete and save tracer
-        _ <- tracer.complete(result.usage, agentSucceeded, result.error)
+        _ <- tracer.complete(result.usage, agentSucceeded, result.error, result.stopReason)
         tracePath <- tracer.save()
       yield CaseResult(
         caseNum = testCase.caseNum,
@@ -206,7 +207,8 @@ object XlsxSkill extends Skill:
           result.responseText.getOrElse(""),
           task.evaluation.expectedAnswer
         ),
-        tracePath = Some(tracePath)
+        tracePath = Some(tracePath),
+        error = result.error // Non-clean stop (truncation/refusal) is a case error (issue #340)
       )
 
     (for

--- a/xl-agent/src/com/tjclp/xl/agent/benchmark/tracing/ConversationTracer.scala
+++ b/xl-agent/src/com/tjclp/xl/agent/benchmark/tracing/ConversationTracer.scala
@@ -35,7 +35,9 @@ case class ConversationMetadata(
   endTime: Option[Instant] = None,
   usage: Option[TokenUsage] = None,
   passed: Option[Boolean] = None,
-  error: Option[String] = None
+  error: Option[String] = None,
+  /** Final API stop_reason (wire value); non-clean stops also surface via error (issue #340) */
+  stopReason: Option[String] = None
 ):
   def durationMs: Long =
     endTime.map(e => Duration.between(startTime, e).toMillis).getOrElse(0L)
@@ -52,7 +54,8 @@ object ConversationMetadata:
       "durationMs" -> m.durationMs.asJson,
       "usage" -> m.usage.asJson,
       "passed" -> m.passed.asJson,
-      "error" -> m.error.asJson
+      "error" -> m.error.asJson,
+      "stopReason" -> m.stopReason.asJson
     )
   }
 
@@ -165,7 +168,8 @@ class ConversationTracer private (
   def complete(
     usage: TokenUsage,
     passed: Boolean,
-    error: Option[String] = None
+    error: Option[String] = None,
+    stopReason: Option[String] = None
   ): IO[Unit] =
     for
       now <- IO.realTimeInstant
@@ -176,7 +180,8 @@ class ConversationTracer private (
           endTime = Some(now),
           usage = Some(usage),
           passed = Some(passed),
-          error = error
+          error = error,
+          stopReason = stopReason
         )
       )
       _ <- IO.whenA(streaming)(

--- a/xl-agent/src/com/tjclp/xl/agent/benchmark/tracing/StreamingConsole.scala
+++ b/xl-agent/src/com/tjclp/xl/agent/benchmark/tracing/StreamingConsole.scala
@@ -231,11 +231,18 @@ object StreamingConsole:
     error: Option[String] = None
   ): IO[Unit] =
     IO.blocking {
-      Console.println("\n" + formatCompleteLine(taskId, caseNum, passed, durationMs, error))
+      Console.println(
+        "\n" + formatCompleteLine(skillName, taskId, caseNum, passed, durationMs, error)
+      )
     }
 
-  /** Completion line, with the error surfaced on failure so crashes are visible live */
+  /**
+   * Completion line, with the error surfaced on failure so crashes are visible live. Carries the
+   * skill in the same '[skill task.case]' shape as event lines, so parallel multi-skill streams
+   * stay attributable (issue #340).
+   */
   private[tracing] def formatCompleteLine(
+    skillName: String,
     taskId: String,
     caseNum: Int,
     passed: Boolean,
@@ -243,11 +250,12 @@ object StreamingConsole:
     error: Option[String]
   ): String =
     val status = if passed then s"${Green}PASSED" else s"${Red}FAILED"
+    val ctxStr = formatContext(StreamContext(taskId, skillName, caseNum))
     val duration = f"${durationMs / 1000.0}%.1fs"
     val errorSuffix = error.fold("") { e =>
       s" $Red${e.replace("\n", " ").take(MaxErrorChars)}$Reset"
     }
-    s"$status$Reset Task $taskId:$caseNum ($duration)$errorSuffix"
+    s"$status$Reset [$ctxStr] ($duration)$errorSuffix"
 
   private def truncateLines(s: String, maxLines: Int): String =
     val lines = s.split("\n")

--- a/xl-agent/test/src/com/tjclp/xl/agent/ModelsSpec.scala
+++ b/xl-agent/test/src/com/tjclp/xl/agent/ModelsSpec.scala
@@ -57,10 +57,31 @@ class ModelsSpec extends CatsEffectSuite:
     assertEquals(json.hcursor.get[String]("command").toOption, Some("ls -la"))
   }
 
+  test("AgentResult JSON carries the stop reason") {
+    val result = AgentResult(
+      success = true,
+      outputFileId = None,
+      outputPath = None,
+      usage = TokenUsage.zero,
+      latencyMs = 191_000L,
+      transcript = Vector.empty,
+      responseText = Some("done"),
+      error = Some("turn truncated: stop_reason=max_tokens (raise --max-tokens)"),
+      stopReason = Some("max_tokens")
+    )
+    val json = result.asJson
+    assertEquals(json.hcursor.get[String]("stopReason").toOption, Some("max_tokens"))
+
+    val absent = result.copy(stopReason = None, error = None)
+    assertEquals(absent.asJson.hcursor.get[Option[String]]("stopReason"), Right(None))
+  }
+
   test("AgentConfig defaults") {
     val config = AgentConfig()
     // Default is Sonnet 5 (near-Opus coding/agentic quality at Sonnet cost)
     assertEquals(config.model, "claude-sonnet-5")
-    assertEquals(config.maxTokens, 16384)
+    // 32K leaves headroom for adaptive thinking, which counts against maxTokens
+    // (GH-340: a 16K cap truncated a real benchmark turn at 16,819 output tokens)
+    assertEquals(config.maxTokens, 32768)
     assertEquals(config.verbose, false)
   }

--- a/xl-agent/test/src/com/tjclp/xl/agent/StopReasonPolicySpec.scala
+++ b/xl-agent/test/src/com/tjclp/xl/agent/StopReasonPolicySpec.scala
@@ -1,0 +1,68 @@
+package com.tjclp.xl.agent
+
+import com.anthropic.models.beta.messages.BetaStopReason
+import munit.FunSuite
+
+/**
+ * Pins the stop_reason -> error mapping (issue #340): non-clean stops must become loud agent
+ * errors, clean stops and absent stop reasons must stay silent.
+ */
+class StopReasonPolicySpec extends FunSuite:
+
+  private def errorForConstant(reason: BetaStopReason): Option[String] =
+    StopReasonPolicy.errorFor(Some(reason.asString))
+
+  test("clean stops map to no error") {
+    assertEquals(errorForConstant(BetaStopReason.END_TURN), None)
+    assertEquals(errorForConstant(BetaStopReason.TOOL_USE), None)
+    assertEquals(errorForConstant(BetaStopReason.STOP_SEQUENCE), None)
+  }
+
+  test("absent stop reason maps to no error") {
+    assertEquals(StopReasonPolicy.errorFor(None), None)
+  }
+
+  test("max_tokens maps to a truncation error naming the remedy") {
+    assertEquals(
+      errorForConstant(BetaStopReason.MAX_TOKENS),
+      Some("turn truncated: stop_reason=max_tokens (raise --max-tokens)")
+    )
+  }
+
+  test("refusal maps to a refusal error") {
+    assertEquals(
+      errorForConstant(BetaStopReason.REFUSAL),
+      Some("model refused: stop_reason=refusal")
+    )
+  }
+
+  test("pause_turn maps to an incomplete-turn error") {
+    assertEquals(
+      errorForConstant(BetaStopReason.PAUSE_TURN),
+      Some("turn incomplete: stop_reason=pause_turn")
+    )
+  }
+
+  test("remaining SDK constants are flagged, never silent") {
+    assertEquals(
+      errorForConstant(BetaStopReason.COMPACTION),
+      Some("turn incomplete: stop_reason=compaction")
+    )
+    assertEquals(
+      errorForConstant(BetaStopReason.MODEL_CONTEXT_WINDOW_EXCEEDED),
+      Some("turn incomplete: stop_reason=model_context_window_exceeded")
+    )
+  }
+
+  test("every SDK stop reason constant has a deliberate mapping") {
+    // If the SDK grows a new constant this fails, forcing a policy decision
+    val known = BetaStopReason.Value.values.toList.filterNot(_ == BetaStopReason.Value._UNKNOWN)
+    assertEquals(known.size, 8, s"unexpected BetaStopReason constants: $known")
+  }
+
+  test("unknown future stop reasons are flagged rather than ignored") {
+    assertEquals(
+      StopReasonPolicy.errorFor(Some("some_future_reason")),
+      Some("turn incomplete: stop_reason=some_future_reason")
+    )
+  }

--- a/xl-agent/test/src/com/tjclp/xl/agent/anthropic/StreamEventProcessorSpec.scala
+++ b/xl-agent/test/src/com/tjclp/xl/agent/anthropic/StreamEventProcessorSpec.scala
@@ -1,0 +1,170 @@
+package com.tjclp.xl.agent.anthropic
+
+import java.time.Instant
+import java.util.Optional
+
+import cats.effect.{IO, Ref}
+import cats.effect.std.Queue
+import com.anthropic.models.beta.messages.*
+import munit.CatsEffectSuite
+import com.tjclp.xl.agent.AgentEvent
+
+/**
+ * Truncated-stream usage recovery (issue #340): TurnComplete only fires on message_stop, so a
+ * stream that dies mid-turn loses the open turn's token accounting unless flushPartialTurn emits it
+ * — and a flush after a completed turn must never double-count.
+ */
+class StreamEventProcessorSpec extends CatsEffectSuite:
+
+  private def messageStart(inputTokens: Long): BetaRawMessageStreamEvent =
+    BetaRawMessageStreamEvent.ofMessageStart(
+      BetaRawMessageStartEvent
+        .builder()
+        .message(
+          BetaMessage
+            .builder()
+            .id("msg_test")
+            .content(java.util.List.of())
+            .model("claude-test")
+            .stopReason(Optional.empty[BetaStopReason]())
+            .stopSequence(Optional.empty[String]())
+            .container(Optional.empty[BetaContainer]())
+            .contextManagement(Optional.empty[BetaContextManagementResponse]())
+            .diagnostics(Optional.empty[BetaDiagnostics]())
+            .stopDetails(Optional.empty[BetaRefusalStopDetails]())
+            .usage(
+              BetaUsage
+                .builder()
+                .inputTokens(inputTokens)
+                .outputTokens(0L)
+                .cacheCreation(Optional.empty[BetaCacheCreation]())
+                .cacheCreationInputTokens(Optional.empty[java.lang.Long]())
+                .cacheReadInputTokens(Optional.empty[java.lang.Long]())
+                .serverToolUse(Optional.empty[BetaServerToolUsage]())
+                .serviceTier(Optional.empty[BetaUsage.ServiceTier]())
+                .inferenceGeo(Optional.empty[String]())
+                .speed(Optional.empty[BetaUsage.Speed]())
+                .iterations(Optional.empty[java.util.List[BetaUsage.Iteration]]())
+                .outputTokensDetails(Optional.empty[BetaOutputTokensDetails]())
+                .build()
+            )
+            .build()
+        )
+        .build()
+    )
+
+  private def messageDelta(outputTokens: Long): BetaRawMessageStreamEvent =
+    BetaRawMessageStreamEvent.ofMessageDelta(
+      BetaRawMessageDeltaEvent
+        .builder()
+        .contextManagement(Optional.empty[BetaContextManagementResponse]())
+        .delta(
+          BetaRawMessageDeltaEvent.Delta
+            .builder()
+            .stopReason(Optional.empty[BetaStopReason]())
+            .stopSequence(Optional.empty[String]())
+            .container(Optional.empty[BetaContainer]())
+            .stopDetails(Optional.empty[BetaRefusalStopDetails]())
+            .build()
+        )
+        .usage(
+          BetaMessageDeltaUsage
+            .builder()
+            .outputTokens(outputTokens)
+            .inputTokens(Optional.empty[java.lang.Long]())
+            .cacheCreationInputTokens(Optional.empty[java.lang.Long]())
+            .cacheReadInputTokens(Optional.empty[java.lang.Long]())
+            .serverToolUse(Optional.empty[BetaServerToolUsage]())
+            .iterations(Optional.empty[java.util.List[BetaMessageDeltaUsage.Iteration]]())
+            .outputTokensDetails(Optional.empty[BetaOutputTokensDetails]())
+            .build()
+        )
+        .build()
+    )
+
+  private def messageStop: BetaRawMessageStreamEvent =
+    BetaRawMessageStreamEvent.ofMessageStop(BetaRawMessageStopEvent.builder().build())
+
+  private def newProcessor
+    : IO[(StreamEventProcessor, Ref[IO, Vector[AgentEvent]], Queue[IO, AgentEvent])] =
+    for
+      queue <- Queue.unbounded[IO, AgentEvent]
+      seen <- Ref.of[IO, Vector[AgentEvent]](Vector.empty)
+      processor <- StreamEventProcessor.create(queue, e => seen.update(_ :+ e))
+    yield (processor, seen, queue)
+
+  private def turnCompletes(events: Vector[AgentEvent]) =
+    events.collect { case AgentEvent.TurnComplete(usage) => usage }
+
+  test("flushPartialTurn emits a synthetic TurnComplete for a turn cut off mid-stream") {
+    for
+      (processor, seen, _) <- newProcessor
+      _ <- processor.process(messageStart(1000L))
+      _ <- processor.process(messageDelta(500L))
+      // The stream dies here: no message_stop arrives
+      _ <- processor.flushPartialTurn
+      events <- seen.get
+    yield
+      val turns = turnCompletes(events)
+      assertEquals(turns.map(u => (u.inputTokens, u.outputTokens)), Vector((1000L, 500L)))
+      assertEquals(turns.headOption.map(_.turnNum), Some(1))
+  }
+
+  test("flushPartialTurn is a no-op after message_stop reported the turn") {
+    for
+      (processor, seen, _) <- newProcessor
+      _ <- processor.process(messageStart(1000L))
+      _ <- processor.process(messageDelta(500L))
+      _ <- processor.process(messageStop)
+      _ <- processor.flushPartialTurn
+      events <- seen.get
+    yield
+      val turns = turnCompletes(events)
+      assertEquals(
+        turns.map(u => (u.inputTokens, u.outputTokens)),
+        Vector((1000L, 500L)),
+        "a completed turn must never be double-counted"
+      )
+  }
+
+  test("flushPartialTurn emits at most once for the same open turn") {
+    for
+      (processor, seen, _) <- newProcessor
+      _ <- processor.process(messageStart(1000L))
+      _ <- processor.process(messageDelta(500L))
+      _ <- processor.flushPartialTurn
+      _ <- processor.flushPartialTurn
+      events <- seen.get
+    yield assertEquals(turnCompletes(events).size, 1)
+  }
+
+  test("flushPartialTurn is a no-op before any turn started") {
+    for
+      (processor, seen, _) <- newProcessor
+      _ <- processor.flushPartialTurn
+      events <- seen.get
+    yield assertEquals(turnCompletes(events), Vector.empty)
+  }
+
+  test("openTurnUsage is pure: open turns report deltas, closed turns report nothing") {
+    val now = Instant.parse("2026-07-09T00:00:00Z")
+    val open = ProcessorState(
+      turnNum = 2,
+      turnStartTime = Some(now.minusSeconds(5)),
+      prevCumulativeInput = 1000L,
+      prevCumulativeOutput = 200L,
+      lastCumulativeInput = 3500L,
+      lastCumulativeOutput = 700L,
+      turnOpen = true
+    )
+    val usage = open.openTurnUsage(now).getOrElse(fail("open turn must report usage"))
+    assertEquals(usage.turnNum, 2)
+    assertEquals(usage.inputTokens, 2500L)
+    assertEquals(usage.outputTokens, 500L)
+    assertEquals(usage.cumulativeInputTokens, 3500L)
+    assertEquals(usage.cumulativeOutputTokens, 700L)
+    assertEquals(usage.durationMs, 5000L)
+
+    assertEquals(open.copy(turnOpen = false).openTurnUsage(now), None)
+    assertEquals(ProcessorState().openTurnUsage(now), None)
+  }

--- a/xl-agent/test/src/com/tjclp/xl/agent/benchmark/execution/BenchmarkEngineSpec.scala
+++ b/xl-agent/test/src/com/tjclp/xl/agent/benchmark/execution/BenchmarkEngineSpec.scala
@@ -1,0 +1,133 @@
+package com.tjclp.xl.agent.benchmark.execution
+
+import cats.effect.IO
+import munit.CatsEffectSuite
+import com.tjclp.xl.agent.{Agent, AgentConfig, AgentResult, AgentTask}
+import com.tjclp.xl.agent.anthropic.AnthropicClientIO
+import com.tjclp.xl.agent.benchmark.skills.{Skill, SkillContext}
+import com.tjclp.xl.agent.benchmark.task.*
+
+import java.nio.file.{Files, Path}
+
+/**
+ * Engine last-resort failure path (issue #340): a third-party Skill that raises outside its own
+ * guarded sections must still produce a total failing CaseResult AND leave a metadata-only trace on
+ * disk (no tracer exists at the engine level, so events are unrecoverable by design).
+ *
+ * Runs fully offline: the stub skill raises before the dummy-key client could reach the network.
+ */
+class BenchmarkEngineSpec extends CatsEffectSuite:
+
+  private val tempDir = FunFixture[Path](
+    setup = _ => Files.createTempDirectory("benchmark-engine-spec"),
+    teardown = { dir =>
+      import scala.jdk.CollectionConverters.*
+      import scala.util.Using
+      Using.resource(Files.walk(dir)) { stream =>
+        stream.iterator().asScala.toList.reverse.foreach(p => Files.deleteIfExists(p))
+      }
+    }
+  )
+
+  /** A third-party-style skill that raises outside any guarded section */
+  private object ExplodingSkill extends Skill:
+    override val name: String = "exploding"
+    override val displayName: String = "Exploding Skill"
+
+    override def setup(client: AnthropicClientIO, config: AgentConfig): IO[SkillContext] =
+      IO.pure(SkillContext.empty)
+
+    override def teardown(client: AnthropicClientIO, ctx: SkillContext): IO[Unit] = IO.unit
+
+    override def createAgent(
+      client: AnthropicClientIO,
+      ctx: SkillContext,
+      config: AgentConfig
+    ): Agent = new Agent:
+      override def run(task: AgentTask): IO[AgentResult] =
+        IO.raiseError(new IllegalStateException("unused"))
+      override def runStreaming(
+        task: AgentTask,
+        onEvent: com.tjclp.xl.agent.AgentEvent => IO[Unit]
+      ): IO[AgentResult] =
+        IO.raiseError(new IllegalStateException("unused"))
+
+    override def execute(
+      task: BenchmarkTask,
+      ctx: SkillContext,
+      client: AnthropicClientIO,
+      agentConfig: AgentConfig,
+      engineConfig: EngineConfig
+    ): IO[ExecutionResult] =
+      IO.raiseError(new IllegalStateException("skill exploded outside its guard"))
+
+    override def executeCase(
+      testCase: TestCaseFile,
+      task: BenchmarkTask,
+      ctx: SkillContext,
+      client: AnthropicClientIO,
+      agentConfig: AgentConfig,
+      engineConfig: EngineConfig
+    ): IO[CaseResult] =
+      IO.raiseError(new IllegalStateException("skill exploded outside its guard"))
+
+  tempDir.test("a raising Skill yields a failing CaseResult with a metadata-only trace") { dir =>
+    val testCase = TestCaseFile(1, dir.resolve("in.xlsx"), dir.resolve("answer.xlsx"))
+    val task = BenchmarkTask(
+      id = TaskId("999"),
+      instruction = "test instruction",
+      category = TaskCategory.CellLevel,
+      inputSource = InputSource.TestCases(Vector(testCase)),
+      evaluation = EvaluationSpec.fileOnly
+    )
+    AnthropicClientIO.resource("dummy-key-never-used").use { client =>
+      BenchmarkEngine
+        .default(client)
+        .run(
+          tasks = List(task),
+          skills = List(ExplodingSkill),
+          agentConfig = AgentConfig(model = "claude-test"),
+          config = EngineConfig.default.copy(outputDir = dir, stream = false)
+        )
+        .map { run =>
+          val execResult = run
+            .skillResults("exploding")
+            .results
+            .headOption
+            .getOrElse(fail("missing execution result"))
+          val caseResult =
+            execResult.caseResults.headOption.getOrElse(fail("missing case result"))
+
+          assertEquals(caseResult.passed, false)
+          assert(
+            caseResult.error.exists(_.contains("IllegalStateException: skill exploded")),
+            s"error must be recorded: ${caseResult.error}"
+          )
+
+          // All cases errored -> the task itself is an execution failure (issue #340)
+          assert(
+            execResult.error.exists(_.contains("skill exploded")),
+            s"all-errored task must carry a task-level error: ${execResult.error}"
+          )
+
+          // The engine fallback saved a metadata-only trace
+          val traceDir =
+            caseResult.tracePath.getOrElse(fail("engine fallback must save a trace"))
+          val traceJson = Files.readString(traceDir.resolve("conversation.json"))
+          val parsed =
+            io.circe.parser.parse(traceJson).getOrElse(fail("unparseable trace JSON"))
+          val meta = parsed.hcursor.downField("metadata")
+          assertEquals(meta.get[Boolean]("passed"), Right(false))
+          assertEquals(meta.get[String]("model"), Right("claude-test"))
+          assert(
+            meta.get[String]("error").exists(_.contains("skill exploded")),
+            s"trace metadata must carry the error: $traceJson"
+          )
+          assertEquals(
+            parsed.hcursor.downField("events").as[Vector[io.circe.Json]].map(_.size),
+            Right(0),
+            "engine fallback traces are metadata-only"
+          )
+        }
+    }
+  }

--- a/xl-agent/test/src/com/tjclp/xl/agent/benchmark/runner/UnifiedRunnerSpec.scala
+++ b/xl-agent/test/src/com/tjclp/xl/agent/benchmark/runner/UnifiedRunnerSpec.scala
@@ -69,6 +69,61 @@ class UnifiedRunnerSpec extends CatsEffectSuite:
     assert(!line.contains("X" * 201), "long errors must be truncated")
   }
 
+  test("all-errored task renders the red error glyph") {
+    // Every case errored: the task is an execution failure, not a graded fail (GH-340)
+    val result = ExecutionResult.fromCases(
+      TaskId("13894"),
+      "xl",
+      Vector(failedCase(1), failedCase(2), failedCase(3)),
+      TokenUsage.zero,
+      570_000L
+    )
+    assertEquals(result.error, Some(caseError))
+    val line = UnifiedRunner.formatExecutionResult(result)
+    assert(line.contains(Console.RED + "✗"), s"all-errored task must render red ✗: $line")
+    assert(line.contains(caseError), line)
+  }
+
+  test("partially-errored task keeps the yellow glyph") {
+    // One clean pass among the errors: not an execution failure, just a failing score
+    val result = ExecutionResult.fromCases(
+      TaskId("13894"),
+      "xl",
+      Vector(CaseResult.passed(1, TokenUsage.zero, 1000), failedCase(2), failedCase(3)),
+      TokenUsage.zero,
+      571_000L
+    )
+    assertEquals(result.error, None)
+    val line = UnifiedRunner.formatExecutionResult(result)
+    assert(
+      line.contains(Console.YELLOW + "○"),
+      s"partially-errored task must keep yellow ○: $line"
+    )
+    assert(line.contains(caseError), line)
+  }
+
+  test("all-passed task keeps fromCases error empty") {
+    val result = ExecutionResult.fromCases(
+      TaskId("2768"),
+      "xl",
+      Vector(CaseResult.passed(1, TokenUsage.zero, 1000)),
+      TokenUsage.zero,
+      1000L
+    )
+    assertEquals(result.error, None)
+    val line = UnifiedRunner.formatExecutionResult(result)
+    assert(line.contains(Console.GREEN + "✓"), line)
+  }
+
+  test("--max-tokens is parsed and defaults to 32768") {
+    for
+      parsed <- UnifiedRunner.parseArgs(List("--max-tokens", "65536"))
+      defaults <- UnifiedRunner.parseArgs(Nil)
+    yield
+      assertEquals(parsed.maxTokens, 65536)
+      assertEquals(defaults.maxTokens, 32768)
+  }
+
   test("legacy report entries carry the per-case error") {
     val result = ExecutionResult.fromCases(
       TaskId("13894"),

--- a/xl-agent/test/src/com/tjclp/xl/agent/benchmark/skills/CaseFailureSpec.scala
+++ b/xl-agent/test/src/com/tjclp/xl/agent/benchmark/skills/CaseFailureSpec.scala
@@ -2,7 +2,7 @@ package com.tjclp.xl.agent.benchmark.skills
 
 import cats.effect.{Clock, IO}
 import munit.CatsEffectSuite
-import com.tjclp.xl.agent.AgentEvent
+import com.tjclp.xl.agent.{AgentEvent, TurnUsage}
 import com.tjclp.xl.agent.benchmark.tracing.ConversationTracer
 
 import java.nio.file.{Files, Path}
@@ -61,6 +61,66 @@ class CaseFailureSpec extends CatsEffectSuite:
         traceJson.contains("partial progress before the crash"),
         "events collected before the failure must survive in the trace"
       )
+  }
+
+  tempDir.test("withPartialTrace sums the partial trace's per-turn usage (issue #340)") { dir =>
+    for
+      tracer <- ConversationTracer.create(
+        outputDir = dir,
+        taskId = "13894",
+        skillName = "xl",
+        caseNum = 3,
+        streaming = false,
+        model = Some("claude-test")
+      )
+      // Two completed turns before the crash: per-turn deltas must be summed
+      // (not the cumulative fields, which would double-count turn 1)
+      _ <- tracer.onEvent(
+        AgentEvent.TurnComplete(TurnUsage(1, 1000L, 200L, 1000L, 200L, 1500L))
+      )
+      _ <- tracer.onEvent(
+        AgentEvent.TurnComplete(TurnUsage(2, 2500L, 300L, 3500L, 500L, 900L))
+      )
+      start <- Clock[IO].monotonic.map(_.toMillis)
+      result <- CaseFailure.withPartialTrace(
+        tracer,
+        caseNum = 3,
+        startTimeMs = start,
+        error = new RuntimeException("boom mid-run")
+      )
+      traceJson <- IO.blocking {
+        val traceDir = result.tracePath.getOrElse(fail("expected a saved trace path"))
+        Files.readString(traceDir.resolve("conversation.json"))
+      }
+    yield
+      assertEquals(result.usage.inputTokens, 3500L)
+      assertEquals(result.usage.outputTokens, 500L)
+
+      val parsed = io.circe.parser.parse(traceJson).getOrElse(fail("unparseable trace JSON"))
+      val usage = parsed.hcursor.downField("metadata").downField("usage")
+      assertEquals(usage.get[Long]("inputTokens"), Right(3500L))
+      assertEquals(usage.get[Long]("outputTokens"), Right(500L))
+  }
+
+  tempDir.test("withPartialTrace records zero usage when no turn completed") { dir =>
+    for
+      tracer <- ConversationTracer.create(
+        outputDir = dir,
+        taskId = "13894",
+        skillName = "xl",
+        caseNum = 1
+      )
+      _ <- tracer.onEvent(AgentEvent.TextOutput("no TurnComplete before the crash"))
+      start <- Clock[IO].monotonic.map(_.toMillis)
+      result <- CaseFailure.withPartialTrace(
+        tracer,
+        caseNum = 1,
+        startTimeMs = start,
+        error = new RuntimeException("early crash")
+      )
+    yield
+      assertEquals(result.usage.inputTokens, 0L)
+      assertEquals(result.usage.outputTokens, 0L)
   }
 
   tempDir.test("withPartialTrace is total when the trace cannot be saved") { dir =>

--- a/xl-agent/test/src/com/tjclp/xl/agent/benchmark/tracing/ConversationTracerSpec.scala
+++ b/xl-agent/test/src/com/tjclp/xl/agent/benchmark/tracing/ConversationTracerSpec.scala
@@ -1,0 +1,66 @@
+package com.tjclp.xl.agent.benchmark.tracing
+
+import cats.effect.IO
+import munit.CatsEffectSuite
+import com.tjclp.xl.agent.TokenUsage
+
+import java.nio.file.{Files, Path}
+
+/** Pins stop_reason capture in the trace metadata (issue #340) */
+class ConversationTracerSpec extends CatsEffectSuite:
+
+  private val tempDir = FunFixture[Path](
+    setup = _ => Files.createTempDirectory("conversation-tracer-spec"),
+    teardown = { dir =>
+      import scala.jdk.CollectionConverters.*
+      import scala.util.Using
+      Using.resource(Files.walk(dir)) { stream =>
+        stream.iterator().asScala.toList.reverse.foreach(p => Files.deleteIfExists(p))
+      }
+    }
+  )
+
+  tempDir.test("complete records the stop reason in the saved metadata") { dir =>
+    for
+      tracer <- ConversationTracer.create(
+        outputDir = dir,
+        taskId = "13894",
+        skillName = "xl",
+        caseNum = 3,
+        streaming = false,
+        model = Some("claude-test")
+      )
+      _ <- tracer.complete(
+        TokenUsage(100, 16819),
+        passed = false,
+        error = Some("turn truncated: stop_reason=max_tokens (raise --max-tokens)"),
+        stopReason = Some("max_tokens")
+      )
+      traceDir <- tracer.save()
+      traceJson <- IO.blocking(Files.readString(traceDir.resolve("conversation.json")))
+    yield
+      val parsed = io.circe.parser.parse(traceJson).getOrElse(fail("unparseable trace JSON"))
+      val meta = parsed.hcursor.downField("metadata")
+      assertEquals(meta.get[String]("stopReason"), Right("max_tokens"))
+      assertEquals(
+        meta.get[String]("error"),
+        Right("turn truncated: stop_reason=max_tokens (raise --max-tokens)")
+      )
+  }
+
+  tempDir.test("stop reason is null in metadata when never provided") { dir =>
+    for
+      tracer <- ConversationTracer.create(
+        outputDir = dir,
+        taskId = "13894",
+        skillName = "xl",
+        caseNum = 1
+      )
+      _ <- tracer.complete(TokenUsage.zero, passed = true)
+      traceDir <- tracer.save()
+      traceJson <- IO.blocking(Files.readString(traceDir.resolve("conversation.json")))
+    yield
+      val parsed = io.circe.parser.parse(traceJson).getOrElse(fail("unparseable trace JSON"))
+      val meta = parsed.hcursor.downField("metadata")
+      assertEquals(meta.get[Option[String]]("stopReason"), Right(None))
+  }

--- a/xl-agent/test/src/com/tjclp/xl/agent/benchmark/tracing/StreamingConsoleSpec.scala
+++ b/xl-agent/test/src/com/tjclp/xl/agent/benchmark/tracing/StreamingConsoleSpec.scala
@@ -6,14 +6,25 @@ import munit.FunSuite
 class StreamingConsoleSpec extends FunSuite:
 
   test("completion line shows PASSED without an error suffix") {
-    val line = StreamingConsole.formatCompleteLine("13894", 3, passed = true, 9_500L, None)
+    val line = StreamingConsole.formatCompleteLine("xl", "13894", 3, passed = true, 9_500L, None)
     assert(line.contains("PASSED"), line)
-    assert(line.contains("13894:3"), line)
+    assert(line.contains("[xl 13894.3]"), line)
     assert(line.contains("9.5s"), line)
+  }
+
+  test("completion line attributes the case to its skill (issue #340)") {
+    // Same '[skill task.case]' shape as event lines, so parallel multi-skill
+    // streams stay attributable without scrollback
+    val xl = StreamingConsole.formatCompleteLine("xl", "13894", 3, passed = true, 9_500L, None)
+    val xlsx = StreamingConsole.formatCompleteLine("xlsx", "13894", 3, passed = true, 9_500L, None)
+    assert(xl.contains("[xl 13894.3]"), xl)
+    assert(xlsx.contains("[xlsx 13894.3]"), xlsx)
+    assertNotEquals(xl, xlsx)
   }
 
   test("completion line shows FAILED with the error message") {
     val line = StreamingConsole.formatCompleteLine(
+      "xl",
       "13894",
       3,
       passed = false,
@@ -21,12 +32,13 @@ class StreamingConsoleSpec extends FunSuite:
       Some("RuntimeException: boom mid-run")
     )
     assert(line.contains("FAILED"), line)
+    assert(line.contains("[xl 13894.3]"), line)
     assert(line.contains("RuntimeException: boom mid-run"), line)
   }
 
   test("completion line keeps errors single-line and bounded") {
     val messy = "Y" * 500 + "\nsecond line"
-    val line = StreamingConsole.formatCompleteLine("t", 1, passed = false, 100L, Some(messy))
+    val line = StreamingConsole.formatCompleteLine("xl", "t", 1, passed = false, 100L, Some(messy))
     assert(!line.contains("\n"), "completion line must stay a single line")
     assert(!line.contains("Y" * 201), "long errors must be truncated")
   }

--- a/xl-evaluator/src/com/tjclp/xl/formula/eval/Aggregator.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/eval/Aggregator.scala
@@ -62,6 +62,17 @@ trait Aggregator[A]:
    */
   def countsEmpty: Boolean = false
 
+  /**
+   * GH-337: whether a carried error ELEMENT in an evaluated expression array (e.g. `SUM((A1:A2)*1)`
+   * where the broadcast carried a #DIV/0!) fails the aggregate loudly.
+   *
+   * Excel propagates errors through nearly every aggregate; COUNT alone genuinely ignores them (it
+   * counts numbers, and an error is not a number). COUNTA/COUNTBLANK are governed by their counts*
+   * modes instead (an error element is non-empty). Raw-RANGE arguments keep their pre-existing skip
+   * semantics — this flag governs expression-array elements only.
+   */
+  def propagatesErrors: Boolean = true
+
 object Aggregator:
   /** Registry of all aggregators by name (uppercase) */
   private lazy val registry: Map[String, Aggregator[?]] = Map(
@@ -105,6 +116,8 @@ object Aggregator:
     def empty = 0
     def combine(acc: Int, value: BigDecimal) = acc + 1
     def finalize(acc: Int) = BigDecimal(acc)
+    // GH-337: Excel's COUNT counts numbers only — error elements are skipped, not propagated
+    override def propagatesErrors: Boolean = false
 
   /** COUNTA: Count non-empty cells in a range (not just numeric) */
   given countaAggregator: Aggregator[Int] with

--- a/xl-evaluator/src/com/tjclp/xl/formula/eval/ArrayArithmetic.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/eval/ArrayArithmetic.scala
@@ -146,7 +146,9 @@ object ArrayArithmetic:
    * number < text < logical — text never parses as a number under comparison (unlike arithmetic).
    * Empty cells coerce to the other operand's zero value (0 against numbers, "" against text, FALSE
    * against booleans; two empties are equal). Error values refuse to compare with a clean Left
-   * naming the Excel error code.
+   * naming the Excel error code — on the SCALAR path only: the array broadcasts pre-check both
+   * operands with [[carriedError]] and carry error elements through instead (GH-337), so this
+   * refusal surfaces solely from scalar comparisons like `=A1<B1` on an error cell.
    *
    * @return
    *   the comparison sign (negative, zero, positive), or Left for incomparable values
@@ -380,6 +382,11 @@ object ArrayArithmetic:
    * array condition) and the logical functions' array paths (AND/OR aggregation, NOT broadcast):
    * booleans as-is, numbers zero/non-zero, empty is FALSE (the ScalarCoercion Bool conventions);
    * text and errors refuse cleanly with a Left naming the position via `label`.
+   *
+   * GH-337: the refusal Left is the ABORT convention of the logical folds (AND/OR/NOT keep it — a
+   * text or error element fails those formulas whole). broadcastIf instead pre-checks errors with
+   * [[carriedError]] and demotes its residual refusals to error elements, so its condition failures
+   * stay positional.
    */
   def conditionTruthy(label: String, cv: CellValue): Either[EvalError, Boolean] = cv match
     case CellValue.Bool(b) => Right(b)
@@ -392,8 +399,9 @@ object ArrayArithmetic:
 
   /**
    * GH-338: truthiness of every element (row-major), for the AND/OR aggregation folds (AND =
-   * forall, OR = exists). The first refusing element (text/error) short-circuits with its Left,
-   * consistent with broadcastIf's whole-array traversal.
+   * forall, OR = exists). The first refusing element (text/error) short-circuits with its Left —
+   * the logical functions keep abort semantics, deliberately NOT the positional error carriage
+   * broadcastIf gained in GH-337.
    */
   def truthyElements(label: String, arr: ArrayResult): Either[EvalError, Vector[Boolean]] =
     traverseV(arr.values.flatten)(cv => conditionTruthy(label, cv))
@@ -427,7 +435,8 @@ object ArrayArithmetic:
    * `=A1:A3=B1:B3` equality use identical semantics. GH-335: defined via [[compareCellValues]] so
    * = and < agree — empty cells equal 0 / "" / FALSE, dates equal their serial number, and
    * cross-type values (which never coerce under comparison) are simply unequal. Error values
-   * equal nothing.
+   * equal nothing on this scalar path; the equality broadcast pre-checks them with
+   * [[carriedError]] and carries error elements instead (GH-337).
    */
   def cellValueEquals(a: CellValue, b: CellValue): Boolean =
     compareCellValues(a, b).fold(_ => false, _ == 0)

--- a/xl-evaluator/src/com/tjclp/xl/formula/eval/ArrayArithmetic.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/eval/ArrayArithmetic.scala
@@ -341,7 +341,9 @@ object ArrayArithmetic:
    * the resulting array.
    *
    * Condition elements follow Excel truthiness (booleans as-is, numbers zero/non-zero, empty is
-   * FALSE); text or error elements refuse with a clean Left.
+   * FALSE). GH-337: a condition element carrying an error emits THAT error at its output position
+   * (masking whatever the branches hold there); a text condition element demotes to a #VALUE!
+   * element. Returns Left ONLY for broadcast-dimension mismatch.
    */
   def broadcastIf(
     cond: ArrayResult,
@@ -359,10 +361,17 @@ object ArrayArithmetic:
         }
       ) { case (row, col) =>
         val condCV = getWithBroadcastCV(cond.values, row, col, cond.rows, cond.cols)
-        conditionTruthy("IF condition", condCV).map { truthy =>
-          if truthy then getWithBroadcastCV(ifTrue.values, row, col, ifTrue.rows, ifTrue.cols)
-          else getWithBroadcastCV(ifFalse.values, row, col, ifFalse.rows, ifFalse.cols)
-        }
+        carriedError(condCV) match
+          case Some(err) => Right(CellValue.Error(err))
+          case None =>
+            conditionTruthy("IF condition", condCV) match
+              case Right(truthy) =>
+                Right(
+                  if truthy then
+                    getWithBroadcastCV(ifTrue.values, row, col, ifTrue.rows, ifTrue.cols)
+                  else getWithBroadcastCV(ifFalse.values, row, col, ifFalse.rows, ifFalse.cols)
+                )
+              case Left(e) => toErrorElement(e)
       }
     yield ArrayResult(result)
 

--- a/xl-evaluator/src/com/tjclp/xl/formula/eval/ArrayArithmetic.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/eval/ArrayArithmetic.scala
@@ -1,7 +1,7 @@
 package com.tjclp.xl.formula.eval
 
 import com.tjclp.xl.addressing.{ARef, CellRange}
-import com.tjclp.xl.cells.CellValue
+import com.tjclp.xl.cells.{CellError, CellValue}
 import com.tjclp.xl.sheets.Sheet
 
 /**
@@ -12,6 +12,12 @@ import com.tjclp.xl.sheets.Sheet
  *   - 1xN * MxN -> broadcast row across M rows
  *   - Mx1 * MxN -> broadcast column across N columns
  *   - MxN * MxN -> element-wise (dimensions must match)
+ *
+ * GH-337: errors propagate ELEMENTWISE through the broadcasts (compare, arithmetic, IF), matching
+ * Excel: a carried `CellValue.Error` input element (left operand's error wins) or an element-local
+ * failure (non-numeric text, division by zero) becomes an error OUTPUT element via
+ * [[EvalError.toCellError]] instead of failing the whole formula. The broadcasts return Left only
+ * for broadcast-dimension mismatch; aggregators decide whether consumed error elements propagate.
  */
 object ArrayArithmetic:
 
@@ -96,6 +102,10 @@ object ArrayArithmetic:
   /**
    * Perform broadcasting binary operation.
    *
+   * GH-337: the array arms operate per CellValue element, carrying errors elementwise (see
+   * [[applyOpCarrying]]) — only the scalar*scalar fast path keeps the whole-result Left for element
+   * failures (scalar `=10/0` stays a formula error, matching Excel's scalar semantics).
+   *
    * @param left
    *   Left operand (scalar or array)
    * @param right
@@ -115,17 +125,13 @@ object ArrayArithmetic:
       case (ArrayOperand.Scalar(l), ArrayOperand.Scalar(r)) =>
         op(l, r).map(ArrayOperand.Scalar(_))
 
-      // scalar * array -> broadcast scalar to all elements
+      // scalar * array -> the scalar broadcasts as a 1x1 array (keeps operand order for op)
       case (ArrayOperand.Scalar(s), ArrayOperand.Array(arr)) =>
-        arrayToNumeric(arr).flatMap { nums =>
-          traverseVV(nums)(v => op(s, v)).map(toArrayResult).map(ArrayOperand.Array(_))
-        }
+        broadcastArrays(ArrayResult.single(CellValue.Number(s)), arr, op).map(ArrayOperand.Array(_))
 
-      // array * scalar -> broadcast scalar to all elements
+      // array * scalar -> the scalar broadcasts as a 1x1 array (keeps operand order for op)
       case (ArrayOperand.Array(arr), ArrayOperand.Scalar(s)) =>
-        arrayToNumeric(arr).flatMap { nums =>
-          traverseVV(nums)(v => op(v, s)).map(toArrayResult).map(ArrayOperand.Array(_))
-        }
+        broadcastArrays(arr, ArrayResult.single(CellValue.Number(s)), op).map(ArrayOperand.Array(_))
 
       // array * array -> broadcast with dimension matching
       case (ArrayOperand.Array(l), ArrayOperand.Array(r)) =>
@@ -191,10 +197,14 @@ object ArrayArithmetic:
    * GH-335: broadcast an ordered comparison over two arrays elementwise (scalar operands wrap as
    * 1x1 arrays and broadcast like any other dimension-1 axis).
    *
+   * GH-337: error elements carry through elementwise — a carried error on either operand (left
+   * wins) becomes the OUTPUT element, and a residual per-element comparison refusal (e.g. an
+   * uncomparable value) demotes to #VALUE!. Returns Left ONLY for broadcast-dimension mismatch.
+   *
    * @param op
    *   interprets the comparison sign from [[compareCellValues]] (e.g. `_ < 0` for Lt)
    * @return
-   *   ArrayResult of CellValue.Bool values
+   *   ArrayResult of CellValue.Bool values with carried CellValue.Error elements
    */
   def broadcastOrderedCompare(
     left: ArrayResult,
@@ -212,7 +222,14 @@ object ArrayArithmetic:
             (lVal, rVal)
           }
         }
-      ) { case (l, r) => compareCellValues(l, r).map(c => CellValue.Bool(op(c))) }
+      ) { case (l, r) =>
+        carriedError(l).orElse(carriedError(r)) match
+          case Some(err) => Right(CellValue.Error(err))
+          case None =>
+            compareCellValues(l, r) match
+              case Right(sign) => Right(CellValue.Bool(op(sign)))
+              case Left(e) => toErrorElement(e)
+      }
     yield ArrayResult(result)
 
   /**
@@ -220,6 +237,10 @@ object ArrayArithmetic:
    *
    * Works on CellValue directly for polymorphic equality (strings, numbers, booleans). Used by
    * Eq/Neq operators.
+   *
+   * GH-337: a carried error on either operand (left wins) becomes the OUTPUT element — errors are
+   * never "equal" or "unequal", they propagate (negate does not flip them). Returns Left ONLY for
+   * broadcast-dimension mismatch.
    */
   def broadcastEqualityCompare(
     left: ArrayResult,
@@ -230,10 +251,7 @@ object ArrayArithmetic:
       case Right(scalar) =>
         // Array vs scalar - compare each element to the scalar
         val scalarCV = anyToCellValue(scalar)
-        Right(ArrayResult(left.values.map(_.map { cv =>
-          val eq = cellValueEquals(cv, scalarCV)
-          CellValue.Bool(if negate then !eq else eq)
-        })))
+        Right(ArrayResult(left.values.map(_.map(cv => equalityElement(cv, scalarCV, negate)))))
       case Left(rightArr) =>
         // Array vs array - broadcast
         for
@@ -244,11 +262,18 @@ object ArrayArithmetic:
             (0 until outCols).toVector.map { col =>
               val lVal = getWithBroadcastCV(left.values, row, col, left.rows, left.cols)
               val rVal = getWithBroadcastCV(rightArr.values, row, col, rightArr.rows, rightArr.cols)
-              val eq = cellValueEquals(lVal, rVal)
-              CellValue.Bool(if negate then !eq else eq)
+              equalityElement(lVal, rVal, negate)
             }
           }
           ArrayResult(result)
+
+  /** GH-337: one equality output element — carried errors win (left first), then Bool equality. */
+  private def equalityElement(l: CellValue, r: CellValue, negate: Boolean): CellValue =
+    carriedError(l).orElse(carriedError(r)) match
+      case Some(err) => CellValue.Error(err)
+      case None =>
+        val eq = cellValueEquals(l, r)
+        CellValue.Bool(if negate then !eq else eq)
 
   /** Get CellValue with broadcasting. */
   private def getWithBroadcastCV(
@@ -261,6 +286,51 @@ object ArrayArithmetic:
     val r = if arrRows == 1 then 0 else row
     val c = if arrCols == 1 then 0 else col
     arr(r)(c)
+
+  /**
+   * GH-337: the Excel error an element carries, if any — a `CellValue.Error` directly or cached
+   * inside a formula value. Package-visible so the aggregate error guards (FunctionSpecsAggregate)
+   * share the exact matching semantics of the broadcasts.
+   */
+  private[formula] def carriedError(cv: CellValue): Option[CellError] = cv match
+    case CellValue.Error(err) => Some(err)
+    case CellValue.Formula(_, Some(cached)) => carriedError(cached)
+    case _ => None
+
+  /**
+   * GH-337: demote an element-local failure to the error ELEMENT it carries, via the
+   * [[EvalError.toCellError]] table. Failures with no element form (CircularRef — structural, never
+   * element-local) stay a fatal Left.
+   */
+  private def toErrorElement(e: EvalError): Either[EvalError, CellValue] =
+    EvalError.toCellError(e) match
+      case Some(err) => Right(CellValue.Error(err))
+      case None => Left(e)
+
+  /**
+   * GH-337: apply a numeric binary op to two elements, carrying errors elementwise: a carried error
+   * on either operand wins (left first), and element-local failures (non-numeric text → #VALUE!,
+   * division by zero → #DIV/0!) become error elements rather than failing the whole broadcast.
+   * Accepted micro-divergence: pow overflow arrives as a generic EvalFailed and surfaces as #VALUE!
+   * (Excel: #NUM!).
+   */
+  private def applyOpCarrying(
+    l: CellValue,
+    r: CellValue,
+    op: BinaryOp
+  ): Either[EvalError, CellValue] =
+    carriedError(l).orElse(carriedError(r)) match
+      case Some(err) => Right(CellValue.Error(err))
+      case None =>
+        val computed =
+          for
+            ln <- cellValueToNumeric(l)
+            rn <- cellValueToNumeric(r)
+            v <- op(ln, rn)
+          yield CellValue.Number(v)
+        computed match
+          case Right(cv) => Right(cv)
+          case Left(e) => toErrorElement(e)
 
   /**
    * GH-333: elementwise IF over an array condition (Excel CSE semantics).
@@ -354,7 +424,8 @@ object ArrayArithmetic:
     compareCellValues(a, b).fold(_ => false, _ == 0)
 
   /**
-   * Broadcast two arrays together.
+   * Broadcast two arrays together, operating per CellValue element (GH-337: errors carry
+   * elementwise via [[applyOpCarrying]]; Left ONLY for broadcast-dimension mismatch).
    */
   private def broadcastArrays(
     left: ArrayResult,
@@ -365,18 +436,16 @@ object ArrayArithmetic:
     for
       outRows <- broadcastDim(left.rows, right.rows, "rows")
       outCols <- broadcastDim(left.cols, right.cols, "columns")
-      leftNums <- arrayToNumeric(left)
-      rightNums <- arrayToNumeric(right)
       result <- traverseVV(
         (0 until outRows).toVector.map { row =>
           (0 until outCols).toVector.map { col =>
-            val lVal = getWithBroadcast(leftNums, row, col, left.rows, left.cols)
-            val rVal = getWithBroadcast(rightNums, row, col, right.rows, right.cols)
+            val lVal = getWithBroadcastCV(left.values, row, col, left.rows, left.cols)
+            val rVal = getWithBroadcastCV(right.values, row, col, right.rows, right.cols)
             (lVal, rVal)
           }
         }
-      ) { case (l, r) => op(l, r) }
-    yield toArrayResult(result)
+      ) { case (l, r) => applyOpCarrying(l, r, op) }
+    yield ArrayResult(result)
 
   /**
    * Compute broadcast output dimension for a single axis.
@@ -392,26 +461,6 @@ object ArrayArithmetic:
           None
         )
       )
-
-  /**
-   * Get value with broadcasting (dimensions of 1 repeat).
-   */
-  private def getWithBroadcast(
-    arr: Vector[Vector[BigDecimal]],
-    row: Int,
-    col: Int,
-    arrRows: Int,
-    arrCols: Int
-  ): BigDecimal =
-    val r = if arrRows == 1 then 0 else row
-    val c = if arrCols == 1 then 0 else col
-    arr(r)(c)
-
-  /**
-   * Convert numeric matrix to ArrayResult.
-   */
-  private def toArrayResult(nums: Vector[Vector[BigDecimal]]): ArrayResult =
-    ArrayResult(nums.map(_.map(n => CellValue.Number(n))))
 
   // ===== Helper: traverse for Vector[Vector[A]] =====
   // We don't have Cats, so implement manually

--- a/xl-evaluator/src/com/tjclp/xl/formula/eval/EvalError.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/eval/EvalError.scala
@@ -8,6 +8,7 @@ import com.tjclp.xl.formula.parser.{FormulaParser, ParseError}
 import com.tjclp.xl.formula.Clock
 
 import com.tjclp.xl.addressing.ARef
+import com.tjclp.xl.cells.CellError
 import com.tjclp.xl.error.XLError
 import com.tjclp.xl.codec.CodecError
 
@@ -142,6 +143,25 @@ object EvalError:
     formula match
       case Some(f) => XLError.FormulaError(f, message)
       case None => XLError.Other(s"Formula evaluation error: $message")
+
+  /**
+   * GH-337: map an evaluation failure to the Excel error VALUE it carries as an array element.
+   *
+   * Elementwise error carriage (array compare/arithmetic/IF) demotes element-local failures to
+   * `CellValue.Error` elements instead of failing the whole formula; this is the single
+   * EvalError→CellError table for that demotion. `None` marks errors that must stay a fatal `Left`
+   * (CircularRef — a structural property of the sheet, not of any one element).
+   *
+   * Known micro-divergences from Excel, accepted by design: pow overflow surfaces as #VALUE!
+   * (Excel: #NUM!) because it arrives as a generic EvalFailed.
+   */
+  def toCellError(error: EvalError): Option[CellError] = error match
+    case DivByZero(_, _) => Some(CellError.Div0)
+    case RefError(_, _) => Some(CellError.Ref)
+    case TypeMismatch(_, _, _) => Some(CellError.Value)
+    case CodecFailed(_, _) => Some(CellError.Value)
+    case EvalFailed(_, _) => Some(CellError.Value)
+    case CircularRef(_) => None
 
   /**
    * Create a RefError with standard "cell not found" message.

--- a/xl-evaluator/src/com/tjclp/xl/formula/eval/Evaluator.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/eval/Evaluator.scala
@@ -745,6 +745,10 @@ private class EvaluatorImpl(
         )
       case ldt: java.time.LocalDateTime =>
         Right(ArrayArithmetic.ArrayOperand.Scalar(BigDecimal(CellValue.dateTimeToExcelSerial(ldt))))
+      // GH-337: a scalar error VALUE (e.g. a carried #N/A) enters array arithmetic as a 1x1
+      // error element and broadcasts across the other operand instead of failing the formula.
+      case cv @ CellValue.Error(_) =>
+        Right(ArrayArithmetic.ArrayOperand.Array(ArrayResult.single(cv)))
       case _ => Left(EvalError.TypeMismatch("arithmetic", "number or array", value.toString))
 
   /**

--- a/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpecsAggregate.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpecsAggregate.scala
@@ -12,7 +12,7 @@ import com.tjclp.xl.formula.eval.{
 import com.tjclp.xl.formula.{Clock, Arity}
 
 import com.tjclp.xl.addressing.{ARef, CellRange, Column, Row}
-import com.tjclp.xl.cells.CellValue
+import com.tjclp.xl.cells.{CellError, CellValue}
 
 trait FunctionSpecsAggregate extends FunctionSpecsBase:
   import ArgSpec.NumericArg
@@ -22,6 +22,13 @@ trait FunctionSpecsAggregate extends FunctionSpecsBase:
 
   private type RowBounds = (Row, Row)
   private type ColBounds = (Column, Column)
+
+  /**
+   * GH-337: the loud failure for a carried error element consumed from an evaluated expression
+   * array — names the function and the Excel error code, and stays IFERROR-catchable.
+   */
+  private def propagatedElementError(fnName: String, err: CellError): EvalError =
+    EvalError.EvalFailed(s"$fnName: array element contains ${err.toExcel} error", None)
 
   /**
    * GH-192: Compute shared bounds across all involved sheets for full-column/row optimization.
@@ -225,30 +232,49 @@ trait FunctionSpecsAggregate extends FunctionSpecsBase:
         case (Right(acc), Right(expr)) =>
           // GH-122: evaluate array-aware so a range-returning call (e.g. OFFSET) flattens into the
           // aggregate exactly like a literal range would; scalars keep their existing behavior.
-          ctx.evalArrayExpr(expr.asInstanceOf[TExpr[Any]]).map {
+          // GH-337: carried error ELEMENTS in the evaluated array fail loudly (per the
+          // aggregator's propagatesErrors policy) instead of silently skipping — an error the
+          // broadcast carried must not vanish into a wrong number. Raw-range arguments (the
+          // Left(location) branch above) keep their pre-existing skip semantics.
+          ctx.evalArrayExpr(expr.asInstanceOf[TExpr[Any]]).flatMap {
             case ar: ArrayResult =>
-              ar.values.flatten.foldLeft(acc) { (values, cellValue) =>
-                if agg.countsNonEmpty then
-                  cellValue match
-                    case CellValue.Empty => values
-                    case _ => values :+ BigDecimal(1)
-                else if agg.countsEmpty then
-                  cellValue match
-                    case CellValue.Empty => values :+ BigDecimal(1)
-                    case _ => values
-                else
-                  extractNumericValue(cellValue) match
-                    case Some(n) => values :+ n
-                    case None => values
+              ar.values.flatten.foldLeft[Either[EvalError, Vector[BigDecimal]]](Right(acc)) {
+                case (Left(err), _) => Left(err)
+                case (Right(values), cellValue) =>
+                  if agg.countsNonEmpty then
+                    cellValue match
+                      case CellValue.Empty => Right(values)
+                      case _ => Right(values :+ BigDecimal(1))
+                  else if agg.countsEmpty then
+                    cellValue match
+                      case CellValue.Empty => Right(values :+ BigDecimal(1))
+                      case _ => Right(values)
+                  else
+                    ArrayArithmetic.carriedError(cellValue) match
+                      case Some(err) if agg.propagatesErrors =>
+                        Left(propagatedElementError(agg.name, err))
+                      case Some(_) => Right(values) // COUNT: errors are not numbers
+                      case None =>
+                        extractNumericValue(cellValue) match
+                          case Some(n) => Right(values :+ n)
+                          case None => Right(values)
               }
             case value: BigDecimal =>
-              if agg.countsNonEmpty || agg.countsEmpty then acc :+ BigDecimal(1) else acc :+ value
+              Right(
+                if agg.countsNonEmpty || agg.countsEmpty then acc :+ BigDecimal(1) else acc :+ value
+              )
             case other =>
-              if agg.countsNonEmpty || agg.countsEmpty then acc :+ BigDecimal(1)
+              if agg.countsNonEmpty || agg.countsEmpty then Right(acc :+ BigDecimal(1))
               else
-                extractNumericValue(ArrayArithmetic.anyToCellValue(other)) match
-                  case Some(n) => acc :+ n
-                  case None => acc
+                val cellValue = ArrayArithmetic.anyToCellValue(other)
+                ArrayArithmetic.carriedError(cellValue) match
+                  case Some(err) if agg.propagatesErrors =>
+                    Left(propagatedElementError(agg.name, err))
+                  case Some(_) => Right(acc)
+                  case None =>
+                    extractNumericValue(cellValue) match
+                      case Some(n) => Right(acc :+ n)
+                      case None => Right(acc)
           }
       }
 
@@ -1132,13 +1158,22 @@ trait FunctionSpecsAggregate extends FunctionSpecsBase:
                   val boundedExpr = constrainExprRanges(expr)
                   ctx.evalArrayExpr(boundedExpr).flatMap {
                     case ar: ArrayResult =>
-                      // Convert ArrayResult to numeric matrix with boolean coercion
-                      val matrix = (0 until ar.rows).map { row =>
-                        (0 until ar.cols).map { col =>
-                          coerceToNumeric(ar.values(row)(col))
-                        }.toVector
-                      }.toVector
-                      Right(acc :+ MatrixArray(matrix))
+                      // Convert ArrayResult to numeric matrix with boolean coercion.
+                      // GH-337: a carried error element fails loudly naming the code — the
+                      // pre-carriage coerceToNumeric would silently turn it into 0 and produce
+                      // a wrong sum for the exact issue-cited =SUMPRODUCT((A1:A3<5)*1) case.
+                      val matrix = ar.values.flatten
+                        .collectFirst(Function.unlift(ArrayArithmetic.carriedError)) match
+                        case Some(err) => Left(propagatedElementError("SUMPRODUCT", err))
+                        case None =>
+                          Right(
+                            (0 until ar.rows).map { row =>
+                              (0 until ar.cols).map { col =>
+                                coerceToNumeric(ar.values(row)(col))
+                              }.toVector
+                            }.toVector
+                          )
+                      matrix.map(m => acc :+ MatrixArray(m))
                     case bd: BigDecimal =>
                       // Scalar treated as 1x1 matrix
                       Right(acc :+ MatrixArray(Vector(Vector(bd))))
@@ -1147,8 +1182,10 @@ trait FunctionSpecsAggregate extends FunctionSpecsBase:
                       val n = if b then BigDecimal(1) else BigDecimal(0)
                       Right(acc :+ MatrixArray(Vector(Vector(n))))
                     case cv: CellValue =>
-                      // CellValue coerced to numeric
-                      Right(acc :+ MatrixArray(Vector(Vector(coerceToNumeric(cv)))))
+                      // CellValue coerced to numeric; GH-337: carried errors fail loudly
+                      ArrayArithmetic.carriedError(cv) match
+                        case Some(err) => Left(propagatedElementError("SUMPRODUCT", err))
+                        case None => Right(acc :+ MatrixArray(Vector(Vector(coerceToNumeric(cv)))))
                     case other =>
                       Left(EvalError.TypeMismatch("SUMPRODUCT", "array or number", other.toString))
                   }

--- a/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpecsConditional.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpecsConditional.scala
@@ -13,6 +13,27 @@ import com.tjclp.xl.formula.{Clock, Arity}
 import com.tjclp.xl.cells.{CellError, CellValue}
 
 trait FunctionSpecsConditional extends FunctionSpecsBase:
+
+  /**
+   * GH-339: demote a whole-result evaluation failure to a 1x1 carried-error element (via the
+   * [[EvalError.toCellError]] table) so an error from an entirely-unselected IF/IFS branch no
+   * longer poisons the formula — broadcastIf selects it away positionally, and it only surfaces
+   * where selected (as an error element, or loudly via a consuming aggregate). Failures with no
+   * element form (CircularRef) stay a fatal Left.
+   */
+  private def carryLeft(result: Either[EvalError, Any]): Either[EvalError, Any] =
+    result match
+      case Left(e) =>
+        EvalError
+          .toCellError(e)
+          .map(err => ArrayResult.single(CellValue.Error(err)): Any)
+          .toRight(e)
+      case right => right
+
+  /** GH-339: evaluate an IF/IFS branch expression, carrying a failure as a 1x1 error element. */
+  private def evalBranchCarrying(ctx: EvalContext, expr: TExpr[?]): Either[EvalError, Any] =
+    carryLeft(evalMaybeArrayArg(ctx, expr))
+
   val ifFn: FunctionSpec[Any] { type Args = IfArgs } =
     FunctionSpec.simple[Any, IfArgs]("IF", Arity.three) { (args, ctx) =>
       val (condExpr, ifTrueExpr, ifFalseExpr) = args
@@ -20,13 +41,16 @@ trait FunctionSpecsConditional extends FunctionSpecsBase:
       // MIN(IF(A1:A10>0,…)) CSE idiom) yields an ArrayResult that must broadcast elementwise —
       // collapsing it to a scalar (the old ctx.evalExpr path) delivered a CellValue.Bool into a
       // Boolean position and crashed with a ClassCastException.
+      // A failing CONDITION stays fatal (it is not a branch); GH-339 carriage below applies to
+      // the two branch expressions only.
       evalMaybeArrayArg(ctx, condExpr).flatMap {
         case condArr: ArrayResult =>
           // CSE semantics: both branches evaluate (they broadcast elementwise against the
-          // condition), so branch laziness only applies to the scalar path below.
+          // condition), so branch laziness only applies to the scalar path below. GH-339: a
+          // branch that fails wholesale carries as a 1x1 error element instead of aborting.
           for
-            ifTrueVal <- evalMaybeArrayArg(ctx, ifTrueExpr)
-            ifFalseVal <- evalMaybeArrayArg(ctx, ifFalseExpr)
+            ifTrueVal <- evalBranchCarrying(ctx, ifTrueExpr)
+            ifFalseVal <- evalBranchCarrying(ctx, ifFalseExpr)
             result <- ArrayArithmetic.broadcastIf(
               condArr,
               toCellArray(ifTrueVal),
@@ -53,14 +77,17 @@ trait FunctionSpecsConditional extends FunctionSpecsBase:
       // the lazy pair walk; an array condition switches to CSE semantics — its value and the
       // remaining pairs all evaluate, chaining elementwise through broadcastIf with the no-match
       // #N/A as the final fallback: IFS(c1,v1,c2,v2) = if c1 then v1 else (if c2 then v2 else NA).
+      // GH-339: under an array condition, the pair's VALUE and the remaining-pairs fallback are
+      // branches — their failures carry as 1x1 error elements. The CURRENT pair's condition
+      // failure stays fatal (it is not a branch).
       def loop(pairs: List[TExpr[Any]]): Either[EvalError, Any] =
         pairs match
           case cond :: value :: rest =>
             evalMaybeArrayArg(ctx, cond).flatMap {
               case condArr: ArrayResult =>
                 for
-                  valueVal <- evalMaybeArrayArg(ctx, value)
-                  restVal <- loop(rest)
+                  valueVal <- evalBranchCarrying(ctx, value)
+                  restVal <- carryLeft(loop(rest))
                   result <- ArrayArithmetic.broadcastIf(
                     condArr,
                     toCellArray(valueVal),

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/AggregateErrorPolicySpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/AggregateErrorPolicySpec.scala
@@ -1,0 +1,113 @@
+package com.tjclp.xl.formula
+
+import munit.FunSuite
+
+import com.tjclp.xl.addressing.ARef
+import com.tjclp.xl.cells.{CellError, CellValue}
+import com.tjclp.xl.formula.eval.SheetEvaluator.*
+import com.tjclp.xl.sheets.Sheet
+import com.tjclp.xl.syntax.*
+
+/**
+ * GH-337: aggregate error policy over expression arrays.
+ *
+ * Elementwise error carriage (GH-337) would silently CHANGE answers if aggregates kept skipping
+ * non-numeric elements: pre-GH-337, =SUMPRODUCT((A1:A3<5)*1) with an error cell failed loudly; with
+ * carriage but no guard, the error element would coerce to 0 and produce a wrong number. These
+ * guards make the exact issue-cited case loud again, matching Excel: an error element consumed by
+ * an aggregate surfaces as the aggregate's failure (catchable by IFERROR), except COUNT, which
+ * genuinely counts numbers only.
+ *
+ * Raw-RANGE arguments (=SUM(A1:A2) over cells) keep their pre-existing skip/coerce semantics —
+ * pinned below as documentation of that boundary.
+ */
+@SuppressWarnings(Array("org.wartremover.warts.OptionPartial"))
+class AggregateErrorPolicySpec extends FunSuite:
+
+  private def num(n: Int): CellValue = CellValue.Number(BigDecimal(n))
+
+  // A1=1, A2=#DIV/0!, A3=2 — the GH-337 issue-cited data shape.
+  private val withError = Sheet("Test")
+    .put(ref"A1", num(1))
+    .put(ref"A2", CellValue.Error(CellError.Div0))
+    .put(ref"A3", num(2))
+
+  private val twoWithError = Sheet("Test")
+    .put(ref"A1", num(3))
+    .put(ref"A2", CellValue.Error(CellError.Div0))
+
+  private def assertLoud(sheet: Sheet, formula: String, fnName: String, code: String)(implicit
+    loc: munit.Location
+  ): Unit =
+    val result = sheet.evaluateFormula(formula)
+    assert(result.isLeft, s"$formula: expected loud Left, got $result")
+    val message = result.left.toOption.get.message
+    assert(message.contains(code), s"$formula: expected '$code' in message, got: $message")
+    assert(message.contains(fnName), s"$formula: expected '$fnName' in message, got: $message")
+
+  // ===== The GH-337 headline: SUMPRODUCT must not treat error elements as 0 =====
+
+  test("GH-337: =SUMPRODUCT((A1:A3<5)*1) with an error cell fails loudly naming #DIV/0!") {
+    assertLoud(withError, "=SUMPRODUCT((A1:A3<5)*1)", "SUMPRODUCT", "#DIV/0!")
+  }
+
+  test("GH-337: SUMPRODUCT scalar (1x1) expression arm is guarded too") {
+    assertLoud(twoWithError, "=SUMPRODUCT((A2:A2)*1)", "SUMPRODUCT", "#DIV/0!")
+  }
+
+  // ===== Variadic aggregates over expression arrays: loud by default =====
+
+  test("GH-337: SUM/MIN/MAX/AVERAGE over an error-bearing expression array fail loudly") {
+    assertLoud(twoWithError, "=SUM((A1:A2)*1)", "SUM", "#DIV/0!")
+    assertLoud(twoWithError, "=MIN((A1:A2)*1)", "MIN", "#DIV/0!")
+    assertLoud(twoWithError, "=MAX((A1:A2)*1)", "MAX", "#DIV/0!")
+    assertLoud(twoWithError, "=AVERAGE((A1:A2)*1)", "AVERAGE", "#DIV/0!")
+  }
+
+  test("GH-337: SUM over a mixed IF selection that SELECTS an error is loud") {
+    // GH-339 companion: the error is selected at the FALSE position, so the aggregate sees it.
+    val mixed = Sheet("Test").put(ref"A1", num(5)).put(ref"A2", num(-3))
+    assertLoud(mixed, "=SUM(IF(A1:A2>0,A1:A2,1/0))", "SUM", "#DIV/0!")
+  }
+
+  test("GH-337: =SUM(IFS(A1:A2>100,1)) with every element #N/A is loud (behavior flip)") {
+    // Pre-GH-337 the all-#N/A IFS array summed to 0 by skipping; error elements now propagate.
+    val sheet = Sheet("Test").put(ref"A1", num(5)).put(ref"A2", num(-1))
+    assertLoud(sheet, "=SUM(IFS(A1:A2>100,1))", "SUM", "#N/A")
+  }
+
+  // ===== COUNT-family parity =====
+
+  test("GH-337: =COUNT((A1:A2)*1) with an error element counts numeric elements only") {
+    assertEquals(twoWithError.evaluateFormula("=COUNT((A1:A2)*1)"), Right(num(1)))
+  }
+
+  test("GH-337: COUNTA counts error elements, COUNTBLANK does not") {
+    assertEquals(twoWithError.evaluateFormula("=COUNTA((A1:A2)*1)"), Right(num(2)))
+    assertEquals(twoWithError.evaluateFormula("=COUNTBLANK((A1:A2)*1)"), Right(num(0)))
+  }
+
+  // ===== The loud Lefts stay IFERROR-catchable =====
+
+  test("GH-337: =IFERROR(SUM((A1:A2)*1),0) catches the loud aggregate failure") {
+    assertEquals(twoWithError.evaluateFormula("=IFERROR(SUM((A1:A2)*1),0)"), Right(num(0)))
+    assertEquals(
+      withError.evaluateFormula("=IFERROR(SUMPRODUCT((A1:A3<5)*1),-1)"),
+      Right(num(-1))
+    )
+  }
+
+  // ===== Raw-range boundary: unchanged, pinned as documentation =====
+
+  test("GH-337: raw-range =SUM(A1:A2) with an error cell still skips it") {
+    assertEquals(twoWithError.evaluateFormula("=SUM(A1:A2)"), Right(num(3)))
+  }
+
+  test("GH-337: raw-range SUMPRODUCT still coerces error cells to 0 (unchanged boundary)") {
+    val sheet = Sheet("Test")
+      .put(ref"A1", num(2))
+      .put(ref"A2", CellValue.Error(CellError.Div0))
+      .put(ref"B1", num(3))
+      .put(ref"B2", num(4))
+    assertEquals(sheet.evaluateFormula("=SUMPRODUCT(A1:A2,B1:B2)"), Right(num(6)))
+  }

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/ArrayArithmeticSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/ArrayArithmeticSpec.scala
@@ -145,7 +145,8 @@ class ArrayArithmeticSpec extends FunSuite:
     assert(result.swap.toOption.get.toString.contains("mismatch"))
   }
 
-  test("division by zero in array returns error") {
+  test("division by zero in array yields an elementwise #DIV/0! (GH-337)") {
+    // Pre-GH-337 this was a whole-broadcast Left; Excel carries the error per element.
     val arr = ArrayResult(
       Vector(
         Vector(CellValue.Number(1), CellValue.Number(0), CellValue.Number(3))
@@ -159,7 +160,12 @@ class ArrayArithmeticSpec extends FunSuite:
       ArrayArithmetic.div
     )
 
-    assert(result.isLeft, s"Expected Left (div by zero), got $result")
+    result match
+      case Right(ArrayArithmetic.ArrayOperand.Array(out)) =>
+        assertEquals(out(0, 0), CellValue.Number(10))
+        assertEquals(out(0, 1), CellValue.Error(com.tjclp.xl.cells.CellError.Div0))
+        assertEquals(out(0, 2), CellValue.Number(BigDecimal(10) / BigDecimal(3)))
+      case other => fail(s"Expected Array with elementwise #DIV/0!, got $other")
   }
 
   // ========== Integration Tests with evaluateArrayFormula ==========

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/ArrayErrorPropagationSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/ArrayErrorPropagationSpec.scala
@@ -1,0 +1,46 @@
+package com.tjclp.xl.formula
+
+import munit.ScalaCheckSuite
+
+import com.tjclp.xl.addressing.ARef
+import com.tjclp.xl.cells.{CellError, CellValue}
+import com.tjclp.xl.codec.CodecError
+import com.tjclp.xl.formula.eval.EvalError
+import com.tjclp.xl.sheets.Sheet
+import com.tjclp.xl.syntax.*
+
+/**
+ * GH-337: errors propagate ELEMENTWISE through array operations instead of failing the whole
+ * formula.
+ *
+ * Excel semantics: `(A1:A3<5)*1` with a #DIV/0! cell at A2 yields the array {1, #DIV/0!, 1} — the
+ * error only surfaces when an aggregation consumes that element. Pre-GH-337 the comparison refused
+ * with a whole-formula Left ("cannot compare #REF! error value"), which was total and deterministic
+ * but not Excel.
+ *
+ * The demotion table lives in [[EvalError.toCellError]]; the carriage lives in the ArrayArithmetic
+ * broadcasts (compare, arithmetic, IF). CircularRef stays a fatal Left.
+ */
+@SuppressWarnings(Array("org.wartremover.warts.OptionPartial", "org.wartremover.warts.IterableOps"))
+class ArrayErrorPropagationSpec extends ScalaCheckSuite:
+
+  // ===== Commit 1: the EvalError -> CellError demotion table =====
+
+  test("GH-337: toCellError maps each EvalError to its carried Excel error") {
+    val a1 = ARef.from0(0, 0)
+    val table: List[(EvalError, Option[CellError])] = List(
+      EvalError.DivByZero("10", "0") -> Some(CellError.Div0),
+      EvalError.RefError(a1, "cell not found") -> Some(CellError.Ref),
+      EvalError.TypeMismatch("arithmetic", "number", "text: x") -> Some(CellError.Value),
+      EvalError.CodecFailed(a1, CodecError.TypeMismatch("Numeric", CellValue.Text("x"))) -> Some(
+        CellError.Value
+      ),
+      EvalError.EvalFailed("anything", None) -> Some(CellError.Value),
+      // CircularRef is a structural failure of the sheet, never an element-local one: it must
+      // stay a fatal Left rather than demote to an error element.
+      EvalError.CircularRef(List(a1)) -> None
+    )
+    table.foreach { case (evalError, expected) =>
+      assertEquals(EvalError.toCellError(evalError), expected, s"toCellError($evalError)")
+    }
+  }

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/ArrayErrorPropagationSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/ArrayErrorPropagationSpec.scala
@@ -1,11 +1,14 @@
 package com.tjclp.xl.formula
 
 import munit.ScalaCheckSuite
+import org.scalacheck.{Gen, Prop}
+import org.scalacheck.Prop.forAll
 
 import com.tjclp.xl.addressing.ARef
 import com.tjclp.xl.cells.{CellError, CellValue}
 import com.tjclp.xl.codec.CodecError
-import com.tjclp.xl.formula.eval.EvalError
+import com.tjclp.xl.formula.eval.{ArrayArithmetic, ArrayResult, EvalError}
+import com.tjclp.xl.formula.eval.SheetEvaluator.*
 import com.tjclp.xl.sheets.Sheet
 import com.tjclp.xl.syntax.*
 
@@ -42,5 +45,375 @@ class ArrayErrorPropagationSpec extends ScalaCheckSuite:
     )
     table.foreach { case (evalError, expected) =>
       assertEquals(EvalError.toCellError(evalError), expected, s"toCellError($evalError)")
+    }
+  }
+
+  // ===== Helpers =====
+
+  private def num(n: Int): CellValue = CellValue.Number(BigDecimal(n))
+  private val div0 = CellValue.Error(CellError.Div0)
+  private val refErr = CellValue.Error(CellError.Ref)
+  private val na = CellValue.Error(CellError.NA)
+  private val valueErr = CellValue.Error(CellError.Value)
+
+  /** 1xN row array. */
+  private def rowOf(values: CellValue*): ArrayResult = ArrayResult(Vector(values.toVector))
+
+  /** Nx1 column array. */
+  private def colOf(values: CellValue*): ArrayResult =
+    ArrayResult(values.toVector.map(Vector(_)))
+
+  private def elementsOf(result: Either[EvalError, ArrayResult])(implicit
+    loc: munit.Location
+  ): Vector[CellValue] =
+    result match
+      case Right(ar) => ar.values.flatten
+      case Left(err) => fail(s"expected Right(ArrayResult), got Left($err)")
+
+  // ===== Commit 2: compare carriage =====
+
+  test("GH-337: ordered compare carries error elements, left operand's error wins") {
+    val left = rowOf(num(1), refErr, div0)
+    val right = rowOf(div0, num(2), na)
+    val result = ArrayArithmetic.broadcastOrderedCompare(left, right, _ < 0)
+    assertEquals(elementsOf(result), Vector(div0, refErr, div0))
+  }
+
+  test("GH-337: equality compare carries error elements (array-array and array-scalar)") {
+    val arrArr =
+      ArrayArithmetic.broadcastEqualityCompare(
+        rowOf(num(1), div0),
+        Left(rowOf(num(1), num(2))),
+        false
+      )
+    assertEquals(elementsOf(arrArr), Vector(CellValue.Bool(true), div0))
+
+    val arrScalar =
+      ArrayArithmetic.broadcastEqualityCompare(rowOf(num(1), num(2)), Right(na), false)
+    assertEquals(elementsOf(arrScalar), Vector(na, na))
+
+    // Left operand's error wins over the scalar's, and negate doesn't flip errors
+    val leftWins = ArrayArithmetic.broadcastEqualityCompare(rowOf(div0, num(2)), Right(na), true)
+    assertEquals(elementsOf(leftWins), Vector(div0, na))
+  }
+
+  test("GH-337: carried errors recurse through cached formula values") {
+    val cachedErr = CellValue.Formula("=1/0", Some(div0))
+    val compared =
+      ArrayArithmetic.broadcastOrderedCompare(rowOf(cachedErr), rowOf(num(1)), _ < 0)
+    assertEquals(elementsOf(compared), Vector(div0))
+
+    val summed = ArrayArithmetic.broadcast(
+      ArrayArithmetic.ArrayOperand.Array(rowOf(cachedErr)),
+      ArrayArithmetic.ArrayOperand.Scalar(BigDecimal(1)),
+      ArrayArithmetic.add
+    )
+    summed match
+      case Right(ArrayArithmetic.ArrayOperand.Array(out)) => assertEquals(out(0, 0), div0)
+      case other => fail(s"expected Array result, got $other")
+  }
+
+  // ===== Commit 2: arithmetic carriage =====
+
+  test("GH-337: arithmetic carries error elements and maps local failures per element") {
+    // {1, #REF!, "abc", 0} entering 10/x: carried #REF! stays, text is #VALUE!, 0 is #DIV/0!
+    val operand = rowOf(num(1), refErr, CellValue.Text("abc"), num(0))
+    val result = ArrayArithmetic.broadcast(
+      ArrayArithmetic.ArrayOperand.Scalar(BigDecimal(10)),
+      ArrayArithmetic.ArrayOperand.Array(operand),
+      ArrayArithmetic.div
+    )
+    result match
+      case Right(ArrayArithmetic.ArrayOperand.Array(out)) =>
+        assertEquals(out(0, 0), num(10))
+        assertEquals(out(0, 1), refErr)
+        assertEquals(out(0, 2), valueErr)
+        assertEquals(out(0, 3), div0)
+      case other => fail(s"expected Array result, got $other")
+  }
+
+  test("GH-337: array-array arithmetic: left operand's error wins") {
+    val result = ArrayArithmetic.broadcast(
+      ArrayArithmetic.ArrayOperand.Array(rowOf(refErr, num(2))),
+      ArrayArithmetic.ArrayOperand.Array(rowOf(div0, na)),
+      ArrayArithmetic.add
+    )
+    result match
+      case Right(ArrayArithmetic.ArrayOperand.Array(out)) =>
+        assertEquals(out(0, 0), refErr)
+        assertEquals(out(0, 1), na)
+      case other => fail(s"expected Array result, got $other")
+  }
+
+  test("GH-337: a 1x1 scalar error array broadcasts across the other operand (NA()+range shape)") {
+    // The =NA()+A1:A3 shape: a scalar error operand enters as a 1x1 error array and broadcasts.
+    val result = ArrayArithmetic.broadcast(
+      ArrayArithmetic.ArrayOperand.Array(ArrayResult.single(na)),
+      ArrayArithmetic.ArrayOperand.Array(colOf(num(1), num(2), num(3))),
+      ArrayArithmetic.add
+    )
+    result match
+      case Right(ArrayArithmetic.ArrayOperand.Array(out)) =>
+        assertEquals(out.rows, 3)
+        assertEquals(out.values.flatten, Vector(na, na, na))
+      case other => fail(s"expected Array result, got $other")
+  }
+
+  test("GH-337: dimension mismatch stays a whole-broadcast Left even with error elements") {
+    val left = rowOf(num(1), div0, num(3)) // 1x3
+    val right = rowOf(num(1), num(2)) // 1x2
+    assert(ArrayArithmetic.broadcastOrderedCompare(left, right, _ < 0).isLeft)
+    assert(
+      ArrayArithmetic
+        .broadcast(
+          ArrayArithmetic.ArrayOperand.Array(left),
+          ArrayArithmetic.ArrayOperand.Array(right),
+          ArrayArithmetic.mul
+        )
+        .isLeft
+    )
+    assert(ArrayArithmetic.broadcastEqualityCompare(left, Left(right), false).isLeft)
+  }
+
+  // ===== Commit 2: end-to-end shapes =====
+
+  test("GH-337: =A1:A3<5 with an error cell spills {TRUE; #DIV/0!; TRUE}") {
+    val sheet = Sheet("Test")
+      .put(ref"A1", num(1))
+      .put(ref"A2", div0)
+      .put(ref"A3", num(2))
+    val result = sheet.evaluateArrayFormula("=A1:A3<5", ref"C1")
+    assert(result.isRight, s"expected Right, got $result")
+    val (updated, spill) = result.toOption.get
+    assertEquals(spill.height, 3)
+    assertEquals(updated(ref"C1").value, CellValue.Bool(true))
+    assertEquals(updated(ref"C2").value, div0)
+    assertEquals(updated(ref"C3").value, CellValue.Bool(true))
+  }
+
+  test("GH-337: =10/A1:A3 with a zero yields an elementwise #DIV/0!") {
+    val sheet = Sheet("Test")
+      .put(ref"A1", num(1))
+      .put(ref"A2", num(0))
+      .put(ref"A3", num(2))
+    val result = sheet.evaluateArrayFormula("=10/A1:A3", ref"C1")
+    assert(result.isRight, s"expected Right, got $result")
+    val (updated, _) = result.toOption.get
+    assertEquals(updated(ref"C1").value, num(10))
+    assertEquals(updated(ref"C2").value, div0)
+    assertEquals(updated(ref"C3").value, num(5))
+  }
+
+  test("GH-337: text elements in array arithmetic become #VALUE! elements") {
+    val sheet = Sheet("Test")
+      .put(ref"A1", CellValue.Text("abc"))
+      .put(ref"A2", num(3))
+    val result = sheet.evaluateArrayFormula("=A1:A2*2", ref"C1")
+    assert(result.isRight, s"expected Right, got $result")
+    val (updated, _) = result.toOption.get
+    assertEquals(updated(ref"C1").value, valueErr)
+    assertEquals(updated(ref"C2").value, num(6))
+  }
+
+  test("GH-337: comparing a range against a scalar error cell carries the error elementwise") {
+    val sheet = Sheet("Test")
+      .put(ref"A1", num(1))
+      .put(ref"A2", num(2))
+      .put(ref"B1", na)
+    val ordered = sheet.evaluateArrayFormula("=A1:A2<B1", ref"C1")
+    assert(ordered.isRight, s"expected Right, got $ordered")
+    val (updatedOrd, _) = ordered.toOption.get
+    assertEquals(updatedOrd(ref"C1").value, na)
+    assertEquals(updatedOrd(ref"C2").value, na)
+
+    val equality = sheet.evaluateArrayFormula("=A1:A2=B1", ref"D1")
+    assert(equality.isRight, s"expected Right, got $equality")
+    val (updatedEq, _) = equality.toOption.get
+    assertEquals(updatedEq(ref"D1").value, na)
+    assertEquals(updatedEq(ref"D2").value, na)
+  }
+
+  test("GH-337: scalar entry collapses — error at top-left refuses, error elsewhere intersects") {
+    // Implicit intersection takes the top-left element; a carried error there refuses cleanly,
+    // while an error elsewhere in the array no longer poisons the collapsed scalar (improvement
+    // over the pre-GH-337 whole-formula Left).
+    val errTopLeft = Sheet("Test").put(ref"A1", div0).put(ref"A2", num(5))
+    val collapsed = errTopLeft.evaluateFormula("=A1:A2*2")
+    assert(collapsed.isLeft, s"expected Left, got $collapsed")
+    assert(
+      collapsed.left.toOption.get.message.contains("cannot coerce"),
+      s"unexpected error: $collapsed"
+    )
+
+    val errBelow = Sheet("Test").put(ref"A1", num(5)).put(ref"A2", div0)
+    assertEquals(errBelow.evaluateFormula("=A1:A2*2"), Right(num(10)))
+  }
+
+  // ===== Commit 2: property tests =====
+
+  private val genPlainValue: Gen[CellValue] = Gen.oneOf(
+    Gen.chooseNum(-50, 50).map(n => CellValue.Number(BigDecimal(n))),
+    Gen.oneOf("abc", "42", "").map(CellValue.Text(_)),
+    Gen.oneOf(true, false).map(CellValue.Bool(_)),
+    Gen.const(CellValue.Empty)
+  )
+
+  private val genErrorValue: Gen[CellValue] =
+    Gen.oneOf(CellError.values.toIndexedSeq).map(CellValue.Error(_))
+
+  private val genElement: Gen[CellValue] =
+    Gen.frequency(4 -> genPlainValue, 1 -> genErrorValue)
+
+  private def genArrayOf(gen: Gen[CellValue], rows: Int, cols: Int): Gen[ArrayResult] =
+    Gen
+      .listOfN(rows * cols, gen)
+      .map(values => ArrayResult.fromFlat(values.toVector, rows, cols))
+
+  /** A pair of broadcast-compatible arrays (each axis matches the output or is 1). */
+  private def genBroadcastablePair(gen: Gen[CellValue]): Gen[(ArrayResult, ArrayResult)] =
+    for
+      outRows <- Gen.choose(1, 3)
+      outCols <- Gen.choose(1, 3)
+      lRows <- Gen.oneOf(1, outRows)
+      lCols <- Gen.oneOf(1, outCols)
+      rRows <- Gen.oneOf(1, outRows)
+      rCols <- Gen.oneOf(1, outCols)
+      left <- genArrayOf(gen, lRows, lCols)
+      right <- genArrayOf(gen, rRows, rCols)
+    yield (left, right)
+
+  private val genOp: Gen[ArrayArithmetic.BinaryOp] =
+    Gen.oneOf(ArrayArithmetic.add, ArrayArithmetic.sub, ArrayArithmetic.mul, ArrayArithmetic.div)
+
+  /** Broadcast indexing: a 1-sized axis repeats. */
+  private def broadcastAt(a: ArrayResult, row: Int, col: Int): CellValue =
+    a.values(if a.rows == 1 then 0 else row)(if a.cols == 1 then 0 else col)
+
+  private def isErrorElement(cv: CellValue): Boolean = cv match
+    case CellValue.Error(_) => true
+    case _ => false
+
+  property("GH-337: broadcast compare/arith never Left for element-local failures") {
+    forAll(genBroadcastablePair(genElement), genOp) { case ((left, right), op) =>
+      val compare = ArrayArithmetic.broadcastOrderedCompare(left, right, _ < 0)
+      val equality = ArrayArithmetic.broadcastEqualityCompare(left, Left(right), false)
+      val arith = ArrayArithmetic.broadcast(
+        ArrayArithmetic.ArrayOperand.Array(left),
+        ArrayArithmetic.ArrayOperand.Array(right),
+        op
+      )
+      Prop(compare.isRight && equality.isRight && arith.isRight) :| s"$compare / $equality / $arith"
+    }
+  }
+
+  property("GH-337: arithmetic output element is Error iff an input carries one or the op fails") {
+    forAll(genBroadcastablePair(genElement), genOp) { case ((left, right), op) =>
+      ArrayArithmetic.broadcast(
+        ArrayArithmetic.ArrayOperand.Array(left),
+        ArrayArithmetic.ArrayOperand.Array(right),
+        op
+      ) match
+        case Right(ArrayArithmetic.ArrayOperand.Array(out)) =>
+          Prop.all(
+            (for
+              row <- 0 until out.rows
+              col <- 0 until out.cols
+            yield
+              val l = broadcastAt(left, row, col)
+              val r = broadcastAt(right, row, col)
+              val localFailure =
+                isErrorElement(l) || isErrorElement(r) ||
+                  (for
+                    ln <- ArrayArithmetic.cellValueToNumeric(l)
+                    rn <- ArrayArithmetic.cellValueToNumeric(r)
+                    v <- op(ln, rn)
+                  yield v).isLeft
+              Prop(isErrorElement(out(row, col)) == localFailure) :|
+                s"($row,$col): l=$l r=$r out=${out(row, col)}"
+            )*
+          )
+        case other => Prop.falsified :| s"expected Array result, got $other"
+    }
+  }
+
+  property("GH-337: compare output element is Error iff an input element carries an error") {
+    forAll(genBroadcastablePair(genElement)) { case (left, right) =>
+      ArrayArithmetic.broadcastOrderedCompare(left, right, _ < 0) match
+        case Right(out) =>
+          Prop.all(
+            (for
+              row <- 0 until out.rows
+              col <- 0 until out.cols
+            yield
+              val carried =
+                isErrorElement(broadcastAt(left, row, col)) ||
+                  isErrorElement(broadcastAt(right, row, col))
+              Prop(isErrorElement(out(row, col)) == carried) :| s"($row,$col)"
+            )*
+          )
+        case Left(err) => Prop.falsified :| s"expected Right, got Left($err)"
+    }
+  }
+
+  property("GH-337: error-free arithmetic agrees with the numeric-matrix reference") {
+    forAll(genBroadcastablePair(genPlainValue), genOp) { case ((left, right), op) =>
+      val reference: Either[EvalError, Vector[Vector[CellValue]]] =
+        for
+          lNums <- ArrayArithmetic.arrayToNumeric(left)
+          rNums <- ArrayArithmetic.arrayToNumeric(right)
+          rows = math.max(left.rows, right.rows)
+          cols = math.max(left.cols, right.cols)
+          out <- (0 until rows).foldLeft[Either[EvalError, Vector[Vector[CellValue]]]](
+            Right(Vector.empty)
+          ) { (accRows, row) =>
+            accRows.flatMap { rowsSoFar =>
+              (0 until cols)
+                .foldLeft[Either[EvalError, Vector[CellValue]]](Right(Vector.empty)) {
+                  (accCols, col) =>
+                    accCols.flatMap { colsSoFar =>
+                      val l = lNums(if left.rows == 1 then 0 else row)(
+                        if left.cols == 1 then 0 else col
+                      )
+                      val r = rNums(if right.rows == 1 then 0 else row)(
+                        if right.cols == 1 then 0 else col
+                      )
+                      op(l, r).map(v => colsSoFar :+ CellValue.Number(v))
+                    }
+                }
+                .map(rowsSoFar :+ _)
+            }
+          }
+        yield out
+      reference match
+        case Right(expected) =>
+          ArrayArithmetic.broadcast(
+            ArrayArithmetic.ArrayOperand.Array(left),
+            ArrayArithmetic.ArrayOperand.Array(right),
+            op
+          ) match
+            case Right(ArrayArithmetic.ArrayOperand.Array(out)) =>
+              Prop(out.values == expected) :| s"out=${out.values} expected=$expected"
+            case other => Prop.falsified :| s"expected Array result, got $other"
+        // Reference itself fails (text/div-zero): covered by the local-failure properties above
+        case Left(_) => Prop.passed
+    }
+  }
+
+  property("GH-337: error-free compares agree with elementwise compareCellValues") {
+    forAll(genBroadcastablePair(genPlainValue)) { case (left, right) =>
+      ArrayArithmetic.broadcastOrderedCompare(left, right, _ < 0) match
+        case Right(out) =>
+          Prop.all(
+            (for
+              row <- 0 until out.rows
+              col <- 0 until out.cols
+            yield
+              val expected = ArrayArithmetic
+                .compareCellValues(broadcastAt(left, row, col), broadcastAt(right, row, col))
+                .map(sign => CellValue.Bool(sign < 0))
+              Prop(expected == Right(out(row, col))) :| s"($row,$col)"
+            )*
+          )
+        case Left(err) => Prop.falsified :| s"expected Right, got Left($err)"
     }
   }

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/ArrayErrorPropagationSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/ArrayErrorPropagationSpec.scala
@@ -249,6 +249,89 @@ class ArrayErrorPropagationSpec extends ScalaCheckSuite:
     assertEquals(errBelow.evaluateFormula("=A1:A2*2"), Right(num(10)))
   }
 
+  // ===== Commit 3: broadcastIf condition carriage =====
+
+  test("GH-337: broadcastIf carries a condition element's error to the output position") {
+    val cond = colOf(CellValue.Bool(true), div0, CellValue.Bool(false))
+    val ifTrue = colOf(num(1), num(2), num(3))
+    val ifFalse = ArrayResult.single(num(99))
+    val result = ArrayArithmetic.broadcastIf(cond, ifTrue, ifFalse)
+    assertEquals(elementsOf(result), Vector(num(1), div0, num(99)))
+  }
+
+  test("GH-337: broadcastIf demotes a text condition element to #VALUE! (was whole-formula Left)") {
+    val cond = colOf(CellValue.Bool(true), CellValue.Text("x"))
+    val result =
+      ArrayArithmetic.broadcastIf(cond, ArrayResult.single(num(1)), ArrayResult.single(num(2)))
+    assertEquals(elementsOf(result), Vector(num(1), valueErr))
+  }
+
+  test("GH-337: broadcastIf condition errors mask branch errors positionally") {
+    // The condition's own error wins at its position; other positions still select normally,
+    // including selecting error elements from a branch.
+    val cond = colOf(na, CellValue.Bool(false))
+    val result = ArrayArithmetic.broadcastIf(
+      cond,
+      ArrayResult.single(num(1)),
+      ArrayResult.single(div0)
+    )
+    assertEquals(elementsOf(result), Vector(na, div0))
+  }
+
+  test("GH-337: =IF over a condition range with an error cell selects errors positionally") {
+    val sheet = Sheet("Test")
+      .put(ref"A1", num(1))
+      .put(ref"A2", div0)
+      .put(ref"A3", num(-1))
+    val result = sheet.evaluateArrayFormula("=IF(A1:A3>0,1,2)", ref"C1")
+    assert(result.isRight, s"expected Right, got $result")
+    val (updated, _) = result.toOption.get
+    assertEquals(updated(ref"C1").value, num(1))
+    assertEquals(updated(ref"C2").value, div0)
+    assertEquals(updated(ref"C3").value, num(2))
+  }
+
+  property("GH-337: broadcastIf never Lefts for element-local condition failures") {
+    val genCondElement: Gen[CellValue] = Gen.frequency(
+      3 -> Gen.oneOf(
+        Gen.oneOf(true, false).map(CellValue.Bool(_)),
+        Gen.chooseNum(-5, 5).map(n => CellValue.Number(BigDecimal(n))),
+        Gen.const(CellValue.Empty)
+      ),
+      1 -> genErrorValue,
+      1 -> Gen.oneOf("abc", "").map(CellValue.Text(_))
+    )
+    forAll(
+      Gen.choose(1, 3).flatMap(n => Gen.listOfN(n, genCondElement)),
+      Gen.chooseNum(-50, 50),
+      Gen.chooseNum(-50, 50)
+    ) { (condElems, t, f) =>
+      val cond = ArrayResult(condElems.toVector.map(Vector(_)))
+      val result = ArrayArithmetic.broadcastIf(
+        cond,
+        ArrayResult.single(CellValue.Number(BigDecimal(t))),
+        ArrayResult.single(CellValue.Number(BigDecimal(f)))
+      )
+      result match
+        case Right(out) =>
+          Prop.all(
+            condElems.zipWithIndex.map { case (condCV, idx) =>
+              val expected = condCV match
+                case CellValue.Error(err) => CellValue.Error(err)
+                case CellValue.Text(_) => valueErr
+                case CellValue.Bool(b) =>
+                  if b then CellValue.Number(BigDecimal(t)) else CellValue.Number(BigDecimal(f))
+                case CellValue.Number(n) =>
+                  if n.signum != 0 then CellValue.Number(BigDecimal(t))
+                  else CellValue.Number(BigDecimal(f))
+                case _ => CellValue.Number(BigDecimal(f)) // Empty is FALSE
+              Prop(out(idx, 0) == expected) :| s"idx=$idx cond=$condCV out=${out(idx, 0)}"
+            }*
+          )
+        case Left(err) => Prop.falsified :| s"expected Right, got Left($err)"
+    }
+  }
+
   // ===== Commit 2: property tests =====
 
   private val genPlainValue: Gen[CellValue] = Gen.oneOf(

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/ArrayErrorPropagationSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/ArrayErrorPropagationSpec.scala
@@ -233,6 +233,17 @@ class ArrayErrorPropagationSpec extends ScalaCheckSuite:
     assertEquals(updatedEq(ref"D2").value, na)
   }
 
+  test("GH-337: SCALAR comparison against an error cell still refuses (unchanged boundary)") {
+    // Carriage is an array-path behavior: the scalar compare path keeps its clean Left.
+    val sheet = Sheet("Test").put(ref"A1", num(1)).put(ref"B1", na)
+    val result = sheet.evaluateFormula("=A1<B1")
+    assert(result.isLeft, s"expected Left, got $result")
+    assert(
+      result.left.toOption.get.message.contains("cannot compare"),
+      s"unexpected error: $result"
+    )
+  }
+
   test("GH-337: scalar entry collapses — error at top-left refuses, error elsewhere intersects") {
     // Implicit intersection takes the top-left element; a carried error there refuses cleanly,
     // while an error elsewhere in the array no longer poisons the collapsed scalar (improvement

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/IfBranchErrorSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/IfBranchErrorSpec.scala
@@ -1,0 +1,106 @@
+package com.tjclp.xl.formula
+
+import munit.FunSuite
+
+import com.tjclp.xl.addressing.ARef
+import com.tjclp.xl.cells.{CellError, CellValue}
+import com.tjclp.xl.formula.eval.SheetEvaluator.*
+import com.tjclp.xl.sheets.Sheet
+import com.tjclp.xl.syntax.*
+
+/**
+ * GH-339: array-path IF/IFS evaluate both branches eagerly (CSE semantics require it for the
+ * broadcast), so an error produced by an entirely-unselected branch used to poison the whole
+ * formula.
+ *
+ * With GH-337 elementwise error carriage, a whole-branch evaluation failure demotes to a 1x1
+ * carried-error element: broadcastIf then selects it away at positions where the other branch wins,
+ * and it only surfaces (as an error element, or loudly via an aggregate) where actually selected.
+ * Scalar IF/IFS keep lazy branch selection — re-pinned here adjacent to the array semantics.
+ *
+ * Accepted micro-divergence (by design): a broadcast-dimension mismatch INSIDE a branch expression
+ * also demotes to a 1x1 #VALUE! element instead of staying a whole-formula Left.
+ */
+@SuppressWarnings(Array("org.wartremover.warts.OptionPartial"))
+class IfBranchErrorSpec extends FunSuite:
+
+  private val div0 = CellValue.Error(CellError.Div0)
+
+  private def num(n: Int): CellValue = CellValue.Number(BigDecimal(n))
+
+  // The GH-339 headline: every condition element is TRUE, so the erroring FALSE branch is
+  // never selected and must not fail the formula.
+  private val allPositive = Sheet("Test")
+    .put(ref"A1", num(5))
+    .put(ref"A2", num(3))
+
+  private val mixed = Sheet("Test")
+    .put(ref"A1", num(5))
+    .put(ref"A2", num(-3))
+
+  test("GH-339: =SUM(IF(A1:A2>0,A1:A2,1/0)) succeeds when every condition is TRUE") {
+    assertEquals(allPositive.evaluateFormula("=SUM(IF(A1:A2>0,A1:A2,1/0))"), Right(num(8)))
+
+    val arrayEntry = allPositive.evaluateArrayFormula("=SUM(IF(A1:A2>0,A1:A2,1/0))", ref"D1")
+    assert(arrayEntry.isRight, s"expected Right, got $arrayEntry")
+    assertEquals(arrayEntry.toOption.get._1(ref"D1").value, num(8))
+  }
+
+  test("GH-339: mixed conditions surface the branch error only at FALSE positions") {
+    val result = mixed.evaluateArrayFormula("=IF(A1:A2>0,A1:A2,1/0)", ref"C1")
+    assert(result.isRight, s"expected Right, got $result")
+    val (updated, spill) = result.toOption.get
+    assertEquals(spill.height, 2)
+    assertEquals(updated(ref"C1").value, num(5))
+    assertEquals(updated(ref"C2").value, div0)
+  }
+
+  test("GH-339: =IF(A1:A2>0,1/0,2) with every condition FALSE yields {2;2}") {
+    val allNegative = Sheet("Test")
+      .put(ref"A1", num(-5))
+      .put(ref"A2", num(-3))
+    val result = allNegative.evaluateArrayFormula("=IF(A1:A2>0,1/0,2)", ref"C1")
+    assert(result.isRight, s"expected Right, got $result")
+    val (updated, _) = result.toOption.get
+    assertEquals(updated(ref"C1").value, num(2))
+    assertEquals(updated(ref"C2").value, num(2))
+  }
+
+  test("GH-339: IFS carries an erroring later condition as elements at unmatched positions") {
+    // A1=5 matches the first pair; A2=-3 falls through to the second pair, whose condition
+    // divides by zero — that failure carries as #DIV/0! only where the fallthrough is selected.
+    val result = mixed.evaluateArrayFormula("=IFS(A1:A2>0,A1:A2,1/0>0,99)", ref"C1")
+    assert(result.isRight, s"expected Right, got $result")
+    val (updated, _) = result.toOption.get
+    assertEquals(updated(ref"C1").value, num(5))
+    assertEquals(updated(ref"C2").value, div0)
+  }
+
+  test("GH-339: IFS carries an erroring matched VALUE as elements at matched positions") {
+    val result = mixed.evaluateArrayFormula("=IFS(A1:A2>0,1/0,TRUE,5)", ref"C1")
+    assert(result.isRight, s"expected Right, got $result")
+    val (updated, _) = result.toOption.get
+    assertEquals(updated(ref"C1").value, div0)
+    assertEquals(updated(ref"C2").value, num(5))
+  }
+
+  test("GH-339: the CURRENT pair's condition failure stays fatal (scalar condition shape)") {
+    // A scalar condition that fails to evaluate is not a branch — it aborts the formula.
+    assert(allPositive.evaluateFormula("=SUM(IF(1/0>0,A1:A2,0))").isLeft)
+    assert(allPositive.evaluateFormula("=IFS(1/0>0,1,TRUE,2)").isLeft)
+  }
+
+  // ===== Scalar laziness re-pins (adjacent to the array semantics they contrast with) =====
+
+  test("GH-339: scalar IF keeps lazy branch selection (untaken 1/0 never evaluates)") {
+    assertEquals(allPositive.evaluateFormula("=IF(A1>0,42,1/0)"), Right(num(42)))
+    assertEquals(allPositive.evaluateFormula("=IF(A1<0,1/0,42)"), Right(num(42)))
+  }
+
+  test("GH-339: scalar IFS keeps lazy pair selection (later erroring pairs never evaluate)") {
+    assertEquals(allPositive.evaluateFormula("=IFS(TRUE,42,1/0>0,99)"), Right(num(42)))
+    assertEquals(
+      allPositive.evaluateFormula("=IFS(1>2,1)"),
+      Right(CellValue.Error(CellError.NA))
+    )
+  }


### PR DESCRIPTION
## Summary

Ultracode wave 11 per the approved plan — two worktree-isolated TDD clusters, both adversarially reviewed and approved first-pass. Closes #337. Closes #339. Closes #340.

### fix(evaluator): elementwise error carriage (#337) + array-IF branch errors (#339) — 7 serialized commits

- New `EvalError.toCellError` demotion table (`DivByZero→#DIV/0!`, `RefError→#REF!`, `TypeMismatch/CodecFailed/EvalFailed→#VALUE!`, **CircularRef stays fatal**)
- `broadcastOrderedCompare`/`broadcastEqualityCompare` and array arithmetic carry error operand elements per Excel (left operand's error wins; per-element `#DIV/0!`; text → `#VALUE!`); scalar `CellValue.Error` operands broadcast as 1×1 arrays (`=NA()+A1:A3` → `{#N/A;#N/A}`); **new invariant: broadcast ops return `Left` only for dimension mismatch** (property-tested)
- `broadcastIf` carries condition-element errors positionally; text condition elements → `#VALUE!` elements; AND/OR/NOT abort semantics deliberately untouched
- **#339**: IF/IFS branch `Left`s demote to 1×1 error arrays at the boundary — `=SUM(IF(A1:A2>0,A1:A2,1/0))` on all-positive data now evaluates (unselected error positions discarded per CSE); scalar-path laziness re-pinned
- **Aggregate do-no-harm guards** (the design pass's forced widening): `Aggregator.propagatesErrors` (COUNT exempt per Excel), variadic aggregates + SUMPRODUCT fail **loudly** naming the Excel code instead of silently zeroing/skipping carried errors — the red run proved pre-guard `=SUMPRODUCT((A1:A3<5)*1)` with an error cell returned **2** silently. Guards stay IFERROR-catchable (pinned)
- Scalar (non-array) comparison/arith refusals unchanged and now explicitly pinned; 42 new tests across `ArrayErrorPropagationSpec` (incl. 5 property tests), `IfBranchErrorSpec`, `AggregateErrorPolicySpec`; exactly one pre-existing pin flipped (array div-zero whole-`Left` → `#DIV/0!` element)

### feat(agent): stop_reason capture + failure-path polish (#340, all six items)

- `Agent.runStreaming` captures `BetaMessage.stopReason()`; pure `StopReasonPolicy.errorFor` maps `max_tokens`/`refusal`/`pause_turn`(+unknowns) to case errors — a truncated turn is now **loud** end-to-end (reports, glyphs, stream lines) instead of reading as clean completion (the 13894-c3 failure, `outputTokens 16819` vs 16384 cap, twice)
- `AgentConfig.maxTokens` 16384 → **32768** + new `--max-tokens` runner flag (documented in help + CLAUDE.md)
- `CaseFailure.withPartialTrace` recovers summed per-turn usage instead of zero; engine last-resort handler now writes a metadata-only failure trace for third-party skills; all-errored tasks render red ✗; stream completion lines carry the skill name

### Documented divergences / follow-up material (noted in code + wave reports)
pow-overflow → `#VALUE!` (Excel `#NUM!`); dimension mismatch inside an IF branch → 1×1 `#VALUE!`; AND/OR error-element abort (vs Excel propagation); aggregate error-*value* returns need `FunctionSpec` result-type changes; PAUSE_TURN auto-resume; `SkillSummary` exclusion of all-errored tasks from aggregation.

## Test plan
- [x] Baseline gate: 3,927 green pre-wave; both clusters TDD (red runs recorded, incl. the silent-SUMPRODUCT hazard proof)
- [x] Adversarial reviews: both approve, no rework round
- [x] Integrated branch: full `__.test` green, global `checkFormatAll`, `test-examples.sh`, `verify-skill-snippets.sh --local`
- [x] `make install` + installed-CLI E2E: `=10/A1:A3` spills `{10, #DIV/0!, 5}`; `=SUM(IF(A1:A3>=0,A1:A3,1/0))` → 3; `=SUMPRODUCT((10/A1:A3)*1)` fails loudly naming `#DIV/0!`

🤖 Generated with [Claude Code](https://claude.com/claude-code)