### PR TITLE
chore(release): Bump version to 0.12.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,68 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.6] "Fieldwork" - 2026-07-15
+
+Production-feedback hardening from agent-fleet use on real deal workbooks
+(#349–#354, PRs #363–#368): external-workbook references parse and keep their
+Excel caches, batch writes recalculate, output truncation is visible,
+DOCTYPE-bearing workbooks read, the native binary reports real parse errors,
+and linux-arm64 binaries ship.
+
+### Added
+
+- **`xl recalc` command** (#352): recalculate any workbook from the CLI
+  (`xl -f model.xlsx -i recalc`), reporting per-cell formula errors without
+  failing the write.
+- **Truncation reporting** (#351): `view`/`search` now say when `--limit`
+  (default 50) clips output — a `… showing N of M rows` trailer in markdown,
+  a stderr notice for csv (stdout stays machine-parseable), and
+  `truncated`/`totalRows` fields in json; `--limit 0` means unlimited, and
+  `search` reports its true match total.
+- **linux-arm64 native binaries** (#354): the release matrix builds on
+  `ubuntu-24.04-arm` with arch-safe cache keys and a per-platform binary smoke
+  test; the generated installer maps `Linux-aarch64` and fails loud when an
+  asset is missing instead of installing an error page.
+
+### Fixed
+
+- **External-workbook references parse and pin their Excel caches** (#353):
+  `[2]Book1!A1` / `'[3]Sheet Name'!B2` forms parse to a dedicated AST node
+  with exact printer round-trip and anchor-aware shifting; they contribute no
+  dependency edges, `recalculate()` preserves the Excel-written cached value
+  of external-formula cells verbatim (dependents compute from those caches),
+  uncached external cells report a clear per-cell error instead of
+  `UnexpectedChar([`, and one such formula no longer poisons evaluation of
+  the rest of the workbook. Resolving external workbooks / reading
+  `externalLinks` cache parts remains future work.
+- **Batch writes recalculate** (#352): cell-mutating `batch` runs end with one
+  global recalculation, so `putf` cells carry cached `<v>` values (previously
+  blank in `data_only` readers, pandas, and previewers); formula errors are
+  surfaced in the batch summary without aborting the write. Also fixes a
+  latent core bug: recalculated caches now survive surgical writes of
+  disk-read workbooks (the modification tracker never saw cache-only changes,
+  so the writer preserved stale worksheet XML verbatim); sheets whose caches
+  are unchanged still ride byte-for-byte preservation.
+- **Benign leading DOCTYPE no longer rejects core parts** (#350): a
+  `<!DOCTYPE …>` prolog (with or without an internal subset) on
+  workbook/sheet/styles/sharedStrings parts is stripped by a conservative
+  scanner before parsing — the parser itself stays fully locked down
+  (doctype disallowed, external entities off) — and core-part parse errors
+  now carry line/column plus the offending construct. A hostile-but-valid
+  fixture joins the corpus laws.
+- **Native-image parse diagnostics** (#349): the JDK-internal Xerces/Xalan
+  message bundles are registered for native-image, so the shipped binary
+  reports real parse errors (line/column and reason) instead of
+  `Could not load any resource bundle by …XMLMessages`; the release workflow
+  now smoke-tests every native binary against a valid and a malformed
+  workbook.
+
+### Docs
+
+- **Skill field-gotchas refresh** (#362): production-verified gotchas,
+  warning triage, and 0.12.5 recalculation notes in the `xl-cli` and
+  `xl-scripting` skills (updated again in this release for the fixes above).
+
 ## [0.12.5] "Memo" - 2026-07-13
 
 Kills an exponential blowup in the formula evaluator on recursive multi-branch

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ```scala 3 raw
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.5
+//> using dep com.tjclp::xl:0.12.6
 
 import com.tjclp.xl.{*, given}
 
@@ -55,13 +55,13 @@ import com.tjclp.xl.{*, given}
 
 ```scala 3 ignore
 // build.mill — single dependency for everything
-def ivyDeps = Agg(ivy"com.tjclp::xl:0.12.5")
+def ivyDeps = Agg(ivy"com.tjclp::xl:0.12.6")
 
 // Or individual modules for minimal footprint:
-// ivy"com.tjclp::xl-core:0.12.5"        — Pure domain model only
-// ivy"com.tjclp::xl-ooxml:0.12.5"       — Add OOXML read/write
-// ivy"com.tjclp::xl-cats-effect:0.12.5" — Add IO streaming
-// ivy"com.tjclp::xl-evaluator:0.12.5"   — Add formula evaluation
+// ivy"com.tjclp::xl-core:0.12.6"        — Pure domain model only
+// ivy"com.tjclp::xl-ooxml:0.12.6"       — Add OOXML read/write
+// ivy"com.tjclp::xl-cats-effect:0.12.6" — Add IO streaming
+// ivy"com.tjclp::xl-evaluator:0.12.6"   — Add formula evaluation
 ```
 
 ### Basic Usage

--- a/build.mill
+++ b/build.mill
@@ -14,7 +14,7 @@ val organization = "com.tjclp"
 /** Shared build configuration constants */
 object BuildConfig {
   /** Project version: CI sets PUBLISH_VERSION; local builds use this fallback */
-  val version: String = sys.env.getOrElse("PUBLISH_VERSION", "0.12.5")
+  val version: String = sys.env.getOrElse("PUBLISH_VERSION", "0.12.6")
 
   /** JVM options to silence Scala 3 LazyVals sun.misc.Unsafe deprecation warnings (JDK 21+) */
   val lazyValsJvmArgs: Seq[String] = Seq(

--- a/docs/QUICK-START.md
+++ b/docs/QUICK-START.md
@@ -12,19 +12,19 @@ import mill._, scalalib._
 
 object myproject extends ScalaModule {
   def scalaVersion = "3.8.3"
-  def ivyDeps = Agg(ivy"com.tjclp::xl:0.12.5")
+  def ivyDeps = Agg(ivy"com.tjclp::xl:0.12.6")
 }
 ```
 
 ### With sbt (build.sbt)
 ```scala
 scalaVersion := "3.8.3"
-libraryDependencies += "com.tjclp" %% "xl" % "0.12.5"
+libraryDependencies += "com.tjclp" %% "xl" % "0.12.6"
 ```
 
 ### With Scala CLI
 ```scala
-//> using dep com.tjclp::xl:0.12.5
+//> using dep com.tjclp::xl:0.12.6
 ```
 
 ### Individual Modules (Optional)
@@ -44,7 +44,7 @@ For scripts, skip the build setup entirely: a two-line `scala-cli` header and ON
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.5
+//> using dep com.tjclp::xl:0.12.6
 
 import com.tjclp.xl.scripting.{*, given}
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,12 +1,19 @@
 # XL Project Status
 
-**Last Updated**: 2026-07-13 (0.12.5)
+**Last Updated**: 2026-07-15 (0.12.6)
 
 ## Current State
 
 > **For detailed phase completion status and roadmap, see [plan/roadmap.md](plan/roadmap.md)**
 
 ### What Works (Production-Ready)
+
+**New in 0.12.6** (2026-07-15):
+- ✅ **External-workbook references** (#353) — `[2]Book1!A1` forms parse (dedicated AST node, exact printer round-trip, anchor-aware shifting), contribute no dependency edges, and `recalculate()` pins their Excel-written caches verbatim while dependents compute from them; uncached external cells report a clear per-cell error instead of `UnexpectedChar([`
+- ✅ **Batch recalculation + `xl recalc`** (#352) — cell-mutating batches end with one global recalculation (cached `<v>` for `putf` cells, errors surfaced in the summary), plus a latent fix: recalculated caches survive surgical writes of disk-read workbooks
+- ✅ **Visible truncation** (#351) — `view`/`search` report `showing N of M rows` when `--limit` clips (markdown trailer, stderr for csv, `truncated`/`totalRows` in json); `--limit 0` = unlimited
+- ✅ **DOCTYPE-tolerant core-part reads** (#350) — benign `<!DOCTYPE>` prologs stripped by a conservative scanner (parser stays locked down); parse errors carry line/column
+- ✅ **Native-image diagnostics + arm64** (#349, #354) — Xerces message bundles registered (real parse errors on the shipped binary, release smoke test per platform); linux-arm64 native binaries join the release matrix
 
 **New in 0.12.5** (2026-07-13):
 - ✅ **Evaluator memoization + workbook-level recalculation** (#346) — recursive uncached-reference evaluation is memoized per pass, and `recalculate()` runs one topological order over the qualified (sheet!cell) graph: the recursive debt-schedule shape drops from hours (exponential in dependency paths) to milliseconds; cross-sheet cycles now report circular/blocked like same-sheet ones; cross-sheet aggregates over uncached formula cells compute correctly regardless of sheet order

--- a/docs/plan/roadmap.md
+++ b/docs/plan/roadmap.md
@@ -10,9 +10,9 @@
 
 ## TL;DR
 
-**Current Status**: Production-ready with **107 formula functions** (incl. dynamic arrays SEQUENCE/SORT/UNIQUE/FILTER and OFFSET), **structural editing** (insert/delete rows & columns with formula rewriting), the **scripting prelude** (`com.tjclp.xl.scripting`), whole-workbook `recalculate`, named-range & hyperlink authoring, **typed charts + embedded pictures** (0.12.0), **conditional formatting** (0.12.1), SAX streaming (36% faster than POI), Excel tables, and full OOXML round-trip. 4,000 tests passing.
+**Current Status**: Production-ready with **107 formula functions** (incl. dynamic arrays SEQUENCE/SORT/UNIQUE/FILTER and OFFSET), **structural editing** (insert/delete rows & columns with formula rewriting), the **scripting prelude** (`com.tjclp.xl.scripting`), whole-workbook `recalculate`, named-range & hyperlink authoring, **typed charts + embedded pictures** (0.12.0), **conditional formatting** (0.12.1), SAX streaming (36% faster than POI), Excel tables, and full OOXML round-trip. 4,085 tests passing.
 
-**Current Version**: **0.12.5 "Memo"** (released 2026-07-13)
+**Current Version**: **0.12.6 "Fieldwork"** (released 2026-07-15)
 
 ---
 
@@ -60,6 +60,10 @@ Phased: (a) verbatim chart/drawing preservation proven by the wave-2 fixture cor
 ### v0.12.1 "Clean Sweep" — wave 7 (Released 2026-06-11)
 
 Every remaining open issue closed in one wave. **Conditional formatting** ([#136](https://github.com/TJC-LP/xl/issues/136)) is the headline — typed cellIs/expression/colorScale/dataBar/top10/text rules + `dxf` differential formats, `sheet.conditionalFormat` authoring with auto-priority, structural-edit range shifting, unmodeled families preserved byte-faithfully — alongside twelve fidelity/writer fixes: openpyxl comment subdirectory dialect (#292), RichText SST keying (#303), exact surgical SST counts (#304), `[Content_Types]` preservation (#314), identity-keyed source mappings (#315), activeTab (#294), fitToPage tri-state (#284), `Cell.comment` deprecated→`Sheet.comments` (#295). Codec `put` paths 2.4x faster (#297).
+
+### v0.12.6 "Fieldwork" (Released 2026-07-15)
+
+Field-reported bugs from production agent use on real deal workbooks ([#349](https://github.com/TJC-LP/xl/issues/349)–[#354](https://github.com/TJC-LP/xl/issues/354), PRs #363–#368, each adversarially reviewed): external-workbook reference parsing with Excel-cache pinning ([#353](https://github.com/TJC-LP/xl/issues/353)), batch recalculation + the `xl recalc` command incl. a latent recalc-cache/surgical-write fix ([#352](https://github.com/TJC-LP/xl/issues/352)), visible `view`/`search` truncation ([#351](https://github.com/TJC-LP/xl/issues/351)), DOCTYPE-tolerant core-part reads with line/column diagnostics ([#350](https://github.com/TJC-LP/xl/issues/350)), native-image Xerces message bundles + per-platform release smoke tests ([#349](https://github.com/TJC-LP/xl/issues/349)), and linux-arm64 native binaries ([#354](https://github.com/TJC-LP/xl/issues/354)). Companion skill-docs refresh (#362). Enhancement backlog from the same field triage: #355–#361.
 
 ### v0.12.5 "Memo" (Released 2026-07-13)
 

--- a/docs/reference/scripting.md
+++ b/docs/reference/scripting.md
@@ -33,7 +33,7 @@ release bump is a mechanical substitution):
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.5
+//> using dep com.tjclp::xl:0.12.6
 import com.tjclp.xl.scripting.{*, given}
 
 val sheet = Sheet("Demo").put(ref"A1", "Hello").put(ref"B1", 42)
@@ -51,7 +51,7 @@ read and write is pure values.
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.5
+//> using dep com.tjclp::xl:0.12.6
 import com.tjclp.xl.scripting.{*, given}
 
 val wb = Excel.read("input.xlsx")
@@ -135,7 +135,7 @@ throw — they are collected per cell.
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.5
+//> using dep com.tjclp::xl:0.12.6
 import com.tjclp.xl.scripting.{*, given}
 
 val title = CellStyle.default.bold.size(14.0).center
@@ -246,7 +246,7 @@ them explicitly:
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.5
+//> using dep com.tjclp::xl:0.12.6
 import com.tjclp.xl.scripting.{*, given}
 import com.tjclp.xl.sheets.{HeaderFooter, PageMargins, PageSetup, SheetView}
 
@@ -300,7 +300,7 @@ the whole workbook:
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.5
+//> using dep com.tjclp::xl:0.12.6
 import com.tjclp.xl.scripting.{*, given}
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global

--- a/docs/reference/testing-guide.md
+++ b/docs/reference/testing-guide.md
@@ -1,6 +1,6 @@
 # Testing & Laws — Property Suites, Round-Trips, and Coverage
 
-**Current Status**: CI runs the full Mill test graph across the library, evaluator, CLI, and support modules — **4,000 tests** as of 0.12.5. Use `./mill __.test` as the authoritative count.
+**Current Status**: CI runs the full Mill test graph across the library, evaluator, CLI, and support modules — **4,085 tests** as of 0.12.6. Use `./mill __.test` as the authoritative count.
 
 ## Test Infrastructure
 
@@ -211,18 +211,18 @@ GitHub Actions runs:
 
 ## Test Counts by Module
 
-As of 0.12.5 (per-module `./mill <module>.test`; macros are part of xl-core — there is no separate xl-macros module):
+As of 0.12.6 (per-module `./mill <module>.test`; macros are part of xl-core — there is no separate xl-macros module):
 
 | Module | Tests |
 |--------|-------|
-| xl-evaluator | 1575 |
+| xl-evaluator | 1599 |
 | xl-core | 1104 |
-| xl-ooxml | 684 |
-| xl-cli | 406 |
-| xl-cats-effect | 110 |
+| xl-ooxml | 702 |
+| xl-cli | 448 |
+| xl-cats-effect | 111 |
 | xl-agent | 102 |
 | xl (prelude probes, `xlprelude.ScriptingPreludeTest`) | 19 |
-| **Total** | **4,000** |
+| **Total** | **4,085** |
 
 ## Test Quality Metrics
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -170,7 +170,7 @@ chmod +x examples/my_example.sc
 ./examples/my_example.sc
 ```
 
-The `project.scala` file centralizes dependencies (`com.tjclp::xl:0.12.5`) for all examples.
+The `project.scala` file centralizes dependencies (`com.tjclp::xl:0.12.6`) for all examples.
 
 ## Scripting Prelude & Skill
 

--- a/examples/project.scala
+++ b/examples/project.scala
@@ -2,4 +2,4 @@
 //> using repository ivy2Local
 
 // XL aggregate - includes all modules (core, ooxml, cats-effect, evaluator)
-//> using dep com.tjclp::xl:0.12.5
+//> using dep com.tjclp::xl:0.12.6

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "xl",
   "description": "LLM-friendly Excel tooling: the xl CLI for reading, writing, styling, and analyzing spreadsheets (xl-cli skill), plus type-safe Scala scripting against the xl library via scala-cli for bulk transformations, pipelines, and formula models (xl-scripting skill).",
-  "version": "0.12.5",
+  "version": "0.12.6",
   "author": {
     "name": "TJC L.P.",
     "url": "https://github.com/TJC-LP"

--- a/plugin/skills/xl-cli/SKILL.md
+++ b/plugin/skills/xl-cli/SKILL.md
@@ -19,9 +19,9 @@ LATEST=$(curl -s "https://api.github.com/repos/$REPO/releases/latest" | grep '"t
 VERSION=${LATEST#v}
 case "$(uname -s)-$(uname -m)" in
   Linux-x86_64)  BINARY="xl-$VERSION-linux-amd64" ;;
-  # linux-arm64 native binaries are not published yet (xl#354) — on aarch64 Linux use
-  # the JAR distribution (xl-$VERSION-cli.tar.gz, needs a JRE) instead.
-  Linux-aarch64) echo "No linux-arm64 binary published (see TJC-LP/xl#354); use xl-$VERSION-cli.tar.gz" && exit 1 ;;
+  # linux-arm64 binaries ship from v0.12.6 (xl#354); on older releases the curl below
+  # fails loud — fall back to the JAR distribution (xl-$VERSION-cli.tar.gz, needs a JRE).
+  Linux-aarch64) BINARY="xl-$VERSION-linux-arm64" ;;
   Darwin-x86_64) BINARY="xl-$VERSION-darwin-amd64" ;;
   Darwin-arm64)  BINARY="xl-$VERSION-darwin-arm64" ;;
   *) echo "Unsupported: $(uname -s)-$(uname -m)" && exit 1 ;;
@@ -89,7 +89,7 @@ xl -f <file> -s <sheet> view <range> --formulas   # Show formulas
 xl -f <file> -s <sheet> view <range> --eval       # Computed values
 ```
 
-**Note**: since 0.12.5, `--eval` computes deep multi-hop cross-sheet chains in one pass (global dependency order with memoization). The remaining exception: formulas whose precedents include **external-workbook references** (`[2]Book!A1`) fail to evaluate ([#353](https://github.com/TJC-LP/xl/issues/353)) — read those cells' cached values with a plain `view` instead.
+**Note**: since 0.12.5, `--eval` computes deep multi-hop cross-sheet chains in one pass (global dependency order with memoization). Since 0.12.6, formulas containing **external-workbook references** (`[2]Book!A1`) evaluate from their Excel-written cached values ([#353](https://github.com/TJC-LP/xl/issues/353)); on ≤0.12.5 they fail with `UnexpectedChar([` — read those cells with a plain `view` there.
 
 ### Write Operations (require `-o` or `-i`)
 ```bash
@@ -553,25 +553,25 @@ xl -f huge.xlsx --max-size 500 cell A1    # Custom 500MB limit
 
 ## Field Gotchas (verified in production)
 
-Hard-won rules from fleet use on real deal workbooks. Issue links track the underlying fixes; until they land, treat these as law.
+Hard-won rules from fleet use on real deal workbooks. Items marked **fixed in 0.12.6** still apply when the installed binary is older — check `xl --version`.
 
 **Reading**
-- **`view` and `search` clip at `--limit` (default 50) with no truncation marker** ([#351](https://github.com/TJC-LP/xl/issues/351)). A `view A1:A259` returning ~50 rows is NOT the whole range — pass `--limit <n>` explicitly, or chunk long scans into ≤45-row windows and verify the last row you expected is present.
+- **`view` and `search` clip at `--limit` (default 50)** ([#351](https://github.com/TJC-LP/xl/issues/351)). Since 0.12.6 the clip is visible (`… showing N of M rows` trailer; stderr notice for csv; `truncated`/`totalRows` in json; `--limit 0` = unlimited). **On ≤0.12.5 the clip is SILENT** — a `view A1:A259` returning ~50 rows is NOT the whole range; pass `--limit <n>` explicitly and verify the last expected row is present.
 - **Use `--show-labels` whenever row numbers matter** in CSV output — hidden rows shift positional counting silently.
 - **`--formulas --format json` replaces `value` with the formula text** and emits no separate `formula` key ([#357](https://github.com/TJC-LP/xl/issues/357)). To scan formulas programmatically, use `--format csv --formulas --show-labels` and parse with a CSV reader.
-- **`eval` fails on formulas whose precedents include external-workbook refs** (`[2]Book!A1` → `Parse error: UnexpectedChar([`, [#353](https://github.com/TJC-LP/xl/issues/353)) and on **percent literals** (`=A1*10%`, [#355](https://github.com/TJC-LP/xl/issues/355) — write `/100` instead). For external-link workbooks, compute from cached values (plain `view`).
+- **Percent literals fail to evaluate** (`=A1*10%`, [#355](https://github.com/TJC-LP/xl/issues/355)) — write `/100` instead. External-workbook refs are **fixed in 0.12.6** (evaluate from Excel-written caches; uncached external cells report a clear per-cell error); on ≤0.12.5 any formula whose precedents include one dies with `UnexpectedChar([` — use plain `view` there.
 
 **Writing**
-- **`batch` writes formulas with no cached values** — `data_only` readers, pandas, and previewers show blanks for every `putf` cell ([#352](https://github.com/TJC-LP/xl/issues/352)). Until fixed: prefer single `putf` commands (they recalculate dependents), verify with `--eval`, or recalculate via the scripting API before shipping.
+- **`batch` recalculates at the end since 0.12.6** ([#352](https://github.com/TJC-LP/xl/issues/352)): `putf` cells carry cached values and formula errors appear in the batch summary; `xl recalc` (also 0.12.6+) refreshes any workbook. **On ≤0.12.5 batch writes formulas with NO cached values** — `data_only` readers, pandas, and previewers show blanks for every `putf` cell; prefer single `putf` commands there, verify with `--eval`, or recalculate via the scripting API before shipping.
 - **Batch `putf` has no `format` field** ([#356](https://github.com/TJC-LP/xl/issues/356)) — number formats on formula cells need a follow-up `style` op / `xl style RANGE --format '…'`.
 - **Batch JSON style keys are camelCase**: `numFormat`, `borderTop`, `borderBottom`, `borderLeft`, `borderRight`, `borderColor`. Kebab-case (`border-top`) is treated as an unknown property — the warning goes to stderr only, so it is easy to miss.
-- **Build cross-sheet models in dependency order** (put referenced cells before the formulas that use them) — batches evaluate nothing, and single-command recalcs are dependents-only.
+- **Build cross-sheet models in dependency order** (put referenced cells before the formulas that use them) — on ≤0.12.5 batches evaluate nothing and single-command recalcs are dependents-only; on 0.12.6+ the batch-end recalculation makes order matter less, but dependency order remains the safe habit.
 - **`-i` (in-place) round-trips preserve hand-patched XML**: sheetPr/tabColor, pageSetup, headerFooter, sheetView gridlines/zoom, sheet-local `_xlnm.Print_Area`, and hand-inserted cached `<v>` values all survive later xl writes.
 - **Sheet appearance/print setup (gridlines off, zoom, tab color, landscape, footers) has no CLI yet** ([#358](https://github.com/TJC-LP/xl/issues/358)) — until then it requires zip round-trip XML patching.
 
 **Rendering & environment**
 - **PNG/PDF on the native binary needs an external rasterizer** (Batik is JAR-only; [#359](https://github.com/TJC-LP/xl/issues/359)): install `cairosvg` (`pip install cairosvg`) or `rsvg-convert`, and check availability with `xl rasterizers`. Add `--eval` when rendering or formula cells show as text.
-- **Style-bloated real-world workbooks can fail to read** with an opaque `Parse error at xl/workbook.xml … XMLMessages` ([#349](https://github.com/TJC-LP/xl/issues/349)/[#350](https://github.com/TJC-LP/xl/issues/350)). Fallback: read with openpyxl, rebuild clean, then xl works on the rebuilt file.
+- **Real-world workbooks that fail to read**: since 0.12.6, benign `<!DOCTYPE>` prologs are tolerated and parse errors name the construct with line/column ([#350](https://github.com/TJC-LP/xl/issues/350)); the native binary reports real Xerces messages instead of the opaque `Could not load any resource bundle …XMLMessages` ([#349](https://github.com/TJC-LP/xl/issues/349)). If a file still refuses to read (on any version): read with openpyxl, rebuild clean, then xl works on the rebuilt file — and report the 0.12.6+ error message upstream.
 
 ---
 

--- a/plugin/skills/xl-scripting/SKILL.md
+++ b/plugin/skills/xl-scripting/SKILL.md
@@ -38,7 +38,7 @@ The canonical header for every script (this is the single source of truth — re
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.5
+//> using dep com.tjclp::xl:0.12.6
 
 import com.tjclp.xl.scripting.{*, given}
 
@@ -100,7 +100,7 @@ wb.update("Sales", f).unsafe                       // throws structured XLExcept
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.5
+//> using dep com.tjclp::xl:0.12.6
 import com.tjclp.xl.scripting.{*, given}
 
 val wb = Excel.read("input.xlsx")
@@ -235,7 +235,7 @@ Or lean on totality so there is nothing to unwrap: literal refs, `upsert`, range
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.5
+//> using dep com.tjclp::xl:0.12.6
 import com.tjclp.xl.scripting.{*, given}
 import java.nio.file.{Files, Paths}
 import scala.jdk.CollectionConverters.*
@@ -257,7 +257,7 @@ println(s"merged ${inputs.size} files, ${merged.sheets.size} sheets")
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.5
+//> using dep com.tjclp::xl:0.12.6
 import com.tjclp.xl.scripting.{*, given}
 
 val data = List(("North", 125000.50), ("South", 98000.25), ("West", 143500.00))
@@ -285,7 +285,7 @@ println(if result.isClean then "✓ report written" else result.errors.map(_.ren
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.5
+//> using dep com.tjclp::xl:0.12.6
 import com.tjclp.xl.scripting.{*, given}
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
@@ -315,7 +315,7 @@ Switch to streaming above ~100k rows; `Excel.read` loads the whole workbook. Str
 - **First run is slow** (dependency download); afterwards scala-cli caches everything.
 - **`.sc` files**: top-level statements, no `@main`. A `.scala` file needs `@main def run(): Unit`.
 - **`Excel.write` does NOT recalculate** — freshly built `fx"…"` cells are written with no cached values, so Excel-before-recalc, openpyxl `data_only`, pandas, and previewers all show blanks. Always `val result = wb.recalculate()` and write `result.workbook` (a single pass is sufficient on 0.12.5+; see "Formulas & recalculation" above). Tracking a recalculating-write affordance: [#360](https://github.com/TJC-LP/xl/issues/360).
-- **Formulas containing external-workbook refs (`[2]Book!A1`) or percent literals (`10%`)** fail to parse/evaluate ([#353](https://github.com/TJC-LP/xl/issues/353), [#355](https://github.com/TJC-LP/xl/issues/355)) — compute external-linked cells from their cached values, and write `/100` instead of `%`.
+- **Percent literals (`10%`) fail to parse** ([#355](https://github.com/TJC-LP/xl/issues/355)) — write `/100` instead of `%`. External-workbook refs (`[2]Book!A1`) parse and pin their Excel-written caches **since 0.12.6** ([#353](https://github.com/TJC-LP/xl/issues/353)): `recalculate()` preserves those cells verbatim and dependents compute from the caches (uncached external cells yield a per-cell error); on ≤0.12.5 they fail to parse entirely — compute from cached values there.
 - **`setColumnProperties` wants a compile-time literal** (`ref"D1".col`); runtime-parsed refs don't expose `.col`, so column loops over runtime letters can't feed it directly ([#361](https://github.com/TJC-LP/xl/issues/361)). Until then, set widths with literal refs per column.
 
 ## Reference

--- a/plugin/skills/xl-scripting/reference/RECIPES.md
+++ b/plugin/skills/xl-scripting/reference/RECIPES.md
@@ -10,7 +10,7 @@ Apply a 5% price increase to column C of every workbook in a directory, in place
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.5
+//> using dep com.tjclp::xl:0.12.6
 import com.tjclp.xl.scripting.{*, given}
 import java.nio.file.{Files, Paths}
 import scala.jdk.CollectionConverters.*
@@ -42,7 +42,7 @@ Read rows into case classes; collect per-cell validation failures into a new Iss
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.5
+//> using dep com.tjclp::xl:0.12.6
 import com.tjclp.xl.scripting.{*, given}
 
 final case class Order(id: Int, customer: String, amount: BigDecimal)
@@ -76,7 +76,7 @@ Three-year projection with growth formulas; fail the script if any formula error
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.5
+//> using dep com.tjclp::xl:0.12.6
 import com.tjclp.xl.scripting.{*, given}
 
 val header = CellStyle.default.bold.size(12.0).center
@@ -111,7 +111,7 @@ Stack the data rows of every input file under one header.
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.5
+//> using dep com.tjclp::xl:0.12.6
 import com.tjclp.xl.scripting.{*, given}
 import java.nio.file.{Files, Paths}
 import scala.jdk.CollectionConverters.*
@@ -147,7 +147,7 @@ println(s"combined ${files.size} files, ${combined.cells.size} cells")
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.5
+//> using dep com.tjclp::xl:0.12.6
 import com.tjclp.xl.scripting.{*, given}
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
@@ -176,7 +176,7 @@ println("✓ filtered (constant memory)")
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.5
+//> using dep com.tjclp::xl:0.12.6
 import com.tjclp.xl.scripting.{*, given}
 
 val before = Excel.read("before.xlsx")
@@ -204,7 +204,7 @@ else
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.5
+//> using dep com.tjclp::xl:0.12.6
 import com.tjclp.xl.scripting.{*, given}
 import java.nio.file.{Files, Paths}
 import scala.jdk.CollectionConverters.*

--- a/xl-core/src/com/tjclp/xl/workbooks/WorkbookMetadata.scala
+++ b/xl-core/src/com/tjclp/xl/workbooks/WorkbookMetadata.scala
@@ -21,7 +21,7 @@ final case class WorkbookMetadata(
   modified: Option[java.time.LocalDateTime] = None,
   lastModifiedBy: Option[String] = None,
   application: Option[String] = Some("XL - Pure Scala 3.8 Excel Library"),
-  appVersion: Option[String] = Some("0.12.5"),
+  appVersion: Option[String] = Some("0.12.6"),
   theme: ThemePalette = ThemePalette.office,
   definedNames: Vector[DefinedName] = Vector.empty,
   sheetStates: Map[SheetName, Option[String]] = Map.empty,

--- a/xl/src/com/tjclp/xl/scripting.scala
+++ b/xl/src/com/tjclp/xl/scripting.scala
@@ -4,7 +4,7 @@ package com.tjclp.xl
  * Scripting prelude: everything a script needs in one import.
  *
  * {{{
- * //> using dep com.tjclp::xl:0.12.5
+ * //> using dep com.tjclp::xl:0.12.6
  * import com.tjclp.xl.scripting.{*, given}
  *
  * val wb = Excel.read("input.xlsx")


### PR DESCRIPTION
## Summary

Version bump for **0.12.6 "Fieldwork"** — the production-feedback hardening release (#349–#354, PRs #363–#368, docs #362).

⚠️ **Merge order**: land **#368** (linux-arm64 release matrix) *before* this PR — the CHANGELOG, the restored `Linux-aarch64` installer mapping in the xl-cli skill, and the release smoke coverage all assume its matrix change is on main. I'll rebase this branch after #368 merges if needed (adjacent hunks in the skill install snippet).

## What changed

- **Version pins** 0.12.5 → 0.12.6 across `build.mill` (`PUBLISH_VERSION` fallback), `WorkbookMetadata.appVersion`, `plugin.json`, README, QUICK-START, scripting docs, examples, the scripting prelude docstring, and every `//> using dep` pin in the xl-scripting skill + RECIPES (release version-gate satisfied).
- **CHANGELOG**: new `[0.12.6] "Fieldwork"` section (Added: `xl recalc`, truncation reporting, linux-arm64 binaries; Fixed: external-ref cache pinning, batch recalculation + the latent surgical-write cache-drop, DOCTYPE tolerance, native-image Xerces diagnostics; Docs: #362).
- **STATUS.md / roadmap.md**: "New in 0.12.6" block, current-version line, release section (with the enhancement backlog #355–#361 noted).
- **Skill gotchas version-scoped**: every fixed item now reads "since 0.12.6 … / on ≤0.12.5 …" so agents on older sandbox binaries still get correct guidance; arm64 install mapping restored (fail-loud curl from #368 covers pre-0.12.6 releases).
- **Test counts refreshed** from the JUnit reports of a green local run: xl-evaluator 1599, xl-core 1104, xl-ooxml 702, xl-cli 448, xl-cats-effect 111, xl-agent 102, xl 19 — **total 4,085** (+85 from the six fix PRs).

## Verification

- `./mill __.compile` + `__.checkFormat` + `__.test` — 4,085/4,085 green on this branch.
- `scripts/verify-skill-snippets.sh --local` — all skill snippets compile against locally-published 0.12.6.
- `scripts/test-examples.sh` — all examples compile/run.
- No SNAPSHOT refs; residual `0.12.5` mentions are historical (CHANGELOG/roadmap history) or deliberately version-scoped gotcha text.

After merge: tag with the prepared annotated message and push to trigger the release workflow (Maven Central + native binaries incl. the first linux-arm64 + skill zips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)