### PR TITLE
chore(release): Bump version to 0.12.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.4] "Carriage" - 2026-07-09
+
+Wave 11: elementwise error semantics through array operations, and loud benchmark
+failure diagnostics. Follow-up divergences tracked in #344.
+
+### Fixed
+
+- **Errors carry elementwise through array operations** (#337): comparisons and
+  arithmetic over arrays containing error values produce the error *as that element*
+  (`=10/A1:A3` with a zero spills `{10, #DIV/0!, 5}`) instead of failing the whole
+  formula. Left operand's error wins for binary ops; per-element division by zero
+  yields `#DIV/0!`; uncoercible text yields `#VALUE!`. New invariant, property-tested:
+  broadcast operations return a formula error only for dimension mismatch.
+- **Unused IF/IFS branch errors no longer poison the array path** (#339):
+  `=SUM(IF(A1:A2>0,A1:A2,1/0))` on all-positive data evaluates — branch failures
+  demote to error elements that unselected positions discard, per Excel CSE.
+  Scalar-path branch laziness is unchanged and pinned.
+- **Aggregates fail loudly on carried errors instead of silently mis-summing**:
+  SUM/MIN/MAX/AVERAGE/SUMPRODUCT over expression arrays containing an error value
+  return a formula error naming the Excel code (previously SUMPRODUCT coerced error
+  elements to 0 — a silently wrong number). COUNT keeps Excel's ignore-errors
+  behavior; the guards remain IFERROR-catchable.
+- **Benchmark truncations are loud** (#340, internal xl-agent): the agent loop now
+  captures `stop_reason` — `max_tokens`/`refusal`/`pause_turn` turns surface as case
+  errors in reports, glyphs, and traces instead of reading as clean completions;
+  default per-iteration output cap raised to 32,768 with a new `--max-tokens` flag;
+  partial usage is recovered from completed turns; engine-level failures leave a
+  metadata trace; all-errored tasks render red; stream lines carry the skill name.
+
+### Changed
+
+- New `EvalError → CellError` demotion table (`#DIV/0!`, `#REF!`, `#VALUE!`);
+  circular references remain fatal formula errors. Documented divergences from
+  Excel (pow-overflow `#VALUE!` vs `#NUM!`, AND/OR error aborts, scalar error
+  refusals, aggregate error-value returns) are enumerated in #344.
+
 ## [0.12.3] "Parity" - 2026-07-09
 
 Waves 10–11: evaluator correctness gaps found by live SpreadsheetBench dogfooding, plus the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ excel.read(path).flatMap(wb => excel.write(wb, outPath))
 
 ```bash
 ./mill __.compile          # Compile all
-./mill __.test             # Run all tests (3,930)
+./mill __.test             # Run all tests (3,996)
 ./mill xl-core.test        # Test specific module
 ./mill __.reformat         # Format (Scalafmt 3.10.1)
 ./mill __.checkFormat      # CI check
@@ -396,12 +396,12 @@ Styles deduplicated by `CellStyle.canonicalKey`. Build style index before emitti
 
 **Framework**: MUnit + ScalaCheck | **Generators**: `xl-core/test/src/com/tjclp/xl/Generators.scala`
 
-**3,930 tests** by module: xl-evaluator (1529), xl-core (1104), xl-ooxml (684), xl-cli (406), xl-cats-effect (110), xl-agent (78), xl prelude probes (19). See `docs/reference/testing-guide.md` for suite structure and patterns.
+**3,996 tests** by module: xl-evaluator (1571), xl-core (1104), xl-ooxml (684), xl-cli (406), xl-cats-effect (110), xl-agent (102), xl prelude probes (19). See `docs/reference/testing-guide.md` for suite structure and patterns.
 
 ## Documentation
 
 - **Roadmap**: `docs/plan/roadmap.md` (single source of truth for work scheduling)
-- **Status**: `docs/STATUS.md` (current capabilities, 3,930 tests)
+- **Status**: `docs/STATUS.md` (current capabilities, 3,996 tests)
 - **Design**: `docs/design/*.md` (architecture, purity charter, domain model)
 - **Reference**: `docs/reference/*.md` (examples, scaffolds, performance guide)
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ```scala 3 raw
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.3
+//> using dep com.tjclp::xl:0.12.4
 
 import com.tjclp.xl.{*, given}
 
@@ -55,13 +55,13 @@ import com.tjclp.xl.{*, given}
 
 ```scala 3 ignore
 // build.mill — single dependency for everything
-def ivyDeps = Agg(ivy"com.tjclp::xl:0.12.3")
+def ivyDeps = Agg(ivy"com.tjclp::xl:0.12.4")
 
 // Or individual modules for minimal footprint:
-// ivy"com.tjclp::xl-core:0.12.3"        — Pure domain model only
-// ivy"com.tjclp::xl-ooxml:0.12.3"       — Add OOXML read/write
-// ivy"com.tjclp::xl-cats-effect:0.12.3" — Add IO streaming
-// ivy"com.tjclp::xl-evaluator:0.12.3"   — Add formula evaluation
+// ivy"com.tjclp::xl-core:0.12.4"        — Pure domain model only
+// ivy"com.tjclp::xl-ooxml:0.12.4"       — Add OOXML read/write
+// ivy"com.tjclp::xl-cats-effect:0.12.4" — Add IO streaming
+// ivy"com.tjclp::xl-evaluator:0.12.4"   — Add formula evaluation
 ```
 
 ### Basic Usage

--- a/build.mill
+++ b/build.mill
@@ -14,7 +14,7 @@ val organization = "com.tjclp"
 /** Shared build configuration constants */
 object BuildConfig {
   /** Project version: CI sets PUBLISH_VERSION; local builds use this fallback */
-  val version: String = sys.env.getOrElse("PUBLISH_VERSION", "0.12.3")
+  val version: String = sys.env.getOrElse("PUBLISH_VERSION", "0.12.4")
 
   /** JVM options to silence Scala 3 LazyVals sun.misc.Unsafe deprecation warnings (JDK 21+) */
   val lazyValsJvmArgs: Seq[String] = Seq(

--- a/docs/QUICK-START.md
+++ b/docs/QUICK-START.md
@@ -12,19 +12,19 @@ import mill._, scalalib._
 
 object myproject extends ScalaModule {
   def scalaVersion = "3.8.3"
-  def ivyDeps = Agg(ivy"com.tjclp::xl:0.12.3")
+  def ivyDeps = Agg(ivy"com.tjclp::xl:0.12.4")
 }
 ```
 
 ### With sbt (build.sbt)
 ```scala
 scalaVersion := "3.8.3"
-libraryDependencies += "com.tjclp" %% "xl" % "0.12.3"
+libraryDependencies += "com.tjclp" %% "xl" % "0.12.4"
 ```
 
 ### With Scala CLI
 ```scala
-//> using dep com.tjclp::xl:0.12.3
+//> using dep com.tjclp::xl:0.12.4
 ```
 
 ### Individual Modules (Optional)
@@ -44,7 +44,7 @@ For scripts, skip the build setup entirely: a two-line `scala-cli` header and ON
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.3
+//> using dep com.tjclp::xl:0.12.4
 
 import com.tjclp.xl.scripting.{*, given}
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,12 +1,17 @@
 # XL Project Status
 
-**Last Updated**: 2026-07-09
+**Last Updated**: 2026-07-09 (0.12.4)
 
 ## Current State
 
 > **For detailed phase completion status and roadmap, see [plan/roadmap.md](plan/roadmap.md)**
 
 ### What Works (Production-Ready)
+
+**New in 0.12.4** (2026-07-09):
+- ✅ **Elementwise error carriage** (#337) — array comparisons/arithmetic carry `#DIV/0!`/`#REF!`/`#VALUE!` per element (Left only on dimension mismatch, property-tested); aggregates fail loudly on carried errors (IFERROR-catchable)
+- ✅ **Array-IF branch errors** (#339) — unused-branch failures demote to discarded error elements per CSE
+- ✅ **Benchmark truncation diagnostics** (#340, internal) — stop_reason capture, 32K output cap + `--max-tokens`; divergence backlog in #344
 
 **New in 0.12.3** (2026-07-09):
 - ✅ **Excel comparison semantics** (#335) — ordered comparisons follow Excel's total order (case-insensitive lexicographic text, `number < text < logical`, dates by serial, empty coercion) in scalar and array paths
@@ -109,16 +114,16 @@
 
 ### Test Coverage
 
-**3,930 tests** (verified via `./mill __.test`, 2026-07-09):
+**3,996 tests** (verified via `./mill __.test`, 2026-07-09):
 
 | Module | Tests | Covers |
 |--------|-------|--------|
-| xl-evaluator | 1529 | parser, evaluator, 107-function library, dependency graph, cross-sheet formulas, recalculation, structural editing, Excel comparison total order, array CSE semantics |
+| xl-evaluator | 1571 | parser, evaluator, 107-function library, dependency graph, cross-sheet formulas, recalculation, structural editing, Excel comparison total order, array CSE semantics |
 | xl-core | 1104 | addressing laws, Patch/StylePatch monoids, codecs, optics, RichText, interpolation, render (HTML/SVG), styles DSL, charts, drawings, conditional formatting |
 | xl-ooxml | 684 | round-trips (cells, styles, tables, comments, hyperlinks, charts, drawings, conditional formatting), compression, security (XXE, ZIP bomb), preservation |
 | xl-cli | 406 | command parsing, batch ops, view/eval/export, streaming mode |
 | xl-cats-effect | 110 | streaming I/O, O(1) memory verification, SAX/StAX write |
-| xl-agent | 78 | benchmark engine, skill abstraction, failure-path diagnostics, release-asset resolution |
+| xl-agent | 102 | benchmark engine, skill abstraction, failure-path diagnostics, release-asset resolution |
 | xl (prelude) | 19 | external-consumer probes (`xl/test/src/xlprelude/`) |
 | xl-testkit | 0 | placeholder (no sources yet) |
 

--- a/docs/plan/roadmap.md
+++ b/docs/plan/roadmap.md
@@ -10,9 +10,9 @@
 
 ## TL;DR
 
-**Current Status**: Production-ready with **107 formula functions** (incl. dynamic arrays SEQUENCE/SORT/UNIQUE/FILTER and OFFSET), **structural editing** (insert/delete rows & columns with formula rewriting), the **scripting prelude** (`com.tjclp.xl.scripting`), whole-workbook `recalculate`, named-range & hyperlink authoring, **typed charts + embedded pictures** (0.12.0), **conditional formatting** (0.12.1), SAX streaming (36% faster than POI), Excel tables, and full OOXML round-trip. 3,930 tests passing.
+**Current Status**: Production-ready with **107 formula functions** (incl. dynamic arrays SEQUENCE/SORT/UNIQUE/FILTER and OFFSET), **structural editing** (insert/delete rows & columns with formula rewriting), the **scripting prelude** (`com.tjclp.xl.scripting`), whole-workbook `recalculate`, named-range & hyperlink authoring, **typed charts + embedded pictures** (0.12.0), **conditional formatting** (0.12.1), SAX streaming (36% faster than POI), Excel tables, and full OOXML round-trip. 3,996 tests passing.
 
-**Current Version**: **0.12.3 "Parity"** (released 2026-07-09)
+**Current Version**: **0.12.4 "Carriage"** (released 2026-07-09)
 
 ---
 
@@ -61,7 +61,11 @@ Phased: (a) verbatim chart/drawing preservation proven by the wave-2 fixture cor
 
 Every remaining open issue closed in one wave. **Conditional formatting** ([#136](https://github.com/TJC-LP/xl/issues/136)) is the headline — typed cellIs/expression/colorScale/dataBar/top10/text rules + `dxf` differential formats, `sheet.conditionalFormat` authoring with auto-priority, structural-edit range shifting, unmodeled families preserved byte-faithfully — alongside twelve fidelity/writer fixes: openpyxl comment subdirectory dialect (#292), RichText SST keying (#303), exact surgical SST counts (#304), `[Content_Types]` preservation (#314), identity-keyed source mappings (#315), activeTab (#294), fitToPage tri-state (#284), `Cell.comment` deprecated→`Sheet.comments` (#295). Codec `put` paths 2.4x faster (#297).
 
-### v0.12.3 "Parity" — waves 10–11 (Released 2026-07-09)
+### v0.12.4 "Carriage" — wave 11 (Released 2026-07-09)
+
+Elementwise error semantics through array operations ([#337](https://github.com/TJC-LP/xl/issues/337) — errors carry per-element with a property-tested Left-only-on-dimension-mismatch invariant; aggregates fail loudly on carried errors instead of silently mis-summing), unused IF/IFS branch errors no longer poison array formulas ([#339](https://github.com/TJC-LP/xl/issues/339)), and loud benchmark failure diagnostics ([#340](https://github.com/TJC-LP/xl/issues/340) — stop_reason capture, 32K default output cap + `--max-tokens`, partial-usage recovery, red glyphs). Live probe: task 13894 xl 3/3 first time. Deliberate divergences tracked in [#344](https://github.com/TJC-LP/xl/issues/344).
+
+### v0.12.3 "Parity" — waves 10–11a (Released 2026-07-09)
 
 Evaluator correctness gaps found by live SpreadsheetBench dogfooding: Excel comparison total order — text/cross-type/date/empty semantics ([#335](https://github.com/TJC-LP/xl/issues/335)), array-aware IF per CSE + elimination of the aggregator crash family ([#333](https://github.com/TJC-LP/xl/issues/333)), AND/OR array aggregation with NOT/IFS broadcast ([#338](https://github.com/TJC-LP/xl/issues/338)), and benchmark failure diagnostics ([#334](https://github.com/TJC-LP/xl/issues/334)). Plus the xl-agent harness refresh (#332): Claude 5 registry, anthropic-java 2.48.0, prompt caching (−52–59%/task), version-agnostic release-asset resolution, Skills API drift fixes. Follow-ups filed: #337 (elementwise error propagation), #339 (IF eager branches, depends on #337), #340 (diagnostics polish).
 

--- a/docs/reference/scripting.md
+++ b/docs/reference/scripting.md
@@ -33,7 +33,7 @@ release bump is a mechanical substitution):
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.3
+//> using dep com.tjclp::xl:0.12.4
 import com.tjclp.xl.scripting.{*, given}
 
 val sheet = Sheet("Demo").put(ref"A1", "Hello").put(ref"B1", 42)
@@ -51,7 +51,7 @@ read and write is pure values.
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.3
+//> using dep com.tjclp::xl:0.12.4
 import com.tjclp.xl.scripting.{*, given}
 
 val wb = Excel.read("input.xlsx")
@@ -135,7 +135,7 @@ throw — they are collected per cell.
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.3
+//> using dep com.tjclp::xl:0.12.4
 import com.tjclp.xl.scripting.{*, given}
 
 val title = CellStyle.default.bold.size(14.0).center
@@ -246,7 +246,7 @@ them explicitly:
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.3
+//> using dep com.tjclp::xl:0.12.4
 import com.tjclp.xl.scripting.{*, given}
 import com.tjclp.xl.sheets.{HeaderFooter, PageMargins, PageSetup, SheetView}
 
@@ -300,7 +300,7 @@ the whole workbook:
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.3
+//> using dep com.tjclp::xl:0.12.4
 import com.tjclp.xl.scripting.{*, given}
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global

--- a/docs/reference/testing-guide.md
+++ b/docs/reference/testing-guide.md
@@ -1,6 +1,6 @@
 # Testing & Laws — Property Suites, Round-Trips, and Coverage
 
-**Current Status**: CI runs the full Mill test graph across the library, evaluator, CLI, and support modules — **3,930 tests** as of 0.12.3. Use `./mill __.test` as the authoritative count.
+**Current Status**: CI runs the full Mill test graph across the library, evaluator, CLI, and support modules — **3,996 tests** as of 0.12.4. Use `./mill __.test` as the authoritative count.
 
 ## Test Infrastructure
 
@@ -211,18 +211,18 @@ GitHub Actions runs:
 
 ## Test Counts by Module
 
-As of 0.12.3 (per-module `./mill <module>.test`; macros are part of xl-core — there is no separate xl-macros module):
+As of 0.12.4 (per-module `./mill <module>.test`; macros are part of xl-core — there is no separate xl-macros module):
 
 | Module | Tests |
 |--------|-------|
-| xl-evaluator | 1529 |
+| xl-evaluator | 1571 |
 | xl-core | 1104 |
 | xl-ooxml | 684 |
 | xl-cli | 406 |
 | xl-cats-effect | 110 |
-| xl-agent | 78 |
+| xl-agent | 102 |
 | xl (prelude probes, `xlprelude.ScriptingPreludeTest`) | 19 |
-| **Total** | **3,930** |
+| **Total** | **3,996** |
 
 ## Test Quality Metrics
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -170,7 +170,7 @@ chmod +x examples/my_example.sc
 ./examples/my_example.sc
 ```
 
-The `project.scala` file centralizes dependencies (`com.tjclp::xl:0.12.3`) for all examples.
+The `project.scala` file centralizes dependencies (`com.tjclp::xl:0.12.4`) for all examples.
 
 ## Scripting Prelude & Skill
 

--- a/examples/project.scala
+++ b/examples/project.scala
@@ -2,4 +2,4 @@
 //> using repository ivy2Local
 
 // XL aggregate - includes all modules (core, ooxml, cats-effect, evaluator)
-//> using dep com.tjclp::xl:0.12.3
+//> using dep com.tjclp::xl:0.12.4

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "xl",
   "description": "LLM-friendly Excel tooling: the xl CLI for reading, writing, styling, and analyzing spreadsheets (xl-cli skill), plus type-safe Scala scripting against the xl library via scala-cli for bulk transformations, pipelines, and formula models (xl-scripting skill).",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "author": {
     "name": "TJC L.P.",
     "url": "https://github.com/TJC-LP"

--- a/plugin/skills/xl-scripting/SKILL.md
+++ b/plugin/skills/xl-scripting/SKILL.md
@@ -38,7 +38,7 @@ The canonical header for every script (this is the single source of truth — re
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.3
+//> using dep com.tjclp::xl:0.12.4
 
 import com.tjclp.xl.scripting.{*, given}
 
@@ -100,7 +100,7 @@ wb.update("Sales", f).unsafe                       // throws structured XLExcept
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.3
+//> using dep com.tjclp::xl:0.12.4
 import com.tjclp.xl.scripting.{*, given}
 
 val wb = Excel.read("input.xlsx")
@@ -235,7 +235,7 @@ Or lean on totality so there is nothing to unwrap: literal refs, `upsert`, range
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.3
+//> using dep com.tjclp::xl:0.12.4
 import com.tjclp.xl.scripting.{*, given}
 import java.nio.file.{Files, Paths}
 import scala.jdk.CollectionConverters.*
@@ -257,7 +257,7 @@ println(s"merged ${inputs.size} files, ${merged.sheets.size} sheets")
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.3
+//> using dep com.tjclp::xl:0.12.4
 import com.tjclp.xl.scripting.{*, given}
 
 val data = List(("North", 125000.50), ("South", 98000.25), ("West", 143500.00))
@@ -285,7 +285,7 @@ println(if result.isClean then "✓ report written" else result.errors.map(_.ren
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.3
+//> using dep com.tjclp::xl:0.12.4
 import com.tjclp.xl.scripting.{*, given}
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global

--- a/plugin/skills/xl-scripting/reference/RECIPES.md
+++ b/plugin/skills/xl-scripting/reference/RECIPES.md
@@ -10,7 +10,7 @@ Apply a 5% price increase to column C of every workbook in a directory, in place
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.3
+//> using dep com.tjclp::xl:0.12.4
 import com.tjclp.xl.scripting.{*, given}
 import java.nio.file.{Files, Paths}
 import scala.jdk.CollectionConverters.*
@@ -42,7 +42,7 @@ Read rows into case classes; collect per-cell validation failures into a new Iss
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.3
+//> using dep com.tjclp::xl:0.12.4
 import com.tjclp.xl.scripting.{*, given}
 
 final case class Order(id: Int, customer: String, amount: BigDecimal)
@@ -76,7 +76,7 @@ Three-year projection with growth formulas; fail the script if any formula error
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.3
+//> using dep com.tjclp::xl:0.12.4
 import com.tjclp.xl.scripting.{*, given}
 
 val header = CellStyle.default.bold.size(12.0).center
@@ -111,7 +111,7 @@ Stack the data rows of every input file under one header.
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.3
+//> using dep com.tjclp::xl:0.12.4
 import com.tjclp.xl.scripting.{*, given}
 import java.nio.file.{Files, Paths}
 import scala.jdk.CollectionConverters.*
@@ -147,7 +147,7 @@ println(s"combined ${files.size} files, ${combined.cells.size} cells")
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.3
+//> using dep com.tjclp::xl:0.12.4
 import com.tjclp.xl.scripting.{*, given}
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
@@ -176,7 +176,7 @@ println("✓ filtered (constant memory)")
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.3
+//> using dep com.tjclp::xl:0.12.4
 import com.tjclp.xl.scripting.{*, given}
 
 val before = Excel.read("before.xlsx")
@@ -204,7 +204,7 @@ else
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.3
+//> using dep com.tjclp::xl:0.12.4
 import com.tjclp.xl.scripting.{*, given}
 import java.nio.file.{Files, Paths}
 import scala.jdk.CollectionConverters.*

--- a/xl-core/src/com/tjclp/xl/workbooks/WorkbookMetadata.scala
+++ b/xl-core/src/com/tjclp/xl/workbooks/WorkbookMetadata.scala
@@ -21,7 +21,7 @@ final case class WorkbookMetadata(
   modified: Option[java.time.LocalDateTime] = None,
   lastModifiedBy: Option[String] = None,
   application: Option[String] = Some("XL - Pure Scala 3.8 Excel Library"),
-  appVersion: Option[String] = Some("0.12.3"),
+  appVersion: Option[String] = Some("0.12.4"),
   theme: ThemePalette = ThemePalette.office,
   definedNames: Vector[DefinedName] = Vector.empty,
   sheetStates: Map[SheetName, Option[String]] = Map.empty,


### PR DESCRIPTION
Release commit for **v0.12.4 "Carriage"** — version pins, CHANGELOG entry for wave 11 (#337/#339/#340 + divergence backlog #344), and living-doc refresh (roadmap, STATUS, testing-guide, CLAUDE.md — authoritative test count 3,996).

**Tagging happens after merge this time** (0.12.3 lesson): merge first, then the annotated `v0.12.4` tag goes on the squash commit so the tag is reachable from main.

Gates on this tree: full `__.test` (3,996) + `test-examples.sh` + `verify-skill-snippets.sh --local` + SNAPSHOT sweep clean. (Global scalafmt runs in CI's build job.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)