### PR TITLE
fix(evaluator): memoize recursive uncached-ref eval + workbook-level recalc order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Recursive uncached-reference evaluation is memoized per pass** (#346): an
+  uncached formula reference (`CellValue.Formula(_, None)`) was recursively
+  re-evaluated once per *path* through the dependency graph — exponential on
+  multi-branch recursive chains (an LBO debt schedule at ~800 formulas ran for
+  hours at 100% CPU; the repro in `RecalcPerfSpec` never finished at n=24
+  periods). A pass-local memo (`Evaluator.EvalMemo`, keyed by sheet identity
+  then ref) threads through recursive evaluation, `EvalContext`, and the
+  aggregate/array uncached-cell readers, so each distinct cell evaluates at
+  most once per top-level evaluation — Excel's own one-computation-per-cell
+  semantics. Errors memoize too (a cycle no longer re-burns the depth guard
+  per path). The n=24 repro drops from unbounded to milliseconds.
+- **`Workbook.recalculate()` orders cells workbook-level, not per sheet**
+  (#346): recalculation now builds one qualified (sheet!cell) dependency graph
+  (`DependencyGraph.fromWorkbookBounded`, ranges bounded by each *target*
+  sheet's used range), prunes cycles with a workbook-level Tarjan pass, and
+  evaluates a single global topological order threading the partially
+  evaluated workbook — every precedent, same-sheet or cross-sheet, is computed
+  exactly once before its dependents instead of being re-derived on demand
+  against the original uncached snapshot. Consequences: mutually-referencing
+  sheets recalculate in linear time; cross-sheet aggregates over uncached
+  formula cells read computed values regardless of sheet order; **cycles that
+  span sheets are now detected and reported as circular** (participants
+  circular, downstream blocked, acyclic remainder evaluates) instead of
+  surfacing as depth-guard evaluation errors. The GH-274/GH-301 dynamic
+  (INDIRECT/OFFSET) evaluate-last bucket and cache-strip semantics are
+  preserved, with the closure now workbook-level.
+
 ## [0.12.4] "Carriage" - 2026-07-09
 
 Wave 11: elementwise error semantics through array operations, and loud benchmark

--- a/xl-evaluator/src/com/tjclp/xl/formula/eval/Evaluator.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/eval/Evaluator.scala
@@ -170,7 +170,8 @@ object Evaluator:
     clock: Clock,
     workbook: Option[Workbook],
     depth: Int = 0,
-    rng: Rng = Rng.system
+    rng: Rng = Rng.system,
+    memo: EvalMemo = new EvalMemo
   ): Either[EvalError, CellValue] =
     boundary:
       // GH-161 review: Add recursion depth limit to prevent stack overflow on circular refs
@@ -195,8 +196,9 @@ object Evaluator:
         case Right(expr) =>
           // Recursively evaluate with depth-aware evaluator (GH-161 cycle protection).
           // The referenced formula is a separate lexical unit: the rng threads through, but LET
-          // bindings never leak across formula boundaries (fresh empty environment).
-          new EvaluatorWithDepth(depth + 1, rng = rng)
+          // bindings never leak across formula boundaries (fresh empty environment). The memo
+          // threads too (GH-346): every cell in this recursion tree evaluates at most once.
+          new EvaluatorWithDepth(depth + 1, rng = rng, memo = Some(memo))
             .eval(expr, targetSheet, clock, workbook)
             .map { result =>
               // Convert typed result to CellValue
@@ -214,6 +216,50 @@ object Evaluator:
                 case ar: ArrayResult => if ar.isEmpty then CellValue.Empty else ar(0, 0)
                 case other => CellValue.Text(other.toString)
             }
+
+  /**
+   * GH-346: per-pass memo for recursively evaluated uncached formula cells.
+   *
+   * Recursive evaluation of a `CellValue.Formula(_, None)` reference re-derived the referenced cell
+   * once per PATH through the dependency graph — exponential on multi-branch recursive chains (an
+   * LBO debt schedule: each period's balance read by several formulas, chained period over period).
+   * The memo makes each distinct cell evaluate at most once per evaluation pass, which is also
+   * Excel's one-computation-per-cell-per-recalc semantics.
+   *
+   * Scope and purity: a memo is created where recursion begins (an uncached reference or a function
+   * reading uncached cells at depth 0) and threads only through the derived `EvaluatorWithDepth`
+   * instances and `EvalContext`s of that pass, so it never outlives a single top-level evaluation
+   * and is invisible at the public API — local mutation only, the same pattern as the iterative
+   * Tarjan engine in DependencyGraph. Entries key by Sheet IDENTITY, then ref: two same-named Sheet
+   * snapshots (a recalc temp sheet vs the original workbook copy) memoize independently, so a stale
+   * snapshot can never serve values for a newer one.
+   *
+   * Errors memoize too — a cycle otherwise re-burns the full recursion-depth guard once per path,
+   * which is itself exponential. A depth-guard error consequently records by first-visit order;
+   * that is observable only on chains deeper than the guard, where results were already
+   * path-dependent (and where whole-workbook `recalculate()`, which orders iteratively, is the
+   * supported path).
+   */
+  private[formula] final class EvalMemo:
+    private val bySheet =
+      new java.util.IdentityHashMap[
+        Sheet,
+        scala.collection.mutable.HashMap[ARef, Either[EvalError, CellValue]]
+      ]()
+
+    def getOrCompute(sheet: Sheet, at: ARef)(
+      compute: => Either[EvalError, CellValue]
+    ): Either[EvalError, CellValue] =
+      val forSheet =
+        bySheet.computeIfAbsent(sheet, _ => scala.collection.mutable.HashMap.empty)
+      forSheet.get(at) match
+        case Some(hit) => hit
+        case None =>
+          // Compute BEFORE storing (never inside a map callback): the computation itself may
+          // recurse into this memo for other cells of the same sheet.
+          val computed = compute
+          forSheet.update(at, computed)
+          computed
 
 /**
  * Private implementation of Evaluator.
@@ -235,6 +281,13 @@ private class EvaluatorImpl(
 ) extends Evaluator:
   /** Current recursion depth for cross-sheet formula evaluation. */
   protected def currentDepth: Int = 0
+
+  /**
+   * GH-346: the current pass's memo for recursively evaluated uncached formula cells — None at the
+   * top level (a memo is created at the first point recursion can begin and threads through every
+   * derived evaluator of the pass via EvaluatorWithDepth).
+   */
+  protected def memoOpt: Option[Evaluator.EvalMemo] = None
   // Suppress asInstanceOf warning for GADT type handling (required for type parameter erasure)
   @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
   def eval[A](
@@ -294,15 +347,20 @@ private class EvaluatorImpl(
                     // Formula has no cached value - parse and evaluate against target sheet
                     // GH-161 review: Apply decoder to Cell with evaluated result (type-safe)
                     // GH-161 review: Pass currentDepth for cycle protection
-                    Evaluator
-                      .evalCrossSheetFormula(
-                        formulaStr,
-                        targetSheet,
-                        clock,
-                        workbook,
-                        currentDepth,
-                        rng
-                      )
+                    // GH-346: memoized per pass — a cell evaluates once, not once per path
+                    val memo = memoOpt.getOrElse(new Evaluator.EvalMemo)
+                    memo
+                      .getOrCompute(targetSheet, at) {
+                        Evaluator.evalCrossSheetFormula(
+                          formulaStr,
+                          targetSheet,
+                          clock,
+                          workbook,
+                          currentDepth,
+                          rng,
+                          memo
+                        )
+                      }
                       .flatMap { evaluatedValue =>
                         val resultCell = Cell(at, evaluatedValue)
                         decode(resultCell).left.map(codecErr => EvalError.CodecFailed(at, codecErr))
@@ -343,8 +401,21 @@ private class EvaluatorImpl(
         // GH-208: Handle same-sheet formula cells without cached values by recursively evaluating
         cell.value match
           case CellValue.Formula(formulaStr, None) =>
-            Evaluator
-              .evalCrossSheetFormula(formulaStr, sheet, clock, workbook, currentDepth, rng)
+            // GH-346: memoized per pass — a cell evaluates once, not once per path
+            val memo = memoOpt.getOrElse(new Evaluator.EvalMemo)
+            memo
+              .getOrCompute(sheet, at) {
+                Evaluator
+                  .evalCrossSheetFormula(
+                    formulaStr,
+                    sheet,
+                    clock,
+                    workbook,
+                    currentDepth,
+                    rng,
+                    memo
+                  )
+              }
               .flatMap { evaluatedValue =>
                 val resultCell = Cell(at, evaluatedValue)
                 decode(resultCell).left.map(codecErr => EvalError.CodecFailed(at, codecErr))
@@ -485,11 +556,22 @@ private class EvaluatorImpl(
             case ar: ArrayResult => ScalarCoercion.collapseArray(ar).asInstanceOf[A]
             case value => value.asInstanceOf[A]
           }
+        // GH-346: functions that read uncached formula cells (aggregates, array materialization)
+        // recurse through the same memo, so a shared precedent evaluates once per pass. Created
+        // here when the pass has none yet — the ctx is per Call node, so it cannot leak across
+        // top-level evaluations.
+        val callMemo = memoOpt.getOrElse(new Evaluator.EvalMemo)
         // GH-197: Array-aware evaluator for functions like SUMPRODUCT that accept array expressions.
         // GH-193: carries the LET environment and recursion depth so array-evaluated arguments
         // (e.g. SUM over a range-valued binding) still resolve in-scope names.
         def evalArrayArg(expr: TExpr[Any]): Either[EvalError, Any] =
-          new EvaluatorWithDepth(currentDepth, allowArrayResults = true, bindings, rng)
+          new EvaluatorWithDepth(
+            currentDepth,
+            allowArrayResults = true,
+            bindings,
+            rng,
+            Some(callMemo)
+          )
             .eval(expr, sheet, clock, workbook, currentCell)
 
         val ctx = EvalContext(
@@ -501,7 +583,8 @@ private class EvaluatorImpl(
           currentCell,
           currentDepth,
           bindings,
-          rng
+          rng,
+          Some(callMemo)
         )
         call.spec.eval(call.args, ctx)
 
@@ -571,7 +654,7 @@ private class EvaluatorImpl(
             // Bare cell refs resolve to the cell's effective value (cached formula extracted,
             // Empty → 0) — same treatment as top-level refs and equality operands (GH-233).
             val resolved = TExpr.asResolvedValueExpr(valueExpr)
-            new EvaluatorWithDepth(currentDepth, allowArrayResults = true, env, rng)
+            new EvaluatorWithDepth(currentDepth, allowArrayResults = true, env, rng, memoOpt)
               .eval(resolved.asInstanceOf[TExpr[Any]], sheet, clock, workbook, currentCell)
               .map(value => env + (name -> unwrapBindingValue(value)))
               .left
@@ -595,7 +678,7 @@ private class EvaluatorImpl(
             .map(targetSheet => ArrayArithmetic.rangeToArray(range, targetSheet))
         case other =>
           val resolvedBody = TExpr.asResolvedValueExpr(other)
-          new EvaluatorWithDepth(currentDepth, allowArrayResults, env, rng)
+          new EvaluatorWithDepth(currentDepth, allowArrayResults, env, rng, memoOpt)
             .eval(resolvedBody.asInstanceOf[TExpr[Any]], sheet, clock, workbook, currentCell)
     }
 
@@ -901,6 +984,8 @@ private class EvaluatorWithDepth(
   depth: Int,
   allowArrayResults: Boolean = false,
   bindings: Map[String, Any] = Map.empty,
-  rng: Rng = Rng.system
+  rng: Rng = Rng.system,
+  memo: Option[Evaluator.EvalMemo] = None
 ) extends EvaluatorImpl(allowArrayResults, bindings, rng):
   override protected def currentDepth: Int = depth
+  override protected def memoOpt: Option[Evaluator.EvalMemo] = memo

--- a/xl-evaluator/src/com/tjclp/xl/formula/eval/Evaluator.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/eval/Evaluator.scala
@@ -237,6 +237,9 @@ object Evaluator:
    * snapshots (a recalc temp sheet vs the original workbook copy) memoize independently, so a stale
    * snapshot can never serve values for a newer one.
    *
+   * Not thread-safe: an evaluation pass is single-threaded and the memo never escapes it — revisit
+   * if evaluation is ever parallelized internally.
+   *
    * Errors memoize too — a cycle otherwise re-burns the full recursion-depth guard once per path,
    * which is itself exponential. A depth-guard error consequently records by first-visit order;
    * that is observable only on chains deeper than the guard, where results were already

--- a/xl-evaluator/src/com/tjclp/xl/formula/eval/Evaluator.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/eval/Evaluator.scala
@@ -230,7 +230,10 @@ object Evaluator:
    * reading uncached cells at depth 0) and threads only through the derived `EvaluatorWithDepth`
    * instances and `EvalContext`s of that pass, so it never outlives a single top-level evaluation
    * and is invisible at the public API — local mutation only, the same pattern as the iterative
-   * Tarjan engine in DependencyGraph. Entries key by Sheet IDENTITY, then ref: two same-named Sheet
+   * Tarjan engine in DependencyGraph. Sharing is per recursion tree, not per top-level eval:
+   * sibling depth-0 references (`=A1+A1`) each start their own memo and re-walk the shared subtree
+   * once each — bounded and linear per subtree, a constant-factor cost accepted to keep the memo's
+   * lifetime trivially safe. Entries key by Sheet IDENTITY, then ref: two same-named Sheet
    * snapshots (a recalc temp sheet vs the original workbook copy) memoize independently, so a stale
    * snapshot can never serve values for a newer one.
    *

--- a/xl-evaluator/src/com/tjclp/xl/formula/eval/WorkbookEvaluator.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/eval/WorkbookEvaluator.scala
@@ -235,36 +235,38 @@ object WorkbookEvaluator:
           else evalOrder.filterNot(bucket.contains) ++ evalOrder.filter(bucket.contains)
 
         val stripBySheet: Map[SheetName, Set[ARef]] = bucket.groupMap(_.sheet)(_.ref)
-        val initialTemps: Map[SheetName, Sheet] =
+        val initialSheets: Vector[Sheet] =
           wb.sheets.map { s =>
             val toStrip = stripBySheet.getOrElse(s.name, Set.empty)
-            s.name ->
-              (if toStrip.isEmpty then s else SheetEvaluator.stripFormulaCaches(s, toStrip))
-          }.toMap
+            if toStrip.isEmpty then s else SheetEvaluator.stripFormulaCaches(s, toStrip)
+          }
+        val sheetIndex: Map[SheetName, Int] =
+          wb.sheets.zipWithIndex.map((s, i) => s.name -> i).toMap
 
         // Evaluate in the single global order, threading the partially evaluated workbook:
         // every reference — same-sheet or cross-sheet — reads its precedents as already-computed
-        // values, so recursive re-derivation only arises on dynamic reads. Rebuilding tempWb per
-        // cell is O(sheets) shallow-copy work per formula — negligible at realistic sheet
-        // counts, and each evaluation must see a workbook consistent with the fold state.
+        // values, so recursive re-derivation only arises on dynamic reads. The temp sheets live
+        // in a Vector parallel to wb.sheets, updated incrementally, so per-cell cost is one
+        // Workbook shell copy + one Vector update rather than re-mapping every sheet.
         val (_, evaluated, evalErrors) = ordered.foldLeft(
-          (initialTemps, Map.empty[SheetName, Map[ARef, CellValue]], Vector.empty[CellEvalError])
-        ) { case ((temps, acc, errs), q) =>
-          temps.get(q.sheet) match
-            case None => (temps, acc, errs) // node names a sheet absent from the workbook
-            case Some(tempSheet) =>
-              val tempWb = wb.copy(sheets = wb.sheets.map(s => temps.getOrElse(s.name, s)))
+          (initialSheets, Map.empty[SheetName, Map[ARef, CellValue]], Vector.empty[CellEvalError])
+        ) { case ((sheets, acc, errs), q) =>
+          sheetIndex.get(q.sheet) match
+            case None => (sheets, acc, errs) // node names a sheet absent from the workbook
+            case Some(idx) =>
+              val tempSheet = sheets(idx)
+              val tempWb = wb.copy(sheets = sheets)
               val evaluatedCell = rngOpt match
                 case Some(rng) => tempSheet.evaluateCell(q.ref, clock, rng, Some(tempWb))
                 case None => tempSheet.evaluateCell(q.ref, clock, Some(tempWb))
               evaluatedCell match
                 case Right(value) =>
                   (
-                    temps.updated(q.sheet, tempSheet.put(q.ref, value)),
+                    sheets.updated(idx, tempSheet.put(q.ref, value)),
                     acc.updated(q.sheet, acc.getOrElse(q.sheet, Map.empty) + (q.ref -> value)),
                     errs
                   )
-                case Left(error) => (temps, acc, errs :+ CellEvalError(q.sheet, q.ref, error))
+                case Left(error) => (sheets, acc, errs :+ CellEvalError(q.sheet, q.ref, error))
         }
 
         // Cache computed values into formula cells on the original sheets; failed cells stay

--- a/xl-evaluator/src/com/tjclp/xl/formula/eval/WorkbookEvaluator.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/eval/WorkbookEvaluator.scala
@@ -244,7 +244,9 @@ object WorkbookEvaluator:
 
         // Evaluate in the single global order, threading the partially evaluated workbook:
         // every reference — same-sheet or cross-sheet — reads its precedents as already-computed
-        // values, so recursive re-derivation only arises on dynamic reads.
+        // values, so recursive re-derivation only arises on dynamic reads. Rebuilding tempWb per
+        // cell is O(sheets) shallow-copy work per formula — negligible at realistic sheet
+        // counts, and each evaluation must see a workbook consistent with the fold state.
         val (_, evaluated, evalErrors) = ordered.foldLeft(
           (initialTemps, Map.empty[SheetName, Map[ARef, CellValue]], Vector.empty[CellEvalError])
         ) { case ((temps, acc, errs), q) =>

--- a/xl-evaluator/src/com/tjclp/xl/formula/eval/WorkbookEvaluator.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/eval/WorkbookEvaluator.scala
@@ -3,6 +3,7 @@ package com.tjclp.xl.formula.eval
 import com.tjclp.xl.formula.ast.TExpr
 import com.tjclp.xl.formula.functions.{FunctionSpec, FunctionSpecs}
 import com.tjclp.xl.formula.graph.DependencyGraph
+import com.tjclp.xl.formula.graph.DependencyGraph.QualifiedRef
 import com.tjclp.xl.formula.printer.FormulaPrinter
 import com.tjclp.xl.formula.parser.{FormulaParser, ParseError}
 import com.tjclp.xl.formula.{Clock, Rng}
@@ -136,12 +137,12 @@ object WorkbookEvaluator:
      * result.toEither                           // Left(errors) when not clean
      * }}}
      *
-     * Scope notes: cycle isolation is per-sheet (Tarjan over each sheet's graph) — a cycle that
-     * spans sheets is caught instead by the evaluator's recursion depth guard and surfaces as a
-     * generic per-cell eval error (still total, still collected; see RecalcSpec). Cross-sheet
-     * references to upstream formulas evaluate on demand against the original workbook snapshot and
-     * are not memoized across sheets — fine for typical workbooks; a workbook-level topological
-     * order is future work for deep cross-sheet fan-out.
+     * Scope notes (GH-346): ordering and cycle isolation are workbook-level — one topological order
+     * over the qualified (sheet!cell) graph, so every precedent (same-sheet or cross-sheet) is
+     * computed exactly once before its dependents and never re-derived on demand, and a cycle that
+     * spans sheets is detected by Tarjan exactly like a same-sheet one (participants reported
+     * circular, downstream dependents blocked, the acyclic remainder still evaluating; see
+     * RecalcSpec).
      *
      * Dynamic references (GH-274): the static graph sees INDIRECT's *arguments*, not its resolved
      * *targets*. INDIRECT-bearing cells and their static dependents evaluate after all other
@@ -169,93 +170,114 @@ object WorkbookEvaluator:
   // ========== recalculate internals ==========
 
   private def recalculateImpl(wb: Workbook, clock: Clock, rngOpt: Option[Rng]): RecalcResult =
-    val perSheet = wb.sheets.map(sheet => recalcSheet(sheet, wb, clock, rngOpt))
-    RecalcResult(
-      workbook = wb.copy(sheets = perSheet.map(_.sheet)),
-      evaluated = perSheet.map(r => r.sheet.name -> r.evaluated).toMap,
-      errors = perSheet.flatMap(_.errors).toVector
-    )
+    val (deps, dependents) = DependencyGraph.fromWorkbookBounded(wb)
 
-  private final case class SheetRecalc(
-    sheet: Sheet,
-    evaluated: Map[ARef, CellValue],
-    errors: Vector[CellEvalError]
-  )
+    def formulaText(q: QualifiedRef): String =
+      wb(q.sheet).toOption.flatMap(_.cells.get(q.ref)).map(_.value) match
+        case Some(CellValue.Formula(expr, _)) => expr
+        case _ => q.ref.toA1
 
-  private def formulaText(sheet: Sheet, ref: ARef): String =
-    sheet.cells.get(ref).map(_.value) match
-      case Some(CellValue.Formula(expr, _)) => expr
-      case _ => ref.toA1
+    // GH-346: cycle isolation on the WORKBOOK-level graph — same-sheet and cross-sheet cycles
+    // alike are detected by Tarjan and removed up front (previously a cross-sheet cycle fell
+    // through to the evaluator's recursion depth guard).
+    val cyclicCore = DependencyGraph.qualifiedCyclicNodes(deps)
+    val blocked = DependencyGraph.qualifiedTransitiveDependents(dependents, cyclicCore)
 
-  private def recalcSheet(
-    sheet: Sheet,
-    wb: Workbook,
-    clock: Clock,
-    rngOpt: Option[Rng]
-  ): SheetRecalc =
-    val graph = DependencyGraph.fromSheet(sheet)
-    val cyclicCore = DependencyGraph.cyclicNodes(graph)
-    val blocked = DependencyGraph.transitiveDependents(graph, cyclicCore)
-
-    val cycleErrors = cyclicCore.toVector.map { ref =>
-      CellEvalError(
-        sheet.name,
-        ref,
-        XLError.FormulaError(formulaText(sheet, ref), "Circular reference")
-      )
+    val cycleErrors = cyclicCore.toVector.map { q =>
+      CellEvalError(q.sheet, q.ref, XLError.FormulaError(formulaText(q), "Circular reference"))
     }
-    // transitiveDependents excludes its seed set, so `blocked` is already disjoint from the core
-    val blockedErrors = blocked.toVector.map { ref =>
+    // qualifiedTransitiveDependents excludes its seed set, so `blocked` is disjoint from the core
+    val blockedErrors = blocked.toVector.map { q =>
       CellEvalError(
-        sheet.name,
-        ref,
-        XLError.FormulaError(formulaText(sheet, ref), "Blocked by an upstream circular reference")
+        q.sheet,
+        q.ref,
+        XLError.FormulaError(formulaText(q), "Blocked by an upstream circular reference")
       )
     }
 
     val removed = cyclicCore ++ blocked
-    val pruned = DependencyGraph(
-      dependencies = (graph.dependencies -- removed).view.mapValues(_ -- removed).toMap,
-      dependents = (graph.dependents -- removed).view.mapValues(_ -- removed).toMap
-    )
+    val prunedDeps = (deps -- removed).view.mapValues(_ -- removed).toMap
+    val prunedDependents = (dependents -- removed).view.mapValues(_ -- removed).toMap
 
-    DependencyGraph.topologicalSort(pruned) match
+    DependencyGraph.qualifiedTopologicalSort(prunedDeps, prunedDependents) match
       case Left(circular) =>
-        // Unreachable: cyclicNodes removed every cycle participant. Stay total regardless.
-        val residual = pruned.dependencies.keySet.toVector.map { ref =>
+        // Unreachable: qualifiedCyclicNodes removed every cycle participant. Stay total anyway.
+        val residual = prunedDeps.keySet.toVector.map { q =>
           CellEvalError(
-            sheet.name,
-            ref,
-            XLError.FormulaError(formulaText(sheet, ref), s"Unresolvable order: $circular")
+            q.sheet,
+            q.ref,
+            XLError.FormulaError(formulaText(q), s"Unresolvable order: $circular")
           )
         }
-        SheetRecalc(sheet, Map.empty, cycleErrors ++ blockedErrors ++ residual)
+        RecalcResult(
+          workbook = wb,
+          evaluated = wb.sheets.map(s => s.name -> Map.empty[ARef, CellValue]).toMap,
+          errors = cycleErrors ++ blockedErrors ++ residual
+        )
 
       case Right(evalOrder) =>
-        // GH-274: INDIRECT-bearing cells and their transitive static dependents evaluate last
-        // (stable evaluate-last partition), against a temp sheet whose bucket members have had
-        // stale caches stripped — a dynamic read of a not-yet-evaluated bucket cell then
-        // recursively evaluates fresh (depth-guarded) instead of trusting a previous
-        // generation's cache. INDIRECT-free sheets take the identity path, bit-identical.
-        val dynamic = DependencyGraph.dynamicCells(sheet) -- removed
-        val (ordered, initial) =
-          SheetEvaluator.deferDynamicWithStrip(sheet, pruned, evalOrder, dynamic)
-        val (tempSheet, results, evalErrors) = ordered.foldLeft(
-          (initial, Map.empty[ARef, CellValue], Vector.empty[CellEvalError])
-        ) { case ((temp, acc, errs), ref) =>
-          val evaluated = rngOpt match
-            case Some(rng) => temp.evaluateCell(ref, clock, rng, Some(wb))
-            case None => temp.evaluateCell(ref, clock, Some(wb))
-          evaluated match
-            case Right(value) => (temp.put(ref, value), acc + (ref -> value), errs)
-            case Left(error) => (temp, acc, errs :+ CellEvalError(sheet.name, ref, error))
+        // GH-274/GH-301: dynamic-reference cells (INDIRECT/OFFSET) and their transitive static
+        // dependents evaluate last (stable partition — preserves topological validity per the
+        // deferDynamic lemma), with stale caches stripped so a dynamic read of a
+        // not-yet-evaluated bucket cell recursively evaluates fresh (depth-guarded) instead of
+        // trusting a previous generation's cache. The closure is workbook-level (GH-346): a
+        // cross-sheet static dependent of a dynamic cell defers with it. Dynamic-free workbooks
+        // take the identity path.
+        val dynamic: Set[QualifiedRef] =
+          wb.sheets.iterator.flatMap { s =>
+            DependencyGraph.dynamicCells(s).iterator.map(r => QualifiedRef(s.name, r))
+          }.toSet -- removed
+        val bucket =
+          if dynamic.isEmpty then Set.empty[QualifiedRef]
+          else dynamic ++ DependencyGraph.qualifiedTransitiveDependents(prunedDependents, dynamic)
+        val ordered =
+          if bucket.isEmpty then evalOrder
+          else evalOrder.filterNot(bucket.contains) ++ evalOrder.filter(bucket.contains)
+
+        val stripBySheet: Map[SheetName, Set[ARef]] = bucket.groupMap(_.sheet)(_.ref)
+        val initialTemps: Map[SheetName, Sheet] =
+          wb.sheets.map { s =>
+            val toStrip = stripBySheet.getOrElse(s.name, Set.empty)
+            s.name ->
+              (if toStrip.isEmpty then s else SheetEvaluator.stripFormulaCaches(s, toStrip))
+          }.toMap
+
+        // Evaluate in the single global order, threading the partially evaluated workbook:
+        // every reference — same-sheet or cross-sheet — reads its precedents as already-computed
+        // values, so recursive re-derivation only arises on dynamic reads.
+        val (_, evaluated, evalErrors) = ordered.foldLeft(
+          (initialTemps, Map.empty[SheetName, Map[ARef, CellValue]], Vector.empty[CellEvalError])
+        ) { case ((temps, acc, errs), q) =>
+          temps.get(q.sheet) match
+            case None => (temps, acc, errs) // node names a sheet absent from the workbook
+            case Some(tempSheet) =>
+              val tempWb = wb.copy(sheets = wb.sheets.map(s => temps.getOrElse(s.name, s)))
+              val evaluatedCell = rngOpt match
+                case Some(rng) => tempSheet.evaluateCell(q.ref, clock, rng, Some(tempWb))
+                case None => tempSheet.evaluateCell(q.ref, clock, Some(tempWb))
+              evaluatedCell match
+                case Right(value) =>
+                  (
+                    temps.updated(q.sheet, tempSheet.put(q.ref, value)),
+                    acc.updated(q.sheet, acc.getOrElse(q.sheet, Map.empty) + (q.ref -> value)),
+                    errs
+                  )
+                case Left(error) => (temps, acc, errs :+ CellEvalError(q.sheet, q.ref, error))
         }
 
-        // Cache computed values into formula cells; failed cells stay uncached
-        val cachedSheet = results.foldLeft(sheet) { case (s, (ref, computed)) =>
-          s.cells.get(ref).map(_.value) match
-            case Some(CellValue.Formula(expr, _)) =>
-              s.put(ref, CellValue.Formula(expr, Some(computed)))
-            case _ => s
+        // Cache computed values into formula cells on the original sheets; failed cells stay
+        // uncached (Excel recalculates them on open)
+        val cachedSheets = wb.sheets.map { orig =>
+          evaluated.getOrElse(orig.name, Map.empty).foldLeft(orig) { case (s, (ref, computed)) =>
+            s.cells.get(ref).map(_.value) match
+              case Some(CellValue.Formula(expr, _)) =>
+                s.put(ref, CellValue.Formula(expr, Some(computed)))
+              case _ => s
+          }
         }
-        SheetRecalc(cachedSheet, results, cycleErrors ++ blockedErrors ++ evalErrors)
+
+        RecalcResult(
+          workbook = wb.copy(sheets = cachedSheets),
+          evaluated = wb.sheets.map(s => s.name -> evaluated.getOrElse(s.name, Map.empty)).toMap,
+          errors = cycleErrors ++ blockedErrors ++ evalErrors
+        )

--- a/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpec.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpec.scala
@@ -57,7 +57,13 @@ final case class EvalContext(
   /** GH-193: in-scope LET bindings (declared name → evaluated value). */
   bindings: Map[String, Any] = Map.empty,
   /** GH-115: randomness capability for RAND/RANDBETWEEN (Clock pattern). */
-  rng: Rng = Rng.system
+  rng: Rng = Rng.system,
+  /**
+   * GH-346: the pass's memo for recursively evaluated uncached formula cells, so functions that
+   * read uncached cells (aggregates, array materialization) evaluate each precedent once per pass
+   * instead of once per reference (see Evaluator.EvalMemo).
+   */
+  memo: Option[Evaluator.EvalMemo] = None
 )
 
 sealed trait ArgValue

--- a/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpecsAggregate.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpecsAggregate.scala
@@ -101,7 +101,7 @@ trait FunctionSpecsAggregate extends FunctionSpecsBase:
   ): Either[EvalError, Option[BigDecimal]] =
     cellValue match
       case CellValue.Formula(formulaStr, None) =>
-        // Recursively evaluate uncached formula
+        // Recursively evaluate uncached formula (GH-346: memoized once per pass)
         Evaluator
           .evalCrossSheetFormula(
             formulaStr,
@@ -109,7 +109,8 @@ trait FunctionSpecsAggregate extends FunctionSpecsBase:
             ctx.clock,
             ctx.workbook,
             ctx.depth + 1,
-            ctx.rng
+            ctx.rng,
+            ctx.memo.getOrElse(new Evaluator.EvalMemo)
           )
           .map {
             case CellValue.Number(n) => Some(n)
@@ -128,7 +129,7 @@ trait FunctionSpecsAggregate extends FunctionSpecsBase:
   ): Either[EvalError, BigDecimal] =
     cellValue match
       case CellValue.Formula(formulaStr, None) =>
-        // Recursively evaluate uncached formula
+        // Recursively evaluate uncached formula (GH-346: memoized once per pass)
         Evaluator
           .evalCrossSheetFormula(
             formulaStr,
@@ -136,7 +137,8 @@ trait FunctionSpecsAggregate extends FunctionSpecsBase:
             ctx.clock,
             ctx.workbook,
             ctx.depth + 1,
-            ctx.rng
+            ctx.rng,
+            ctx.memo.getOrElse(new Evaluator.EvalMemo)
           )
           .map(coerceToNumeric)
       case _ =>
@@ -151,7 +153,7 @@ trait FunctionSpecsAggregate extends FunctionSpecsBase:
   ): Either[EvalError, CellValue] =
     cellValue match
       case CellValue.Formula(formulaStr, None) =>
-        // Recursively evaluate uncached formula
+        // Recursively evaluate uncached formula (GH-346: memoized once per pass)
         Evaluator
           .evalCrossSheetFormula(
             formulaStr,
@@ -159,7 +161,8 @@ trait FunctionSpecsAggregate extends FunctionSpecsBase:
             ctx.clock,
             ctx.workbook,
             ctx.depth + 1,
-            ctx.rng
+            ctx.rng,
+            ctx.memo.getOrElse(new Evaluator.EvalMemo)
           )
       case CellValue.Formula(_, Some(cached)) =>
         // Use cached value

--- a/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpecsArray.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpecsArray.scala
@@ -380,7 +380,8 @@ trait FunctionSpecsArray extends FunctionSpecsBase:
                         targetSheet,
                         ctx.clock,
                         ctx.workbook,
-                        ctx.depth + 1
+                        ctx.depth + 1,
+                        memo = ctx.memo.getOrElse(new Evaluator.EvalMemo)
                       )
                       .map(cols :+ _)
                   case other => Right(cols :+ other)

--- a/xl-evaluator/src/com/tjclp/xl/formula/graph/DependencyGraph.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/graph/DependencyGraph.scala
@@ -628,23 +628,28 @@ object DependencyGraph:
     graph: DependencyGraph,
     refs: Set[ARef]
   ): Set[ARef] =
-    transitiveDependentsImpl(graph, refs, refs, Set.empty)
-
-  @scala.annotation.tailrec
-  private def transitiveDependentsImpl(
-    graph: DependencyGraph,
-    originalRefs: Set[ARef],
-    frontier: Set[ARef],
-    visited: Set[ARef]
-  ): Set[ARef] =
-    val toVisit = frontier -- visited
-    if toVisit.isEmpty then visited -- originalRefs // Exclude starting refs
-    else
-      val directDeps = toVisit.flatMap(ref => graph.dependents.getOrElse(ref, Set.empty))
-      transitiveDependentsImpl(graph, originalRefs, directDeps, visited ++ toVisit)
+    transitiveDependentsOf(graph.dependents, refs)
 
   /**
-   * Iterative Tarjan SCC engine shared by `detectCycles` and `cyclicNodes`.
+   * Reverse-reachability core shared by the sheet-level and workbook-level (qualified) variants —
+   * generic in the node type (GH-346). Excludes the starting refs from the result.
+   */
+  private def transitiveDependentsOf[K](
+    dependents: Map[K, Set[K]],
+    originalRefs: Set[K]
+  ): Set[K] =
+    @scala.annotation.tailrec
+    def impl(frontier: Set[K], visited: Set[K]): Set[K] =
+      val toVisit = frontier -- visited
+      if toVisit.isEmpty then visited -- originalRefs // Exclude starting refs
+      else
+        val directDeps = toVisit.flatMap(ref => dependents.getOrElse(ref, Set.empty))
+        impl(directDeps, visited ++ toVisit)
+    impl(originalRefs, Set.empty)
+
+  /**
+   * Iterative Tarjan SCC engine shared by `detectCycles`, `cyclicNodes`, and their qualified
+   * (workbook-level) counterparts — generic in the node type (GH-346).
    *
    * Uses an explicit work stack instead of recursion: `recalculate` promises totality, and a deep
    * linear dependency chain (e.g. 100k sequential formulas) must not throw StackOverflowError.
@@ -652,24 +657,24 @@ object DependencyGraph:
    * component root last).
    */
   @SuppressWarnings(Array("org.wartremover.warts.Var"))
-  private def foreachScc(graph: DependencyGraph)(onScc: List[ARef] => Unit): Unit =
+  private def foreachSccOf[K](dependencies: Map[K, Set[K]])(onScc: List[K] => Unit): Unit =
     var index = 0
-    var indices = Map.empty[ARef, Int]
-    var lowLinks = Map.empty[ARef, Int]
-    var stack = List.empty[ARef]
-    var onStack = Set.empty[ARef]
+    var indices = Map.empty[K, Int]
+    var lowLinks = Map.empty[K, Int]
+    var stack = List.empty[K]
+    var onStack = Set.empty[K]
     // DFS frames: (node, successors not yet examined)
-    var frames = List.empty[(ARef, List[ARef])]
+    var frames = List.empty[(K, List[K])]
 
-    def push(v: ARef): Unit =
+    def push(v: K): Unit =
       indices = indices.updated(v, index)
       lowLinks = lowLinks.updated(v, index)
       index += 1
       stack = v :: stack
       onStack = onStack + v
-      frames = (v, graph.dependencies.getOrElse(v, Set.empty).toList) :: frames
+      frames = (v, dependencies.getOrElse(v, Set.empty).toList) :: frames
 
-    graph.dependencies.keySet.foreach { root =>
+    dependencies.keySet.foreach { root =>
       if !indices.contains(root) then
         push(root)
         while frames.nonEmpty do
@@ -693,6 +698,9 @@ object DependencyGraph:
                 case Nil => ()
             case Nil => () // unreachable: guarded by frames.nonEmpty
     }
+
+  private def foreachScc(graph: DependencyGraph)(onScc: List[ARef] => Unit): Unit =
+    foreachSccOf(graph.dependencies)(onScc)
 
   /**
    * Detect circular references using Tarjan's strongly connected components algorithm.
@@ -758,6 +766,58 @@ object DependencyGraph:
     cyclic
 
   /**
+   * Kahn's-algorithm core shared by the sheet-level and workbook-level (qualified) sorts — generic
+   * in the node type (GH-346). Only nodes present in `dependencies` (formula cells) are ordered;
+   * edges to non-nodes (constants, empty cells) are ignored. Left carries the nodes that could not
+   * be ordered (cycle participants and everything downstream of them).
+   */
+  private def kahnOrder[K](
+    dependencies: Map[K, Set[K]],
+    dependents: Map[K, Set[K]]
+  ): Either[Set[K], List[K]] =
+    // All formula cells (only process formulas, not constants)
+    val allNodes = dependencies.keySet
+
+    // If no formula cells, early exit
+    if allNodes.isEmpty then scala.util.Right(List.empty[K])
+    else
+      // Calculate in-degree for each node (number of formula cells it depends on)
+      // Only count dependencies on other formula cells, not constants
+      val inDegree = allNodes.map { node =>
+        val deps = dependencies.getOrElse(node, Set.empty)
+        val formulaDeps = deps.filter(allNodes.contains)
+        node -> formulaDeps.size
+      }.toMap
+
+      // Start with nodes that have in-degree 0 (no dependencies)
+      val initialQueue = allNodes.filter(node => inDegree(node) == 0).toList
+
+      @tailrec
+      def process(
+        queue: List[K],
+        processedInDegree: Map[K, Int],
+        acc: List[K]
+      ): (List[K], Map[K, Int]) =
+        queue match
+          case Nil => (acc, processedInDegree)
+          case node :: rest =>
+            val deps = dependents.getOrElse(node, Set.empty).filter(allNodes.contains)
+            val (nextInDegree, newlyZero) = deps.foldLeft((processedInDegree, List.empty[K])) {
+              case ((degreeAcc, zeros), dep) =>
+                val newInDegree = degreeAcc(dep) - 1
+                val updatedDegree = degreeAcc.updated(dep, newInDegree)
+                val nextZeros = if newInDegree == 0 then zeros :+ dep else zeros
+                (updatedDegree, nextZeros)
+            }
+            process(rest ++ newlyZero, nextInDegree, acc :+ node)
+
+      val (result, _) = process(initialQueue, inDegree, List.empty)
+
+      // If all nodes are processed, graph is acyclic
+      if result.size == allNodes.size then scala.util.Right(result)
+      else scala.util.Left(allNodes -- result.toSet)
+
+  /**
    * Topological sort using Kahn's algorithm.
    *
    * Returns a linear ordering of cells such that for every dependency A → B, cell B appears before
@@ -782,52 +842,10 @@ object DependencyGraph:
    * }}}
    */
   def topologicalSort(graph: DependencyGraph): Either[EvalError.CircularRef, List[ARef]] =
-    import scala.util.boundary, boundary.break
-
-    boundary:
-      // All formula cells (only process formulas, not constants)
-      val allNodes = graph.dependencies.keySet
-
-      // If no formula cells, early exit
-      if allNodes.isEmpty then break(scala.util.Right(List.empty[ARef]))
-
-      // Calculate in-degree for each node (number of formula cells it depends on)
-      // Only count dependencies on other formula cells, not constants
-      val inDegree = allNodes.map { node =>
-        val deps = graph.dependencies.getOrElse(node, Set.empty)
-        val formulaDeps = deps.filter(allNodes.contains)
-        node -> formulaDeps.size
-      }.toMap
-
-      // Start with nodes that have in-degree 0 (no dependencies)
-      val initialQueue = allNodes.filter(node => inDegree(node) == 0).toList
-
-      @tailrec
-      def process(
-        queue: List[ARef],
-        processedInDegree: Map[ARef, Int],
-        acc: List[ARef]
-      ): (List[ARef], Map[ARef, Int]) =
-        queue match
-          case Nil => (acc, processedInDegree)
-          case node :: rest =>
-            val deps = graph.dependents.getOrElse(node, Set.empty).filter(allNodes.contains)
-            val (nextInDegree, newlyZero) = deps.foldLeft((processedInDegree, List.empty[ARef])) {
-              case ((degreeAcc, zeros), dep) =>
-                val newInDegree = degreeAcc(dep) - 1
-                val updatedDegree = degreeAcc.updated(dep, newInDegree)
-                val nextZeros = if newInDegree == 0 then zeros :+ dep else zeros
-                (updatedDegree, nextZeros)
-            }
-            process(rest ++ newlyZero, nextInDegree, acc :+ node)
-
-      val (result, _) = process(initialQueue, inDegree, List.empty)
-
-      // If all nodes are processed, graph is acyclic
-      if result.size == allNodes.size then scala.util.Right(result)
-      else
+    kahnOrder(graph.dependencies, graph.dependents) match
+      case scala.util.Right(order) => scala.util.Right(order)
+      case scala.util.Left(remainingNodes) =>
         // Cycle detected: find one cycle for error reporting
-        val remainingNodes = allNodes -- result.toSet
         val cycle = remainingNodes.headOption match
           case Some(start) =>
             // Follow dependencies to reconstruct cycle
@@ -901,143 +919,174 @@ object DependencyGraph:
     }.toMap
 
   /**
-   * Convert a RangeLocation to qualified cell references.
+   * GH-346: workbook-level dependency graph with ranges bounded by each TARGET sheet's used range —
+   * the qualified analog of `fromSheet`'s bounded extraction (a full-column reference must not
+   * enumerate 1M+ cells). Single refs stay exact. Ranges over sheets absent from the workbook (or
+   * empty ones) contribute no edges: they cannot affect evaluation order, and the referencing
+   * formula still errors per cell on evaluation.
    *
-   * For Local ranges, uses the current sheet. For CrossSheet ranges, uses the specified sheet.
+   * Returns forward edges (ref → its dependencies) and reverse edges (ref → its dependents), which
+   * together drive `qualifiedTopologicalSort`.
    */
-  private def locationToQualifiedRefs(
-    location: TExpr.RangeLocation,
-    currentSheet: SheetName
+  def fromWorkbookBounded(
+    workbook: com.tjclp.xl.workbooks.Workbook
+  ): (Map[QualifiedRef, Set[QualifiedRef]], Map[QualifiedRef, Set[QualifiedRef]]) =
+    val bounds: Map[SheetName, Option[CellRange]] =
+      workbook.sheets.map(s => s.name -> s.usedRange).toMap
+    val cellsFor: (SheetName, CellRange) => Set[QualifiedRef] = (sheet, range) =>
+      bounds.get(sheet) match
+        case Some(Some(b)) =>
+          range.intersect(b) match
+            case Some(clipped) => clipped.cells.map(ref => QualifiedRef(sheet, ref)).toSet
+            case None => Set.empty
+        case _ => Set.empty // empty or missing sheet: nothing to depend on
+
+    val dependencies = workbook.sheets.flatMap { sheet =>
+      sheet.cells.flatMap { case (cellRef, cell) =>
+        cell.value match
+          case CellValue.Formula(expression, _) =>
+            val deps = FormulaParser.parse(expression) match
+              case scala.util.Right(expr) =>
+                extractQualifiedDependencies(expr, sheet.name, cellsFor)
+              case scala.util.Left(_) => Set.empty[QualifiedRef]
+            Some(QualifiedRef(sheet.name, cellRef) -> deps)
+          case _ => None
+      }
+    }.toMap
+
+    val dependents =
+      dependencies.foldLeft(Map.empty[QualifiedRef, Set[QualifiedRef]]) { case (acc, (ref, deps)) =>
+        deps.foldLeft(acc) { (acc2, dep) =>
+          acc2.updated(dep, acc2.getOrElse(dep, Set.empty) + ref)
+        }
+      }
+
+    (dependencies, dependents)
+
+  /**
+   * GH-346: every node participating in a reference cycle of the workbook-level graph — the
+   * qualified analog of `cyclicNodes`, sharing the iterative (stack-safe) Tarjan engine. Detects
+   * cycles that span sheets, which per-sheet analysis cannot see.
+   */
+  @SuppressWarnings(Array("org.wartremover.warts.Var"))
+  def qualifiedCyclicNodes(
+    dependencies: Map[QualifiedRef, Set[QualifiedRef]]
   ): Set[QualifiedRef] =
-    location match
-      case TExpr.RangeLocation.Local(range) =>
-        range.cells.map(ref => QualifiedRef(currentSheet, ref)).toSet
-      case TExpr.RangeLocation.CrossSheet(sheet, range) =>
-        range.cells.map(ref => QualifiedRef(sheet, ref)).toSet
+    var cyclic = Set.empty[QualifiedRef]
+    foreachSccOf(dependencies) {
+      case single :: Nil =>
+        if dependencies.get(single).exists(_.contains(single)) then cyclic = cyclic + single
+      case multi => cyclic = cyclic ++ multi
+    }
+    cyclic
+
+  /**
+   * GH-346: transitive dependents over the workbook-level reverse edges (excludes the starting
+   * refs) — the qualified analog of `transitiveDependents`.
+   */
+  def qualifiedTransitiveDependents(
+    dependents: Map[QualifiedRef, Set[QualifiedRef]],
+    refs: Set[QualifiedRef]
+  ): Set[QualifiedRef] =
+    transitiveDependentsOf(dependents, refs)
+
+  /**
+   * GH-346: Kahn order over the workbook-level graph. Left carries the nodes that could not be
+   * ordered (cycle participants and their downstream); callers that prune cycles first only reach
+   * Left as a defensive-totality path.
+   */
+  def qualifiedTopologicalSort(
+    dependencies: Map[QualifiedRef, Set[QualifiedRef]],
+    dependents: Map[QualifiedRef, Set[QualifiedRef]]
+  ): Either[Set[QualifiedRef], List[QualifiedRef]] =
+    kahnOrder(dependencies, dependents)
+
+  /** Unbounded range expansion — the original `fromWorkbook` semantics. */
+  private val unboundedQualifiedCells: (SheetName, CellRange) => Set[QualifiedRef] =
+    (sheet, range) => range.cells.map(ref => QualifiedRef(sheet, ref)).toSet
 
   /**
    * Extract all qualified cell references from TExpr.
    *
    * Similar to extractDependencies but returns QualifiedRef to track cross-sheet references.
-   * Same-sheet references are qualified with the current sheet name.
+   * Same-sheet references are qualified with the current sheet name. Range expansion is delegated
+   * to `cellsFor` so workbook-level callers can bound ranges by the TARGET sheet's used range
+   * (GH-346) — the qualified analog of `extractDependenciesBounded`; single refs stay exact.
    *
    * @param expr
    *   The expression to analyze
    * @param currentSheet
    *   The sheet containing the formula (used for same-sheet ref qualification)
+   * @param cellsFor
+   *   Expands a range on a named sheet to qualified cells (possibly bounded)
    * @return
    *   Set of qualified cell references used in the expression
    */
   @nowarn("msg=Unreachable case")
   private def extractQualifiedDependencies[A](
     expr: TExpr[A],
-    currentSheet: SheetName
+    currentSheet: SheetName,
+    cellsFor: (SheetName, CellRange) => Set[QualifiedRef] = unboundedQualifiedCells
   ): Set[QualifiedRef] =
-    expr match
-      // Same-sheet references - qualify with current sheet
-      case TExpr.Ref(at, _, _) => Set(QualifiedRef(currentSheet, at))
-      case TExpr.PolyRef(at, _) => Set(QualifiedRef(currentSheet, at))
-      case TExpr.RangeRef(range) =>
-        range.cells.map(ref => QualifiedRef(currentSheet, ref)).toSet
+    def locCells(location: TExpr.RangeLocation): Set[QualifiedRef] =
+      location match
+        case TExpr.RangeLocation.Local(range) => cellsFor(currentSheet, range)
+        case TExpr.RangeLocation.CrossSheet(sheet, range) => cellsFor(sheet, range)
 
-      // Cross-sheet references - use target sheet
-      case TExpr.SheetRef(sheet, at, _, _) => Set(QualifiedRef(sheet, at))
-      case TExpr.SheetPolyRef(sheet, at, _) => Set(QualifiedRef(sheet, at))
-      case TExpr.SheetRange(sheet, range) =>
-        range.cells.map(ref => QualifiedRef(sheet, ref)).toSet
-      case TExpr.Add(l, r) =>
-        extractQualifiedDependencies(l, currentSheet) ++ extractQualifiedDependencies(
-          r,
-          currentSheet
-        )
-      case TExpr.Sub(l, r) =>
-        extractQualifiedDependencies(l, currentSheet) ++ extractQualifiedDependencies(
-          r,
-          currentSheet
-        )
-      case TExpr.Mul(l, r) =>
-        extractQualifiedDependencies(l, currentSheet) ++ extractQualifiedDependencies(
-          r,
-          currentSheet
-        )
-      case TExpr.Div(l, r) =>
-        extractQualifiedDependencies(l, currentSheet) ++ extractQualifiedDependencies(
-          r,
-          currentSheet
-        )
-      case TExpr.Pow(l, r) =>
-        extractQualifiedDependencies(l, currentSheet) ++ extractQualifiedDependencies(
-          r,
-          currentSheet
-        )
-      case TExpr.Concat(l, r) =>
-        extractQualifiedDependencies(l, currentSheet) ++ extractQualifiedDependencies(
-          r,
-          currentSheet
-        )
-      case TExpr.Eq(l, r) =>
-        extractQualifiedDependencies(l, currentSheet) ++ extractQualifiedDependencies(
-          r,
-          currentSheet
-        )
-      case TExpr.Neq(l, r) =>
-        extractQualifiedDependencies(l, currentSheet) ++ extractQualifiedDependencies(
-          r,
-          currentSheet
-        )
-      case TExpr.Lt(l, r) =>
-        extractQualifiedDependencies(l, currentSheet) ++ extractQualifiedDependencies(
-          r,
-          currentSheet
-        )
-      case TExpr.Lte(l, r) =>
-        extractQualifiedDependencies(l, currentSheet) ++ extractQualifiedDependencies(
-          r,
-          currentSheet
-        )
-      case TExpr.Gt(l, r) =>
-        extractQualifiedDependencies(l, currentSheet) ++ extractQualifiedDependencies(
-          r,
-          currentSheet
-        )
-      case TExpr.Gte(l, r) =>
-        extractQualifiedDependencies(l, currentSheet) ++ extractQualifiedDependencies(
-          r,
-          currentSheet
-        )
-      // Unary operators
-      case TExpr.ToInt(x) => extractQualifiedDependencies(x, currentSheet)
+    def go(e: TExpr[?]): Set[QualifiedRef] =
+      e match
+        // Same-sheet references - qualify with current sheet
+        case TExpr.Ref(at, _, _) => Set(QualifiedRef(currentSheet, at))
+        case TExpr.PolyRef(at, _) => Set(QualifiedRef(currentSheet, at))
+        case TExpr.RangeRef(range) => cellsFor(currentSheet, range)
 
-      // Reference functions
-      case TExpr.Aggregate(_, location) => locationToQualifiedRefs(location, currentSheet)
+        // Cross-sheet references - use target sheet
+        case TExpr.SheetRef(sheet, at, _, _) => Set(QualifiedRef(sheet, at))
+        case TExpr.SheetPolyRef(sheet, at, _) => Set(QualifiedRef(sheet, at))
+        case TExpr.SheetRange(sheet, range) => cellsFor(sheet, range)
+        case TExpr.Add(l, r) => go(l) ++ go(r)
+        case TExpr.Sub(l, r) => go(l) ++ go(r)
+        case TExpr.Mul(l, r) => go(l) ++ go(r)
+        case TExpr.Div(l, r) => go(l) ++ go(r)
+        case TExpr.Pow(l, r) => go(l) ++ go(r)
+        case TExpr.Concat(l, r) => go(l) ++ go(r)
+        case TExpr.Eq(l, r) => go(l) ++ go(r)
+        case TExpr.Neq(l, r) => go(l) ++ go(r)
+        case TExpr.Lt(l, r) => go(l) ++ go(r)
+        case TExpr.Lte(l, r) => go(l) ++ go(r)
+        case TExpr.Gt(l, r) => go(l) ++ go(r)
+        case TExpr.Gte(l, r) => go(l) ++ go(r)
+        // Unary operators
+        case TExpr.ToInt(x) => go(x)
 
-      case call: TExpr.Call[?] =>
-        val values = call.spec.argSpec.toValues(call.args)
-        values.foldLeft(Set.empty[QualifiedRef]) { (acc, value) =>
-          value match
-            case ArgValue.Expr(expr) => acc ++ extractQualifiedDependencies(expr, currentSheet)
-            case ArgValue.Range(range) => acc ++ locationToQualifiedRefs(range, currentSheet)
-            case ArgValue.Cells(range) =>
-              acc ++ range.cells.map(ref => QualifiedRef(currentSheet, ref)).toSet
-        }
+        // Reference functions
+        case TExpr.Aggregate(_, location) => locCells(location)
 
-      // GH-193: LET — union of binding-value and body dependencies; BindingRef has none
-      case TExpr.Let(bindings, body) =>
-        bindings.foldLeft(extractQualifiedDependencies(body, currentSheet)) {
-          case (acc, (_, value)) => acc ++ extractQualifiedDependencies(value, currentSheet)
-        }
-      case TExpr.BindingRef(_) => Set.empty
-      case TExpr.CoercedBindingRef(_, _) => Set.empty
+        case call: TExpr.Call[?] =>
+          val values = call.spec.argSpec.toValues(call.args)
+          values.foldLeft(Set.empty[QualifiedRef]) { (acc, value) =>
+            value match
+              case ArgValue.Expr(expr) => acc ++ go(expr)
+              case ArgValue.Range(range) => acc ++ locCells(range)
+              case ArgValue.Cells(range) => acc ++ cellsFor(currentSheet, range)
+          }
 
-      // GH-306: runtime coercion wrapper — transparent for analysis
-      case TExpr.Coerced(inner, _) => extractQualifiedDependencies(inner, currentSheet)
+        // GH-193: LET — union of binding-value and body dependencies; BindingRef has none
+        case TExpr.Let(bindings, body) =>
+          bindings.foldLeft(go(body)) { case (acc, (_, value)) => acc ++ go(value) }
+        case TExpr.BindingRef(_) => Set.empty
+        case TExpr.CoercedBindingRef(_, _) => Set.empty
 
-      // Literals and nullary functions (no dependencies)
-      case TExpr.Lit(_) => Set.empty
-      case TExpr.DateToSerial(dateExpr) => extractQualifiedDependencies(dateExpr, currentSheet)
-      case TExpr.DateTimeToSerial(dtExpr) => extractQualifiedDependencies(dtExpr, currentSheet)
+        // GH-306: runtime coercion wrapper — transparent for analysis
+        case TExpr.Coerced(inner, _) => go(inner)
 
-      // Financial functions
+        // Literals and nullary functions (no dependencies)
+        case TExpr.Lit(_) => Set.empty
+        case TExpr.DateToSerial(dateExpr) => go(dateExpr)
+        case TExpr.DateTimeToSerial(dtExpr) => go(dtExpr)
+
+    go(expr)
+
   /**
    * Detect circular references across sheets using Tarjan's SCC algorithm.
    *

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/RecalcPerfSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/RecalcPerfSpec.scala
@@ -1,0 +1,123 @@
+package com.tjclp.xl.formula
+
+import com.tjclp.xl.{*, given}
+import com.tjclp.xl.addressing.{ARef, SheetName}
+import com.tjclp.xl.cells.CellValue
+import com.tjclp.xl.sheets.Sheet
+import com.tjclp.xl.workbooks.Workbook
+import munit.FunSuite
+
+/**
+ * GH-346: recalculate() and formula eval on recursive multi-branch cross-sheet chains (the LBO
+ * debt-schedule shape) must run in time linear in the cell count, not the path count.
+ *
+ * Pre-fix, an uncached formula reference was recursively re-evaluated once per PATH (no
+ * memoization), and whole-workbook recalculation ordered cells per sheet (not globally), so
+ * cross-sheet precedents were always uncached when hit. On this shape — each period's beginning
+ * balance read by three formulas, chained backwards period over period — evaluation cost grew ~3^n:
+ * at n=24 that is ~10^11 evaluations, hours of CPU. Post-fix both paths complete in milliseconds;
+ * the generous wall-clock budgets here only catch a regression to exponential.
+ */
+class RecalcPerfSpec extends FunSuite:
+
+  private val Periods = 24
+  private val BudgetMs = 30000L
+
+  private def num(bd: BigDecimal): CellValue = CellValue.Number(bd)
+  private def formula(expr: String): CellValue = CellValue.Formula(expr, None)
+
+  // 0-based (col, row) helpers for the schedule columns; rows are periods (row i = period i+1)
+  private def at(col: Int, period: Int): ARef = ARef.from0(col, period - 1)
+  private val ColB = 1 // Debt: beginning balance / Forecast: EBITDA
+  private val ColD = 3 // Debt: interest
+  private val ColF = 5 // Debt: cash available for sweep
+  private val ColH = 7 // Debt: sweep
+  private val ColJ = 9 // Debt: ending balance
+
+  /**
+   * Debt-schedule shape (every formula uncached):
+   *   - Forecast!B{i}: EBITDA, 100 growing 10%/period
+   *   - Debt!B{i}: beginning balance (period 1: opening 1000; else prior ending =J{i-1})
+   *   - Debt!D{i}: interest on beginning balance (=B{i}*0.08)
+   *   - Debt!F{i}: cash available (=Forecast!B{i}-D{i}) — cross-sheet
+   *   - Debt!H{i}: sweep (=MIN(F{i},B{i}))
+   *   - Debt!J{i}: ending balance (=B{i}-H{i})
+   *   - Returns!B1: terminal ending + terminal EBITDA — cross-sheet
+   */
+  private def buildWorkbook(n: Int): Workbook =
+    val forecast = (2 to n).foldLeft(
+      Sheet(SheetName.unsafe("Forecast")).put(at(ColB, 1), num(BigDecimal(100)))
+    ) { (s, i) =>
+      s.put(at(ColB, i), formula(s"=B${i - 1}*1.1"))
+    }
+    val debt = (1 to n).foldLeft(Sheet(SheetName.unsafe("Debt"))) { (s, i) =>
+      val withBeginning =
+        if i == 1 then s.put(at(ColB, 1), num(BigDecimal(1000)))
+        else s.put(at(ColB, i), formula(s"=J${i - 1}"))
+      withBeginning
+        .put(at(ColD, i), formula(s"=B$i*0.08"))
+        .put(at(ColF, i), formula(s"=Forecast!B$i-D$i"))
+        .put(at(ColH, i), formula(s"=MIN(F$i,B$i)"))
+        .put(at(ColJ, i), formula(s"=B$i-H$i"))
+    }
+    val returns = Sheet(SheetName.unsafe("Returns"))
+      .put(ARef.from0(1, 0), formula(s"=Debt!J$n+Forecast!B$n"))
+    Workbook(forecast, debt, returns)
+
+  /** Reference values computed with the same BigDecimal operations the evaluator uses. */
+  private case class Terminals(ebitda: BigDecimal, ending: BigDecimal)
+  private def expectedTerminals(n: Int): Terminals =
+    val init = (BigDecimal(100), BigDecimal(1000))
+    val (ebitda, ending) = (1 to n).foldLeft(init) { case ((e, beg), i) =>
+      val ebitda = if i == 1 then e else e * BigDecimal("1.1")
+      val interest = beg * BigDecimal("0.08")
+      val cash = ebitda - interest
+      val sweep = cash.min(beg)
+      val ending = beg - sweep
+      (ebitda, ending)
+    }
+    // The fold threads (current ebitda, ending balance); ending of period i is beginning of i+1
+    Terminals(ebitda, ending)
+
+  private def cached(wb: Workbook, sheetName: String, ref: ARef): Option[CellValue] =
+    wb.sheets
+      .find(_.name.value == sheetName)
+      .flatMap(_.cells.get(ref))
+      .map(_.value)
+      .collect { case CellValue.Formula(_, Some(v)) => v }
+
+  test("GH-346: whole-workbook recalculate() on a recursive schedule is linear and correct"):
+    val wb = buildWorkbook(Periods)
+    val t0 = System.nanoTime()
+    val result = wb.recalculate()
+    val elapsedMs = (System.nanoTime() - t0) / 1000000L
+    assert(result.isClean, s"expected clean, got: ${result.errors.take(5).map(_.render)}")
+    val Terminals(ebitda, ending) = expectedTerminals(Periods)
+    assertEquals(cached(result.workbook, "Debt", at(ColJ, Periods)), Some(num(ending)))
+    assertEquals(cached(result.workbook, "Returns", ARef.from0(1, 0)), Some(num(ending + ebitda)))
+    assert(elapsedMs < BudgetMs, s"recalculate took ${elapsedMs}ms (budget ${BudgetMs}ms)")
+
+  test("GH-346: single-shot eval of a deep uncached cross-sheet cell is memoized, not per-path"):
+    val wb = buildWorkbook(Periods)
+    val t0 = System.nanoTime()
+    val evaluated = wb.evaluateFormula(s"=Debt!J$Periods+0", "Returns")
+    val elapsedMs = (System.nanoTime() - t0) / 1000000L
+    assertEquals(evaluated, Right(num(expectedTerminals(Periods).ending)))
+    assert(elapsedMs < BudgetMs, s"eval took ${elapsedMs}ms (budget ${BudgetMs}ms)")
+
+  test("GH-346: cross-sheet aggregate over uncached formula cells computes their values"):
+    // SUM over ANOTHER sheet's formula cells: with per-sheet ordering the aggregate read the
+    // original uncached snapshot (values silently skipped); the global order must guarantee
+    // computed values regardless of sheet position in the workbook.
+    val b1 = ARef.from0(1, 0)
+    val b2 = ARef.from0(1, 1)
+    val b3 = ARef.from0(1, 2)
+    val data = Sheet(SheetName.unsafe("Data"))
+      .put(b1, num(BigDecimal(10)))
+      .put(b2, formula("=B1*2"))
+      .put(b3, formula("=B2+5"))
+    val summary = Sheet(SheetName.unsafe("Summary")).put(b1, formula("=SUM(Data!B1:B3)"))
+    // Summary placed FIRST so a sheet-ordered pass cannot accidentally see Data computed
+    val result = Workbook(summary, data).recalculate()
+    assert(result.isClean, s"expected clean, got: ${result.errors.map(_.render)}")
+    assertEquals(cached(result.workbook, "Summary", b1), Some(num(BigDecimal(55))))

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/RecalcSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/RecalcSpec.scala
@@ -115,9 +115,10 @@ class RecalcSpec extends FunSuite:
     val result = Workbook(sheet).recalculate()
     assert(result.errors.headOption.exists(_.render.startsWith("S!A1:")))
 
-  test("cross-sheet cycle stays total: caught by depth guard, reported per cell (not Tarjan)"):
-    // Cycle spanning sheets is invisible to the per-sheet Tarjan pass — pin the graceful path:
-    // both cells error (recursion guard), nothing throws, the acyclic remainder still evaluates.
+  test("cross-sheet cycle is detected by workbook-level Tarjan: circular per cell, still total"):
+    // GH-346: the qualified (sheet!cell) graph makes a cycle spanning sheets first-class — both
+    // participants report as circular (previously a generic depth-guard eval error), nothing
+    // throws, and the acyclic remainder still evaluates.
     val s1 = Sheet(SheetName.unsafe("S1"))
       .put(a1, formula("=S2!A1+1"))
       .put(a2, num(5))
@@ -125,14 +126,14 @@ class RecalcSpec extends FunSuite:
     val s2 = Sheet(SheetName.unsafe("S2")).put(a1, formula("=S1!A1+1"))
     val result = Workbook(s1, s2).recalculate()
     assertEquals(cached(result.workbook, "S1", a3), Some(num(10)))
-    val errorRefs = result.errors.map(e => (e.sheet.value, e.ref)).toSet
+    val byRef = result.errors.map(e => (e.sheet.value, e.ref) -> e.error.message).toMap
     assert(
-      errorRefs.contains(("S1", a1)),
-      s"S1!A1 should error, got: ${result.errors.map(_.render)}"
+      byRef.get(("S1", a1)).exists(_.contains("Circular")),
+      s"S1!A1 should be circular, got: ${result.errors.map(_.render)}"
     )
     assert(
-      errorRefs.contains(("S2", a1)),
-      s"S2!A1 should error, got: ${result.errors.map(_.render)}"
+      byRef.get(("S2", a1)).exists(_.contains("Circular")),
+      s"S2!A1 should be circular, got: ${result.errors.map(_.render)}"
     )
     assertEquals(cached(result.workbook, "S1", a1), None)
     assertEquals(cached(result.workbook, "S2", a1), None)

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/RecalcSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/RecalcSpec.scala
@@ -203,6 +203,24 @@ class RecalcSpec extends FunSuite:
     assert(result.isClean, result.errors.map(_.render).mkString("; "))
     assertEquals(cached(result.workbook, "S", ref"D1"), Some(num(7)))
 
+  test("GH-346 workbook-level dynamic closure: cross-sheet static dependent defers with INDIRECT"):
+    // S2!D1 depends statically on S1!C1, which is dynamic. With a per-sheet closure D1 would stay
+    // in the front partition and could evaluate before C1's target A1 refreshes, reading the
+    // stale 999 through the recursive fallback — an evaluation-order lottery. The workbook-level
+    // closure defers D1 with the bucket, so it deterministically reads the fresh chain.
+    val s1 = Sheet(SheetName.unsafe("S1"))
+      .put(ref"X1", num(1))
+      .put(ref"X2", num(2))
+      .put(ref"X3", num(3))
+      .put(ref"A1", CellValue.Formula("=SUM(X1:X3)", Some(num(999)))) // stale cache
+      .put(ref"C1", formula("=INDIRECT(\"A1\")"))
+    val s2 = Sheet(SheetName.unsafe("S2")).put(ref"D1", formula("=S1!C1+1"))
+    val result = Workbook(s1, s2).recalculate()
+    assert(result.isClean, result.errors.map(_.render).mkString("; "))
+    assertEquals(cached(result.workbook, "S1", ref"A1"), Some(num(6)))
+    assertEquals(cached(result.workbook, "S1", ref"C1"), Some(num(6)))
+    assertEquals(cached(result.workbook, "S2", ref"D1"), Some(num(7)))
+
   test("GH-274 stale-cache regression: edit target, recalculate again, INDIRECT chain reflects it"):
     val sheet = Sheet(SheetName.unsafe("S"))
       .put(ref"X1", num(1))


### PR DESCRIPTION
Fixes #346.

## Problem

`recalculate()` and formula evaluation effectively never terminated (hours at 100% CPU) on workbooks with **recursive multi-branch chains** — the LBO debt-schedule shape, where each period's beginning balance is read by several formulas and chains backwards period over period. Two compounding causes:

1. An uncached formula reference (`CellValue.Formula(_, None)`) was recursively re-evaluated **once per path** through the dependency graph (`Evaluator.scala` GH-161/GH-208 paths, plus the GH-187 aggregate readers and array materialization) — cost O(kⁿ) in the number of root-to-leaf paths.
2. Whole-workbook recalculation topologically sorted **per sheet**, so cross-sheet precedents were always still uncached when hit, falling into (1) against the original workbook snapshot. (The old scaladoc called workbook-level ordering "future work" — this is that work.)

## Fix

**1. Pass-local memoization** — `Evaluator.EvalMemo`, keyed by Sheet *identity* then ref, created where recursion begins and threaded through every derived `EvaluatorWithDepth` and `EvalContext` of the pass. Each distinct cell evaluates at most once per top-level evaluation (Excel's own semantics). Errors memoize too, so a cycle no longer re-burns the 100-deep recursion guard once per path. The memo never outlives a single top-level call and is invisible at the public API; identity keying means a recalc temp sheet and the original snapshot can never serve each other stale values.

**2. Workbook-level `recalculate()`** — one qualified (`sheet!cell`) dependency graph via the new `DependencyGraph.fromWorkbookBounded` (ranges bounded by each *target* sheet's used range, the qualified analog of `fromSheet`), workbook-level Tarjan cycle isolation, and a single global topological order that threads the partially evaluated workbook. Every precedent — same-sheet or cross-sheet — is computed exactly once before its dependents. The Tarjan/Kahn/reverse-reachability engines are generalized over the node type and shared by the ARef and QualifiedRef graphs (the iterative, stack-safe engines are unchanged in substance; the 100k-node stack-safety pins still pass).

## Behavior changes (intentional, pinned in tests)

- **Cross-sheet cycles are now detected as circular**: participants report `Circular reference`, downstream dependents `Blocked by an upstream circular reference`, and the acyclic remainder still evaluates — previously they surfaced as generic depth-guard eval errors (RecalcSpec test updated accordingly).
- **Cross-sheet aggregates over uncached formula cells** now read globally-computed values regardless of sheet order in the workbook (new pin in `RecalcPerfSpec`).
- GH-274/GH-301 dynamic (INDIRECT/OFFSET) evaluate-last bucket + cache-strip semantics are preserved; the dependent closure is now workbook-level, so a cross-sheet static dependent of a dynamic cell defers with it.

## Evidence

`RecalcPerfSpec` builds the debt-schedule shape at n=24 periods (~3²⁴ ≈ 3×10¹¹ paths, 120 cells):

| | pre-fix | post-fix |
|---|---|---|
| `recalculate()` on the recursive schedule | killed at 150s, no test completed | **0.1s** |
| single-shot eval of the terminal uncached cell | (same hang class) | **3ms** |

Values are asserted against a reference fold using the same `BigDecimal` operations, and generous 30s wall-clock budgets guard against regression to exponential behavior.

Full suite: **1028/1028 green**, scalafmt clean, WartRemover clean.

Internal tracker: TJC-1612.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
