### PR TITLE
docs(skills): production field gotchas + 0.12.5 eval-note refresh

### DIFF
--- a/plugin/skills/xl-cli/SKILL.md
+++ b/plugin/skills/xl-cli/SKILL.md
@@ -19,7 +19,9 @@ LATEST=$(curl -s "https://api.github.com/repos/$REPO/releases/latest" | grep '"t
 VERSION=${LATEST#v}
 case "$(uname -s)-$(uname -m)" in
   Linux-x86_64)  BINARY="xl-$VERSION-linux-amd64" ;;
-  Linux-aarch64) BINARY="xl-$VERSION-linux-arm64" ;;
+  # linux-arm64 native binaries are not published yet (xl#354) — on aarch64 Linux use
+  # the JAR distribution (xl-$VERSION-cli.tar.gz, needs a JRE) instead.
+  Linux-aarch64) echo "No linux-arm64 binary published (see TJC-LP/xl#354); use xl-$VERSION-cli.tar.gz" && exit 1 ;;
   Darwin-x86_64) BINARY="xl-$VERSION-darwin-amd64" ;;
   Darwin-arm64)  BINARY="xl-$VERSION-darwin-arm64" ;;
   *) echo "Unsupported: $(uname -s)-$(uname -m)" && exit 1 ;;
@@ -87,7 +89,7 @@ xl -f <file> -s <sheet> view <range> --formulas   # Show formulas
 xl -f <file> -s <sheet> view <range> --eval       # Computed values
 ```
 
-**Note**: `--eval` may show formula text instead of computed values for cells with deep multi-hop cross-sheet formula dependencies. The xlsx file will compute correctly when opened in Excel.
+**Note**: since 0.12.5, `--eval` computes deep multi-hop cross-sheet chains in one pass (global dependency order with memoization). The remaining exception: formulas whose precedents include **external-workbook references** (`[2]Book!A1`) fail to evaluate ([#353](https://github.com/TJC-LP/xl/issues/353)) — read those cells' cached values with a plain `view` instead.
 
 ### Write Operations (require `-o` or `-i`)
 ```bash
@@ -546,6 +548,30 @@ xl -f huge.xlsx --max-size 500 cell A1    # Custom 500MB limit
 **Streaming supports**: search, stats, bounds, view (markdown/csv/json), put, putf, style
 
 **Requires in-memory**: cell (dependencies), eval (formulas), HTML/SVG/PDF (styles), formula dragging, `put --csv` (CSV auto-split)
+
+---
+
+## Field Gotchas (verified in production)
+
+Hard-won rules from fleet use on real deal workbooks. Issue links track the underlying fixes; until they land, treat these as law.
+
+**Reading**
+- **`view` and `search` clip at `--limit` (default 50) with no truncation marker** ([#351](https://github.com/TJC-LP/xl/issues/351)). A `view A1:A259` returning ~50 rows is NOT the whole range — pass `--limit <n>` explicitly, or chunk long scans into ≤45-row windows and verify the last row you expected is present.
+- **Use `--show-labels` whenever row numbers matter** in CSV output — hidden rows shift positional counting silently.
+- **`--formulas --format json` replaces `value` with the formula text** and emits no separate `formula` key ([#357](https://github.com/TJC-LP/xl/issues/357)). To scan formulas programmatically, use `--format csv --formulas --show-labels` and parse with a CSV reader.
+- **`eval` fails on formulas whose precedents include external-workbook refs** (`[2]Book!A1` → `Parse error: UnexpectedChar([`, [#353](https://github.com/TJC-LP/xl/issues/353)) and on **percent literals** (`=A1*10%`, [#355](https://github.com/TJC-LP/xl/issues/355) — write `/100` instead). For external-link workbooks, compute from cached values (plain `view`).
+
+**Writing**
+- **`batch` writes formulas with no cached values** — `data_only` readers, pandas, and previewers show blanks for every `putf` cell ([#352](https://github.com/TJC-LP/xl/issues/352)). Until fixed: prefer single `putf` commands (they recalculate dependents), verify with `--eval`, or recalculate via the scripting API before shipping.
+- **Batch `putf` has no `format` field** ([#356](https://github.com/TJC-LP/xl/issues/356)) — number formats on formula cells need a follow-up `style` op / `xl style RANGE --format '…'`.
+- **Batch JSON style keys are camelCase**: `numFormat`, `borderTop`, `borderBottom`, `borderLeft`, `borderRight`, `borderColor`. Kebab-case (`border-top`) is treated as an unknown property — the warning goes to stderr only, so it is easy to miss.
+- **Build cross-sheet models in dependency order** (put referenced cells before the formulas that use them) — batches evaluate nothing, and single-command recalcs are dependents-only.
+- **`-i` (in-place) round-trips preserve hand-patched XML**: sheetPr/tabColor, pageSetup, headerFooter, sheetView gridlines/zoom, sheet-local `_xlnm.Print_Area`, and hand-inserted cached `<v>` values all survive later xl writes.
+- **Sheet appearance/print setup (gridlines off, zoom, tab color, landscape, footers) has no CLI yet** ([#358](https://github.com/TJC-LP/xl/issues/358)) — until then it requires zip round-trip XML patching.
+
+**Rendering & environment**
+- **PNG/PDF on the native binary needs an external rasterizer** (Batik is JAR-only; [#359](https://github.com/TJC-LP/xl/issues/359)): install `cairosvg` (`pip install cairosvg`) or `rsvg-convert`, and check availability with `xl rasterizers`. Add `--eval` when rendering or formula cells show as text.
+- **Style-bloated real-world workbooks can fail to read** with an opaque `Parse error at xl/workbook.xml … XMLMessages` ([#349](https://github.com/TJC-LP/xl/issues/349)/[#350](https://github.com/TJC-LP/xl/issues/350)). Fallback: read with openpyxl, rebuild clean, then xl works on the rebuilt file.
 
 ---
 

--- a/plugin/skills/xl-scripting/SKILL.md
+++ b/plugin/skills/xl-scripting/SKILL.md
@@ -314,6 +314,9 @@ Switch to streaming above ~100k rows; `Excel.read` loads the whole workbook. Str
 - **Navigation is unchecked at the edges**: `ref"A1".up()` produces an invalid "A0" ref that corrupts output if written; keep loop bounds inside your data extent.
 - **First run is slow** (dependency download); afterwards scala-cli caches everything.
 - **`.sc` files**: top-level statements, no `@main`. A `.scala` file needs `@main def run(): Unit`.
+- **`Excel.write` does NOT recalculate** — freshly built `fx"…"` cells are written with no cached values, so Excel-before-recalc, openpyxl `data_only`, pandas, and previewers all show blanks. Always `val result = wb.recalculate()` and write `result.workbook` (a single pass is sufficient on 0.12.5+; see "Formulas & recalculation" above). Tracking a recalculating-write affordance: [#360](https://github.com/TJC-LP/xl/issues/360).
+- **Formulas containing external-workbook refs (`[2]Book!A1`) or percent literals (`10%`)** fail to parse/evaluate ([#353](https://github.com/TJC-LP/xl/issues/353), [#355](https://github.com/TJC-LP/xl/issues/355)) — compute external-linked cells from their cached values, and write `/100` instead of `%`.
+- **`setColumnProperties` wants a compile-time literal** (`ref"D1".col`); runtime-parsed refs don't expose `.col`, so column loops over runtime letters can't feed it directly ([#361](https://github.com/TJC-LP/xl/issues/361)). Until then, set widths with literal refs per column.
 
 ## Reference
 

--- a/xl/src/com/tjclp/xl/scripting.scala
+++ b/xl/src/com/tjclp/xl/scripting.scala
@@ -4,7 +4,7 @@ package com.tjclp.xl
  * Scripting prelude: everything a script needs in one import.
  *
  * {{{
- * //> using dep com.tjclp::xl:0.11.0
+ * //> using dep com.tjclp::xl:0.12.5
  * import com.tjclp.xl.scripting.{*, given}
  *
  * val wb = Excel.read("input.xlsx")


### PR DESCRIPTION
## Summary

Promotes the agent fleet's hard-won xl folklore into the shipped skills, and refreshes notes that 0.12.5 made stale. Sourced from production memory of real deal-workbook builds (2026-07-13/14); every claim was re-verified against the 0.12.5 sources or reproduced on a live binary before writing.

- **xl-cli SKILL.md — new "Field Gotchas (verified in production)" section**: silent `--limit 50` clipping on view/search (#351), `--show-labels` for row-accurate scans, JSON `--formulas` payload shape (#357), eval failures on external-workbook refs (#353) and percent literals (#355), batch `putf` writing uncached formulas (#352) and lacking `format` (#356), camelCase batch style keys, dependency-order batching, what `-i` round-trips preserve, the sheet-appearance CLI gap (#358), native-binary rasterizer requirements (#359), and the style-bloated read failure fallback (#349/#350).
- **`--eval` note refreshed for 0.12.5**: the deep multi-hop cross-sheet caveat predates #347's memoization + global recalc order and is obsolete; the remaining exception (external-workbook refs) is now stated precisely.
- **Install snippet**: `Linux-aarch64` no longer curls a nonexistent asset — it now explains the linux-arm64 gap and points at the JAR distribution (#354).
- **xl-scripting SKILL.md gotchas**: `Excel.write` does not recalculate (#360), external-ref/percent parser gaps, `setColumnProperties` compile-time-literal constraint (#361).
- **scripting.scala**: docstring dep pin `0.11.0` → `0.12.5` (comment-only).

## Verification

- No new ```scala snippet blocks — `scripts/verify-skill-snippets.sh` extraction set is unchanged; the `com.tjclp::xl:$VERSION` release gate pins are untouched.
- Behavioral claims reproduced on a live binary this session: 100-row `view` clipping at 50 with no marker; `=A1*10%` → `UnexpectedChar(%…)`; batch-written `putf` cell serialized as `<c r="C1"><f>A1*2</f></c>` (no `<v>`); `--formulas --format json` emitting the expression as `value`; `SUM(D1:D2)` failing when D1 holds `=SUM([2]Book1!A1:A2)`.
- Code claims cite 0.12.5 sources (BatchParser known-prop sets and `applyPutFormula`, `WriteCommands.batch`, `Main.scala:213` limit default, `JsonRenderer.renderCell`, resource-config bundle list, release matrix).

Companion issue batch: #349–#361.

🤖 Generated with [Claude Code](https://claude.com/claude-code)