### PR TITLE
Fix shared formula dependents on workbook rewrite

### DIFF
--- a/docs/design/io-modes.md
+++ b/docs/design/io-modes.md
@@ -89,6 +89,7 @@ Characteristics:
 - Features:
   - Write: inline strings only, default styles, no row-stream API for merged cells or advanced sheet metadata.
   - Read: values and basic types; you typically use it for ETL/analytics rather than formatting‑preserving workflows.
+  - Shared formulas: the one-pass row reader expands dependents when their master appears first. A dependent with no active master remains formula-shaped as `#REF!` with its cached value preserved. This includes a dependent that physically precedes its master; use `read` for arbitrary physical ordering. The targeted single-cell reader can scan ahead and does not share this limitation.
 
 For an already-materialized `Workbook`, `writeWorkbookStream` uses the SAX/StAX OOXML backend. It is a lower-allocation full-workbook write path, not a row-input streaming API, and it preserves the full metadata handled by `XlsxWriter`.
 
@@ -374,4 +375,4 @@ test("streaming read uses constant memory"):
 
 ## Author
 
-Documented 2025-11-11. Last updated 2026-06-10 (SAX read backend, streaming transforms, feature-matrix corrections).
+Documented 2025-11-11. Last updated 2026-07-15 (shared-formula ordering behavior for row streaming).

--- a/xl-cats-effect/src/com/tjclp/xl/io/Excel.scala
+++ b/xl-cats-effect/src/com/tjclp/xl/io/Excel.scala
@@ -101,8 +101,13 @@ trait Excel[F[_]]:
   /**
    * Stream rows from first sheet.
    *
-   * Good for: Large files (>10k rows), sequential processing, aggregations Memory: O(1) - constant
-   * memory regardless of file size
+   * Good for: Large files (>10k rows), sequential processing, aggregations. Memory is independent
+   * of emitted row count, apart from shared strings and active shared-formula groups.
+   *
+   * Shared formulas are expanded in one pass when the master appears before its dependents. A
+   * dependent with no active master remains formula-shaped as `#REF!` with its cached value
+   * preserved. This includes the spec-legal case where a dependent physically precedes its master;
+   * use `read` for order-independent two-pass handling.
    *
    * Example:
    * {{{
@@ -118,14 +123,16 @@ trait Excel[F[_]]:
   /**
    * Stream rows from specific sheet by name.
    *
-   * Good for: Processing specific sheet in multi-sheet workbook Memory: O(1) constant
+   * Good for: Processing a specific sheet in a multi-sheet workbook. The shared-formula ordering
+   * constraint documented on `readStream` also applies.
    */
   def readSheetStream(path: Path, sheetName: String): Stream[F, RowData]
 
   /**
    * Stream rows from specific sheet by index (1-based).
    *
-   * Good for: Processing sheets by position rather than name Memory: O(1) constant
+   * Good for: Processing sheets by position rather than name. The shared-formula ordering
+   * constraint documented on `readStream` also applies.
    *
    * Example:
    * {{{

--- a/xl-cats-effect/src/com/tjclp/xl/io/ExcelIO.scala
+++ b/xl-cats-effect/src/com/tjclp/xl/io/ExcelIO.scala
@@ -80,6 +80,10 @@ class ExcelIO[F[_]: Async](warningHandler: XlsxReader.Warning => F[Unit])
    * Stream rows from first sheet with constant memory.
    *
    * Uses SAX parser (javax.xml.parsers.SAXParser) for 3-4x speedup vs fs2-data-xml.
+   *
+   * Shared formulas are expanded when their master appears first. A dependent with no active master
+   * is emitted as a `#REF!` formula with its cached value preserved. Use `read` when shared formula
+   * cells may appear in arbitrary physical order.
    */
   def readStream(path: Path): Stream[F, RowData] =
     Stream
@@ -90,7 +94,11 @@ class ExcelIO[F[_]: Async](warningHandler: XlsxReader.Warning => F[Unit])
         readStreamByIndex(zipFile, 1)
       }
 
-  /** Stream rows from first sheet within a bounded range (rows/cols). */
+  /**
+   * Stream rows from first sheet within a bounded range (rows/cols).
+   *
+   * The shared-formula ordering constraint documented on `readStream` also applies.
+   */
   def readStreamRange(path: Path, range: CellRange): Stream[F, RowData] =
     Stream
       .bracket(
@@ -103,7 +111,8 @@ class ExcelIO[F[_]: Async](warningHandler: XlsxReader.Warning => F[Unit])
   /**
    * Stream rows from sheet by name with constant memory.
    *
-   * Uses SAX parser (javax.xml.parsers.SAXParser) for 3-4x speedup vs fs2-data-xml.
+   * Uses SAX parser (javax.xml.parsers.SAXParser) for 3-4x speedup vs fs2-data-xml. The
+   * shared-formula ordering constraint documented on `readStream` also applies.
    */
   def readSheetStream(path: Path, sheetName: String): Stream[F, RowData] =
     Stream
@@ -114,7 +123,11 @@ class ExcelIO[F[_]: Async](warningHandler: XlsxReader.Warning => F[Unit])
         readStreamByName(zipFile, sheetName, None)
       }
 
-  /** Stream rows from sheet by name within a bounded range (rows/cols). */
+  /**
+   * Stream rows from sheet by name within a bounded range (rows/cols).
+   *
+   * The shared-formula ordering constraint documented on `readStream` also applies.
+   */
   def readSheetStreamRange(path: Path, sheetName: String, range: CellRange): Stream[F, RowData] =
     Stream
       .bracket(
@@ -124,7 +137,11 @@ class ExcelIO[F[_]: Async](warningHandler: XlsxReader.Warning => F[Unit])
         readStreamByName(zipFile, sheetName, Some(range))
       }
 
-  /** Stream rows from sheet by index (1-based) with constant memory. */
+  /**
+   * Stream rows from sheet by index (1-based) with constant memory.
+   *
+   * The shared-formula ordering constraint documented on `readStream` also applies.
+   */
   def readStreamByIndex(path: Path, sheetIndex: Int): Stream[F, RowData] =
     Stream
       .bracket(
@@ -134,7 +151,11 @@ class ExcelIO[F[_]: Async](warningHandler: XlsxReader.Warning => F[Unit])
         readStreamByIndex(zipFile, sheetIndex)
       }
 
-  /** Stream rows from sheet by index within a bounded range (rows/cols). */
+  /**
+   * Stream rows from sheet by index within a bounded range (rows/cols).
+   *
+   * The shared-formula ordering constraint documented on `readStream` also applies.
+   */
   def readStreamByIndexRange(
     path: Path,
     sheetIndex: Int,

--- a/xl-cats-effect/src/com/tjclp/xl/io/SaxStreamingReader.scala
+++ b/xl-cats-effect/src/com/tjclp/xl/io/SaxStreamingReader.scala
@@ -355,13 +355,12 @@ object SaxStreamingReader:
                               .getOrElse("#REF!")
                           )
                         case None =>
-                          // A one-pass row stream cannot look ahead for a later master without
-                          // buffering already-emitted rows. Fail explicitly instead of silently
-                          // converting the dependent's cached result into a literal.
-                          val address = currentCellRef.getOrElse("<unknown>")
-                          throw new IllegalArgumentException(
-                            s"Shared formula at $address with si=$index requires the master to appear earlier in the worksheet"
-                          )
+                          // The group may be malformed, expired, or physically later in the XML. A
+                          // one-pass row stream cannot distinguish those cases without retaining
+                          // lifetime history or buffering emitted rows. Use the same visible #REF!
+                          // representation that the DOM reader uses for an unresolved group; unlike
+                          // the DOM path, this one-pass reader cannot resolve a later master.
+                          Some("#REF!")
 
               val cellValue = (expandedFormula, inlineText, cachedValue) match
                 case (Some(formula), _, Some(cached)) =>
@@ -415,8 +414,7 @@ object SaxStreamingReader:
     /**
      * Masters with a valid `ref` range are live only through that range's row-major end. Eviction
      * keeps memory proportional to overlapping shared groups, not total sheet groups. A dependent
-     * encountered after its master has expired is indistinguishable from a not-yet-seen/orphan
-     * group and fails visibly instead of silently becoming a cached constant.
+     * encountered after its master has expired remains visibly formula-shaped as `#REF!`.
      */
     private def evictExpiredSharedMasters(current: ARef): Unit =
       sharedFormulaMasters.filterInPlace { case (_, master) =>

--- a/xl-cats-effect/src/com/tjclp/xl/io/SaxStreamingReader.scala
+++ b/xl-cats-effect/src/com/tjclp/xl/io/SaxStreamingReader.scala
@@ -11,6 +11,8 @@ import com.tjclp.xl.cells.{CellValue, CellError}
 import com.tjclp.xl.ooxml.{SharedStrings, XmlSecurity, XmlUtil}
 import java.util.concurrent.{ArrayBlockingQueue, BlockingQueue}
 import java.util.concurrent.atomic.AtomicBoolean
+import com.tjclp.xl.addressing.{ARef, CellRange}
+import com.tjclp.xl.ooxml.SharedFormula
 
 /**
  * SAX-based streaming XML reader for maximum performance.
@@ -37,8 +39,8 @@ object SaxStreamingReader:
   /**
    * Stream worksheet rows using SAX parser (3-4x faster than fs2-data-xml).
    *
-   * Uses chunked batching to minimize queue synchronization overhead. Memory usage is O(chunkSize)
-   * rather than O(total rows).
+   * Uses chunked batching to minimize queue synchronization overhead. Memory usage is O(chunkSize +
+   * active shared-formula groups), rather than O(total rows or total formula groups).
    *
    * @param stream
    *   Worksheet XML input stream
@@ -163,6 +165,7 @@ object SaxStreamingReader:
 
     // Current cell state
     var currentCellRef: Option[String] = None
+    var currentCellARef: Option[ARef] = None
     var currentCellType: Option[String] = None
     var currentCellColIdx: Option[Int] = None
     var currentCellStyleId: Option[Int] = None
@@ -176,6 +179,9 @@ object SaxStreamingReader:
     var inTextElement = false
     var cachedValue: Option[String] = None
     var formulaText: Option[String] = None
+    var formulaType: Option[String] = None
+    var sharedFormulaIndex: Option[SharedFormula.Index] = None
+    var sharedFormulaRange: Option[CellRange] = None
     var inlineValue: Option[String] = None
     val valueText = new StringBuilder
     // Decoded inline-string runs for the current cell (each run decoded at </t>, GH-305)
@@ -183,6 +189,11 @@ object SaxStreamingReader:
     // Bare <t> text directly under <is> (CT_Rst is (t?, r*, rPh*, phoneticPr?)); the DOM
     // reader ignores it whenever <r> runs exist, so it is accumulated separately.
     val bareInlineText = new StringBuilder
+    // GH-370: shared formula masters are tiny compared with row data and let a one-pass stream
+    // expand every spec-normal (master-first) dependent. Masters are captured even when their
+    // cells fall outside requested row/column bounds.
+    val sharedFormulaMasters: mutable.Map[SharedFormula.Index, SharedFormula.Master] =
+      mutable.Map.empty
 
     // Check cancelled less frequently - every 10k elements
     private var elementCount = 0
@@ -213,6 +224,8 @@ object SaxStreamingReader:
 
         case "c" =>
           currentCellRef = Option(attributes.getValue("r"))
+          currentCellARef = currentCellRef.flatMap(ARef.parse(_).toOption)
+          currentCellARef.foreach(evictExpiredSharedMasters)
           currentCellType = Option(attributes.getValue("t"))
           currentCellStyleId = Option(attributes.getValue("s")).flatMap(_.toIntOption)
           currentCellColIdx = currentCellRef.flatMap(parseCellColumn)
@@ -227,6 +240,10 @@ object SaxStreamingReader:
 
         case "f" =>
           inFormula = true
+          formulaType = Option(attributes.getValue("t"))
+          sharedFormulaIndex = Option(attributes.getValue("si")).flatMap(SharedFormula.parseIndex)
+          sharedFormulaRange = Option(attributes.getValue("ref"))
+            .flatMap(CellRange.parse(_).toOption)
           valueText.clear()
 
         case "is" =>
@@ -250,7 +267,9 @@ object SaxStreamingReader:
         case _ => ()
 
     override def characters(ch: Array[Char], start: Int, length: Int): Unit =
-      if (inValue || inFormula || inTextElement) && !skipRow && !skipCell then
+      // Formula metadata must be read even for a skipped cell: a bounded stream may select a
+      // dependent while its shared master lies just outside the requested row/column range.
+      if inFormula || ((inValue || inTextElement) && !skipRow && !skipCell) then
         valueText.appendAll(ch, start, length)
 
     override def endElement(uri: String, localName: String, qName: String): Unit =
@@ -261,11 +280,17 @@ object SaxStreamingReader:
           valueText.clear()
 
         case "f" if inFormula =>
-          if !skipRow && !skipCell then
-            // GH-293: the in-memory reader trims <f> text and treats a whitespace-only
-            // formula as absent (WorksheetReader `.text.trim` + nonEmpty guard); match it.
-            val trimmed = valueText.toString.trim
-            formulaText = Option.when(trimmed.nonEmpty)(trimmed)
+          // GH-293: the in-memory reader trims <f> text and treats a whitespace-only formula as
+          // absent. Keep that behavior while retaining empty shared dependents (GH-370).
+          val trimmed = valueText.toString.trim
+          formulaText = Option.when(trimmed.nonEmpty)(trimmed)
+          if formulaType.contains("shared") && trimmed.nonEmpty then
+            for
+              index <- sharedFormulaIndex
+              ref <- currentCellARef
+              range <- sharedFormulaRange.filter(_.contains(ref))
+              if !sharedFormulaMasters.contains(index) // malformed active duplicate: first wins
+            do sharedFormulaMasters(index) = SharedFormula.Master(ref, trimmed, Some(range))
           inFormula = false
           valueText.clear()
 
@@ -308,7 +333,37 @@ object SaxStreamingReader:
               // a nonEmpty formula wins; otherwise <is> wins for inline-string cell
               // types; otherwise interpret <v>.
               val inlineText = inlineValue.filter(_ => isInlineStringType)
-              val cellValue = (formulaText, inlineText, cachedValue) match
+              val isSharedMaster =
+                formulaType.contains("shared") &&
+                  formulaText.nonEmpty &&
+                  sharedFormulaIndex.nonEmpty &&
+                  currentCellARef.exists(ref => sharedFormulaRange.exists(_.contains(ref)))
+              val expandedFormula =
+                if !formulaType.contains("shared") || isSharedMaster then formulaText
+                else
+                  sharedFormulaIndex match
+                    // A malformed/missing si cannot identify a group. Preserve a non-empty
+                    // expression when present, otherwise keep the cell visibly formula-shaped.
+                    case None => Some(formulaText.getOrElse("#REF!"))
+                    case Some(index) =>
+                      sharedFormulaMasters.get(index) match
+                        case Some(master) =>
+                          Some(
+                            currentCellARef
+                              .filter(ref => master.range.exists(_.contains(ref)))
+                              .map(ref => SharedFormula.translate(master, ref))
+                              .getOrElse("#REF!")
+                          )
+                        case None =>
+                          // A one-pass row stream cannot look ahead for a later master without
+                          // buffering already-emitted rows. Fail explicitly instead of silently
+                          // converting the dependent's cached result into a literal.
+                          val address = currentCellRef.getOrElse("<unknown>")
+                          throw new IllegalArgumentException(
+                            s"Shared formula at $address with si=$index requires the master to appear earlier in the worksheet"
+                          )
+
+              val cellValue = (expandedFormula, inlineText, cachedValue) match
                 case (Some(formula), _, Some(cached)) =>
                   val parsedCached = interpretCellValue(cached, currentCellType, sst)
                   val cachedOpt =
@@ -327,12 +382,16 @@ object SaxStreamingReader:
                 currentCellStyleId.foreach(sid => currentRowStyles(colIdx) = sid)
 
           currentCellRef = None
+          currentCellARef = None
           currentCellType = None
           currentCellColIdx = None
           currentCellStyleId = None
           skipCell = false
           cachedValue = None
           formulaText = None
+          formulaType = None
+          sharedFormulaIndex = None
+          sharedFormulaRange = None
           inlineValue = None
           inValue = false
           inFormula = false
@@ -352,6 +411,21 @@ object SaxStreamingReader:
           skipRow = false
 
         case _ => ()
+
+    /**
+     * Masters with a valid `ref` range are live only through that range's row-major end. Eviction
+     * keeps memory proportional to overlapping shared groups, not total sheet groups. A dependent
+     * encountered after its master has expired is indistinguishable from a not-yet-seen/orphan
+     * group and fails visibly instead of silently becoming a cached constant.
+     */
+    private def evictExpiredSharedMasters(current: ARef): Unit =
+      sharedFormulaMasters.filterInPlace { case (_, master) =>
+        master.range.exists { range =>
+          val end = range.end
+          end.row.index0 > current.row.index0 ||
+          (end.row.index0 == current.row.index0 && end.col.index0 >= current.col.index0)
+        }
+      }
 
     /** Cell types whose value may come from an <is> inline string (DOM reader contract). */
     private def isInlineStringType: Boolean =

--- a/xl-cats-effect/src/com/tjclp/xl/io/streaming/SaxSingleCellReader.scala
+++ b/xl-cats-effect/src/com/tjclp/xl/io/streaming/SaxSingleCellReader.scala
@@ -3,15 +3,15 @@ package com.tjclp.xl.io.streaming
 import java.io.InputStream
 import org.xml.sax.{Attributes, InputSource}
 import org.xml.sax.helpers.DefaultHandler
-import com.tjclp.xl.addressing.ARef
+import com.tjclp.xl.addressing.{ARef, CellRange}
 import com.tjclp.xl.cells.{CellError, CellValue}
-import com.tjclp.xl.ooxml.{SharedStrings, XmlSecurity, XmlUtil}
+import com.tjclp.xl.ooxml.{SharedFormula, SharedStrings, XmlSecurity, XmlUtil}
 
 /**
  * SAX-based single cell reader with early-abort optimization.
  *
- * Uses stackless exception pattern for O(position) time, O(1) memory extraction of a single cell.
- * Aborts parsing as soon as target cell is found or row index exceeds target.
+ * Uses a stackless exception pattern for O(position) time and O(1) target state. Parsing normally
+ * aborts as soon as the target is resolved; a shared dependent may scan ahead for its master.
  */
 object SaxSingleCellReader:
 
@@ -40,10 +40,22 @@ object SaxSingleCellReader:
   @SuppressWarnings(Array("org.wartremover.warts.Null"))
   private final class CellNotFound extends RuntimeException(null, null, false, false)
 
+  /** Target data retained only when its shared master has not appeared yet. */
+  private final case class PendingSharedTarget(
+    ref: ARef,
+    sharedIndex: SharedFormula.Index,
+    cachedValue: Option[String],
+    cellType: Option[String],
+    styleId: Option[Int]
+  )
+
   /**
    * Extract a single cell from worksheet XML using SAX parser with early-abort.
    *
-   * Time complexity: O(position of cell in file) Memory: O(1) - only current cell buffered
+   * Time complexity: O(position of cell in file) for ordinary/master-first cells. A shared
+   * dependent whose master physically follows it scans until that master. Only shared masters whose
+   * declared ranges contain the target are retained, so memory does not grow with total sheet
+   * groups.
    *
    * @param stream
    *   Worksheet XML input stream
@@ -88,6 +100,7 @@ object SaxSingleCellReader:
     // Mutable state for current parsing context
     var currentRowIndex: Int = 0
     var inTargetCell = false
+    var currentCellRef: Option[ARef] = None
     var currentCellStyleId: Option[Int] = None
 
     // Cell content state
@@ -97,8 +110,15 @@ object SaxSingleCellReader:
     var inTextElement = false
     var cachedValue: Option[String] = None
     var formulaText: Option[String] = None
+    var formulaType: Option[String] = None
+    var sharedFormulaIndex: Option[SharedFormula.Index] = None
+    var sharedFormulaRange: Option[CellRange] = None
     var currentCellType: Option[String] = None
+    var pendingTarget: Option[PendingSharedTarget] = None
     val valueText = new StringBuilder
+    val sharedFormulaMasters
+      : scala.collection.mutable.Map[SharedFormula.Index, SharedFormula.Master] =
+      scala.collection.mutable.Map.empty
 
     override def startElement(
       uri: String,
@@ -112,24 +132,34 @@ object SaxSingleCellReader:
             .flatMap(_.toIntOption)
             .getOrElse(currentRowIndex + 1)
           // Early abort if we've passed the target row
-          if currentRowIndex > targetRowIndex then throw new CellNotFound
+          if currentRowIndex > targetRowIndex && pendingTarget.isEmpty then throw new CellNotFound
 
         case "c" =>
-          val cellRef = Option(attributes.getValue("r"))
-          if cellRef.contains(targetRefA1) then
-            inTargetCell = true
+          val cellRefText = Option(attributes.getValue("r"))
+          currentCellRef = cellRefText.flatMap(ARef.parse(_).toOption)
+          inTargetCell = cellRefText.contains(targetRefA1)
+          currentCellType = None
+          currentCellStyleId = None
+          cachedValue = None
+          formulaText = None
+          formulaType = None
+          sharedFormulaIndex = None
+          sharedFormulaRange = None
+          if inTargetCell then
             currentCellType = Option(attributes.getValue("t"))
             currentCellStyleId = Option(attributes.getValue("s")).flatMap(_.toIntOption)
             valueText.clear()
-            cachedValue = None
-            formulaText = None
 
         case "v" if inTargetCell =>
           inValue = true
           valueText.clear()
 
-        case "f" if inTargetCell =>
+        case "f" =>
           inFormula = true
+          formulaType = Option(attributes.getValue("t"))
+          sharedFormulaIndex = Option(attributes.getValue("si")).flatMap(SharedFormula.parseIndex)
+          sharedFormulaRange = Option(attributes.getValue("ref"))
+            .flatMap(CellRange.parse(_).toOption)
           valueText.clear()
 
         case "is" if inTargetCell =>
@@ -142,7 +172,8 @@ object SaxSingleCellReader:
         case _ => ()
 
     override def characters(ch: Array[Char], start: Int, length: Int): Unit =
-      if inTargetCell && (inValue || inFormula || inTextElement) then
+      // Every formula is observed so a shared master before or after the target can be retained.
+      if inFormula || (inTargetCell && (inValue || inTextElement)) then
         valueText.appendAll(ch, start, length)
 
     override def endElement(uri: String, localName: String, qName: String): Unit =
@@ -152,8 +183,29 @@ object SaxSingleCellReader:
           inValue = false
           valueText.clear()
 
-        case "f" if inFormula && inTargetCell =>
-          formulaText = Some(valueText.toString)
+        case "f" if inFormula =>
+          val trimmed = valueText.toString.trim
+          if inTargetCell then formulaText = Option.when(trimmed.nonEmpty)(trimmed)
+
+          if formulaType.contains("shared") && trimmed.nonEmpty then
+            for
+              index <- sharedFormulaIndex
+              ref <- currentCellRef
+              range <- sharedFormulaRange.filter(_.contains(ref))
+            do
+              val master = SharedFormula.Master(ref, trimmed, Some(range))
+              // A dependent may physically precede its master. Resolve it only from a true
+              // master whose declared range contains both its origin and the target.
+              pendingTarget
+                .filter(pending => pending.sharedIndex == index && range.contains(pending.ref))
+                .foreach { pending =>
+                  throw new CellFound(resultForPending(pending, master))
+                }
+              // Retain only target-relevant masters, keeping memory independent of unrelated
+              // shared-formula groups elsewhere in the sheet.
+              if range.contains(targetRef) && !sharedFormulaMasters.contains(index) then
+                sharedFormulaMasters(index) = master
+
           inFormula = false
           valueText.clear()
 
@@ -166,28 +218,94 @@ object SaxSingleCellReader:
           valueText.clear()
 
         case "c" if inTargetCell =>
-          // Cell complete - construct result and abort
-          val cellValue = (formulaText, cachedValue) match
-            case (Some(formula), Some(cached)) =>
-              val parsedCached = interpretCellValue(cached, currentCellType, sst)
-              val cachedOpt =
-                if parsedCached == CellValue.Empty then None else Some(parsedCached)
-              CellValue.Formula(formula, cachedOpt)
-            case (Some(formula), None) =>
-              CellValue.Formula(formula, None)
-            case (None, Some(value)) =>
-              interpretCellValue(value, currentCellType, sst)
-            case (None, None) =>
-              CellValue.Empty
+          val isSharedMaster =
+            formulaType.contains("shared") &&
+              formulaText.nonEmpty &&
+              sharedFormulaIndex.nonEmpty &&
+              currentCellRef.exists(ref => sharedFormulaRange.exists(_.contains(ref)))
+          val expandedFormula =
+            if !formulaType.contains("shared") || isSharedMaster then formulaText
+            else
+              sharedFormulaIndex match
+                // With no usable group index, retain a non-empty expression as a tolerant
+                // isolated formula fallback; otherwise surface the malformed reference.
+                case None => Some(formulaText.getOrElse("#REF!"))
+                case Some(index) =>
+                  for
+                    master <- sharedFormulaMasters.get(index)
+                    ref <- currentCellRef
+                    if master.range.exists(_.contains(ref))
+                  yield SharedFormula.translate(master, ref)
 
-          val result = CellResult(
-            value = cellValue,
-            styleId = currentCellStyleId,
-            formulaText = formulaText
-          )
-          throw new CellFound(result)
+          if formulaType.contains("shared") && expandedFormula.isEmpty then
+            val index = sharedFormulaIndex.getOrElse(
+              throw new IllegalStateException(s"Shared formula at $targetRefA1 lost its si")
+            )
+            pendingTarget = Some(
+              PendingSharedTarget(
+                targetRef,
+                index,
+                cachedValue,
+                currentCellType,
+                currentCellStyleId
+              )
+            )
+            resetCellState()
+          else
+            throw new CellFound(
+              buildResult(expandedFormula, cachedValue, currentCellType, currentCellStyleId)
+            )
+
+        case "c" => resetCellState()
 
         case _ => ()
+
+    override def endDocument(): Unit =
+      pendingTarget.foreach { pending =>
+        throw new CellFound(
+          buildResult(Some("#REF!"), pending.cachedValue, pending.cellType, pending.styleId)
+        )
+      }
+
+    private def resultForPending(
+      pending: PendingSharedTarget,
+      master: SharedFormula.Master
+    ): CellResult =
+      val formula = SharedFormula.translate(master, pending.ref)
+      buildResult(Some(formula), pending.cachedValue, pending.cellType, pending.styleId)
+
+    private def buildResult(
+      expandedFormula: Option[String],
+      cached: Option[String],
+      cellType: Option[String],
+      styleId: Option[Int]
+    ): CellResult =
+      val cellValue = (expandedFormula, cached) match
+        case (Some(formula), Some(cachedText)) =>
+          val parsedCached = interpretCellValue(cachedText, cellType, sst)
+          val cachedOpt = Option.when(parsedCached != CellValue.Empty)(parsedCached)
+          CellValue.Formula(formula, cachedOpt)
+        case (Some(formula), None) => CellValue.Formula(formula, None)
+        case (None, Some(value)) => interpretCellValue(value, cellType, sst)
+        case (None, None) => CellValue.Empty
+
+      CellResult(cellValue, styleId, expandedFormula)
+
+    private def resetCellState(): Unit =
+      currentCellRef = None
+      inTargetCell = false
+      currentCellStyleId = None
+      currentCellType = None
+      cachedValue = None
+      formulaText = None
+      formulaType = None
+      sharedFormulaIndex = None
+      sharedFormulaRange = None
+      inValue = false
+      inFormula = false
+      inInlineStr = false
+      inTextElement = false
+      valueText.clear()
 
     private def interpretCellValue(
       value: String,

--- a/xl-cats-effect/test/src/com/tjclp/xl/io/SharedFormulaStreamingSpec.scala
+++ b/xl-cats-effect/test/src/com/tjclp/xl/io/SharedFormulaStreamingSpec.scala
@@ -53,7 +53,7 @@ class SharedFormulaStreamingSpec extends CatsEffectSuite:
     }
   }
 
-  test("row stream fails visibly when a dependent physically precedes its master") {
+  test("row stream keeps a dependent-before-master formula-shaped") {
     val xml =
       """<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
         |  <sheetData>
@@ -62,13 +62,9 @@ class SharedFormulaStreamingSpec extends CatsEffectSuite:
         |  </sheetData>
         |</worksheet>""".stripMargin
 
-    rows(xml).attempt.map {
-      case Left(error) =>
-        assert(
-          Option(error.getMessage).exists(_.contains("requires the master to appear")),
-          s"unexpected failure: $error"
-        )
-      case Right(result) => fail(s"expected stream failure, got $result")
+    rows(xml).map { parsed =>
+      assertEquals(valueAt(parsed, 1, 1), formula("#REF!", 1))
+      assertEquals(valueAt(parsed, 2, 1), formula("A2", 2))
     }
   }
 
@@ -83,6 +79,25 @@ class SharedFormulaStreamingSpec extends CatsEffectSuite:
 
     rows(xml).map { parsed =>
       assertEquals(valueAt(parsed, 2, 0), formula("#REF!", 3))
+    }
+  }
+
+  test("row stream keeps a past-end out-of-range dependent formula-shaped") {
+    val xml =
+      """<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+        |  <sheetData>
+        |    <row r="1"><c r="B1"><f t="shared" si="5" ref="B1:B2">A1</f><v>1</v></c></row>
+        |    <row r="2"><c r="B2"><f t="shared" si="5"/><v>2</v></c></row>
+        |    <row r="3">
+        |      <c r="A3"><v>0</v></c>
+        |      <c r="C3"><f t="shared" si="5"/><v>3</v></c>
+        |    </row>
+        |  </sheetData>
+        |</worksheet>""".stripMargin
+
+    rows(xml).map { parsed =>
+      assertEquals(valueAt(parsed, 2, 1), formula("A2", 2))
+      assertEquals(valueAt(parsed, 3, 2), formula("#REF!", 3))
     }
   }
 

--- a/xl-cats-effect/test/src/com/tjclp/xl/io/SharedFormulaStreamingSpec.scala
+++ b/xl-cats-effect/test/src/com/tjclp/xl/io/SharedFormulaStreamingSpec.scala
@@ -1,0 +1,177 @@
+package com.tjclp.xl.io
+
+import java.io.ByteArrayInputStream
+import java.nio.charset.StandardCharsets
+
+import cats.effect.IO
+import munit.CatsEffectSuite
+
+import com.tjclp.xl.addressing.ARef
+import com.tjclp.xl.cells.CellValue
+import com.tjclp.xl.io.streaming.SaxSingleCellReader
+
+/** GH-370 parity and safety checks for the streaming worksheet readers. */
+class SharedFormulaStreamingSpec extends CatsEffectSuite:
+
+  test("row stream expands shared dependents") {
+    rows(masterFirstXml).map { parsed =>
+      assertEquals(valueAt(parsed, 1, 1), formula("A1+$A$1", 2))
+      assertEquals(valueAt(parsed, 2, 1), formula("A2+$A$1", 3))
+      assertEquals(valueAt(parsed, 3, 1), formula("A3+$A$1", 4))
+    }
+  }
+
+  test("bounded row stream captures a shared master outside both row and column bounds") {
+    val xml =
+      """<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+        |  <sheetData>
+        |    <row r="1"><c r="B1"><f t="shared" si="0" ref="B1:C2">A1</f><v>1</v></c></row>
+        |    <row r="2"><c r="C2"><f t="shared" si="0"/><v>2</v></c></row>
+        |  </sheetData>
+        |</worksheet>""".stripMargin
+
+    rows(xml, Some((2, 2)), Some((2, 2))).map { parsed =>
+      assertEquals(parsed.map(_.rowIndex), Vector(2))
+      assertEquals(valueAt(parsed, 2, 2), formula("B2", 2))
+    }
+  }
+
+  test("unrelated malformed shared cells outside a bounded selection do not poison it") {
+    val xml =
+      """<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+        |  <sheetData>
+        |    <row r="1">
+        |      <c r="A1"><f t="shared" si="99"/><v>99</v></c>
+        |      <c r="B1"><f t="shared" si="0" ref="B1:B2">A1</f><v>1</v></c>
+        |    </row>
+        |    <row r="2"><c r="B2"><f t="shared" si="0"/><v>2</v></c></row>
+        |  </sheetData>
+        |</worksheet>""".stripMargin
+
+    rows(xml, Some((2, 2)), Some((1, 1))).map { parsed =>
+      assertEquals(valueAt(parsed, 2, 1), formula("A2", 2))
+    }
+  }
+
+  test("row stream fails visibly when a dependent physically precedes its master") {
+    val xml =
+      """<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+        |  <sheetData>
+        |    <row r="1"><c r="B1"><f t="shared" si="0"/><v>1</v></c></row>
+        |    <row r="2"><c r="B2"><f t="shared" si="0" ref="B1:B2">A2</f><v>2</v></c></row>
+        |  </sheetData>
+        |</worksheet>""".stripMargin
+
+    rows(xml).attempt.map {
+      case Left(error) =>
+        assert(
+          Option(error.getMessage).exists(_.contains("requires the master to appear")),
+          s"unexpected failure: $error"
+        )
+      case Right(result) => fail(s"expected stream failure, got $result")
+    }
+  }
+
+  test("row stream keeps a known out-of-range dependent formula-shaped") {
+    val xml =
+      """<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+        |  <sheetData>
+        |    <row r="1"><c r="B1"><f t="shared" si="5" ref="B1:B2">A1</f><v>1</v></c></row>
+        |    <row r="2"><c r="A2"><f t="shared" si="5"/><v>3</v></c></row>
+        |  </sheetData>
+        |</worksheet>""".stripMargin
+
+    rows(xml).map { parsed =>
+      assertEquals(valueAt(parsed, 2, 0), formula("#REF!", 3))
+    }
+  }
+
+  test("single-cell reader expands a master that precedes the target") {
+    val result = extract(masterFirstXml, "B3").getOrElse(fail("missing B3"))
+    assertEquals(result.value, formula("A3+$A$1", 4))
+    assertEquals(result.formulaText, Some("A3+$A$1"))
+  }
+
+  test("single-cell reader defers a target whose master appears later") {
+    val xml =
+      """<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+        |  <sheetData>
+        |    <row r="1"><c r="B1"><f t="shared" si="7">JUNK99</f><v>1</v></c></row>
+        |    <row r="2"><c r="B2"><f t="shared" si="07" ref="B1:B2">A2</f><v>2</v></c></row>
+        |  </sheetData>
+        |</worksheet>""".stripMargin
+
+    val result = extract(xml, "B1").getOrElse(fail("missing B1"))
+    assertEquals(result.value, formula("A1", 1))
+    assertEquals(result.formulaText, Some("A1"))
+  }
+
+  test("single-cell reader keeps an orphan dependent formula-shaped") {
+    val xml =
+      """<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+        |  <sheetData>
+        |    <row r="1">
+        |      <c r="A1"><f t="shared">UNRELATED()</f><v>5</v></c>
+        |      <c r="B1"><f t="shared" si="404"/><v>9</v></c>
+        |    </row>
+        |  </sheetData>
+        |</worksheet>""".stripMargin
+
+    val result = extract(xml, "B1").getOrElse(fail("missing B1"))
+    assertEquals(result.value, formula("#REF!", 9))
+    assertEquals(result.formulaText, Some("#REF!"))
+  }
+
+  test("single-cell reader rejects a matching group outside its declared range") {
+    val xml =
+      """<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+        |  <sheetData>
+        |    <row r="1"><c r="B1"><f t="shared" si="8" ref="B1:B2">A1</f><v>1</v></c></row>
+        |    <row r="2"><c r="C2"><f t="shared" si="8">STALE1</f><v>9</v></c></row>
+        |  </sheetData>
+        |</worksheet>""".stripMargin
+
+    val result = extract(xml, "C2").getOrElse(fail("missing C2"))
+    assertEquals(result.value, formula("#REF!", 9))
+    assertEquals(result.formulaText, Some("#REF!"))
+  }
+
+  private val masterFirstXml =
+    """<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+      |  <sheetData>
+      |    <row r="1">
+      |      <c r="A1"><v>1</v></c>
+      |      <c r="B1"><f t="shared" si="01" ref="B1:B3">A1+$A$1</f><v>2</v></c>
+      |    </row>
+      |    <row r="2"><c r="B2"><f t="shared" si="1"/><v>3</v></c></row>
+      |    <row r="3"><c r="B3"><f t="shared" si="1"/><v>4</v></c></row>
+      |  </sheetData>
+      |</worksheet>""".stripMargin
+
+  private def rows(
+    xml: String,
+    rowBounds: Option[(Int, Int)] = None,
+    colBounds: Option[(Int, Int)] = None
+  ): IO[Vector[RowData]] =
+    SaxStreamingReader
+      .parseWorksheetStream[IO](input(xml), None, rowBounds, colBounds)
+      .compile
+      .toVector
+
+  private def extract(xml: String, address: String): Option[SaxSingleCellReader.CellResult] =
+    SaxSingleCellReader.extractCell(input(xml), cellRef(address), None)
+
+  private def input(xml: String): ByteArrayInputStream =
+    new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8))
+
+  private def cellRef(address: String): ARef =
+    ARef.parse(address).fold(error => fail(error), identity)
+
+  private def valueAt(rows: Vector[RowData], row: Int, col: Int): CellValue =
+    rows
+      .find(_.rowIndex == row)
+      .flatMap(_.cells.get(col))
+      .getOrElse(fail(s"missing row=$row col=$col"))
+
+  private def formula(expression: String, cached: Int): CellValue =
+    CellValue.Formula(expression, Some(CellValue.Number(BigDecimal(cached))))

--- a/xl-core/src/com/tjclp/xl/ooxml/SharedFormula.scala
+++ b/xl-core/src/com/tjclp/xl/ooxml/SharedFormula.scala
@@ -1,0 +1,332 @@
+package com.tjclp.xl.ooxml
+
+import scala.collection.mutable.StringBuilder
+
+import com.tjclp.xl.addressing.{ARef, CellRange, Column, Row}
+
+/**
+ * OOXML shared-formula support shared by the DOM and streaming readers.
+ *
+ * A shared-formula dependent stores only a group index; its formula is the master's expression
+ * copied from the master cell to the dependent cell. Copying is anchor-aware, so this translator
+ * rewrites A1 references without requiring the evaluator's deliberately smaller formula grammar. In
+ * particular, unsupported Excel functions and syntax remain opaque while references still move.
+ */
+private[xl] object SharedFormula:
+
+  type Index = Long
+
+  private val MaxUnsignedInt = 4_294_967_295L
+
+  /** Normalize the xsd:unsignedInt lexical space used by `<f si="...">`. */
+  def parseIndex(raw: String): Option[Index] =
+    raw.trim.toLongOption.filter(index => index >= 0L && index <= MaxUnsignedInt)
+
+  final case class Master(
+    origin: ARef,
+    expression: String,
+    range: Option[CellRange] = None
+  )
+
+  /** Expand `master` for `target`, following Excel fill/copy reference semantics. */
+  def translate(master: Master, target: ARef): String =
+    val colDelta = target.col.index0 - master.origin.col.index0
+    val rowDelta = target.row.index0 - master.origin.row.index0
+    if colDelta == 0 && rowDelta == 0 then master.expression
+    else translateExpression(master.expression, colDelta, rowDelta)
+
+  private final case class ColPart(index0: Int, absolute: Boolean, end: Int)
+  private final case class RowPart(index0: Int, absolute: Boolean, end: Int)
+  private final case class CellPart(
+    colIndex0: Int,
+    rowIndex0: Int,
+    colAbsolute: Boolean,
+    rowAbsolute: Boolean,
+    end: Int
+  )
+
+  /**
+   * Lexically translate references while leaving strings, quoted sheet/workbook names, and
+   * structured-reference brackets untouched. This intentionally does not parse the whole formula:
+   * shared formulas may contain any function Excel supports, not just xl-evaluator's typed subset.
+   * Structured-reference payloads stay deliberately opaque: horizontal table-column translation
+   * requires table schema/context that this low-level OOXML reader does not have.
+   */
+  @SuppressWarnings(Array("org.wartremover.warts.Var", "org.wartremover.warts.While"))
+  private def translateExpression(expression: String, colDelta: Int, rowDelta: Int): String =
+    val out = new StringBuilder(expression.length + 16)
+    var index = 0
+    var bracketDepth = 0
+
+    while index < expression.length do
+      val ch = expression.charAt(index)
+
+      if bracketDepth > 0 then
+        out.append(ch)
+        if ch == '[' then bracketDepth += 1
+        else if ch == ']' then bracketDepth -= 1
+        index += 1
+      else
+        ch match
+          case '"' =>
+            val end = quotedEnd(expression, index, '"')
+            out.append(expression.substring(index, end))
+            index = end
+
+          case '\'' =>
+            // Single quotes delimit sheet/workbook qualifiers. A doubled quote escapes a quote in
+            // the name, just as doubled double-quotes do in string literals.
+            val end = quotedEnd(expression, index, '\'')
+            out.append(expression.substring(index, end))
+            index = end
+
+          case '[' =>
+            // Covers both external-workbook qualifiers ([Book.xlsx]) and structured references.
+            // Neither may have its contents translated as ordinary A1 references.
+            out.append(ch)
+            bracketDepth = 1
+            index += 1
+
+          case _ =>
+            val replacement =
+              parseCellRange(expression, index)
+                .map { case (start, end) =>
+                  val rendered = renderCellRange(start, end, colDelta, rowDelta)
+                  (end.end, rendered)
+                }
+                .orElse {
+                  parseColumnRange(expression, index).map { case (start, end) =>
+                    val rendered = renderColumnRange(start, end, colDelta)
+                    (end.end, rendered)
+                  }
+                }
+                .orElse {
+                  parseRowRange(expression, index).map { case (start, end) =>
+                    val rendered = renderRowRange(start, end, rowDelta)
+                    (end.end, rendered)
+                  }
+                }
+                .orElse {
+                  // Avoid rescanning every suffix of a long defined name. Once the first
+                  // character has failed to form a reference, every later character in that
+                  // name has a non-boundary predecessor and can be rejected in O(1).
+                  if !hasBoundaryBefore(expression, index) then None
+                  else
+                    parseCellPart(expression, index)
+                      .filter(cell => hasBoundaryAfter(expression, cell.end))
+                      .map { cell =>
+                        val original = expression.substring(index, cell.end)
+                        val rendered =
+                          if isNonReferenceUse(expression, cell.end) then original
+                          else renderCell(cell, colDelta, rowDelta)
+                        (cell.end, rendered)
+                      }
+                }
+
+            replacement match
+              case Some((end, text)) =>
+                out.append(text)
+                index = end
+              case None =>
+                out.append(ch)
+                index += 1
+
+    out.result()
+
+  /** End (exclusive) of a quoted formula segment, tolerating malformed/unclosed input. */
+  @SuppressWarnings(Array("org.wartremover.warts.Var", "org.wartremover.warts.While"))
+  private def quotedEnd(input: String, start: Int, quote: Char): Int =
+    var index = start + 1
+    var closed = false
+    while index < input.length && !closed do
+      if input.charAt(index) == quote then
+        if index + 1 < input.length && input.charAt(index + 1) == quote then index += 2
+        else
+          index += 1
+          closed = true
+      else index += 1
+    index
+
+  private def parseCellRange(input: String, start: Int): Option[(CellPart, CellPart)] =
+    if !hasBoundaryBefore(input, start) then None
+    else
+      for
+        first <- parseCellPart(input, start)
+        if first.end < input.length && input.charAt(first.end) == ':'
+        second <- parseCellPart(input, first.end + 1)
+        if hasBoundaryAfter(input, second.end)
+        if !isNonReferenceUse(input, second.end)
+      yield (first, second)
+
+  private def parseColumnRange(input: String, start: Int): Option[(ColPart, ColPart)] =
+    if !hasBoundaryBefore(input, start) then None
+    else
+      for
+        first <- parseColPart(input, start)
+        if first.end < input.length && input.charAt(first.end) == ':'
+        second <- parseColPart(input, first.end + 1)
+        if hasBoundaryAfter(input, second.end)
+        if !isNonReferenceUse(input, second.end)
+      yield (first, second)
+
+  private def parseRowRange(input: String, start: Int): Option[(RowPart, RowPart)] =
+    if !hasBoundaryBefore(input, start) then None
+    else
+      for
+        first <- parseRowPart(input, start)
+        if first.end < input.length && input.charAt(first.end) == ':'
+        second <- parseRowPart(input, first.end + 1)
+        if hasBoundaryAfter(input, second.end)
+        if !isNonReferenceUse(input, second.end)
+      yield (first, second)
+
+  private def parseCellPart(input: String, start: Int): Option[CellPart] =
+    val colAbsolute = start < input.length && input.charAt(start) == '$'
+    val colStart = if colAbsolute then start + 1 else start
+
+    val lettersEnd = spanLetters(input, colStart)
+    val letterCount = lettersEnd - colStart
+    if letterCount < 1 || letterCount > 3 then None
+    else
+      val rowAbsolute = lettersEnd < input.length && input.charAt(lettersEnd) == '$'
+      val rowStart = if rowAbsolute then lettersEnd + 1 else lettersEnd
+      val digitsEnd = spanDigits(input, rowStart)
+      if digitsEnd == rowStart then None
+      else
+        for
+          col <- Column.fromLetter(input.substring(colStart, lettersEnd)).toOption
+          row1 <- input.substring(rowStart, digitsEnd).toIntOption
+          if row1 >= 1 && row1 <= Row.MaxIndex0 + 1
+        yield CellPart(col.index0, row1 - 1, colAbsolute, rowAbsolute, digitsEnd)
+
+  private def parseColPart(input: String, start: Int): Option[ColPart] =
+    val absolute = start < input.length && input.charAt(start) == '$'
+    val lettersStart = if absolute then start + 1 else start
+    val end = spanLetters(input, lettersStart)
+    val count = end - lettersStart
+    if count < 1 || count > 3 then None
+    else
+      Column
+        .fromLetter(input.substring(lettersStart, end))
+        .toOption
+        .map(col => ColPart(col.index0, absolute, end))
+
+  private def parseRowPart(input: String, start: Int): Option[RowPart] =
+    val absolute = start < input.length && input.charAt(start) == '$'
+    val digitsStart = if absolute then start + 1 else start
+    val end = spanDigits(input, digitsStart)
+    if end == digitsStart then None
+    else
+      input
+        .substring(digitsStart, end)
+        .toIntOption
+        .filter(row1 => row1 >= 1 && row1 <= Row.MaxIndex0 + 1)
+        .map(row1 => RowPart(row1 - 1, absolute, end))
+
+  @SuppressWarnings(Array("org.wartremover.warts.Var", "org.wartremover.warts.While"))
+  private def spanLetters(input: String, start: Int): Int =
+    var end = start
+    while end < input.length && isAsciiLetter(input.charAt(end)) do end += 1
+    end
+
+  @SuppressWarnings(Array("org.wartremover.warts.Var", "org.wartremover.warts.While"))
+  private def spanDigits(input: String, start: Int): Int =
+    var end = start
+    while end < input.length && isAsciiDigit(input.charAt(end)) do end += 1
+    end
+
+  private def isAsciiLetter(ch: Char): Boolean =
+    (ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z')
+
+  private def isAsciiDigit(ch: Char): Boolean = ch >= '0' && ch <= '9'
+
+  private def renderCellRange(
+    start: CellPart,
+    end: CellPart,
+    colDelta: Int,
+    rowDelta: Int
+  ): String =
+    (shiftedCell(start, colDelta, rowDelta), shiftedCell(end, colDelta, rowDelta)) match
+      case (Some(first), Some(second)) => s"$first:$second"
+      case _ => "#REF!"
+
+  private def renderColumnRange(start: ColPart, end: ColPart, colDelta: Int): String =
+    (shiftedColumn(start, colDelta), shiftedColumn(end, colDelta)) match
+      case (Some(first), Some(second)) => s"$first:$second"
+      case _ => "#REF!"
+
+  private def renderRowRange(start: RowPart, end: RowPart, rowDelta: Int): String =
+    (shiftedRow(start, rowDelta), shiftedRow(end, rowDelta)) match
+      case (Some(first), Some(second)) => s"$first:$second"
+      case _ => "#REF!"
+
+  private def renderCell(cell: CellPart, colDelta: Int, rowDelta: Int): String =
+    shiftedCell(cell, colDelta, rowDelta).getOrElse("#REF!")
+
+  private def shiftedCell(cell: CellPart, colDelta: Int, rowDelta: Int): Option[String] =
+    val col = shiftedIndex(cell.colIndex0, cell.colAbsolute, colDelta, Column.MaxIndex0)
+    val row = shiftedIndex(cell.rowIndex0, cell.rowAbsolute, rowDelta, Row.MaxIndex0)
+    for
+      colIndex <- col
+      rowIndex <- row
+    yield
+      val colAnchor = if cell.colAbsolute then "$" else ""
+      val rowAnchor = if cell.rowAbsolute then "$" else ""
+      s"$colAnchor${Column.from0(colIndex).toLetter}$rowAnchor${rowIndex + 1}"
+
+  private def shiftedColumn(column: ColPart, delta: Int): Option[String] =
+    shiftedIndex(column.index0, column.absolute, delta, Column.MaxIndex0).map { index =>
+      val anchor = if column.absolute then "$" else ""
+      s"$anchor${Column.from0(index).toLetter}"
+    }
+
+  private def shiftedRow(row: RowPart, delta: Int): Option[String] =
+    shiftedIndex(row.index0, row.absolute, delta, Row.MaxIndex0).map { index =>
+      val anchor = if row.absolute then "$" else ""
+      s"$anchor${index + 1}"
+    }
+
+  private def shiftedIndex(index: Int, absolute: Boolean, delta: Int, max: Int): Option[Int] =
+    val shifted = if absolute then index.toLong else index.toLong + delta.toLong
+    Option.when(shifted >= 0L && shifted <= max.toLong)(shifted.toInt)
+
+  private def hasBoundaryBefore(input: String, start: Int): Boolean =
+    start == 0 || !isNameChar(input.charAt(start - 1))
+
+  private def hasBoundaryAfter(input: String, end: Int): Boolean =
+    end >= input.length || !isNameChar(input.charAt(end))
+
+  private def isNameChar(ch: Char): Boolean =
+    ch.isLetterOrDigit || ch == '_' || ch == '.' || ch == '\\' || ch == '?' || ch.toInt > 127
+
+  /**
+   * A cell-shaped token is not a reference when it names a function (`LOG10(`), is a short table
+   * name before a structured reference (`T1[...]`), or belongs to a sheet/3-D qualifier (`S1!` or
+   * `S1:S2!`). Defined names cannot otherwise have the shape of a valid Excel cell reference.
+   */
+  private def isNonReferenceUse(input: String, end: Int): Boolean =
+    nextNonWhitespace(input, end) match
+      case Some(('(', _)) | Some(('[', _)) | Some(('!', _)) => true
+      case Some((':', colon)) => qualifierBangFollows(input, colon + 1)
+      case _ => false
+
+  @SuppressWarnings(Array("org.wartremover.warts.Var", "org.wartremover.warts.While"))
+  private def nextNonWhitespace(input: String, start: Int): Option[(Char, Int)] =
+    var index = start
+    while index < input.length && input.charAt(index).isWhitespace do index += 1
+    Option.when(index < input.length)((input.charAt(index), index))
+
+  /** True when the remainder of `token:token!` is a 3-D sheet qualifier, not a cell range. */
+  @SuppressWarnings(Array("org.wartremover.warts.Var", "org.wartremover.warts.While"))
+  private def qualifierBangFollows(input: String, start: Int): Boolean =
+    var index = start
+    var found = false
+    var stopped = false
+    while index < input.length && !found && !stopped do
+      input.charAt(index) match
+        case '!' => found = true
+        case '+' | '-' | '*' | '/' | '^' | '&' | '=' | '<' | '>' | ',' | ';' | '(' | ')' | '{' |
+            '}' | ' ' | '\t' | '\r' | '\n' =>
+          stopped = true
+        case _ => index += 1
+    found

--- a/xl-core/src/com/tjclp/xl/ooxml/SharedFormula.scala
+++ b/xl-core/src/com/tjclp/xl/ooxml/SharedFormula.scala
@@ -1,7 +1,5 @@
 package com.tjclp.xl.ooxml
 
-import scala.collection.mutable.StringBuilder
-
 import com.tjclp.xl.addressing.{ARef, CellRange, Column, Row}
 
 /**

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/WorksheetReader.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/WorksheetReader.scala
@@ -13,7 +13,7 @@ import com.tjclp.xl.ooxml.XmlUtil.{
   getTextPreservingWhitespace,
   parseTextRuns
 }
-import com.tjclp.xl.ooxml.{SharedStrings, XmlReadable}
+import com.tjclp.xl.ooxml.{SharedFormula, SharedStrings, XmlReadable}
 
 /** Reader for parsing OoxmlWorksheet from XML */
 object WorksheetReader extends XmlReadable[OoxmlWorksheet]:
@@ -28,7 +28,13 @@ object WorksheetReader extends XmlReadable[OoxmlWorksheet]:
       // Parse sheetData (required)
       sheetDataElem <- getChild(elem, "sheetData")
       rowElems = getChildren(sheetDataElem, "row")
-      rows <- parseRows(rowElems, sst)
+      // GH-370: collect shared masters before parsing any cells. Although Excel normally emits
+      // the master first, OOXML does not require physical row/cell order to match coordinates.
+      // A two-pass DOM read therefore also handles a dependent that precedes its master in XML.
+      sharedFormulaMasters = parseSharedFormulaMasters(
+        rowElems.flatMap(row => getChildren(row, "c"))
+      )
+      rows <- parseRows(rowElems, sst, sharedFormulaMasters)
 
       // Parse mergeCells (optional)
       mergedRanges <- parseMergeCells(elem)
@@ -146,7 +152,8 @@ object WorksheetReader extends XmlReadable[OoxmlWorksheet]:
 
   private def parseRows(
     elems: Seq[Elem],
-    sst: Option[SharedStrings]
+    sst: Option[SharedStrings],
+    sharedFormulaMasters: Map[SharedFormula.Index, SharedFormula.Master]
   ): Either[String, Seq[OoxmlRow]] =
     val parsed = elems.map { e =>
       for
@@ -171,7 +178,7 @@ object WorksheetReader extends XmlReadable[OoxmlWorksheet]:
         dyDescent = attrs.get("x14ac:dyDescent").flatMap(_.toDoubleOption)
 
         cellElems = getChildren(e, "c")
-        cells <- parseCells(cellElems, sst)
+        cells <- parseCells(cellElems, sst, sharedFormulaMasters)
       yield OoxmlRow(
         rowIdx,
         cells,
@@ -195,7 +202,8 @@ object WorksheetReader extends XmlReadable[OoxmlWorksheet]:
 
   private def parseCells(
     elems: Seq[Elem],
-    sst: Option[SharedStrings]
+    sst: Option[SharedStrings],
+    sharedFormulaMasters: Map[SharedFormula.Index, SharedFormula.Master]
   ): Either[String, Seq[OoxmlCell]] =
     val parsed = elems.map { e =>
       for
@@ -203,7 +211,7 @@ object WorksheetReader extends XmlReadable[OoxmlWorksheet]:
         ref <- ARef.parse(refStr)
         cellType = getAttrOpt(e, "t").getOrElse("")
         styleIdx = getAttrOpt(e, "s").flatMap(_.toIntOption)
-        value <- parseCellValue(e, cellType, sst)
+        value <- parseCellValue(e, ref, cellType, sst, sharedFormulaMasters)
       yield OoxmlCell(ref, value, styleIdx, cellType)
     }
 
@@ -213,36 +221,85 @@ object WorksheetReader extends XmlReadable[OoxmlWorksheet]:
 
   private def parseCellValue(
     elem: Elem,
+    ref: ARef,
     cellType: String,
-    sst: Option[SharedStrings]
+    sst: Option[SharedStrings],
+    sharedFormulaMasters: Map[SharedFormula.Index, SharedFormula.Master]
   ): Either[String, CellValue] =
-    // Check for formula element first (before cellType dispatch)
-    (elem \ "f").headOption.map(_.text.trim) match
-      case Some(formulaExpr) if formulaExpr.nonEmpty =>
-        // Formula cell - parse cached value from <v> if present
-        val cachedValue: Option[CellValue] = (elem \ "v").headOption.map(_.text).flatMap { vText =>
-          // Infer cached value type from cellType attribute
-          cellType match
-            case "n" | "" =>
-              try Some(CellValue.Number(BigDecimal(vText)))
-              catch case _: NumberFormatException => None
-            case "b" =>
-              vText match
-                case "1" | "true" => Some(CellValue.Bool(true))
-                case "0" | "false" => Some(CellValue.Bool(false))
-                case _ => None
-            case "e" =>
-              import com.tjclp.xl.cells.CellError
-              CellError.parse(vText).toOption.map(CellValue.Error.apply)
-            case "str" | "inlineStr" =>
-              Some(CellValue.Text(decodeXstring(vText)))
-            case _ => None
-        }
-        Right(CellValue.Formula(formulaExpr, cachedValue))
+    // Check for formula element first (before cellType dispatch). A shared dependent has an empty
+    // <f t="shared" si="N"/>; resolve it from the master's expression instead of treating its
+    // cached <v> as a literal (GH-370).
+    (elem \ "f").headOption.collect { case formula: Elem => formula } match
+      case Some(formulaElem) if getAttrOpt(formulaElem, "t").contains("shared") =>
+        val ownExpression = formulaElem.text.trim
+        val sharedIndex = getAttrOpt(formulaElem, "si").flatMap(SharedFormula.parseIndex)
+        val masterRange = getAttrOpt(formulaElem, "ref")
+          .flatMap(CellRange.parse(_).toOption)
+          .filter(_.contains(ref))
+        val isMaster = ownExpression.nonEmpty && sharedIndex.isDefined && masterRange.isDefined
+        val expression =
+          if isMaster then ownExpression
+          else
+            sharedIndex
+              .flatMap(sharedFormulaMasters.get)
+              .filter(_.range.exists(_.contains(ref)))
+              .map(master => SharedFormula.translate(master, ref))
+              // A malformed shared formula with no usable group index remains readable using its
+              // own text. When si is valid, however, non-master text is stale/junk by definition
+              // and must never override the real master.
+              .orElse(Option.when(sharedIndex.isEmpty && ownExpression.nonEmpty)(ownExpression))
+              // A malformed/orphan shared dependent must remain visibly formula-shaped. Falling
+              // back to its cached literal would recreate the silent data loss GH-370 fixes.
+              .getOrElse("#REF!")
+        Right(CellValue.Formula(expression, parseFormulaCache(elem, cellType)))
+
+      case Some(formulaElem) if formulaElem.text.trim.nonEmpty =>
+        Right(CellValue.Formula(formulaElem.text.trim, parseFormulaCache(elem, cellType)))
 
       case _ =>
-        // No formula - dispatch on cellType as before
+        // No material formula - dispatch on cellType as before.
         parseCellValueWithoutFormula(elem, cellType, sst)
+
+  /** Collect every well-formed non-empty shared master; first duplicate wins. */
+  private def parseSharedFormulaMasters(
+    cells: Seq[Elem]
+  ): Map[SharedFormula.Index, SharedFormula.Master] =
+    cells.foldLeft(Map.empty[SharedFormula.Index, SharedFormula.Master]) { (masters, cell) =>
+      (cell \ "f").headOption.collect { case formula: Elem => formula } match
+        case Some(formula)
+            if getAttrOpt(formula, "t").contains("shared") && formula.text.trim.nonEmpty =>
+          (for
+            refText <- getAttrOpt(cell, "r")
+            ref <- ARef.parse(refText).toOption
+            sharedIndex <- getAttrOpt(formula, "si").flatMap(SharedFormula.parseIndex)
+            range <- getAttrOpt(formula, "ref")
+              .flatMap(CellRange.parse(_).toOption)
+              .filter(_.contains(ref))
+          yield (sharedIndex, SharedFormula.Master(ref, formula.text.trim, Some(range)))) match
+            case Some((sharedIndex, master)) if !masters.contains(sharedIndex) =>
+              masters.updated(sharedIndex, master)
+            case _ => masters
+        case _ => masters
+    }
+
+  /** Parse the cached result of a formula according to the cell's `t` attribute. */
+  private def parseFormulaCache(elem: Elem, cellType: String): Option[CellValue] =
+    (elem \ "v").headOption.map(_.text).flatMap { valueText =>
+      cellType match
+        case "n" | "" =>
+          try Some(CellValue.Number(BigDecimal(valueText)))
+          catch case _: NumberFormatException => None
+        case "b" =>
+          valueText match
+            case "1" | "true" => Some(CellValue.Bool(true))
+            case "0" | "false" => Some(CellValue.Bool(false))
+            case _ => None
+        case "e" =>
+          import com.tjclp.xl.cells.CellError
+          CellError.parse(valueText).toOption.map(CellValue.Error.apply)
+        case "str" | "inlineStr" => Some(CellValue.Text(decodeXstring(valueText)))
+        case _ => None
+    }
 
   /** Parse cell value when no formula element is present */
   private def parseCellValueWithoutFormula(

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/SharedFormulaSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/SharedFormulaSpec.scala
@@ -1,0 +1,254 @@
+package com.tjclp.xl.ooxml
+
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.util.zip.{ZipEntry, ZipInputStream, ZipOutputStream}
+
+import scala.xml.{Elem, XML}
+
+import munit.FunSuite
+
+import com.tjclp.xl.addressing.ARef
+import com.tjclp.xl.api.*
+import com.tjclp.xl.cells.{CellError, CellValue}
+import com.tjclp.xl.macros.ref
+import com.tjclp.xl.ooxml.writer.{WriterConfig, XmlBackend}
+
+/** GH-370: shared formula dependents remain formulas through read and sheet regeneration. */
+class SharedFormulaSpec extends FunSuite:
+
+  test("shared formula translation is anchor-aware and lexical") {
+    val master = SharedFormula.Master(
+      cellRef("B2"),
+      """A1+$A1+A$1+$A$1+SUM(A1:B2)+'Other 1'!C1+"A1"+LOG10(A1)+""" +
+        """'[Book.xlsx]S 1'!D2+[1]S1!A1+T1[A1]+A:A+$A:B+1:2+$1:2+S1:S2!A1+""" +
+        """Rate?A1+€A1+A١"""
+    )
+
+    assertEquals(
+      SharedFormula.translate(master, cellRef("C3")),
+      """B2+$A2+B$1+$A$1+SUM(B2:C3)+'Other 1'!D2+"A1"+LOG10(B2)+""" +
+        """'[Book.xlsx]S 1'!E3+[1]S1!B2+T1[A1]+B:B+$A:C+2:3+$1:3+S1:S2!B2+""" +
+        """Rate?A1+€A1+A١"""
+    )
+  }
+
+  test("shared formula indexes normalize the xsd:unsignedInt lexical space") {
+    assertEquals(SharedFormula.parseIndex(" 0001 "), Some(1L))
+    assertEquals(SharedFormula.parseIndex("4294967295"), Some(4_294_967_295L))
+    assertEquals(SharedFormula.parseIndex("-1"), None)
+    assertEquals(SharedFormula.parseIndex("4294967296"), None)
+  }
+
+  test("shared formula translation renders out-of-bounds references as #REF!") {
+    val master = SharedFormula.Master(cellRef("B2"), "A1+B2+$A1+A$1+SUM(A1:B2)")
+    assertEquals(
+      SharedFormula.translate(master, cellRef("A1")),
+      "#REF!+A1+#REF!+#REF!+SUM(#REF!)"
+    )
+  }
+
+  test("DOM reader resolves a dependent even when its master appears later") {
+    val worksheet = XML.loadString(
+      """<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+        |  <sheetData>
+        |    <row r="1"><c r="B1"><f t="shared" si="1">Z99</f><v>2</v></c></row>
+        |    <row r="2"><c r="B2"><f t="shared" si="01" ref="B1:B2">A2*2</f><v>4</v></c></row>
+        |  </sheetData>
+        |</worksheet>""".stripMargin
+    )
+
+    val parsed = OoxmlWorksheet.fromXml(worksheet).fold(error => fail(error), identity)
+    assertEquals(valueAt(parsed, "B1"), CellValue.Formula("A1*2", Some(CellValue.Number(2))))
+    assertEquals(valueAt(parsed, "B2"), CellValue.Formula("A2*2", Some(CellValue.Number(4))))
+  }
+
+  test("malformed shared groups stay formula-shaped and duplicate masters keep the first") {
+    val worksheet = XML.loadString(
+      """<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+        |  <sheetData>
+        |    <row r="1">
+        |      <c r="A1"><f t="shared"/><v>1</v></c>
+        |      <c r="B1"><f t="shared" si="4" ref="B1:B2">A1</f><v>1</v></c>
+        |      <c r="C1"><f t="shared" si="4" ref="C1:C2">Z1</f><v>1</v></c>
+        |      <c r="D1"><f t="shared">D9+1</f><v>2</v></c>
+        |    </row>
+        |    <row r="2">
+        |      <c r="B2"><f t="shared" si="4"/><v>2</v></c>
+        |      <c r="E2"><f t="shared" si="99"/><v>9</v></c>
+        |      <c r="F2"><f t="shared" si="4"/><v>8</v></c>
+        |    </row>
+        |  </sheetData>
+        |</worksheet>""".stripMargin
+    )
+
+    val parsed = OoxmlWorksheet.fromXml(worksheet).fold(error => fail(error), identity)
+    assertEquals(valueAt(parsed, "A1"), CellValue.Formula("#REF!", Some(CellValue.Number(1))))
+    assertEquals(valueAt(parsed, "B2"), CellValue.Formula("A2", Some(CellValue.Number(2))))
+    assertEquals(valueAt(parsed, "D1"), CellValue.Formula("D9+1", Some(CellValue.Number(2))))
+    assertEquals(valueAt(parsed, "E2"), CellValue.Formula("#REF!", Some(CellValue.Number(9))))
+    assertEquals(valueAt(parsed, "F2"), CellValue.Formula("#REF!", Some(CellValue.Number(8))))
+  }
+
+  test("shared dependents retain numeric, boolean, string, and error caches") {
+    val worksheet = XML.loadString(
+      """<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+        |  <sheetData>
+        |    <row r="1">
+        |      <c r="A1"><f t="shared" si="0" ref="A1:A2">1</f><v>1</v></c>
+        |      <c r="B1" t="b"><f t="shared" si="1" ref="B1:B2">TRUE</f><v>1</v></c>
+        |      <c r="C1" t="str"><f t="shared" si="2" ref="C1:C2">&quot;x&quot;</f><v>x</v></c>
+        |      <c r="D1" t="e"><f t="shared" si="3" ref="D1:D2">1/0</f><v>#DIV/0!</v></c>
+        |    </row>
+        |    <row r="2">
+        |      <c r="A2"><f t="shared" si="0"/><v>2</v></c>
+        |      <c r="B2" t="b"><f t="shared" si="1"/><v>0</v></c>
+        |      <c r="C2" t="str"><f t="shared" si="2"/><v>y</v></c>
+        |      <c r="D2" t="e"><f t="shared" si="3"/><v>#DIV/0!</v></c>
+        |    </row>
+        |  </sheetData>
+        |</worksheet>""".stripMargin
+    )
+
+    val parsed = OoxmlWorksheet.fromXml(worksheet).fold(error => fail(error), identity)
+    assertEquals(valueAt(parsed, "A2"), CellValue.Formula("1", Some(CellValue.Number(2))))
+    assertEquals(valueAt(parsed, "B2"), CellValue.Formula("TRUE", Some(CellValue.Bool(false))))
+    assertEquals(valueAt(parsed, "C2"), CellValue.Formula("\"x\"", Some(CellValue.Text("y"))))
+    assertEquals(
+      valueAt(parsed, "D2"),
+      CellValue.Formula("1/0", Some(CellValue.Error(CellError.Div0)))
+    )
+  }
+
+  List(
+    "ScalaXml" -> WriterConfig(backend = XmlBackend.ScalaXml),
+    "SaxStax" -> WriterConfig(backend = XmlBackend.SaxStax)
+  ).foreach { case (backendName, config) =>
+    test(
+      s"read-edit-rewrite expands shared dependents instead of converting them to constants ($backendName)"
+    ) {
+      verifyReadEditRewrite(config)
+    }
+  }
+
+  private def verifyReadEditRewrite(config: WriterConfig): Unit =
+    val input = rawXlsx(
+      """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        |<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+        |  <sheetData>
+        |    <row r="1">
+        |      <c r="A1"><v>1</v></c>
+        |      <c r="B1"><f t="shared" si="0" ref="B1:B3">A1*2</f><v>2</v></c>
+        |    </row>
+        |    <row r="2"><c r="B2"><f t="shared" si="0"/><v>4</v></c></row>
+        |    <row r="3"><c r="B3"><f t="shared" si="0"/><v>6</v></c></row>
+        |  </sheetData>
+        |</worksheet>""".stripMargin
+    )
+
+    val workbook = XlsxReader.readFromBytes(input).fold(err => fail(err.message), identity)
+    val originalSheet = workbook.sheets.headOption.getOrElse(fail("missing Sheet1"))
+    assertEquals(originalSheet(ref"B2").value, formula("A2*2", 4))
+    assertEquals(originalSheet(ref"B3").value, formula("A3*2", 6))
+
+    val edited = workbook.put(originalSheet.put(ref"A1", CellValue.Number(10)))
+    val outputPath = Files.createTempFile("xl-shared-formula-rewrite-", ".xlsx")
+    XlsxWriter.writeWith(edited, outputPath, config).fold(err => fail(err.message), identity)
+    val output = Files.readAllBytes(outputPath)
+    Files.deleteIfExists(outputPath)
+    val outputSheetXml = XML.loadString(zipEntry(output, "xl/worksheets/sheet1.xml"))
+
+    val formulas = (outputSheetXml \\ "c").collect { case cell: Elem =>
+      val address = cell \@ "r"
+      val expression = (cell \ "f").headOption.map(_.text)
+      address -> expression
+    }.toMap
+    assertEquals(formulas.get("B1"), Some(Some("A1*2")))
+    assertEquals(formulas.get("B2"), Some(Some("A2*2")))
+    assertEquals(formulas.get("B3"), Some(Some("A3*2")))
+
+    val reread = XlsxReader.readFromBytes(output).fold(err => fail(err.message), identity)
+    val rewrittenSheet = reread.sheets.headOption.getOrElse(fail("missing rewritten Sheet1"))
+    assertEquals(rewrittenSheet(ref"B2").value, formula("A2*2", 4))
+    assertEquals(rewrittenSheet(ref"B3").value, formula("A3*2", 6))
+
+  private def valueAt(worksheet: OoxmlWorksheet, address: String): CellValue =
+    worksheet.rows
+      .flatMap(_.cells)
+      .find(_.ref == cellRef(address))
+      .map(_.value)
+      .getOrElse(fail(s"missing $address"))
+
+  private def cellRef(address: String): ARef =
+    ARef.parse(address).fold(error => fail(error), identity)
+
+  private def formula(expression: String, cached: Int): CellValue =
+    CellValue.Formula(expression, Some(CellValue.Number(BigDecimal(cached))))
+
+  private val workbookXml =
+    """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+      |<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+      |          xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+      |  <sheets><sheet name="Sheet1" sheetId="1" r:id="rId1"/></sheets>
+      |</workbook>""".stripMargin
+
+  private val workbookRelsXml =
+    """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+      |<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+      |  <Relationship Id="rId1"
+      |    Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"
+      |    Target="worksheets/sheet1.xml"/>
+      |</Relationships>""".stripMargin
+
+  private val rootRelsXml =
+    """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+      |<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+      |  <Relationship Id="rId1"
+      |    Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument"
+      |    Target="xl/workbook.xml"/>
+      |</Relationships>""".stripMargin
+
+  private val contentTypesXml =
+    """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+      |<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+      |  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+      |  <Default Extension="xml" ContentType="application/xml"/>
+      |  <Override PartName="/xl/workbook.xml"
+      |    ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+      |  <Override PartName="/xl/worksheets/sheet1.xml"
+      |    ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+      |</Types>""".stripMargin
+
+  private def rawXlsx(sheetXml: String): Array[Byte] =
+    val output = new ByteArrayOutputStream()
+    val zip = new ZipOutputStream(output)
+    try
+      List(
+        "[Content_Types].xml" -> contentTypesXml,
+        "_rels/.rels" -> rootRelsXml,
+        "xl/workbook.xml" -> workbookXml,
+        "xl/_rels/workbook.xml.rels" -> workbookRelsXml,
+        "xl/worksheets/sheet1.xml" -> sheetXml
+      ).foreach { case (name, content) =>
+        zip.putNextEntry(new ZipEntry(name))
+        zip.write(content.getBytes(StandardCharsets.UTF_8))
+        zip.closeEntry()
+      }
+    finally zip.close()
+    output.toByteArray
+
+  @SuppressWarnings(Array("org.wartremover.warts.Var", "org.wartremover.warts.While"))
+  private def zipEntry(bytes: Array[Byte], name: String): String =
+    val zip = new ZipInputStream(new ByteArrayInputStream(bytes))
+    var current = zip.getNextEntry
+    var result: Option[String] = None
+    try
+      while current != null && result.isEmpty do
+        if current.getName == name then
+          result = Some(new String(zip.readAllBytes(), StandardCharsets.UTF_8))
+        else
+          zip.closeEntry()
+          current = zip.getNextEntry
+    finally zip.close()
+    result.getOrElse(fail(s"missing ZIP entry $name"))


### PR DESCRIPTION
## Summary

- expand OOXML shared-formula dependents during DOM, row-streaming, and single-cell reads
- translate A1 references with relative and absolute anchors while preserving cached results
- normalize shared indices, reject stale dependent text, and keep streaming memory bounded
- rewrite dependents as ordinary formulas instead of silently converting them to constants

## Root cause

A shared-formula dependent stores an empty `<f t="shared" si="…"/>` plus a cached `<v>`. The reader treated the empty formula as absent, so any later sheet regeneration serialized the cached value as a literal and permanently dropped the formula.

## Impact

Read/edit/write workflows now preserve every shared-formula dependent as a formula. The streaming reader expands master-first groups and fails visibly when a valid group cannot be resolved without buffering; single-cell reads can scan forward for a later master.

## Validation

- `xl-ooxml.test`: 239/239
- `xl-cats-effect.test`: 341/341
- whole-repository compile and format checks
- real-workbook smoke: 38 formulas before and after rewrite; G6 expands to `=F6+1` with cached value `4`

Fixes #370