### PR TITLE
chore(release): Bump version to 0.12.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.5] "Memo" - 2026-07-13
+
+Kills an exponential blowup in the formula evaluator on recursive multi-branch
+models (the LBO debt-schedule shape) — hours of CPU down to milliseconds — and
+moves whole-workbook recalculation onto a single workbook-level dependency
+order.
+
 ### Fixed
 
 - **Recursive uncached-reference evaluation is memoized per pass** (#346): an

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ```scala 3 raw
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.4
+//> using dep com.tjclp::xl:0.12.5
 
 import com.tjclp.xl.{*, given}
 
@@ -55,13 +55,13 @@ import com.tjclp.xl.{*, given}
 
 ```scala 3 ignore
 // build.mill — single dependency for everything
-def ivyDeps = Agg(ivy"com.tjclp::xl:0.12.4")
+def ivyDeps = Agg(ivy"com.tjclp::xl:0.12.5")
 
 // Or individual modules for minimal footprint:
-// ivy"com.tjclp::xl-core:0.12.4"        — Pure domain model only
-// ivy"com.tjclp::xl-ooxml:0.12.4"       — Add OOXML read/write
-// ivy"com.tjclp::xl-cats-effect:0.12.4" — Add IO streaming
-// ivy"com.tjclp::xl-evaluator:0.12.4"   — Add formula evaluation
+// ivy"com.tjclp::xl-core:0.12.5"        — Pure domain model only
+// ivy"com.tjclp::xl-ooxml:0.12.5"       — Add OOXML read/write
+// ivy"com.tjclp::xl-cats-effect:0.12.5" — Add IO streaming
+// ivy"com.tjclp::xl-evaluator:0.12.5"   — Add formula evaluation
 ```
 
 ### Basic Usage

--- a/build.mill
+++ b/build.mill
@@ -14,7 +14,7 @@ val organization = "com.tjclp"
 /** Shared build configuration constants */
 object BuildConfig {
   /** Project version: CI sets PUBLISH_VERSION; local builds use this fallback */
-  val version: String = sys.env.getOrElse("PUBLISH_VERSION", "0.12.4")
+  val version: String = sys.env.getOrElse("PUBLISH_VERSION", "0.12.5")
 
   /** JVM options to silence Scala 3 LazyVals sun.misc.Unsafe deprecation warnings (JDK 21+) */
   val lazyValsJvmArgs: Seq[String] = Seq(

--- a/docs/QUICK-START.md
+++ b/docs/QUICK-START.md
@@ -12,19 +12,19 @@ import mill._, scalalib._
 
 object myproject extends ScalaModule {
   def scalaVersion = "3.8.3"
-  def ivyDeps = Agg(ivy"com.tjclp::xl:0.12.4")
+  def ivyDeps = Agg(ivy"com.tjclp::xl:0.12.5")
 }
 ```
 
 ### With sbt (build.sbt)
 ```scala
 scalaVersion := "3.8.3"
-libraryDependencies += "com.tjclp" %% "xl" % "0.12.4"
+libraryDependencies += "com.tjclp" %% "xl" % "0.12.5"
 ```
 
 ### With Scala CLI
 ```scala
-//> using dep com.tjclp::xl:0.12.4
+//> using dep com.tjclp::xl:0.12.5
 ```
 
 ### Individual Modules (Optional)
@@ -44,7 +44,7 @@ For scripts, skip the build setup entirely: a two-line `scala-cli` header and ON
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.4
+//> using dep com.tjclp::xl:0.12.5
 
 import com.tjclp.xl.scripting.{*, given}
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,12 +1,15 @@
 # XL Project Status
 
-**Last Updated**: 2026-07-09 (0.12.4)
+**Last Updated**: 2026-07-13 (0.12.5)
 
 ## Current State
 
 > **For detailed phase completion status and roadmap, see [plan/roadmap.md](plan/roadmap.md)**
 
 ### What Works (Production-Ready)
+
+**New in 0.12.5** (2026-07-13):
+- ✅ **Evaluator memoization + workbook-level recalculation** (#346) — recursive uncached-reference evaluation is memoized per pass, and `recalculate()` runs one topological order over the qualified (sheet!cell) graph: the recursive debt-schedule shape drops from hours (exponential in dependency paths) to milliseconds; cross-sheet cycles now report circular/blocked like same-sheet ones; cross-sheet aggregates over uncached formula cells compute correctly regardless of sheet order
 
 **New in 0.12.4** (2026-07-09):
 - ✅ **Elementwise error carriage** (#337) — array comparisons/arithmetic carry `#DIV/0!`/`#REF!`/`#VALUE!` per element (Left only on dimension mismatch, property-tested); aggregates fail loudly on carried errors (IFERROR-catchable)

--- a/docs/plan/roadmap.md
+++ b/docs/plan/roadmap.md
@@ -10,9 +10,9 @@
 
 ## TL;DR
 
-**Current Status**: Production-ready with **107 formula functions** (incl. dynamic arrays SEQUENCE/SORT/UNIQUE/FILTER and OFFSET), **structural editing** (insert/delete rows & columns with formula rewriting), the **scripting prelude** (`com.tjclp.xl.scripting`), whole-workbook `recalculate`, named-range & hyperlink authoring, **typed charts + embedded pictures** (0.12.0), **conditional formatting** (0.12.1), SAX streaming (36% faster than POI), Excel tables, and full OOXML round-trip. 3,996 tests passing.
+**Current Status**: Production-ready with **107 formula functions** (incl. dynamic arrays SEQUENCE/SORT/UNIQUE/FILTER and OFFSET), **structural editing** (insert/delete rows & columns with formula rewriting), the **scripting prelude** (`com.tjclp.xl.scripting`), whole-workbook `recalculate`, named-range & hyperlink authoring, **typed charts + embedded pictures** (0.12.0), **conditional formatting** (0.12.1), SAX streaming (36% faster than POI), Excel tables, and full OOXML round-trip. 4,000 tests passing.
 
-**Current Version**: **0.12.4 "Carriage"** (released 2026-07-09)
+**Current Version**: **0.12.5 "Memo"** (released 2026-07-13)
 
 ---
 
@@ -60,6 +60,10 @@ Phased: (a) verbatim chart/drawing preservation proven by the wave-2 fixture cor
 ### v0.12.1 "Clean Sweep" — wave 7 (Released 2026-06-11)
 
 Every remaining open issue closed in one wave. **Conditional formatting** ([#136](https://github.com/TJC-LP/xl/issues/136)) is the headline — typed cellIs/expression/colorScale/dataBar/top10/text rules + `dxf` differential formats, `sheet.conditionalFormat` authoring with auto-priority, structural-edit range shifting, unmodeled families preserved byte-faithfully — alongside twelve fidelity/writer fixes: openpyxl comment subdirectory dialect (#292), RichText SST keying (#303), exact surgical SST counts (#304), `[Content_Types]` preservation (#314), identity-keyed source mappings (#315), activeTab (#294), fitToPage tri-state (#284), `Cell.comment` deprecated→`Sheet.comments` (#295). Codec `put` paths 2.4x faster (#297).
+
+### v0.12.5 "Memo" (Released 2026-07-13)
+
+Evaluator performance and correctness on recursive models ([#346](https://github.com/TJC-LP/xl/issues/346)): pass-local memoization of recursively evaluated uncached formula references (direct refs, aggregate readers, array materialization — each cell computes once per pass instead of once per dependency path), and `Workbook.recalculate()` rebuilt on a workbook-level qualified graph with global Tarjan cycle isolation + one global Kahn order. An LBO-style debt schedule that previously ran for hours (exponential) recalculates in milliseconds; cross-sheet cycles report as circular/blocked; cross-sheet aggregates over uncached formulas are sheet-order-independent.
 
 ### v0.12.4 "Carriage" — wave 11 (Released 2026-07-09)
 

--- a/docs/reference/scripting.md
+++ b/docs/reference/scripting.md
@@ -33,7 +33,7 @@ release bump is a mechanical substitution):
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.4
+//> using dep com.tjclp::xl:0.12.5
 import com.tjclp.xl.scripting.{*, given}
 
 val sheet = Sheet("Demo").put(ref"A1", "Hello").put(ref"B1", 42)
@@ -51,7 +51,7 @@ read and write is pure values.
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.4
+//> using dep com.tjclp::xl:0.12.5
 import com.tjclp.xl.scripting.{*, given}
 
 val wb = Excel.read("input.xlsx")
@@ -135,7 +135,7 @@ throw — they are collected per cell.
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.4
+//> using dep com.tjclp::xl:0.12.5
 import com.tjclp.xl.scripting.{*, given}
 
 val title = CellStyle.default.bold.size(14.0).center
@@ -246,7 +246,7 @@ them explicitly:
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.4
+//> using dep com.tjclp::xl:0.12.5
 import com.tjclp.xl.scripting.{*, given}
 import com.tjclp.xl.sheets.{HeaderFooter, PageMargins, PageSetup, SheetView}
 
@@ -300,7 +300,7 @@ the whole workbook:
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.4
+//> using dep com.tjclp::xl:0.12.5
 import com.tjclp.xl.scripting.{*, given}
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global

--- a/docs/reference/testing-guide.md
+++ b/docs/reference/testing-guide.md
@@ -1,6 +1,6 @@
 # Testing & Laws — Property Suites, Round-Trips, and Coverage
 
-**Current Status**: CI runs the full Mill test graph across the library, evaluator, CLI, and support modules — **3,996 tests** as of 0.12.4. Use `./mill __.test` as the authoritative count.
+**Current Status**: CI runs the full Mill test graph across the library, evaluator, CLI, and support modules — **4,000 tests** as of 0.12.5. Use `./mill __.test` as the authoritative count.
 
 ## Test Infrastructure
 
@@ -211,18 +211,18 @@ GitHub Actions runs:
 
 ## Test Counts by Module
 
-As of 0.12.4 (per-module `./mill <module>.test`; macros are part of xl-core — there is no separate xl-macros module):
+As of 0.12.5 (per-module `./mill <module>.test`; macros are part of xl-core — there is no separate xl-macros module):
 
 | Module | Tests |
 |--------|-------|
-| xl-evaluator | 1571 |
+| xl-evaluator | 1575 |
 | xl-core | 1104 |
 | xl-ooxml | 684 |
 | xl-cli | 406 |
 | xl-cats-effect | 110 |
 | xl-agent | 102 |
 | xl (prelude probes, `xlprelude.ScriptingPreludeTest`) | 19 |
-| **Total** | **3,996** |
+| **Total** | **4,000** |
 
 ## Test Quality Metrics
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -170,7 +170,7 @@ chmod +x examples/my_example.sc
 ./examples/my_example.sc
 ```
 
-The `project.scala` file centralizes dependencies (`com.tjclp::xl:0.12.4`) for all examples.
+The `project.scala` file centralizes dependencies (`com.tjclp::xl:0.12.5`) for all examples.
 
 ## Scripting Prelude & Skill
 

--- a/examples/project.scala
+++ b/examples/project.scala
@@ -2,4 +2,4 @@
 //> using repository ivy2Local
 
 // XL aggregate - includes all modules (core, ooxml, cats-effect, evaluator)
-//> using dep com.tjclp::xl:0.12.4
+//> using dep com.tjclp::xl:0.12.5

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "xl",
   "description": "LLM-friendly Excel tooling: the xl CLI for reading, writing, styling, and analyzing spreadsheets (xl-cli skill), plus type-safe Scala scripting against the xl library via scala-cli for bulk transformations, pipelines, and formula models (xl-scripting skill).",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "author": {
     "name": "TJC L.P.",
     "url": "https://github.com/TJC-LP"

--- a/plugin/skills/xl-scripting/SKILL.md
+++ b/plugin/skills/xl-scripting/SKILL.md
@@ -38,7 +38,7 @@ The canonical header for every script (this is the single source of truth — re
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.4
+//> using dep com.tjclp::xl:0.12.5
 
 import com.tjclp.xl.scripting.{*, given}
 
@@ -100,7 +100,7 @@ wb.update("Sales", f).unsafe                       // throws structured XLExcept
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.4
+//> using dep com.tjclp::xl:0.12.5
 import com.tjclp.xl.scripting.{*, given}
 
 val wb = Excel.read("input.xlsx")
@@ -235,7 +235,7 @@ Or lean on totality so there is nothing to unwrap: literal refs, `upsert`, range
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.4
+//> using dep com.tjclp::xl:0.12.5
 import com.tjclp.xl.scripting.{*, given}
 import java.nio.file.{Files, Paths}
 import scala.jdk.CollectionConverters.*
@@ -257,7 +257,7 @@ println(s"merged ${inputs.size} files, ${merged.sheets.size} sheets")
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.4
+//> using dep com.tjclp::xl:0.12.5
 import com.tjclp.xl.scripting.{*, given}
 
 val data = List(("North", 125000.50), ("South", 98000.25), ("West", 143500.00))
@@ -285,7 +285,7 @@ println(if result.isClean then "✓ report written" else result.errors.map(_.ren
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.4
+//> using dep com.tjclp::xl:0.12.5
 import com.tjclp.xl.scripting.{*, given}
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global

--- a/plugin/skills/xl-scripting/reference/RECIPES.md
+++ b/plugin/skills/xl-scripting/reference/RECIPES.md
@@ -10,7 +10,7 @@ Apply a 5% price increase to column C of every workbook in a directory, in place
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.4
+//> using dep com.tjclp::xl:0.12.5
 import com.tjclp.xl.scripting.{*, given}
 import java.nio.file.{Files, Paths}
 import scala.jdk.CollectionConverters.*
@@ -42,7 +42,7 @@ Read rows into case classes; collect per-cell validation failures into a new Iss
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.4
+//> using dep com.tjclp::xl:0.12.5
 import com.tjclp.xl.scripting.{*, given}
 
 final case class Order(id: Int, customer: String, amount: BigDecimal)
@@ -76,7 +76,7 @@ Three-year projection with growth formulas; fail the script if any formula error
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.4
+//> using dep com.tjclp::xl:0.12.5
 import com.tjclp.xl.scripting.{*, given}
 
 val header = CellStyle.default.bold.size(12.0).center
@@ -111,7 +111,7 @@ Stack the data rows of every input file under one header.
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.4
+//> using dep com.tjclp::xl:0.12.5
 import com.tjclp.xl.scripting.{*, given}
 import java.nio.file.{Files, Paths}
 import scala.jdk.CollectionConverters.*
@@ -147,7 +147,7 @@ println(s"combined ${files.size} files, ${combined.cells.size} cells")
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.4
+//> using dep com.tjclp::xl:0.12.5
 import com.tjclp.xl.scripting.{*, given}
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
@@ -176,7 +176,7 @@ println("✓ filtered (constant memory)")
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.4
+//> using dep com.tjclp::xl:0.12.5
 import com.tjclp.xl.scripting.{*, given}
 
 val before = Excel.read("before.xlsx")
@@ -204,7 +204,7 @@ else
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.4
+//> using dep com.tjclp::xl:0.12.5
 import com.tjclp.xl.scripting.{*, given}
 import java.nio.file.{Files, Paths}
 import scala.jdk.CollectionConverters.*

--- a/xl-core/src/com/tjclp/xl/workbooks/WorkbookMetadata.scala
+++ b/xl-core/src/com/tjclp/xl/workbooks/WorkbookMetadata.scala
@@ -21,7 +21,7 @@ final case class WorkbookMetadata(
   modified: Option[java.time.LocalDateTime] = None,
   lastModifiedBy: Option[String] = None,
   application: Option[String] = Some("XL - Pure Scala 3.8 Excel Library"),
-  appVersion: Option[String] = Some("0.12.4"),
+  appVersion: Option[String] = Some("0.12.5"),
   theme: ThemePalette = ThemePalette.office,
   definedNames: Vector[DefinedName] = Vector.empty,
   sheetStates: Map[SheetName, Option[String]] = Map.empty,


### PR DESCRIPTION
Release prep for **0.12.5 "Memo"** — the evaluator memoization + workbook-level recalculation release (#346, merged in #347).

Per the `release-prep` runbook:
- Version pins 0.12.4 → 0.12.5: `build.mill`, `WorkbookMetadata.appVersion`, `plugin.json`, `xl-scripting` SKILL.md + RECIPES.md (release-workflow gate), README, QUICK-START, scripting reference, examples
- CHANGELOG: `[Unreleased]` → `## [0.12.5] "Memo" - 2026-07-13`
- STATUS/roadmap/testing-guide prose refreshed; test counts verified by actual run (xl-evaluator 1571 → **1575**, total **4,000**)
- Historical 0.12.4 mentions intentionally untouched

Verified locally: `./mill __.compile` + `./mill __.test` green, `scripts/test-examples.sh` ✓ (version-drift guard + examples on the local build), `scripts/verify-skill-snippets.sh --local` ✓, no SNAPSHOT refs.

After merge: annotated tag `v0.12.5` (notes from the CHANGELOG heading) → release workflow publishes Maven Central + native binaries + GitHub Release.

Internal tracker: TJC-1612.

🤖 Generated with [Claude Code](https://claude.com/claude-code)