### PR TITLE
fix(cli): recalculate before write in batch + add xl recalc command (#352)

### DIFF
--- a/xl-cli/src/com/tjclp/xl/cli/Command.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/Command.scala
@@ -98,6 +98,8 @@ enum CliCommand:
   case RowOp(row: Int, height: Option[Double], hide: Boolean, show: Boolean)
   case ColOp(col: String, width: Option[Double], hide: Boolean, show: Boolean, autoFit: Boolean)
   case Batch(source: String, dryRun: Boolean = false) // "-" for stdin or file path
+  // Whole-workbook recalculation: cache every formula's value (GH-352)
+  case Recalc
   case Import(
     csvPath: String,
     startRef: Option[String],

--- a/xl-cli/src/com/tjclp/xl/cli/Main.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/Main.scala
@@ -99,7 +99,7 @@ object Main
     // Sheet-level write: --file, --sheet, and --output (required)
     // --stream uses SAX/StAX workbook writes for modifying commands.
     val sheetWriteSubcmds =
-      putCmd orElse putfCmd orElse styleCmd orElse rowCmd orElse colCmd orElse autoFitCmd orElse batchCmd orElse importCmd orElse importMdCmd orElse addSheetCmd orElse removeSheetCmd orElse renameSheetCmd orElse moveSheetCmd orElse copySheetCmd orElse mergeCmd orElse unmergeCmd orElse commentCmd orElse removeCommentCmd orElse clearCmd orElse fillCmd orElse sortCmd orElse freezeCmd orElse unfreezeCmd orElse copyCmd orElse nameCmd orElse insertRowsCmd orElse deleteRowsCmd orElse insertColsCmd orElse deleteColsCmd orElse chartCmd orElse addImageCmd
+      putCmd orElse putfCmd orElse styleCmd orElse rowCmd orElse colCmd orElse autoFitCmd orElse batchCmd orElse recalcCmd orElse importCmd orElse importMdCmd orElse addSheetCmd orElse removeSheetCmd orElse renameSheetCmd orElse moveSheetCmd orElse copySheetCmd orElse mergeCmd orElse unmergeCmd orElse commentCmd orElse removeCommentCmd orElse clearCmd orElse fillCmd orElse sortCmd orElse freezeCmd orElse unfreezeCmd orElse copyCmd orElse nameCmd orElse insertRowsCmd orElse deleteRowsCmd orElse insertColsCmd orElse deleteColsCmd orElse chartCmd orElse addImageCmd
 
     val sheetWriteOpts =
       (
@@ -939,6 +939,26 @@ Use --dry-run to validate JSON without writing."""
   val batchCmd: Opts[CliCommand] =
     Opts.subcommand("batch", batchHelp) {
       (batchArg, dryRunOpt).mapN(CliCommand.Batch.apply)
+    }
+
+  // --- Recalc command (GH-352) ---
+  private val recalcHelp = """Recalculate all formulas and rewrite cached values.
+
+Runs one whole-workbook recalculation and writes the result, so every formula
+cell carries a cached value (<v>) that cached-value readers see (pandas,
+openpyxl data_only=True, previewers, Excel before a manual recalc).
+
+Formula errors (e.g. circular references) are data conditions, not tool
+failures: affected cells are left uncached, the file is still written, the
+errors are listed in the summary, and the exit code is 0.
+
+USAGE:
+  xl -f in.xlsx -o out.xlsx recalc
+  xl -f in.xlsx -i recalc"""
+
+  val recalcCmd: Opts[CliCommand] =
+    Opts.subcommand("recalc", recalcHelp) {
+      Opts(CliCommand.Recalc)
     }
 
   // --- Import command ---
@@ -1828,6 +1848,11 @@ Use --dry-run to validate JSON without writing."""
     case CliCommand.Batch(source, _) =>
       requireOutput(outputOpt, backendOpt, stream)(
         WriteCommands.batch(wb, sheetOpt, source, _, _, _)
+      )
+
+    case CliCommand.Recalc =>
+      requireOutput(outputOpt, backendOpt, stream)(
+        WriteCommands.recalc(wb, _, _, _)
       )
 
     case CliCommand.Import(csvPath, startRefOpt, delim, skipHeader, enc, newSheetOpt, noInfer) =>

--- a/xl-cli/src/com/tjclp/xl/cli/commands/WriteCommands.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/commands/WriteCommands.scala
@@ -677,7 +677,47 @@ object WriteCommands:
     ColumnAutoFit.calculateWidth(sheet, col)
 
   /**
+   * Whether a batch op can change a cell's value or formula, requiring recalculation before write
+   * (GH-352).
+   *
+   * Rule: recalculate whenever any op writes, clears, or copies cell content — such an op can
+   * invalidate cached formula values anywhere in the workbook (cross-sheet dependents included),
+   * and `BatchParser` stores batch formulas uncached (`Formula(expr, None)`). Ops that only touch
+   * presentation or metadata (styles, comments, widths, visibility, merges, freeze panes, sheet
+   * management, hyperlinks) leave every existing cached value correct — a rename even rewrites
+   * referencing formulas without changing their values — so a batch made exclusively of them skips
+   * the recalculation and preserves the input's caches as-is.
+   */
+  private def isCellMutating(op: BatchParser.BatchOp): Boolean =
+    op match
+      case _: BatchParser.BatchOp.Put | _: BatchParser.BatchOp.PutFormula |
+          _: BatchParser.BatchOp.PutFormulaDragging | _: BatchParser.BatchOp.PutFormulas |
+          _: BatchParser.BatchOp.PutValues | _: BatchParser.BatchOp.Clear |
+          _: BatchParser.BatchOp.CopyRange =>
+        true
+      case _ => false
+
+  /**
+   * One-line recalculation summary: formula count plus the first few failing refs (GH-352). Formula
+   * errors are data conditions — they are reported, never thrown.
+   */
+  private def formatRecalcSummary(result: RecalcResult): String =
+    val formulaCount = result.evaluated.valuesIterator.map(_.size).sum
+    val formulasLabel = if formulaCount == 1 then "formula" else "formulas"
+    if result.isClean then s"Recalculated $formulaCount $formulasLabel"
+    else
+      val maxShown = 3
+      val shown = result.errors.take(maxShown).map(_.render).mkString("; ")
+      val ellipsis = if result.errors.size > maxShown then "; ..." else ""
+      val errorsLabel = if result.errors.size == 1 then "error" else "errors"
+      s"Recalculated $formulaCount $formulasLabel; ${result.errors.size} $errorsLabel ($shown$ellipsis)"
+
+  /**
    * Apply multiple operations atomically (JSON from stdin or file).
+   *
+   * Ends with one global `recalculate()` when any op mutates cell content (GH-352), so batch putf
+   * carries cached values (`<v>`) exactly like single-op putf. Formula errors do not abort the
+   * write: the workbook is written regardless and errors surface in the summary.
    *
    * @param stream
    *   If true, uses the SAX/StAX workbook writer
@@ -695,13 +735,39 @@ object WriteCommands:
         // Print warnings to stderr within IO monad
         IO(result.warnings.foreach(System.err.println)) *>
           BatchParser.applyBatchOperations(wb, sheetOpt, result.ops).flatMap { updatedWb =>
-            writeWorkbook(updatedWb, outputPath, config, stream).map { _ =>
+            val recalcOpt =
+              if result.ops.exists(isCellMutating) then Some(updatedWb.recalculate())
+              else None
+            val finalWb = recalcOpt.fold(updatedWb)(_.workbook)
+            writeWorkbook(finalWb, outputPath, config, stream).map { _ =>
               val ops = result.ops
               val summary = BatchParser.formatSummary(ops)
-              s"Applied ${ops.size} operations:\n$summary\n${saveSuffix(outputPath, stream)}"
+              val recalcLine = recalcOpt.fold("")(r => s"${formatRecalcSummary(r)}\n")
+              s"Applied ${ops.size} operations:\n$summary\n$recalcLine${saveSuffix(outputPath, stream)}"
             }
           }
       }
+    }
+
+  /**
+   * Recalculate every formula in the workbook and cache the results (GH-352).
+   *
+   * Formula errors (circular references, bad refs) are data conditions, not tool failures: failing
+   * cells are left uncached — exactly as Excel leaves them — the workbook is still written, and the
+   * errors are reported in the summary. Callers exit 0 either way.
+   *
+   * @param stream
+   *   If true, uses the SAX/StAX workbook writer
+   */
+  def recalc(
+    wb: Workbook,
+    outputPath: Path,
+    config: WriterConfig,
+    stream: Boolean = false
+  ): IO[String] =
+    val result = wb.recalculate()
+    writeWorkbook(result.workbook, outputPath, config, stream).map { _ =>
+      s"${formatRecalcSummary(result)}\n${saveSuffix(outputPath, stream)}"
     }
 
   /**

--- a/xl-cli/src/com/tjclp/xl/cli/commands/WriteCommands.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/commands/WriteCommands.scala
@@ -687,15 +687,30 @@ object WriteCommands:
    * management, hyperlinks) leave every existing cached value correct — a rename even rewrites
    * referencing formulas without changing their values — so a batch made exclusively of them skips
    * the recalculation and preserves the input's caches as-is.
+   *
+   * The match is deliberately exhaustive (no wildcard): a future `BatchOp` must be consciously
+   * classified here, or the compiler flags this match — a silent `false` default would skip the
+   * recalculation for a new cell-mutating op and reintroduce GH-352.
    */
   private def isCellMutating(op: BatchParser.BatchOp): Boolean =
     op match
       case _: BatchParser.BatchOp.Put | _: BatchParser.BatchOp.PutFormula |
           _: BatchParser.BatchOp.PutFormulaDragging | _: BatchParser.BatchOp.PutFormulas |
-          _: BatchParser.BatchOp.PutValues | _: BatchParser.BatchOp.Clear |
-          _: BatchParser.BatchOp.CopyRange =>
+          _: BatchParser.BatchOp.PutValues | _: BatchParser.BatchOp.CopyRange =>
         true
-      case _ => false
+      // A styles-only or comments-only clear leaves every cell value intact — mirror
+      // BatchParser.applyClear's clearContents condition so those take the no-recalc path.
+      case c: BatchParser.BatchOp.Clear => c.all || (!c.styles && !c.comments)
+      case _: BatchParser.BatchOp.Style | _: BatchParser.BatchOp.Merge |
+          _: BatchParser.BatchOp.Unmerge | _: BatchParser.BatchOp.ColWidth |
+          _: BatchParser.BatchOp.RowHeight | _: BatchParser.BatchOp.AddComment |
+          _: BatchParser.BatchOp.RemoveComment | _: BatchParser.BatchOp.ColHide |
+          _: BatchParser.BatchOp.ColShow | _: BatchParser.BatchOp.RowHide |
+          _: BatchParser.BatchOp.RowShow | _: BatchParser.BatchOp.AutoFit |
+          _: BatchParser.BatchOp.AddSheet | _: BatchParser.BatchOp.RenameSheet |
+          _: BatchParser.BatchOp.Freeze | BatchParser.BatchOp.Unfreeze |
+          _: BatchParser.BatchOp.Hyperlink =>
+        false
 
   /**
    * One-line recalculation summary: formula count plus the first few failing refs (GH-352). Formula

--- a/xl-cli/test/src/com/tjclp/xl/cli/BatchRecalcSpec.scala
+++ b/xl-cli/test/src/com/tjclp/xl/cli/BatchRecalcSpec.scala
@@ -1,0 +1,218 @@
+package com.tjclp.xl.cli
+
+import munit.FunSuite
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path}
+
+import cats.effect.{IO, unsafe}
+import com.tjclp.xl.{Workbook, Sheet}
+import com.tjclp.xl.addressing.ARef
+import com.tjclp.xl.cells.CellValue
+import com.tjclp.xl.cli.commands.WriteCommands
+import com.tjclp.xl.io.ExcelIO
+import com.tjclp.xl.ooxml.writer.WriterConfig
+
+/**
+ * GH-352: batch must end with one global recalculation so batch putf carries cached values (`<v>`)
+ * exactly like single-op putf, formula errors surface in the summary without aborting the write,
+ * presentation-only batches skip the recalculation, and the standalone `recalc` command freshens
+ * any workbook.
+ */
+@SuppressWarnings(
+  Array("org.wartremover.warts.OptionPartial", "org.wartremover.warts.IterableOps")
+)
+class BatchRecalcSpec extends FunSuite:
+
+  given unsafe.IORuntime = unsafe.IORuntime.global
+
+  val config: WriterConfig = WriterConfig.default
+
+  private def tempXlsx(): Path = Files.createTempFile("recalc-test", ".xlsx")
+
+  private def writeOps(json: String): Path =
+    val path = Files.createTempFile("batch-ops", ".json")
+    Files.write(path, json.getBytes(StandardCharsets.UTF_8))
+    path
+
+  private def readBack(path: Path): Workbook =
+    ExcelIO.instance[IO].read(path).unsafeRunSync()
+
+  /** Cached value of the formula cell at (col0, row0) on the first sheet, failing otherwise. */
+  private def cachedFormulaValue(wb: Workbook, col0: Int, row0: Int): Option[CellValue] =
+    wb.sheets.head.cells.get(ARef.from0(col0, row0)).map(_.value) match
+      case Some(CellValue.Formula(_, cached)) => cached
+      case other => fail(s"Expected Formula cell, got $other")
+
+  private def assertCachedNumber(cached: Option[CellValue], expected: Double): Unit =
+    cached match
+      case Some(CellValue.Number(n)) => assertEquals(n.toDouble, expected)
+      case other => fail(s"Expected cached Number($expected), got $other")
+
+  test("batch put+putf caches the formula value (GH-352 repro)") {
+    val wb = Workbook(Sheet("Data"))
+    val ops = writeOps("""[
+      {"op":"put","ref":"A1","value":5},
+      {"op":"putf","ref":"C1","value":"=A1*2"}
+    ]""")
+    val out = tempXlsx()
+
+    val result = WriteCommands
+      .batch(wb, Some(wb.sheets.head), ops.toString, out, config)
+      .unsafeRunSync()
+
+    assert(result.contains("Applied 2 operations"))
+    assert(result.contains("Recalculated 1 formula"))
+
+    assertCachedNumber(cachedFormulaValue(readBack(out), 2, 0), 10.0)
+    Files.deleteIfExists(out)
+    Files.deleteIfExists(ops)
+  }
+
+  test("batch putf and single-op putf converge on the same cached value") {
+    val wb = Workbook(Sheet("Data").put(ARef.from0(0, 0), CellValue.Number(BigDecimal(5))))
+
+    val singleOut = tempXlsx()
+    WriteCommands
+      .putFormula(wb, Some(wb.sheets.head), "C1", List("=A1*2"), singleOut, config)
+      .unsafeRunSync()
+
+    val batchOut = tempXlsx()
+    val ops = writeOps("""[{"op":"putf","ref":"C1","value":"=A1*2"}]""")
+    WriteCommands
+      .batch(wb, Some(wb.sheets.head), ops.toString, batchOut, config)
+      .unsafeRunSync()
+
+    val singleCached = cachedFormulaValue(readBack(singleOut), 2, 0)
+    val batchCached = cachedFormulaValue(readBack(batchOut), 2, 0)
+    assertCachedNumber(singleCached, 10.0)
+    assertEquals(batchCached, singleCached)
+    Files.deleteIfExists(singleOut)
+    Files.deleteIfExists(batchOut)
+    Files.deleteIfExists(ops)
+  }
+
+  test("batch with a formula error still writes and reports it in the summary") {
+    val wb = Workbook(Sheet("Data"))
+    val ops = writeOps("""[
+      {"op":"put","ref":"A1","value":5},
+      {"op":"putf","ref":"B1","value":"=B1+1"},
+      {"op":"putf","ref":"C1","value":"=A1*3"}
+    ]""")
+    val out = tempXlsx()
+
+    val result = WriteCommands
+      .batch(wb, Some(wb.sheets.head), ops.toString, out, config)
+      .unsafeRunSync()
+
+    // Write proceeded and the error is surfaced (count + ref), not thrown
+    assert(result.contains("Saved:"))
+    assert(result.contains("1 error"))
+    assert(result.contains("B1"))
+    assert(result.contains("Circular reference"))
+
+    val imported = readBack(out)
+    // The healthy formula still cached; the circular one stays uncached
+    assertCachedNumber(cachedFormulaValue(imported, 2, 0), 15.0)
+    assertEquals(cachedFormulaValue(imported, 1, 0), None)
+    Files.deleteIfExists(out)
+    Files.deleteIfExists(ops)
+  }
+
+  test("style-only batch does not recalculate (uncached formulas stay uncached)") {
+    val wb = Workbook(
+      Sheet("Data")
+        .put(ARef.from0(0, 0), CellValue.Number(BigDecimal(5)))
+        .put(ARef.from0(2, 0), CellValue.Formula("A1*2", None))
+    )
+    val ops = writeOps("""[{"op":"style","range":"A1","bold":true}]""")
+    val out = tempXlsx()
+
+    val result = WriteCommands
+      .batch(wb, Some(wb.sheets.head), ops.toString, out, config)
+      .unsafeRunSync()
+
+    assert(!result.contains("Recalculated"))
+    assertEquals(cachedFormulaValue(readBack(out), 2, 0), None)
+    Files.deleteIfExists(out)
+    Files.deleteIfExists(ops)
+  }
+
+  test("recalc command caches a previously-uncached workbook (disk round-trip)") {
+    // Round-trip through disk: workbooks read from a file carry a SourceContext whose
+    // ModificationTracker gates the surgical writer — recalculated caches must survive it
+    // (GH-352: recalculateImpl now reinstalls changed sheets via Workbook.put).
+    val staleFile = tempXlsx()
+    ExcelIO
+      .instance[IO]
+      .write(
+        Workbook(
+          Sheet("Data")
+            .put(ARef.from0(0, 0), CellValue.Number(BigDecimal(5)))
+            .put(ARef.from0(2, 0), CellValue.Formula("A1*2", None))
+        ),
+        staleFile
+      )
+      .unsafeRunSync()
+    val wb = readBack(staleFile)
+    assertEquals(cachedFormulaValue(wb, 2, 0), None) // starts uncached on disk
+
+    val out = tempXlsx()
+    val result = WriteCommands.recalc(wb, out, config).unsafeRunSync()
+
+    assert(result.contains("Recalculated 1 formula"))
+    assertCachedNumber(cachedFormulaValue(readBack(out), 2, 0), 10.0)
+    Files.deleteIfExists(staleFile)
+    Files.deleteIfExists(out)
+  }
+
+  test("batch refreshes cross-sheet dependent caches read from disk") {
+    // A batch edit on Data must refresh the cached value of an Other!A1 formula that
+    // depends on it — including through the surgical writer's preservation logic.
+    val srcFile = tempXlsx()
+    ExcelIO
+      .instance[IO]
+      .write(
+        Workbook(
+          Sheet("Data").put(ARef.from0(0, 0), CellValue.Number(BigDecimal(5))),
+          Sheet("Other").put(ARef.from0(0, 0), CellValue.Formula("Data!A1*10", None))
+        ),
+        srcFile
+      )
+      .unsafeRunSync()
+    val wb = readBack(srcFile)
+
+    val ops = writeOps("""[{"op":"put","ref":"Data!A1","value":7}]""")
+    val out = tempXlsx()
+    WriteCommands.batch(wb, wb.sheets.headOption, ops.toString, out, config).unsafeRunSync()
+
+    val imported = readBack(out)
+    val otherSheet = imported.sheets.find(_.name.value == "Other").getOrElse(fail("no Other"))
+    otherSheet.cells.get(ARef.from0(0, 0)).map(_.value) match
+      case Some(CellValue.Formula(_, Some(CellValue.Number(n)))) => assertEquals(n.toDouble, 70.0)
+      case other => fail(s"Expected cached cross-sheet formula, got $other")
+    Files.deleteIfExists(srcFile)
+    Files.deleteIfExists(out)
+    Files.deleteIfExists(ops)
+  }
+
+  test("recalc command reports formula errors without failing (exit stays clean)") {
+    val wb = Workbook(
+      Sheet("Data")
+        .put(ARef.from0(0, 0), CellValue.Formula("A1+1", None)) // self-circular
+        .put(ARef.from0(2, 0), CellValue.Formula("41+1", None))
+    )
+    val out = tempXlsx()
+
+    // Must not raise: formula errors are data conditions, not tool failures
+    val result = WriteCommands.recalc(wb, out, config).unsafeRunSync()
+
+    assert(result.contains("1 error"))
+    assert(result.contains("Circular reference"))
+    assert(result.contains("Saved:"))
+
+    val imported = readBack(out)
+    assertCachedNumber(cachedFormulaValue(imported, 2, 0), 42.0)
+    assertEquals(cachedFormulaValue(imported, 0, 0), None)
+    Files.deleteIfExists(out)
+  }

--- a/xl-cli/test/src/com/tjclp/xl/cli/BatchRecalcSpec.scala
+++ b/xl-cli/test/src/com/tjclp/xl/cli/BatchRecalcSpec.scala
@@ -38,6 +38,53 @@ class BatchRecalcSpec extends FunSuite:
   private def readBack(path: Path): Workbook =
     ExcelIO.instance[IO].read(path).unsafeRunSync()
 
+  /** Raw bytes of a zip entry (e.g. `xl/worksheets/sheet2.xml`) inside an xlsx package. */
+  private def zipEntryBytes(path: Path, entryName: String): Array[Byte] =
+    val zip = new java.util.zip.ZipFile(path.toFile)
+    try
+      Option(zip.getEntry(entryName)) match
+        case Some(entry) => zip.getInputStream(entry).readAllBytes()
+        case None => fail(s"missing $entryName in $path")
+    finally zip.close()
+
+  /**
+   * Marker comment that the writer never emits: it survives ONLY when the surgical writer copies
+   * the worksheet part verbatim, so its presence distinguishes byte-for-byte preservation from a
+   * (possibly byte-identical) regeneration.
+   */
+  private val preservationMarker = "<!--BatchRecalcSpec preservation marker-->"
+
+  /** Rewrite one zip entry in place, leaving every other entry untouched. */
+  private def rewriteZipEntry(path: Path, entryName: String)(
+    transform: Array[Byte] => Array[Byte]
+  ): Unit =
+    import java.util.zip.{ZipEntry, ZipFile, ZipOutputStream}
+    import scala.jdk.CollectionConverters.*
+    val tmp = Files.createTempFile("zip-edit", ".xlsx")
+    val zip = new ZipFile(path.toFile)
+    try
+      val out = new ZipOutputStream(Files.newOutputStream(tmp))
+      try
+        zip.entries().asScala.foreach { entry =>
+          val bytes = zip.getInputStream(entry).readAllBytes()
+          out.putNextEntry(new ZipEntry(entry.getName))
+          out.write(if entry.getName == entryName then transform(bytes) else bytes)
+          out.closeEntry()
+        }
+      finally out.close()
+    finally zip.close()
+    Files.move(tmp, path, java.nio.file.StandardCopyOption.REPLACE_EXISTING)
+
+  /** Inject the preservation marker just before `</worksheet>` in a worksheet part. */
+  private def injectPreservationMarker(path: Path, entryName: String): Unit =
+    rewriteZipEntry(path, entryName) { bytes =>
+      val xml = new String(bytes, StandardCharsets.UTF_8)
+      assert(xml.contains("</worksheet>"), s"unexpected worksheet XML in $entryName")
+      xml
+        .replace("</worksheet>", s"$preservationMarker</worksheet>")
+        .getBytes(StandardCharsets.UTF_8)
+    }
+
   /** Cached value of the formula cell at (col0, row0) on the first sheet, failing otherwise. */
   private def cachedFormulaValue(wb: Workbook, col0: Int, row0: Int): Option[CellValue] =
     wb.sheets.head.cells.get(ARef.from0(col0, row0)).map(_.value) match
@@ -120,11 +167,21 @@ class BatchRecalcSpec extends FunSuite:
   }
 
   test("style-only batch does not recalculate (uncached formulas stay uncached)") {
-    val wb = Workbook(
-      Sheet("Data")
-        .put(ARef.from0(0, 0), CellValue.Number(BigDecimal(5)))
-        .put(ARef.from0(2, 0), CellValue.Formula("A1*2", None))
-    )
+    // Disk round-trip so the no-recalc path is pinned against the SourceContext /
+    // ModificationTracker seam, not just the in-memory workbook.
+    val srcFile = tempXlsx()
+    ExcelIO
+      .instance[IO]
+      .write(
+        Workbook(
+          Sheet("Data")
+            .put(ARef.from0(0, 0), CellValue.Number(BigDecimal(5)))
+            .put(ARef.from0(2, 0), CellValue.Formula("A1*2", None))
+        ),
+        srcFile
+      )
+      .unsafeRunSync()
+    val wb = readBack(srcFile)
     val ops = writeOps("""[{"op":"style","range":"A1","bold":true}]""")
     val out = tempXlsx()
 
@@ -134,6 +191,110 @@ class BatchRecalcSpec extends FunSuite:
 
     assert(!result.contains("Recalculated"))
     assertEquals(cachedFormulaValue(readBack(out), 2, 0), None)
+    Files.deleteIfExists(srcFile)
+    Files.deleteIfExists(out)
+    Files.deleteIfExists(ops)
+  }
+
+  test("styles-only clear does not recalculate (values untouched, presentation-only path)") {
+    // BatchParser.applyClear only clears contents when `all || (!styles && !comments)`;
+    // a styles-only clear must classify as non-mutating and skip the recalculation.
+    val wb = Workbook(
+      Sheet("Data")
+        .put(ARef.from0(0, 0), CellValue.Number(BigDecimal(5)))
+        .put(ARef.from0(2, 0), CellValue.Formula("A1*2", None))
+    )
+    val ops = writeOps("""[{"op":"clear","range":"A1","styles":true}]""")
+    val out = tempXlsx()
+
+    val result = WriteCommands
+      .batch(wb, Some(wb.sheets.head), ops.toString, out, config)
+      .unsafeRunSync()
+
+    assert(!result.contains("Recalculated"))
+    val imported = readBack(out)
+    // The cleared-styles cell keeps its value; the formula stays uncached
+    assertEquals(
+      imported.sheets.head.cells.get(ARef.from0(0, 0)).map(_.value),
+      Some(CellValue.Number(BigDecimal(5)))
+    )
+    assertEquals(cachedFormulaValue(imported, 2, 0), None)
+    Files.deleteIfExists(out)
+    Files.deleteIfExists(ops)
+  }
+
+  test("contents clear still recalculates (default clear mutates cell values)") {
+    val wb = Workbook(
+      Sheet("Data")
+        .put(ARef.from0(0, 0), CellValue.Number(BigDecimal(5)))
+        .put(ARef.from0(2, 0), CellValue.Formula("A1*2", None))
+    )
+    val ops = writeOps("""[{"op":"clear","range":"A1"}]""")
+    val out = tempXlsx()
+
+    val result = WriteCommands
+      .batch(wb, Some(wb.sheets.head), ops.toString, out, config)
+      .unsafeRunSync()
+
+    assert(result.contains("Recalculated"))
+    Files.deleteIfExists(out)
+    Files.deleteIfExists(ops)
+  }
+
+  test("mutating batch preserves untouched formula-bearing sheets byte-for-byte") {
+    // Regression pin for the GH-352 over-marking hazard: a batch edit on Inputs recalculates
+    // the whole workbook, but Report's formula recomputes to the value it already cached, so
+    // Report must NOT be marked modified — the surgical writer then preserves its worksheet
+    // XML verbatim (which is also what keeps unparsed parts like pivot tables alive).
+    val srcFile = tempXlsx()
+    ExcelIO
+      .instance[IO]
+      .write(
+        Workbook(
+          Sheet("Inputs").put(ARef.from0(0, 0), CellValue.Number(BigDecimal(5))),
+          Sheet("Report")
+            .put(ARef.from0(0, 0), CellValue.Number(BigDecimal(3)))
+            .put(
+              ARef.from0(1, 0),
+              CellValue.Formula("A1*2", Some(CellValue.Number(BigDecimal(6))))
+            )
+        ),
+        srcFile
+      )
+      .unsafeRunSync()
+    // Stand-in for content our writer can't regenerate (pivot tables, slicers, ...): it
+    // survives only if Report is never marked modified and rides the verbatim copy path.
+    injectPreservationMarker(srcFile, "xl/worksheets/sheet2.xml")
+    val wb = readBack(srcFile)
+
+    // Edit Inputs!A1; no Report formula depends on it, so Report's caches are already correct
+    val ops = writeOps("""[{"op":"put","ref":"Inputs!A1","value":7}]""")
+    val out = tempXlsx()
+    val result = WriteCommands
+      .batch(wb, wb.sheets.headOption, ops.toString, out, config)
+      .unsafeRunSync()
+    assert(result.contains("Recalculated"))
+
+    // Report (sheet2.xml) rides byte-for-byte preservation; the Inputs edit still lands
+    assertEquals(
+      zipEntryBytes(out, "xl/worksheets/sheet2.xml").toSeq,
+      zipEntryBytes(srcFile, "xl/worksheets/sheet2.xml").toSeq
+    )
+    assert(
+      new String(zipEntryBytes(out, "xl/worksheets/sheet2.xml"), StandardCharsets.UTF_8)
+        .contains(preservationMarker),
+      "Report worksheet was regenerated: preservation marker lost"
+    )
+    val imported = readBack(out)
+    assertEquals(
+      imported.sheets.head.cells.get(ARef.from0(0, 0)).map(_.value),
+      Some(CellValue.Number(BigDecimal(7)))
+    )
+    val report = imported.sheets.find(_.name.value == "Report").getOrElse(fail("no Report"))
+    report.cells.get(ARef.from0(1, 0)).map(_.value) match
+      case Some(CellValue.Formula(_, Some(CellValue.Number(n)))) => assertEquals(n.toDouble, 6.0)
+      case other => fail(s"Expected cached Report formula, got $other")
+    Files.deleteIfExists(srcFile)
     Files.deleteIfExists(out)
     Files.deleteIfExists(ops)
   }
@@ -163,6 +324,44 @@ class BatchRecalcSpec extends FunSuite:
     assert(result.contains("Recalculated 1 formula"))
     assertCachedNumber(cachedFormulaValue(readBack(out), 2, 0), 10.0)
     Files.deleteIfExists(staleFile)
+    Files.deleteIfExists(out)
+  }
+
+  test("recalc on an already-fresh workbook preserves worksheet XML byte-for-byte") {
+    // Every recomputed value equals its existing cache, so no sheet may be marked modified
+    // and the surgical writer must copy the worksheet part verbatim.
+    val srcFile = tempXlsx()
+    ExcelIO
+      .instance[IO]
+      .write(
+        Workbook(
+          Sheet("Data")
+            .put(ARef.from0(0, 0), CellValue.Number(BigDecimal(5)))
+            .put(
+              ARef.from0(2, 0),
+              CellValue.Formula("A1*2", Some(CellValue.Number(BigDecimal(10))))
+            )
+        ),
+        srcFile
+      )
+      .unsafeRunSync()
+    injectPreservationMarker(srcFile, "xl/worksheets/sheet1.xml")
+    val wb = readBack(srcFile)
+
+    val out = tempXlsx()
+    val result = WriteCommands.recalc(wb, out, config).unsafeRunSync()
+
+    assert(result.contains("Recalculated 1 formula"))
+    assertEquals(
+      zipEntryBytes(out, "xl/worksheets/sheet1.xml").toSeq,
+      zipEntryBytes(srcFile, "xl/worksheets/sheet1.xml").toSeq
+    )
+    assert(
+      new String(zipEntryBytes(out, "xl/worksheets/sheet1.xml"), StandardCharsets.UTF_8)
+        .contains(preservationMarker),
+      "worksheet was regenerated despite fresh caches: preservation marker lost"
+    )
+    Files.deleteIfExists(srcFile)
     Files.deleteIfExists(out)
   }
 

--- a/xl-evaluator/src/com/tjclp/xl/formula/eval/WorkbookEvaluator.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/eval/WorkbookEvaluator.scala
@@ -270,24 +270,30 @@ object WorkbookEvaluator:
         }
 
         // Cache computed values into formula cells on the original sheets; failed cells stay
-        // uncached (Excel recalculates them on open)
-        val cachedSheets = wb.sheets.map { orig =>
-          evaluated.getOrElse(orig.name, Map.empty).foldLeft(orig) { case (s, (ref, computed)) =>
-            s.cells.get(ref).map(_.value) match
-              case Some(CellValue.Formula(expr, _)) =>
-                s.put(ref, CellValue.Formula(expr, Some(computed)))
-              case _ => s
+        // uncached (Excel recalculates them on open). Track per sheet whether any recomputed
+        // value actually differs from the pre-existing cache (a newly cached cell — prior
+        // cache None — counts as a change).
+        val cachedSheets: Vector[(Sheet, Boolean)] = wb.sheets.map { orig =>
+          evaluated.getOrElse(orig.name, Map.empty).foldLeft((orig, false)) {
+            case ((s, changed), (ref, computed)) =>
+              s.cells.get(ref).map(_.value) match
+                case Some(CellValue.Formula(expr, cached)) if !cached.contains(computed) =>
+                  (s.put(ref, CellValue.Formula(expr, Some(computed))), true)
+                case _ => (s, changed)
           }
         }
 
         // Reinstall changed sheets via Workbook.put — not copy — so the surgical-write
-        // ModificationTracker sees every sheet whose caches were refreshed (GH-352). A raw
+        // ModificationTracker sees every sheet whose caches actually changed (GH-352). A raw
         // copy leaves disk-read workbooks looking untouched, and the writer then preserves
         // the original worksheet XML verbatim, silently dropping the new cached values.
-        // Sheets with no evaluated cells are left alone to keep byte-for-byte preservation.
+        // Sheets whose recomputed caches all equal the existing ones are left alone: putting
+        // them would mark them modified, forcing the writer to regenerate their XML and drop
+        // any unparsed parts (pivot tables, slicers, ctrlProps) that can only survive via
+        // byte-for-byte preservation.
         val workbookWithCaches =
-          cachedSheets.foldLeft(wb) { (acc, cached) =>
-            if evaluated.getOrElse(cached.name, Map.empty).nonEmpty then acc.put(cached) else acc
+          cachedSheets.foldLeft(wb) { case (acc, (cached, changed)) =>
+            if changed then acc.put(cached) else acc
           }
 
         RecalcResult(

--- a/xl-evaluator/src/com/tjclp/xl/formula/eval/WorkbookEvaluator.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/eval/WorkbookEvaluator.scala
@@ -280,8 +280,18 @@ object WorkbookEvaluator:
           }
         }
 
+        // Reinstall changed sheets via Workbook.put — not copy — so the surgical-write
+        // ModificationTracker sees every sheet whose caches were refreshed (GH-352). A raw
+        // copy leaves disk-read workbooks looking untouched, and the writer then preserves
+        // the original worksheet XML verbatim, silently dropping the new cached values.
+        // Sheets with no evaluated cells are left alone to keep byte-for-byte preservation.
+        val workbookWithCaches =
+          cachedSheets.foldLeft(wb) { (acc, cached) =>
+            if evaluated.getOrElse(cached.name, Map.empty).nonEmpty then acc.put(cached) else acc
+          }
+
         RecalcResult(
-          workbook = wb.copy(sheets = cachedSheets),
+          workbook = workbookWithCaches,
           evaluated = wb.sheets.map(s => s.name -> evaluated.getOrElse(s.name, Map.empty)).toMap,
           errors = cycleErrors ++ blockedErrors ++ evalErrors
         )


### PR DESCRIPTION
## Summary

Formulas written through `batch` carried no cached `<v>` — `BatchParser.applyPutFormula` stores `CellValue.Formula(expr, None)` and `WriteCommands.batch` went parse → apply → write with no recalculation, while single-op `putf` caches via `recalculateDependents`. Anything reading cached values (openpyxl `data_only=True`, pandas, previewers, Excel before a recalc) showed blanks.

Post-0.12.5 a whole-workbook `recalculate()` is one cheap memoized Kahn pass, so `batch` now ends with exactly one.

## What changed

- **`WriteCommands.batch`** runs one global `recalculate()` before writing whenever the op list contains any cell-mutating op (`put`/`putf`/putf-dragging/`putfs`/put-values/`clear`/`copy`). Presentation-only batches (style, comments, widths, visibility, merges, freeze, sheet management, hyperlinks) skip it — those ops leave every existing cached value correct, preserving byte-for-byte part passthrough. Formula errors do **not** abort the write: the workbook is written regardless and the summary reports them, e.g. `Recalculated 3 formulas; 1 error (Data!B1: Formula error in 'B1+1': Circular reference)` (count + first 3 refs). `BatchParser` stays pure; the recalc lives at the command seam.
- **Root-cause evaluator fix** (`WorkbookEvaluator.recalculateImpl`): the result workbook was rebuilt via `wb.copy(sheets = ...)`, bypassing `Workbook.put` and therefore the surgical-write `ModificationTracker`. For workbooks read from disk, the writer preserved the original worksheet XML verbatim and silently dropped every refreshed cache — `xl recalc` would have been a no-op on real files, and cross-sheet dependents of a batch edit kept stale `<v>` values. Changed sheets are now reinstalled via `Workbook.put` (only those with ≥1 evaluated cell), matching what `recalculateDependents` already did.
- **New `xl recalc` command**: reads `-f`, runs one global recalculation, writes via `-o`/`-i`, prints the same summary line. Its `--help` documents that formula errors are data conditions, not tool failures — the file is still written and the exit code stays 0.

## Verification

- 7 new tests in `xl-cli/test/.../BatchRecalcSpec.scala`: batch put+putf caches the formula value (issue repro); batch putf and single-op putf converge on the same cached value; a batch with a circular reference still writes and reports the error; a style-only batch does not recalculate (uncached stays uncached); `recalc` caches a previously-uncached workbook **through a disk round-trip** (this is what exposed the tracker bug); batch refreshes cross-sheet dependent caches read from disk; `recalc` reports errors without raising.
- Suites: `xl-cli.test` 343/343, `xl-evaluator.test` 188/188, `xl-ooxml.test` 239/239; `__.compile` clean under WartRemover; scalafmt clean.
- End-to-end through the compiled CLI: the issue's exact repro now writes `<c r="C1" t="n"><f>A1*2</f><v>10.0</v></c>`; `xl recalc` freshens a `<v>`-stripped file; a circular-ref batch prints the error summary and still saves; streaming batch (`--stream`, the O(1) ZIP-transform path) is unaffected and still works.

Fixes #352

🤖 Generated with [Claude Code](https://claude.com/claude-code)