### PR TITLE
Wave 12: file integrity — property rows, cached DateTime, rFont, part identity, comment pruning, theme part, IRR containment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+File-integrity wave from the tjc-modeling byte-exact replication campaign
+(#327, #328, #378, #381, #383, #387, #388): every workaround that campaign
+shipped as post-write zip surgery is now unnecessary — packages are
+self-consistent, schema-valid, and `recalculate()` is total.
+
+### Fixed
+
+- **Property-only rows survive scratch-build writes** (#381): rows carrying
+  only `RowProperties` (height/hidden/outline via `setRowProperties`, no
+  cells) now emit their `<row>` element on the default writer backend —
+  spacer-row heights and collapsed outline groups no longer vanish. The
+  streaming (SaxStax) backend already handled this; backends now agree,
+  pinned by cross-backend parity tests.
+- **Formula cells keep cached DateTime results** (#378): `=TODAY()`,
+  `=EDATE(...)`, `=EOMONTH(...)` cells written after `recalculate()` now
+  carry their cached value as an Excel serial in `<v>` (with `t="n"`) on all
+  three writer backends, so `data_only` readers, pandas, and previewers see
+  values instead of blanks. The cats-effect streaming writer also gained the
+  missing `t="str"` mapping for cached text.
+- **Comment rich runs are schema-valid** (#383): run properties in
+  `xl/comments*.xml` (and freshly-authored shared-string/inline rich runs)
+  emit `<rFont val=…/>` per CT_RPrElt instead of the styles.xml `<name>`
+  shape — strict parsers (openpyxl) can open XL-authored comments again.
+  The reader now parses `<rFont>` (real Excel comments no longer silently
+  lose their font) while still accepting legacy `<name>` files.
+- **Modified sheets keep their source part names** (#327): on source-backed
+  writes, a modified sheet's output part, its rels, and the workbook-rels
+  reconciliation all derive from one identity-resolved source path — writes
+  against Excel-reordered files no longer fail with a duplicate-zip-entry
+  `IOError` when an index-derived name collides with an unmodified
+  neighbor's part.
+- **Removing a sheet's last comment prunes its package footprint** (#328):
+  a cell-edit write that drops a sheet's final comment no longer leaves the
+  orphan comments/VML `[Content_Types].xml` overrides, dangling sheet rels,
+  or `legacyDrawing` reference behind; other sheets' comments survive, and
+  foreign part dialects (openpyxl naming) prune by resolved path.
+- **Scratch workbooks with theme colors ship a theme part** (#387): writing
+  a from-scratch workbook whose styles (or conditional-formatting dxfs)
+  reference `Color.Theme` now emits a default Office `xl/theme/theme1.xml`
+  plus its content-type override and workbook relationship — packages are
+  self-consistent for strict consumers. RGB-only workbooks gain nothing;
+  source-backed writes keep preserving the original theme.
+- **Financial-function divergence is contained per-cell** (#388): `IRR()`
+  Newton divergence (and the same overflow class in XIRR/XNPV/NPV and the
+  TVM family) returns a per-cell evaluation error instead of throwing
+  `ArithmeticException` out of `recalculate()`; a defense-in-depth backstop
+  in the workbook evaluator guarantees recalculation is total even if a
+  future function forgets to guard.
+
 ## [0.12.6] "Fieldwork" - 2026-07-15
 
 Production-feedback hardening from agent-fleet use on real deal workbooks

--- a/xl-cats-effect/src/com/tjclp/xl/io/StreamingXmlWriter.scala
+++ b/xl-cats-effect/src/com/tjclp/xl/io/StreamingXmlWriter.scala
@@ -284,13 +284,22 @@ object StreamingXmlWriter:
               XmlEvent.XmlString(err.toExcel, false),
               XmlEvent.EndTag(QName("v"))
             )
-          case _ => Nil // Empty, RichText, Formula, DateTime - don't write
+          case CellValue.DateTime(dt) =>
+            // GH-378: cached DateTime serializes as the Excel serial (t="n"), like Excel itself
+            List(
+              XmlEvent.StartTag(QName("v"), Nil, false),
+              XmlEvent.XmlString(XmlUtil.plainNumber(CellValue.dateTimeToExcelSerial(dt)), false),
+              XmlEvent.EndTag(QName("v"))
+            )
+          case _ => Nil // Empty, RichText, Formula - don't write
         }
-        // Cell type based on cached value
+        // Cell type based on cached value (mirrors OoxmlWorksheet.fromDomainWithMetadata)
         val cellType = cachedValue match
           case Some(CellValue.Number(_)) => "n"
           case Some(CellValue.Bool(_)) => "b"
           case Some(CellValue.Error(_)) => "e"
+          case Some(CellValue.Text(_)) => "str"
+          case Some(CellValue.DateTime(_)) => "n"
           case _ => ""
         (cellType, formulaEvents ++ cachedEvents)
 

--- a/xl-cats-effect/test/src/com/tjclp/xl/io/streaming/StreamingFormulaCachedValueSpec.scala
+++ b/xl-cats-effect/test/src/com/tjclp/xl/io/streaming/StreamingFormulaCachedValueSpec.scala
@@ -1,0 +1,95 @@
+package com.tjclp.xl.io.streaming
+
+import java.nio.file.{Files, Path}
+import java.time.LocalDateTime
+import java.util.zip.ZipFile
+
+import cats.effect.IO
+import munit.CatsEffectSuite
+
+import com.tjclp.xl.cells.CellValue
+import com.tjclp.xl.io.{ExcelIO, RowData}
+import com.tjclp.xl.macros.ref
+import com.tjclp.xl.ooxml.XlsxReader
+
+/**
+ * GH-378: streaming writes must serialize formula cached values for every cached type.
+ *
+ * DateTime caches are written as the Excel serial with t="n" (matching what Excel itself stores
+ * after recalculation); Text caches carry t="str". Dropping the cached <v> strands `=TODAY()` /
+ * `=EDATE(...)` cells uncached, so openpyxl data_only / pandas / previewers see blanks.
+ */
+class StreamingFormulaCachedValueSpec extends CatsEffectSuite:
+
+  private val excel = ExcelIO.instance[IO]
+
+  private def tempXlsx(label: String): Path =
+    val p = Files.createTempFile(s"xl-stream-cached-$label-", ".xlsx")
+    p.toFile.deleteOnExit()
+    p
+
+  private def entryText(path: Path, name: String): String =
+    val zip = new ZipFile(path.toFile)
+    try
+      Option(zip.getEntry(name)) match
+        case Some(e) => new String(zip.getInputStream(e).readAllBytes(), "UTF-8")
+        case None => fail(s"zip entry $name not found")
+    finally zip.close()
+
+  test("writeStream serializes formula cached DateTime as Excel serial with t=\"n\" (GH-378)") {
+    val path = tempXlsx("datetime")
+    // Jan 1, 2000 noon = serial 36526.5 exactly
+    val cached = LocalDateTime.of(2000, 1, 1, 12, 0, 0)
+    val rows = fs2.Stream
+      .emits(
+        List(
+          RowData(1, Map(0 -> CellValue.DateTime(cached))),
+          RowData(2, Map(0 -> CellValue.Formula("EDATE(A1,0)", Some(CellValue.DateTime(cached)))))
+        )
+      )
+      .covary[IO]
+    rows.through(excel.writeStream(path, "Data")).compile.drain.map { _ =>
+      val sheetXml = entryText(path, "xl/worksheets/sheet1.xml")
+      val cellXml = """(?s)<c r="A2".*?</c>""".r
+        .findFirstIn(sheetXml)
+        .getOrElse(fail(s"A2 cell missing from worksheet XML: $sheetXml"))
+      assert(cellXml.contains("""t="n""""), cellXml)
+      assert(cellXml.contains("<v>36526.5</v>"), cellXml)
+
+      val wb = XlsxReader.read(path).fold(e => fail(s"read: ${e.message}"), identity)
+      wb.sheets(0)(ref"A2").value match
+        case CellValue.Formula(expr, Some(CellValue.Number(serial))) =>
+          assertEquals(expr, "EDATE(A1,0)")
+          assertEquals(serial.toDouble, 36526.5, 0.000001)
+        case other => fail(s"Expected Formula with cached serial Number, got $other")
+    }
+  }
+
+  test("writeStream marks formula cached Text with t=\"str\" (GH-378)") {
+    val path = tempXlsx("text")
+    val rows = fs2.Stream
+      .emits(
+        List(
+          RowData(
+            1,
+            Map(0 -> CellValue.Formula("""CONCATENATE("a","b")""", Some(CellValue.Text("ab"))))
+          )
+        )
+      )
+      .covary[IO]
+    rows.through(excel.writeStream(path, "Data")).compile.drain.map { _ =>
+      val sheetXml = entryText(path, "xl/worksheets/sheet1.xml")
+      val cellXml = """(?s)<c r="A1".*?</c>""".r
+        .findFirstIn(sheetXml)
+        .getOrElse(fail(s"A1 cell missing from worksheet XML: $sheetXml"))
+      assert(cellXml.contains("""t="str""""), cellXml)
+      assert(cellXml.contains("<v>ab</v>"), cellXml)
+
+      val wb = XlsxReader.read(path).fold(e => fail(s"read: ${e.message}"), identity)
+      wb.sheets(0)(ref"A1").value match
+        case CellValue.Formula(expr, Some(CellValue.Text(t))) =>
+          assertEquals(expr, """CONCATENATE("a","b")""")
+          assertEquals(t, "ab")
+        case other => fail(s"Expected Formula with cached Text, got $other")
+    }
+  }

--- a/xl-evaluator/src/com/tjclp/xl/formula/eval/WorkbookEvaluator.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/eval/WorkbookEvaluator.scala
@@ -14,6 +14,8 @@ import com.tjclp.xl.error.{XLError, XLResult}
 import com.tjclp.xl.sheets.Sheet
 import com.tjclp.xl.workbooks.Workbook
 
+import scala.util.control.NonFatal
+
 // Import SheetEvaluator extension methods
 import SheetEvaluator.*
 
@@ -256,9 +258,23 @@ object WorkbookEvaluator:
             case Some(idx) =>
               val tempSheet = sheets(idx)
               val tempWb = wb.copy(sheets = sheets)
-              val evaluatedCell = rngOpt match
-                case Some(rng) => tempSheet.evaluateCell(q.ref, clock, rng, Some(tempWb))
-                case None => tempSheet.evaluateCell(q.ref, clock, Some(tempWb))
+              // GH-388 defense in depth: recalculate is documented total — a numeric blowup
+              // escaping a function implementation (e.g. BigDecimal scale overflow in a
+              // diverging Newton loop) must degrade to this cell's per-cell error, never
+              // unwind the whole recalculation.
+              val evaluatedCell =
+                try
+                  rngOpt match
+                    case Some(rng) => tempSheet.evaluateCell(q.ref, clock, rng, Some(tempWb))
+                    case None => tempSheet.evaluateCell(q.ref, clock, Some(tempWb))
+                catch
+                  case NonFatal(e) =>
+                    Left(
+                      XLError.FormulaError(
+                        formulaText(q),
+                        s"Evaluation threw ${e.getClass.getName}"
+                      )
+                    )
               evaluatedCell match
                 case Right(value) =>
                   (

--- a/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpecsFinancialCashflow.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpecsFinancialCashflow.scala
@@ -8,6 +8,25 @@ import com.tjclp.xl.formula.{Clock, Arity}
 import com.tjclp.xl.addressing.CellRange
 import java.time.LocalDate
 import java.time.temporal.ChronoUnit
+import scala.util.control.NonFatal
+
+/**
+ * GH-388: containment for numeric blowups in financial math.
+ *
+ * Newton–Raphson divergence can push BigDecimal scales past `Int.MaxValue`
+ * (`java.lang.ArithmeticException` from `checkScale`), and NaN/Infinity doubles explode in
+ * `BigDecimal.apply` (`NumberFormatException`). Totality requires those to surface as the same
+ * contained per-cell `EvalFailed` the non-convergence path produces — never as an exception
+ * unwinding `recalculate()`. Same precedent as the `ArrayArithmetic.pow` guard.
+ */
+private[functions] object NumericGuard:
+  def contained[A](fn: String, usage: String)(
+    body: => Either[EvalError, A]
+  ): Either[EvalError, A] =
+    try body
+    catch
+      case NonFatal(_) =>
+        Left(EvalError.EvalFailed(s"$fn diverged (numeric overflow)", Some(usage)))
 
 trait FunctionSpecsFinancialCashflow extends FunctionSpecsBase:
   private def numericValues(range: CellRange, ctx: EvalContext): List[BigDecimal] =
@@ -39,14 +58,16 @@ trait FunctionSpecsFinancialCashflow extends FunctionSpecsBase:
             )
           )
         else
-          val cashFlows = numericValues(range, ctx)
+          NumericGuard.contained("NPV", "NPV(rate, values)") {
+            val cashFlows = numericValues(range, ctx)
 
-          val npv =
-            cashFlows.zipWithIndex.foldLeft(BigDecimal(0)) { case (acc, (cf, idx)) =>
-              val period = idx + 1
-              acc + cf / onePlusR.pow(period)
-            }
-          Right(npv)
+            val npv =
+              cashFlows.zipWithIndex.foldLeft(BigDecimal(0)) { case (acc, (cf, idx)) =>
+                val period = idx + 1
+                acc + cf / onePlusR.pow(period)
+              }
+            Right(npv)
+          }
       }
     }
 
@@ -115,7 +136,7 @@ trait FunctionSpecsFinancialCashflow extends FunctionSpecsBase:
                 if (next - r).abs <= tolerance then Right(next)
                 else loop(iter + 1, next)
 
-          loop(0, guess0)
+          NumericGuard.contained("IRR", "IRR(values[, guess])")(loop(0, guess0))
         }
     }
 
@@ -149,14 +170,17 @@ trait FunctionSpecsFinancialCashflow extends FunctionSpecsBase:
           else
             dates match
               case date0 :: _ =>
-                val onePlusR = BigDecimal(1) + rate
-                val npv = values.zip(dates).foldLeft(BigDecimal(0)) { case (acc, (value, date)) =>
-                  val daysDiff = ChronoUnit.DAYS.between(date0, date)
-                  val yearFraction = BigDecimal(daysDiff) / BigDecimal(365)
-                  val discountFactor = math.pow(onePlusR.toDouble, yearFraction.toDouble)
-                  acc + value / BigDecimal(discountFactor)
+                NumericGuard.contained("XNPV", "XNPV(rate, values, dates)") {
+                  val onePlusR = BigDecimal(1) + rate
+                  val npv =
+                    values.zip(dates).foldLeft(BigDecimal(0)) { case (acc, (value, date)) =>
+                      val daysDiff = ChronoUnit.DAYS.between(date0, date)
+                      val yearFraction = BigDecimal(daysDiff) / BigDecimal(365)
+                      val discountFactor = math.pow(onePlusR.toDouble, yearFraction.toDouble)
+                      acc + value / BigDecimal(discountFactor)
+                    }
+                  Right(npv)
                 }
-                Right(npv)
               case Nil =>
                 Left(EvalError.EvalFailed("XNPV: dates cannot be empty", None))
         }
@@ -248,7 +272,7 @@ trait FunctionSpecsFinancialCashflow extends FunctionSpecsBase:
                     if (next - r).abs <= tolerance then Right(next)
                     else loop(iter + 1, next)
 
-              loop(0, guess0)
+              NumericGuard.contained("XIRR", "XIRR(values, dates[, guess])")(loop(0, guess0))
             case Nil =>
               Left(EvalError.EvalFailed("XIRR: dates cannot be empty", None))
         }

--- a/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpecsFinancialTvm.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpecsFinancialTvm.scala
@@ -23,13 +23,18 @@ trait FunctionSpecsFinancialTvm extends FunctionSpecsBase:
         pmtType <- typeOpt match
           case Some(expr) => ctx.evalExpr(expr).map(v => if v.toInt != 0 then 1 else 0)
           case None => Right(0)
-      yield
-        if math.abs(rate) < 1e-10 then
-          if nper == 0.0 then BigDecimal(Double.NaN)
-          else BigDecimal(-(pv + fv) / nper)
-        else
-          val pvif = math.pow(1.0 + rate, nper)
-          BigDecimal(-rate * (pv * pvif + fv) / ((1.0 + rate * pmtType) * (pvif - 1.0)))
+        // GH-388: BigDecimal(Double) throws NumberFormatException on NaN/Infinity
+        result <- NumericGuard.contained("PMT", "PMT(rate, nper, pv, [fv], [type])") {
+          val payment =
+            if math.abs(rate) < 1e-10 then
+              if nper == 0.0 then BigDecimal(Double.NaN)
+              else BigDecimal(-(pv + fv) / nper)
+            else
+              val pvif = math.pow(1.0 + rate, nper)
+              BigDecimal(-rate * (pv * pvif + fv) / ((1.0 + rate * pmtType) * (pvif - 1.0)))
+          Right(payment)
+        }
+      yield result
     }
 
   val fv: FunctionSpec[BigDecimal] { type Args = TvmArgs } =
@@ -49,12 +54,17 @@ trait FunctionSpecsFinancialTvm extends FunctionSpecsBase:
         pmtType <- typeOpt match
           case Some(expr) => ctx.evalExpr(expr).map(v => if v.toInt != 0 then 1 else 0)
           case None => Right(0)
-      yield
-        if math.abs(rate) < 1e-10 then BigDecimal(-pv - pmt * nper)
-        else
-          val pvif = math.pow(1.0 + rate, nper)
-          val fvifa = (pvif - 1.0) / rate
-          BigDecimal(-pv * pvif - pmt * (1.0 + rate * pmtType) * fvifa)
+        // GH-388: BigDecimal(Double) throws NumberFormatException on NaN/Infinity
+        result <- NumericGuard.contained("FV", "FV(rate, nper, pmt, [pv], [type])") {
+          val futureValue =
+            if math.abs(rate) < 1e-10 then BigDecimal(-pv - pmt * nper)
+            else
+              val pvif = math.pow(1.0 + rate, nper)
+              val fvifa = (pvif - 1.0) / rate
+              BigDecimal(-pv * pvif - pmt * (1.0 + rate * pmtType) * fvifa)
+          Right(futureValue)
+        }
+      yield result
     }
 
   val pv: FunctionSpec[BigDecimal] { type Args = TvmArgs } =
@@ -74,12 +84,17 @@ trait FunctionSpecsFinancialTvm extends FunctionSpecsBase:
         pmtType <- typeOpt match
           case Some(expr) => ctx.evalExpr(expr).map(v => if v.toInt != 0 then 1 else 0)
           case None => Right(0)
-      yield
-        if math.abs(rate) < 1e-10 then BigDecimal(-fv - pmt * nper)
-        else
-          val pvif = math.pow(1.0 + rate, nper)
-          val fvifa = (pvif - 1.0) / rate
-          BigDecimal((-fv - pmt * (1.0 + rate * pmtType) * fvifa) / pvif)
+        // GH-388: BigDecimal(Double) throws NumberFormatException on NaN/Infinity
+        result <- NumericGuard.contained("PV", "PV(rate, nper, pmt, [fv], [type])") {
+          val presentValue =
+            if math.abs(rate) < 1e-10 then BigDecimal(-fv - pmt * nper)
+            else
+              val pvif = math.pow(1.0 + rate, nper)
+              val fvifa = (pvif - 1.0) / rate
+              BigDecimal((-fv - pmt * (1.0 + rate * pmtType) * fvifa) / pvif)
+          Right(presentValue)
+        }
+      yield result
     }
 
   val nper: FunctionSpec[BigDecimal] { type Args = TvmArgs } =
@@ -99,15 +114,21 @@ trait FunctionSpecsFinancialTvm extends FunctionSpecsBase:
         pmtType <- typeOpt match
           case Some(expr) => ctx.evalExpr(expr).map(v => if v.toInt != 0 then 1 else 0)
           case None => Right(0)
-      yield
-        if math.abs(rate) < 1e-10 then
-          if pmt == 0.0 then BigDecimal(Double.NaN)
-          else BigDecimal(-(pv + fv) / pmt)
-        else
-          val ratep1 = 1.0 + rate
-          val numerator = -fv * rate + pmt * (1.0 + rate * pmtType)
-          val denominator = pv * rate + pmt * (1.0 + rate * pmtType)
-          BigDecimal(math.log(numerator / denominator) / math.log(ratep1))
+        // GH-388: BigDecimal(Double) throws NumberFormatException on NaN/Infinity
+        // (zero payment, or math.log of a non-positive ratio)
+        result <- NumericGuard.contained("NPER", "NPER(rate, pmt, pv, [fv], [type])") {
+          val periods =
+            if math.abs(rate) < 1e-10 then
+              if pmt == 0.0 then BigDecimal(Double.NaN)
+              else BigDecimal(-(pv + fv) / pmt)
+            else
+              val ratep1 = 1.0 + rate
+              val numerator = -fv * rate + pmt * (1.0 + rate * pmtType)
+              val denominator = pv * rate + pmt * (1.0 + rate * pmtType)
+              BigDecimal(math.log(numerator / denominator) / math.log(ratep1))
+          Right(periods)
+        }
+      yield result
     }
 
   val rate: FunctionSpec[BigDecimal] { type Args = RateArgs } =
@@ -130,7 +151,9 @@ trait FunctionSpecsFinancialTvm extends FunctionSpecsBase:
         guess <- guessOpt match
           case Some(expr) => ctx.evalExpr(expr).map(_.toDouble)
           case None => Right(0.1)
-        result <- {
+        // GH-388: the converged Right(BigDecimal(next)) must never explode on a
+        // non-finite double
+        result <- NumericGuard.contained("RATE", "RATE(nper, pmt, pv, [fv], [type], [guess])") {
           val maxIter = 100
           val tolerance = 1e-7
 

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/FinancialFunctionsSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/FinancialFunctionsSpec.scala
@@ -5,9 +5,11 @@ import com.tjclp.xl.addressing.ARef
 import com.tjclp.xl.cells.{Cell, CellValue}
 import com.tjclp.xl.sheets.Sheet
 import com.tjclp.xl.syntax.*
+import com.tjclp.xl.workbooks.Workbook
 import munit.ScalaCheckSuite
 import org.scalacheck.Prop.*
 
+import java.time.LocalDate
 import scala.math.BigDecimal
 
 /**
@@ -239,6 +241,116 @@ class FinancialFunctionsSpec extends ScalaCheckSuite:
     val parsed = FormulaParser.parse(formula).getOrElse(fail("Parse failed"))
     val printed = FormulaPrinter.print(parsed)
     assertEquals(printed, formula)
+  }
+
+  // ==================== GH-388: Newton Divergence Containment ====================
+
+  // Issue repro: a thin one-entry/one-exit strip whose exit approaches zero. Newton
+  // overshoots below -1 and diverges doubly-exponentially until BigDecimal's int scale
+  // overflows (java.lang.ArithmeticException from checkScale). Totality requires the same
+  // contained EvalFailed as the documented non-convergence path — never a thrown exception.
+  private def divergingStrip: Sheet = sheetWith(
+    ARef.from0(0, 0) -> CellValue.Number(BigDecimal("-228")),
+    ARef.from0(0, 1) -> CellValue.Number(BigDecimal("0")),
+    ARef.from0(0, 2) -> CellValue.Number(BigDecimal("0")),
+    ARef.from0(0, 3) -> CellValue.Number(BigDecimal("0")),
+    ARef.from0(0, 4) -> CellValue.Number(BigDecimal("0")),
+    ARef.from0(0, 5) -> CellValue.Number(BigDecimal("0.0001"))
+  )
+
+  test("IRR: Newton divergence returns contained error, never throws (GH-388)") {
+    val expr = TExpr.irr(CellRange.parse("A1:A6").getOrElse(fail("Invalid range")))
+    evalErr(expr, divergingStrip) match
+      case EvalError.EvalFailed(reason, _) =>
+        assert(reason.contains("IRR"), s"unexpected reason: $reason")
+      case other => fail(s"Expected EvalFailed, got $other")
+  }
+
+  test("IRR: Newton divergence inside recalculate() is a per-cell error, never throws (GH-388)") {
+    val s = divergingStrip
+      .put(ARef.from0(1, 0), CellValue.Formula("=IRR(A1:A6)", None))
+      .put(ARef.from0(1, 1), CellValue.Formula("=SUM(A1:A6)", None))
+    // Documented contract (see also LetFunctionSpec): recalculate is total — per-cell
+    // error reporting, never a thrown exception.
+    val result = Workbook(Vector(s)).recalculate()
+    assert(
+      result.errors.exists(e => e.ref == ARef.from0(1, 0)),
+      s"expected a per-cell error for B1, got: ${result.errors}"
+    )
+    val evaluated = result.evaluated.getOrElse(SheetName.unsafe("Test"), Map.empty)
+    assert(evaluated.get(ARef.from0(1, 0)).isEmpty, "diverging IRR must not cache a value")
+    assertEquals(
+      evaluated.get(ARef.from0(1, 1)),
+      Some(CellValue.Number(BigDecimal("-227.9999")))
+    )
+  }
+
+  // ==================== XNPV / XIRR Evaluation Tests ====================
+
+  /** Two cash flows anchored at 2020-01-01 with a parameterized exit flow and date. */
+  private def xSchedule(entry: BigDecimal, exit: BigDecimal, exitDate: LocalDate): Sheet =
+    sheetWith(
+      ARef.from0(0, 0) -> CellValue.Number(entry),
+      ARef.from0(0, 1) -> CellValue.Number(exit),
+      ARef.from0(1, 0) -> CellValue.DateTime(LocalDate.of(2020, 1, 1).atStartOfDay),
+      ARef.from0(1, 1) -> CellValue.DateTime(exitDate.atStartOfDay)
+    )
+
+  test("XNPV: discounts irregular cash flows by actual/365 year fractions") {
+    val expr = TExpr.xnpv(
+      TExpr.Lit(BigDecimal("0.1")),
+      CellRange.parse("A1:A2").getOrElse(fail("Invalid range")),
+      CellRange.parse("B1:B2").getOrElse(fail("Invalid range"))
+    )
+    val sheet = xSchedule(BigDecimal("-1000"), BigDecimal("1200"), LocalDate.of(2021, 1, 1))
+    val result = evalOk(expr, sheet)
+    // -1000 + 1200 / 1.1^(366/365) — 2020 is a leap year, 366 days between the dates
+    val expected = -1000.0 + 1200.0 / math.pow(1.1, 366.0 / 365.0)
+    assert((result.toDouble - expected).abs < 0.01, s"got $result, expected ~$expected")
+  }
+
+  test("XIRR: two-flow investment rate makes XNPV zero") {
+    val expr = TExpr.xirr(
+      CellRange.parse("A1:A2").getOrElse(fail("Invalid range")),
+      CellRange.parse("B1:B2").getOrElse(fail("Invalid range"))
+    )
+    val sheet = xSchedule(BigDecimal("-1000"), BigDecimal("1100"), LocalDate.of(2021, 1, 1))
+    val result = evalOk(expr, sheet)
+    val npvAtResult = -1000.0 + 1100.0 / math.pow(1.0 + result.toDouble, 366.0 / 365.0)
+    assert(
+      math.abs(npvAtResult) < 0.001,
+      s"XNPV at computed XIRR should be ~0, got $npvAtResult (rate: $result)"
+    )
+  }
+
+  test("XIRR: Newton divergence returns contained error, never throws (GH-388)") {
+    // Same shape as the IRR repro: near-zero exit five years out. Newton overshoots to a
+    // hugely negative rate; math.pow(negative base, fractional exponent) yields NaN, and
+    // BigDecimal(NaN) must not escape as a NumberFormatException.
+    val expr = TExpr.xirr(
+      CellRange.parse("A1:A2").getOrElse(fail("Invalid range")),
+      CellRange.parse("B1:B2").getOrElse(fail("Invalid range"))
+    )
+    val sheet = xSchedule(BigDecimal("-228"), BigDecimal("0.0001"), LocalDate.of(2025, 1, 1))
+    evalErr(expr, sheet) match
+      case EvalError.EvalFailed(reason, _) =>
+        assert(reason.contains("XIRR"), s"unexpected reason: $reason")
+      case other => fail(s"Expected EvalFailed, got $other")
+  }
+
+  test("XNPV: non-finite discount factor is a contained error, never throws (GH-388)") {
+    // Rate 1e300 over a ~5-year fraction: math.pow(1e300, ~5) = Infinity, and
+    // BigDecimal(Infinity) must not escape as a NumberFormatException.
+    val expr = TExpr.xnpv(
+      TExpr.Lit(BigDecimal("1e300")),
+      CellRange.parse("A1:A2").getOrElse(fail("Invalid range")),
+      CellRange.parse("B1:B2").getOrElse(fail("Invalid range"))
+    )
+    val sheet = xSchedule(BigDecimal("-1000"), BigDecimal("1200"), LocalDate.of(2025, 1, 1))
+    evalErr(expr, sheet) match
+      case EvalError.EvalFailed(reason, _) =>
+        assert(reason.contains("XNPV"), s"unexpected reason: $reason")
+      case other => fail(s"Expected EvalFailed, got $other")
   }
 
   // ==================== VLOOKUP Tests ====================
@@ -713,4 +825,71 @@ class FinancialFunctionsSpec extends ScalaCheckSuite:
     val fvFormula = s"=FV(0.005, $nper, -200, 10000)"
     val fv = evalNumeric(fvFormula)
     assertApprox(fv, 0.0, 1.0)
+  }
+
+  // ==================== GH-388: TVM Numeric Containment ====================
+
+  /** Expect a contained EvalFailed naming the function — the eval must never throw. */
+  private def assertContained(expr: TExpr[BigDecimal], fn: String): Unit =
+    evalErr(expr, sheetWith()) match
+      case EvalError.EvalFailed(reason, _) =>
+        assert(reason.contains(fn), s"unexpected reason: $reason")
+      case other => fail(s"Expected EvalFailed, got $other")
+
+  test("PMT: zero rate with zero periods is a contained error, never throws (GH-388)") {
+    // rate ≈ 0, nper = 0 hits the BigDecimal(Double.NaN) branch
+    val expr = TExpr.pmt(
+      TExpr.Lit(BigDecimal(0)),
+      TExpr.Lit(BigDecimal(0)),
+      TExpr.Lit(BigDecimal(10000))
+    )
+    assertContained(expr, "PMT")
+  }
+
+  test("PMT: non-finite intermediate (huge rate and nper) is a contained error (GH-388)") {
+    // pow(1e300, 1e300) = Infinity, -Inf/Inf = NaN → BigDecimal(NaN) must be contained
+    val expr = TExpr.pmt(
+      TExpr.Lit(BigDecimal("1e300")),
+      TExpr.Lit(BigDecimal("1e300")),
+      TExpr.Lit(BigDecimal(10000))
+    )
+    assertContained(expr, "PMT")
+  }
+
+  test("FV: non-finite intermediate (huge rate and nper) is a contained error (GH-388)") {
+    val expr = TExpr.fv(
+      TExpr.Lit(BigDecimal("1e300")),
+      TExpr.Lit(BigDecimal("1e300")),
+      TExpr.Lit(BigDecimal(100))
+    )
+    assertContained(expr, "FV")
+  }
+
+  test("PV: non-finite intermediate (huge rate and nper) is a contained error (GH-388)") {
+    val expr = TExpr.pv(
+      TExpr.Lit(BigDecimal("1e300")),
+      TExpr.Lit(BigDecimal("1e300")),
+      TExpr.Lit(BigDecimal(100))
+    )
+    assertContained(expr, "PV")
+  }
+
+  test("NPER: zero rate with zero payment is a contained error, never throws (GH-388)") {
+    val expr = TExpr.nper(
+      TExpr.Lit(BigDecimal(0)),
+      TExpr.Lit(BigDecimal(0)),
+      TExpr.Lit(BigDecimal(10000))
+    )
+    assertContained(expr, "NPER")
+  }
+
+  test("RATE: NaN-producing inputs yield a contained non-convergence error (GH-388)") {
+    // pow(1.1, 1e10) = Infinity → f and df both NaN; the Newton loop must exhaust its
+    // iterations with a contained EvalFailed rather than surfacing NaN or throwing.
+    val expr = TExpr.rate(
+      TExpr.Lit(BigDecimal("1e10")),
+      TExpr.Lit(BigDecimal(-500)),
+      TExpr.Lit(BigDecimal(10000))
+    )
+    assertContained(expr, "RATE")
   }

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/Comments.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/Comments.scala
@@ -311,7 +311,8 @@ object OoxmlComments extends XmlReadable[OoxmlComments]:
         }
 
         props += elem("sz", "val" -> f.sizePt.toString)()
-        props += elem("name", "val" -> f.name)()
+        // CT_RPrElt spells the font element <rFont>, not the CT_Font <name> (GH-383)
+        props += elem("rFont", "val" -> f.name)()
 
         elem("rPr")(props.result()*)
       }

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/ContentTypes.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/ContentTypes.scala
@@ -69,6 +69,14 @@ case class ContentTypes(
       copy(overrides = overrides ++ overridesToAdd)
 
   /**
+   * Register the generated default theme part (GH-387) — only when the write actually emits it (a
+   * scratch workbook whose styles reference theme colors). Idempotent.
+   */
+  def withThemeOverride(hasGeneratedTheme: Boolean): ContentTypes =
+    if !hasGeneratedTheme then this
+    else copy(overrides = overrides + ("/xl/theme/theme1.xml" -> ctTheme))
+
+  /**
    * Register drawing-part overrides (GH-221). `partPaths` are zip paths without the leading slash
    * ("xl/drawings/drawing1.xml"). Idempotent.
    */

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/ContentTypes.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/ContentTypes.scala
@@ -46,6 +46,22 @@ case class ContentTypes(
     if commentAdds.isEmpty && vmlAdds.isEmpty then this
     else copy(overrides = overrides ++ commentAdds ++ vmlAdds)
 
+  /**
+   * Prune comment-class overrides (comments + VML) whose parts are NOT in `shippedParts` (zip paths
+   * without the leading slash) — the mirror of [[withEmittedCommentParts]] for the preserved-CT
+   * branch (GH-328): a cell edit that removes a sheet's LAST comment keeps the preserved
+   * [Content_Types].xml byte-stable, whose comment/VML overrides would otherwise dangle behind the
+   * withheld parts. Only the writer-owned comment classes are touched — every other preserved
+   * override (pivots, customXml, threadedComments, macro payloads) rides through untouched (the
+   * GH-314 invariant). The metadata-modified branch gets the same guarantee from
+   * [[ContentTypes.reconcile]] (GH-322).
+   */
+  def withoutOrphanCommentParts(shippedParts: Set[String]): ContentTypes =
+    val shippedNames = shippedParts.map(p => s"/$p")
+    copy(overrides = overrides.filter { case (partName, ct) =>
+      (ct != ctComments && ct != ctVmlDrawing) || shippedNames.contains(partName)
+    })
+
   def withTableOverrides(tableCount: Int): ContentTypes =
     if tableCount == 0 then this
     else

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/ContentTypes.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/ContentTypes.scala
@@ -145,14 +145,32 @@ object ContentTypes extends XmlReadable[ContentTypes]:
     hasSharedStrings: Boolean = false,
     sheetsWithComments: Set[Int] = Set.empty
   ): ContentTypes =
+    forSheetPaths(
+      sheetIndices.distinct.sorted.map(idx => s"xl/worksheets/sheet$idx.xml"),
+      hasStyles,
+      hasSharedStrings,
+      sheetsWithComments
+    )
+
+  /**
+   * Create content types registering worksheet parts at their ACTUAL part paths (GH-327): a
+   * source-backed write keeps every sheet's identity-resolved part name, which need not follow the
+   * sheet1..sheetN index scheme. `sheetPaths` are zip paths without the leading slash.
+   */
+  def forSheetPaths(
+    sheetPaths: Seq[String],
+    hasStyles: Boolean = false,
+    hasSharedStrings: Boolean = false,
+    sheetsWithComments: Set[Int] = Set.empty
+  ): ContentTypes =
     val baseDefaults = Map(
       "rels" -> ctRelationships,
       "xml" -> "application/xml",
       "vml" -> ctVmlDrawing
     )
 
-    val sheetOverrides = sheetIndices.distinct.sorted.map { idx =>
-      s"/xl/worksheets/sheet$idx.xml" -> ctWorksheet
+    val sheetOverrides = sheetPaths.distinct.map { path =>
+      s"/$path" -> ctWorksheet
     }
 
     // Add comment overrides for sheets with comments

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/DefaultTheme.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/DefaultTheme.scala
@@ -1,0 +1,31 @@
+package com.tjclp.xl.ooxml
+
+/**
+ * Generated default Office theme part (GH-387).
+ *
+ * A scratch-built workbook whose styles reference `Color.Theme` slots serializes `<color
+ * theme="N"/>` records; without a theme part nothing in the package can resolve them (Excel
+ * silently substitutes its built-in Office theme, strict consumers reject the package). This is the
+ * writer's counterpart to [[ThemeParser]] — parse-only until now — emitting the standard Office
+ * palette for exactly that case. Source-backed writes never use it: a preserved
+ * `xl/theme/theme1.xml` is copied verbatim.
+ *
+ * INVARIANTS:
+ *   - `<a:clrScheme>` children are in OOXML document order (dk1, lt1, dk2, lt2, accent1-6, hlink,
+ *     folHlink) — the SLOT-INDEX mapping consumers apply is `ColorHelpers.themeSlotToIndex` (lt1=0,
+ *     dk1=1, lt2=2, dk2=3, accent1-6=4-9), which is NOT document order; only the element NAMES
+ *     carry identity here.
+ *   - Palette values match [[ThemeParser]]'s per-slot fallback defaults byte-for-byte, so a
+ *     resolved color is identical whether a consumer reads this part or defaults it.
+ *   - Tint stays on the style color (`<color theme="N" tint="..."/>`) — the theme part carries only
+ *     the base palette.
+ *   - Schema-complete `CT_BaseStyles`: clrScheme, fontScheme (latin+ea+cs), and a minimal fmtScheme
+ *     with the required three entries per style list.
+ */
+private[ooxml] object DefaultTheme:
+
+  val path: String = "xl/theme/theme1.xml"
+
+  val xml: String =
+    """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<a:theme xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" name="Office Theme"><a:themeElements><a:clrScheme name="Office"><a:dk1><a:sysClr val="windowText" lastClr="000000"/></a:dk1><a:lt1><a:sysClr val="window" lastClr="FFFFFF"/></a:lt1><a:dk2><a:srgbClr val="44546A"/></a:dk2><a:lt2><a:srgbClr val="E7E6E6"/></a:lt2><a:accent1><a:srgbClr val="4472C4"/></a:accent1><a:accent2><a:srgbClr val="ED7D31"/></a:accent2><a:accent3><a:srgbClr val="A5A5A5"/></a:accent3><a:accent4><a:srgbClr val="FFC000"/></a:accent4><a:accent5><a:srgbClr val="5B9BD5"/></a:accent5><a:accent6><a:srgbClr val="70AD47"/></a:accent6><a:hlink><a:srgbClr val="0563C1"/></a:hlink><a:folHlink><a:srgbClr val="954F72"/></a:folHlink></a:clrScheme><a:fontScheme name="Office"><a:majorFont><a:latin typeface="Calibri Light" panose="020F0302020204030204"/><a:ea typeface=""/><a:cs typeface=""/></a:majorFont><a:minorFont><a:latin typeface="Calibri" panose="020F0502020204030204"/><a:ea typeface=""/><a:cs typeface=""/></a:minorFont></a:fontScheme><a:fmtScheme name="Office"><a:fillStyleLst><a:solidFill><a:schemeClr val="phClr"/></a:solidFill><a:solidFill><a:schemeClr val="phClr"/></a:solidFill><a:solidFill><a:schemeClr val="phClr"/></a:solidFill></a:fillStyleLst><a:lnStyleLst><a:ln w="6350" cap="flat" cmpd="sng" algn="ctr"><a:solidFill><a:schemeClr val="phClr"/></a:solidFill><a:prstDash val="solid"/></a:ln><a:ln w="12700" cap="flat" cmpd="sng" algn="ctr"><a:solidFill><a:schemeClr val="phClr"/></a:solidFill><a:prstDash val="solid"/></a:ln><a:ln w="19050" cap="flat" cmpd="sng" algn="ctr"><a:solidFill><a:schemeClr val="phClr"/></a:solidFill><a:prstDash val="solid"/></a:ln></a:lnStyleLst><a:effectStyleLst><a:effectStyle><a:effectLst/></a:effectStyle><a:effectStyle><a:effectLst/></a:effectStyle><a:effectStyle><a:effectLst/></a:effectStyle></a:effectStyleLst><a:bgFillStyleLst><a:solidFill><a:schemeClr val="phClr"/></a:solidFill><a:solidFill><a:schemeClr val="phClr"/></a:solidFill><a:solidFill><a:schemeClr val="phClr"/></a:solidFill></a:bgFillStyleLst></a:fmtScheme></a:themeElements><a:objectDefaults/><a:extraClrSchemeLst/></a:theme>"""

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/DirectSaxEmitter.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/DirectSaxEmitter.scala
@@ -431,6 +431,11 @@ object DirectSaxEmitter:
         writer.startElement("v")
         writer.writeCharacters(err.toExcel)
         writer.endElement()
+      case CellValue.DateTime(dt) =>
+        // GH-378: cached DateTime serializes as the Excel serial (t="n"), like Excel itself
+        writer.startElement("v")
+        writer.writeCharacters(XmlUtil.plainNumber(CellValue.dateTimeToExcelSerial(dt)))
+        writer.endElement()
       case _ => ()
     }
 

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/DirectSaxEmitter.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/DirectSaxEmitter.scala
@@ -502,7 +502,8 @@ object DirectSaxEmitter:
     writer.writeAttribute("val", font.sizePt.toString)
     writer.endElement()
 
-    writer.startElement("name")
+    // CT_RPrElt spells the font element <rFont>, not the CT_Font <name> (GH-383)
+    writer.startElement("rFont")
     writer.writeAttribute("val", font.name)
     writer.endElement()
 

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/Relationships.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/Relationships.scala
@@ -120,11 +120,28 @@ object Relationships extends XmlReadable[Relationships]:
     hasStyles: Boolean = false,
     hasSharedStrings: Boolean = false
   ): Relationships =
-    val sheets = sheetIndices.zipWithIndex.map { case (sheetIdx, i) =>
-      Relationship(s"rId${i + 1}", relTypeWorksheet, s"worksheets/sheet$sheetIdx.xml")
+    workbookForPaths(
+      sheetIndices.map(idx => s"xl/worksheets/sheet$idx.xml"),
+      hasStyles,
+      hasSharedStrings
+    )
+
+  /**
+   * Create workbook .rels targeting explicit worksheet part paths (GH-327): the writer's fresh rels
+   * must name the SAME output parts the physical writes emit, which need not follow the
+   * sheet1..sheetN index scheme. `sheetPaths` are zip paths ("xl/worksheets/sheet2.xml"); rIds are
+   * sequential in sheet order.
+   */
+  def workbookForPaths(
+    sheetPaths: Seq[String],
+    hasStyles: Boolean = false,
+    hasSharedStrings: Boolean = false
+  ): Relationships =
+    val sheets = sheetPaths.zipWithIndex.map { case (path, i) =>
+      Relationship(s"rId${i + 1}", relTypeWorksheet, workbookTargetOf(path))
     }
 
-    val nextId = sheetIndices.size + 1
+    val nextId = sheetPaths.size + 1
     val styles =
       if hasStyles then Seq(Relationship(s"rId$nextId", relTypeStyles, "styles.xml")) else Seq.empty
     val sst =

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/SharedStrings.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/SharedStrings.scala
@@ -136,7 +136,8 @@ final case class SharedStrings(
                 }
 
                 fontProps += elem("sz", "val" -> f.sizePt.toString)()
-                fontProps += elem("name", "val" -> f.name)()
+                // CT_RPrElt spells the font element <rFont>, not the CT_Font <name> (GH-383)
+                fontProps += elem("rFont", "val" -> f.name)()
 
                 elem("rPr")(fontProps.result()*)
               }.toList
@@ -247,7 +248,8 @@ final case class SharedStrings(
     writer.writeAttribute("val", font.sizePt.toString)
     writer.endElement()
 
-    writer.startElement("name")
+    // CT_RPrElt spells the font element <rFont>, not the CT_Font <name> (GH-383)
+    writer.startElement("rFont")
     writer.writeAttribute("val", font.name)
     writer.endElement()
 

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/XlsxReader.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/XlsxReader.scala
@@ -514,6 +514,11 @@ object XlsxReader:
   /**
    * Parse worksheet relationships to find comment, table, hyperlink, and drawing references.
    *
+   * The rels part is the SIBLING of the sheet's resolved part path (GH-327): sources whose physical
+   * sheetN.xml numbering is permuted vs logical order (Excel reorders on disk; the surgical writer
+   * preserves identity names) keep each sheet's rels with THAT sheet — an index-derived lookup read
+   * a neighbor's rels and mis-associated comments/tables/hyperlinks.
+   *
    * Returns (commentPath, tableTargets, hyperlinkRels, drawingPath) where:
    *   - commentPath: Optional path to comments file (e.g., "../comments1.xml")
    *   - tableTargets: Sequence of table file paths (e.g., ["../tables/table1.xml",
@@ -523,9 +528,12 @@ object XlsxReader:
    */
   private def parseWorksheetRelationships(
     parts: Map[String, String],
-    sheetIndex: Int
+    sheetPath: String
   ): XLResult[(Option[String], Seq[String], Map[String, String], Option[String])] =
-    val relsPath = s"xl/worksheets/_rels/sheet$sheetIndex.xml.rels"
+    val relsPath =
+      val slash = sheetPath.lastIndexOf('/')
+      val (dir, name) = sheetPath.splitAt(slash + 1)
+      s"${dir}_rels/$name.rels"
     parts.get(relsPath) match
       case None => Right((None, Seq.empty, Map.empty, None)) // No relationships for this sheet
       case Some(xml) =>
@@ -856,9 +864,10 @@ object XlsxReader:
             .fromXmlWithSST(elem, sst)
             .left
             .map(err => XLError.ParseError(sheetPath, err): XLError)
-          // Parse worksheet relationships to find comment/table references (1-based sheet index)
+          // Parse worksheet relationships to find comment/table references — resolved from the
+          // sheet's OWN part path, never its index (GH-327: physical numbering can be permuted)
           (commentTarget, tableTargets, hyperlinkRels, drawingTarget) <-
-            parseWorksheetRelationships(parts, idx + 1)
+            parseWorksheetRelationships(parts, sheetPath)
 
           // Parse comments if relationship exists
           comments <- commentTarget match

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/XlsxWriter.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/XlsxWriter.scala
@@ -14,6 +14,7 @@ import com.tjclp.xl.drawings.ImageFormat
 import com.tjclp.xl.error.{XLError, XLResult}
 import com.tjclp.xl.context.{ModificationTracker, SourceContext}
 import com.tjclp.xl.richtext.RichText
+import com.tjclp.xl.styles.{Border, Color, Fill}
 import com.tjclp.xl.tables.TableSpec
 import com.tjclp.xl.ooxml.chart.{ChartCaches, OoxmlChart}
 import com.tjclp.xl.ooxml.drawing.{DrawingReader, OoxmlDrawing}
@@ -468,18 +469,21 @@ object XlsxWriter:
         zip.write(bytes)
         zip.closeEntry()
 
-  /** Write VML part to ZIP (VML is plain text, not standard XML) */
-  private def writeVmlPart(
+  /**
+   * Write a pre-serialized text part to ZIP byte-exact (VML — plain text, not standard XML — and
+   * the generated default theme, GH-387).
+   */
+  private def writeRawTextPart(
     zip: ZipOutputStream,
     entryName: String,
-    vmlXml: String,
+    content: String,
     config: WriterConfig
   ): Unit =
     val entry = new ZipEntry(entryName)
     entry.setTime(0L) // Deterministic timestamps
     entry.setMethod(config.compression.zipMethod)
 
-    val bytes = vmlXml.getBytes(StandardCharsets.UTF_8)
+    val bytes = content.getBytes(StandardCharsets.UTF_8)
 
     config.compression match
       case Compression.Stored =>
@@ -1626,6 +1630,32 @@ object XlsxWriter:
     val styles =
       OoxmlStyles(styleIndex, preservedStylesAttrs, preservedStylesScope, cfPlan.mergedDxfs)
 
+    // GH-387: a scratch write (no source theme to copy) whose emitted artifacts reference theme
+    // colors must ship a theme part — the <color theme="N"/> records in styles.xml/dxfs/rich-text
+    // runs are otherwise unresolvable inside the package (Excel silently substitutes its built-in
+    // Office theme; strict consumers see a self-inconsistent package). RGB/indexed-only workbooks
+    // gain no part; source-backed writes keep the preservation path untouched.
+    val needsGeneratedTheme: Boolean =
+      sourceContext.isEmpty && {
+        def isThemeColor(c: Color): Boolean = c match
+          case Color.Theme(_, _) => true
+          case Color.Rgb(_) => false
+        def fillHasTheme(f: Fill): Boolean = f match
+          case Fill.Solid(c) => isThemeColor(c)
+          case Fill.Pattern(fg, bg, _) => isThemeColor(fg) || isThemeColor(bg)
+          case Fill.None => false
+        def borderHasTheme(b: Border): Boolean =
+          Seq(b.left, b.right, b.top, b.bottom).exists(_.color.exists(isThemeColor))
+        styleIndex.fonts.exists(_.color.exists(isThemeColor)) ||
+        styleIndex.fills.exists(fillHasTheme) ||
+        styleIndex.borders.exists(borderHasTheme) ||
+        cfPlan.mergedDxfs.exists(dxfs => (dxfs \\ "_").exists(_.attribute("theme").isDefined)) ||
+        workbook.sheets.exists(_.cells.valuesIterator.exists(_.value match
+          case CellValue.RichText(rt) =>
+            rt.runs.exists(_.font.exists(_.color.exists(isThemeColor)))
+          case _ => false))
+      }
+
     // Build comments data and VML drawings
     val commentsBySheet = buildCommentsData(workbook)
     val vmlDrawings = commentsBySheet.map { case (idx, comments) =>
@@ -1761,17 +1791,26 @@ object XlsxWriter:
           ensureSharedStrings = sharedStringsInOutput
         )
       case None =>
-        (
-          OoxmlWorkbook.sequentialRelIds(workbook.sheets.size),
-          // GH-327: fresh rels target the SAME output paths the physical writes use (for a
-          // scratch workbook these are exactly worksheets/sheet1..N — byte-identical to the
-          // legacy sheetCount form).
-          Relationships.workbookForPaths(
-            sheetOutputPaths,
-            hasStyles = true,
-            hasSharedStrings = sharedStringsInOutput
-          )
+        // GH-327: fresh rels target the SAME output paths the physical writes use (for a
+        // scratch workbook these are exactly worksheets/sheet1..N — byte-identical to the
+        // legacy sheetCount form). GH-387: the generated theme part gets its relationship
+        // appended with the next free rId.
+        val base = Relationships.workbookForPaths(
+          sheetOutputPaths,
+          hasStyles = true,
+          hasSharedStrings = sharedStringsInOutput
         )
+        val withTheme =
+          if needsGeneratedTheme then
+            Relationships(
+              base.relationships :+ Relationship(
+                s"rId${base.relationships.size + 1}",
+                XmlUtil.relTypeTheme,
+                "theme/theme1.xml"
+              )
+            )
+          else base
+        (OoxmlWorkbook.sequentialRelIds(workbook.sheets.size), withTheme)
 
     // Use preserved workbook structure if available, otherwise create minimal
     val ooxmlWb = preservedWorkbook match
@@ -1867,6 +1906,7 @@ object XlsxWriter:
           .withDrawingOverrides(drawingPlan.allPartPaths)
           .withChartOverrides(drawingPlan.allChartPartPaths)
           .withImageDefaults(drawingPlan.manifestImageDefaults ++ drawingPlan.imageDefaults)
+          .withThemeOverride(needsGeneratedTheme)
         // GH-314: a source can still exist here (metadata-modified write) — merge its preserved
         // content types so exotic parts riding the copy loop keep their registrations. docProps
         // reconciliation is re-applied AFTER the merge: it removes stale preserved overrides for
@@ -1915,12 +1955,14 @@ object XlsxWriter:
       writeStyles(zip, "xl/styles.xml", styles, config)
 
       // Preserve theme file from source if available
-      // Theme is parsed (in "known parts") but not regenerated, so we must copy it explicitly
-      val themePath = "xl/theme/theme1.xml"
+      // Theme is parsed (in "known parts") but not regenerated, so we must copy it explicitly.
+      // GH-387: with no source, a workbook whose styles reference theme colors ships the
+      // generated default Office theme instead (registered in CT + workbook rels below).
       sourceContext.foreach { ctx =>
-        if ctx.partManifest.contains(themePath) then
-          copyPreservedPart(ctx.sourcePath, themePath, zip)
+        if ctx.partManifest.contains(DefaultTheme.path) then
+          copyPreservedPart(ctx.sourcePath, DefaultTheme.path, zip)
       }
+      if needsGeneratedTheme then writeRawTextPart(zip, DefaultTheme.path, DefaultTheme.xml, config)
 
       if regenerateSharedStrings then
         sst.foreach { sharedStrings =>
@@ -2103,7 +2145,7 @@ object XlsxWriter:
             writePart(zip, commentPath, comments, config)
 
             vmlDrawings.get(idx).foreach { vmlXml =>
-              writeVmlPart(zip, vmlPath, vmlXml, config)
+              writeRawTextPart(zip, vmlPath, vmlXml, config)
             }
           }
         else

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/XlsxWriter.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/XlsxWriter.scala
@@ -1129,6 +1129,9 @@ object XlsxWriter:
   private val legacyCommentPathPattern = "^xl/comments(\\d+)\\.xml$".r
   private val legacyVmlPathPattern = "^xl/drawings/vmlDrawing(\\d+)\\.vml$".r
 
+  /** Excel's worksheet part scheme — fresh allocations number above every claimed N (GH-327). */
+  private val worksheetPathPattern = "^xl/worksheets/sheet(\\d+)\\.xml$".r
+
   /**
    * VML drawing part path for a sheet's regenerated comments (GH-292). Excel's numbering scheme is
    * derived from the comment path; foreign comment dialects (openpyxl's xl/comments/comment1.xml)
@@ -1723,11 +1726,32 @@ object XlsxWriter:
     // verbatim rels made the first sheet resolve to xl/theme/theme1.xml: a data-corruption class.)
     val sheetSourcePaths: Vector[Option[String]] =
       workbook.sheets.indices.toVector.map(idx => sourceContext.flatMap(sourceSheetPath(_, idx)))
+    // GH-327: a sheet's OUTPUT part keeps its identity-resolved SOURCE name whether it is
+    // regenerated or copied verbatim. Naming regenerated parts by INDEX collided with an
+    // unmodified neighbor riding verbatim copy to the same physical path whenever the source's
+    // sheetN.xml numbering was permuted vs logical order (Excel reorders on disk) — a duplicate
+    // zip entry that killed the whole write. Sheets with no source part (fresh, or no source at
+    // all) allocate numbers ABOVE everything any manifest worksheet part or identity mapping
+    // claims (the comment-part precedent), so a fresh part can never collide either. Physical
+    // writes, sheet rels, and the workbook-rels reconciliation ALL consume this one vector.
     val sheetOutputPaths: Vector[String] =
-      workbook.sheets.indices.toVector.map { idx =>
-        if sheetsToRegenerate.contains(idx) then s"xl/worksheets/sheet${idx + 1}.xml"
-        else sheetSourcePaths(idx).getOrElse(s"xl/worksheets/sheet${idx + 1}.xml")
-      }
+      val claimedPaths =
+        sourceContext.map(_.partManifest.entries.keySet).getOrElse(Set.empty) ++
+          sheetSourcePaths.flatten
+      val maxClaimedNum = claimedPaths
+        .flatMap {
+          case worksheetPathPattern(n) => Some(n.toInt)
+          case _ => None
+        }
+        .maxOption
+        .getOrElse(0)
+      workbook.sheets.indices.toVector
+        .foldLeft((Vector.empty[String], maxClaimedNum + 1)) { case ((acc, next), idx) =>
+          sheetSourcePaths(idx) match
+            case Some(path) => (acc :+ path, next)
+            case None => (acc :+ s"xl/worksheets/sheet$next.xml", next + 1)
+        }
+        ._1
     val (sheetRelIds, workbookRels) = preservedStructWbRels match
       case Some(preservedRels) =>
         Relationships.reconcileWorkbook(
@@ -1739,8 +1763,11 @@ object XlsxWriter:
       case None =>
         (
           OoxmlWorkbook.sequentialRelIds(workbook.sheets.size),
-          Relationships.workbook(
-            sheetCount = workbook.sheets.size,
+          // GH-327: fresh rels target the SAME output paths the physical writes use (for a
+          // scratch workbook these are exactly worksheets/sheet1..N — byte-identical to the
+          // legacy sheetCount form).
+          Relationships.workbookForPaths(
+            sheetOutputPaths,
             hasStyles = true,
             hasSharedStrings = sharedStringsInOutput
           )
@@ -1806,12 +1833,13 @@ object XlsxWriter:
         // GH-221: this branch regenerates [Content_Types].xml from scratch while preserved
         // drawing/media parts still ride the copy loop, so register EVERY drawing part shipping
         // (manifest + fresh) and every known media extension (manifest + written). GH-222: chart
-        // parts follow the same allPartPaths pattern.
+        // parts follow the same allPartPaths pattern. GH-327: worksheet overrides register the
+        // ACTUAL output paths — identity-named parts need not be sheet1..sheetN.
         val model = ContentTypes
-          .minimal(
+          .forSheetPaths(
+            sheetOutputPaths,
             hasStyles = true,
-            hasSharedStrings = sharedStringsInOutput,
-            sheetCount = workbook.sheets.size
+            hasSharedStrings = sharedStringsInOutput
           )
           .withEmittedCommentParts(commentPathBySheet.values.toSet, vmlPathBySheet.values.toSet)
           .withTableOverrides(totalTableCount)
@@ -1886,8 +1914,9 @@ object XlsxWriter:
         if sheetsToRegenerate.contains(idx) then
           // Regenerate modified sheet with preserved metadata (if available, via the GH-136
           // pre-pass cache — parsed once, consumed by both the cf plan and this loop).
-          // GH-315: the sheet's SOURCE parts (worksheet metadata, rels) resolve by identity; the
-          // OUTPUT entry names follow the current index.
+          // GH-315/GH-327: the sheet's SOURCE parts (worksheet metadata, rels) resolve by
+          // identity, and the OUTPUT entry keeps that same name (sheetOutputPaths) so it can
+          // never collide with a neighbor riding verbatim copy.
           val sourcePathOpt = sourceContext.flatMap(sourceSheetPath(_, idx))
           val preservedMetadata = preservedWorksheets.getOrElse(idx, Right(None)) match
             case Right(value) => value
@@ -1937,7 +1966,7 @@ object XlsxWriter:
                 if sheet.drawings.isEmpty && sheet.conditionalFormats.isEmpty =>
               writeWorksheetDirect(
                 zip,
-                s"xl/worksheets/sheet${idx + 1}.xml",
+                sheetOutputPaths(idx),
                 sheet,
                 sstForSheets,
                 remapping,
@@ -1957,17 +1986,17 @@ object XlsxWriter:
                   drawingPlan.drawingRefs.get(idx),
                   condFmt = Some(cfPlan.condFmtBySheet.getOrElse(idx, Seq.empty))
                 )
-              writeWorksheet(zip, s"xl/worksheets/sheet${idx + 1}.xml", ooxmlSheet, config)
+              writeWorksheet(zip, sheetOutputPaths(idx), ooxmlSheet, config)
 
           // For modified sheets:
           // 1. Copy relationships from source (preserves printerSettings, drawings, customProperty)
           // 2. Regenerate comments/VML from domain model (handles comment add/remove/modify)
-          // GH-315: the OUTPUT rels entry is named by current index; the PRESERVED rels are
-          // looked up by the sheet's identity-resolved source path (they differ after deletion
-          // or reorder). The comment part comes from the per-write assignment (identity-mapped
-          // or collision-free fresh allocation); the index fallback is only reachable for sheets
-          // that emit no comments, where the value is never written.
-          val relsPath = s"xl/worksheets/_rels/sheet${idx + 1}.xml.rels"
+          // GH-315/GH-327: the OUTPUT rels entry is the sibling of the sheet's OUTPUT part; the
+          // PRESERVED rels are looked up by the sheet's identity-resolved source path (they only
+          // differ for a fresh sheet). The comment part comes from the per-write assignment
+          // (identity-mapped or collision-free fresh allocation); the index fallback is only
+          // reachable for sheets that emit no comments, where the value is never written.
+          val relsPath = partRelsPathOf(sheetOutputPaths(idx))
           val sourceRelsPathOpt = sourceContext.flatMap(sourceSheetRelsPath(_, idx))
           val commentPath = commentPathBySheet.getOrElse(idx, s"xl/comments${idx + 1}.xml")
           // GH-292: foreign comment dialects resolve the VML target through the preserved rels
@@ -2045,11 +2074,12 @@ object XlsxWriter:
           }
         else
           // Copy unmodified sheet from source (only if source available). Only reachable with
-          // stable indices — deletion/reorder/metadata changes force full regeneration — but the
-          // source paths resolve by identity anyway (GH-315); the legacy index fallback covers
-          // untracked direct surgery exactly as before.
+          // stable indices — deletion/reorder/metadata changes force full regeneration — and the
+          // copy target is the SAME output-path vector the regeneration and the workbook-rels
+          // reconciliation consume (GH-327): for an unmodified sheet it is always the
+          // identity-resolved source part (GH-315), so the paths cannot desync.
           sourceContext.foreach { ctx =>
-            val sheetPath = sourceSheetPath(ctx, idx).getOrElse(graph.pathForSheet(idx))
+            val sheetPath = sheetOutputPaths(idx)
             copyPreservedPart(ctx.sourcePath, sheetPath, zip)
 
             // Copy comments and relationships using source's actual paths (from mapping)

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/XlsxWriter.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/XlsxWriter.scala
@@ -1807,6 +1807,25 @@ object XlsxWriter:
     val corePropsXml = DocProps.buildCoreXml(workbook.metadata)
     val appPropsXml = DocProps.buildAppXml(workbook.metadata)
 
+    // GH-328: every comment/VML part this write actually SHIPS — emitted for regenerated sheets
+    // plus everything riding verbatim (unmodified sheets' comment parts, surviving VML). A
+    // preserved-CT override of the comment classes naming a part outside this set is an orphan
+    // (a sheet whose comments were ALL removed) and is pruned below; every other content type
+    // rides through untouched (GH-314). Pruning keys on the RESOLVED paths, so foreign comment
+    // dialects (openpyxl's xl/comments/comment1.xml) prune correctly too.
+    val shippedCommentParts: Set[String] =
+      commentPathBySheet.values.toSet ++ vmlPathBySheet.values.toSet ++
+        (sourceContext match
+          case Some(ctx) =>
+            workbook.sheets.zipWithIndex
+              .collect {
+                case (sheet, idx) if !sheetsToRegenerate.contains(idx) =>
+                  ctx.commentPathMapping.get(sheet.name).filter(ctx.partManifest.contains)
+              }
+              .flatten
+              .toSet ++ (preservableParts -- vmlPathsToSkip)
+          case None => Set.empty)
+
     // Content types: preserve from source when available, otherwise generate minimal.
     // GH-315: comment/VML registrations follow the EMITTED part paths (identity-mapped or freshly
     // allocated) — withEmittedCommentParts is conservative, so source-declared parts ride through
@@ -1829,6 +1848,7 @@ object XlsxWriter:
           .withChartOverrides(drawingPlan.freshChartPaths)
           .withImageDefaults(drawingPlan.imageDefaults)
           .withEmittedCommentParts(commentPathBySheet.values.toSet, vmlPathBySheet.values.toSet)
+          .withoutOrphanCommentParts(shippedCommentParts)
       case None =>
         // GH-221: this branch regenerates [Content_Types].xml from scratch while preserved
         // drawing/media parts still ride the copy loop, so register EVERY drawing part shipping
@@ -1918,20 +1938,30 @@ object XlsxWriter:
           // identity, and the OUTPUT entry keeps that same name (sheetOutputPaths) so it can
           // never collide with a neighbor riding verbatim copy.
           val sourcePathOpt = sourceContext.flatMap(sourceSheetPath(_, idx))
-          val preservedMetadata = preservedWorksheets.getOrElse(idx, Right(None)) match
+          val hasComments = commentsBySheet.contains(idx)
+          val mappedCommentPart = sourceContext.flatMap(_.commentPathMapping.get(sheet.name))
+          // GH-328: this write removes the sheet's LAST comment — the comment/VML parts are
+          // withheld (vmlPathsToSkip / buildCommentsData), so the preserved legacyDrawing
+          // element and the preserved comment/VML rels must fall with them or they dangle.
+          // Keyed on "emits none NOW while the source HAD a part", never on the source alone:
+          // form-control VML on a never-commented sheet rides through untouched.
+          val staleCommentRels = !hasComments && mappedCommentPart.isDefined
+          val parsedMetadata = preservedWorksheets.getOrElse(idx, Right(None)) match
             case Right(value) => value
             case Left(err) =>
               throw new IllegalStateException(
                 s"Failed to parse preserved worksheet " +
                   s"${sourcePathOpt.getOrElse(graph.pathForSheet(idx))}: ${err.message}"
               )
+          val preservedMetadata =
+            if staleCommentRels then parsedMetadata.map(_.copy(legacyDrawing = None))
+            else parsedMetadata
           val remapping = sheetRemappings.getOrElse(idx, Map.empty)
 
           // Generate tableParts XML element for modified sheet
           val tablePartsXml = tablesBySheet.get(idx).flatMap { tablesForSheet =>
             if tablesForSheet.isEmpty then None
             else
-              val hasComments = commentsBySheet.contains(idx)
               val rIdOffset = if hasComments then 3 else 1
 
               val tablePartElems =
@@ -2002,7 +2032,6 @@ object XlsxWriter:
           // GH-292: foreign comment dialects resolve the VML target through the preserved rels
           val vmlPath = vmlPathForSheet(sourceContext, sourceRelsPathOpt, idx, commentPath)
 
-          val hasComments = commentsBySheet.contains(idx)
           val tableIds = tablesBySheet.get(idx).map(_.map(_._2)).getOrElse(Seq.empty)
           val hlRels = hyperlinkRelationships(sheet) // GH-235
 
@@ -2014,22 +2043,28 @@ object XlsxWriter:
           // rels appended — the source rels predate them. (A mapped comment part implies the
           // source rels already reference it: the reader resolved the part THROUGH those rels,
           // GH-292 — so only an unmapped emission appends.)
-          val needsCommentRels = hasComments &&
-            sourceContext.flatMap(_.commentPathMapping.get(sheet.name)).isEmpty
+          val needsCommentRels = hasComments && mappedCommentPart.isEmpty
           (sourceContext, sourceRelsPathOpt) match
             case (Some(ctx), Some(sourceRelsPath)) if ctx.partManifest.contains(sourceRelsPath) =>
               if hlRels.isEmpty && drawingRelAdd.isEmpty && !needsCommentRels &&
-                sourceRelsPath == relsPath
+                !staleCommentRels && sourceRelsPath == relsPath
               then copyPreservedPart(ctx.sourcePath, relsPath, zip)
               else
                 // Merge authored hyperlink rels into the preserved sheet rels (parse + append);
-                // also the path for source rels riding to a DIFFERENT output slot (GH-315).
+                // also the path for source rels riding to a DIFFERENT output slot (GH-315) and
+                // for dropping comment/VML rels behind a full comment removal (GH-328).
                 val preserved = withZipFile(ctx.sourcePath) { z =>
                   parseOptionalEntry(z, sourceRelsPath)(Relationships.fromXml)
                 }.getOrElse(Relationships(Seq.empty))
-                // Drop the source's hyperlink rels (we regenerate them from the model) to avoid
-                // orphans, but keep everything else (printerSettings, drawings, ...).
-                val kept = preserved.relationships.filterNot(_.`type` == XmlUtil.relTypeHyperlink)
+                // Drop the source's hyperlink rels (we regenerate them from the model) and the
+                // comment/VML rels when this write emits no comments for the sheet (GH-328 —
+                // the parts no longer ship); keep everything else (printerSettings, ...).
+                val kept = preserved.relationships.filterNot(rel =>
+                  rel.`type` == XmlUtil.relTypeHyperlink ||
+                    (staleCommentRels &&
+                      (rel.`type` == XmlUtil.relTypeComments ||
+                        rel.`type` == XmlUtil.relTypeVmlDrawing))
+                )
                 val commentRelAdds =
                   if needsCommentRels && !kept.exists(_.`type` == XmlUtil.relTypeComments) then
                     Seq(
@@ -2045,12 +2080,11 @@ object XlsxWriter:
                       )
                     )
                   else Seq.empty
-                writePart(
-                  zip,
-                  relsPath,
-                  Relationships(kept ++ hlRels ++ drawingRelAdd.toList ++ commentRelAdds),
-                  config
-                )
+                val merged = kept ++ hlRels ++ drawingRelAdd.toList ++ commentRelAdds
+                // A rels part with nothing left is dropped entirely (GH-328): the regenerated
+                // worksheet no longer references any rId, and an empty <Relationships/> part
+                // serves nothing.
+                if merged.nonEmpty then writePart(zip, relsPath, Relationships(merged), config)
             case _
                 if hasComments || tableIds.nonEmpty || hlRels.nonEmpty || drawingRelAdd.nonEmpty =>
               val base =

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/OoxmlCell.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/OoxmlCell.scala
@@ -157,7 +157,8 @@ case class OoxmlCell(
     writer.writeAttribute("val", font.sizePt.toString)
     writer.endElement()
 
-    writer.startElement("name")
+    // CT_RPrElt spells the font element <rFont>, not the CT_Font <name> (GH-383)
+    writer.startElement("rFont")
     writer.writeAttribute("val", font.name)
     writer.endElement()
 
@@ -230,7 +231,8 @@ case class OoxmlCell(
 
                 // Font size and name
                 fontProps += elem("sz", "val" -> f.sizePt.toString)()
-                fontProps += elem("name", "val" -> f.name)()
+                // CT_RPrElt spells the font element <rFont>, not the CT_Font <name> (GH-383)
+                fontProps += elem("rFont", "val" -> f.name)()
 
                 elem("rPr")(fontProps.result()*)
               }.toList

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/OoxmlCell.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/OoxmlCell.scala
@@ -80,7 +80,12 @@ case class OoxmlCell(
               writer.startElement("v")
               writer.writeCharacters(err.toExcel)
               writer.endElement()
-            case _ => () // Empty, RichText, Formula, DateTime - don't write
+            case CellValue.DateTime(dt) =>
+              // GH-378: cached DateTime serializes as the Excel serial (t="n"), like Excel itself
+              writer.startElement("v")
+              writer.writeCharacters(XmlUtil.plainNumber(CellValue.dateTimeToExcelSerial(dt)))
+              writer.endElement()
+            case _ => () // Empty, RichText, Formula - don't write
           }
 
         case CellValue.Error(err) =>
@@ -273,7 +278,10 @@ case class OoxmlCell(
           case CellValue.Error(err) =>
             import com.tjclp.xl.cells.CellError.toExcel
             Some(elem("v")(Text(err.toExcel)))
-          case _ => None // Empty, RichText, Formula, DateTime - don't write
+          case CellValue.DateTime(dt) =>
+            // GH-378: cached DateTime serializes as the Excel serial (t="n"), like Excel itself
+            Some(elem("v")(Text(XmlUtil.plainNumber(CellValue.dateTimeToExcelSerial(dt)))))
+          case _ => None // Empty, RichText, Formula - don't write
         }
         Seq(formulaElem) ++ cachedElem.toList
       case CellValue.Error(err) =>

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/OoxmlWorksheet.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/OoxmlWorksheet.scala
@@ -577,7 +577,7 @@ object OoxmlWorksheet extends com.tjclp.xl.ooxml.XmlReadable[OoxmlWorksheet]:
       case None =>
         // No preserved metadata - create minimal worksheet with cols from domain
         OoxmlWorksheet(
-          rowsWithCells,
+          allRows, // GH-381: include property-only rows (rowProperties without cells)
           sheet.mergedRanges,
           sheetPr = mergeSheetPrElem(None, sheet.pageSetup), // GH-266: fitToPage flag
           dimension = calculatedDimension,

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/xml.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/xml.scala
@@ -58,6 +58,8 @@ object XmlUtil:
     "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image"
   val relTypeChart =
     "http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart"
+  val relTypeTheme =
+    "http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme"
   // docProps relationships (GH-242): core props is a PACKAGE relationship type, app is officeDocument
   val relTypeCoreProperties =
     "http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties"
@@ -75,6 +77,7 @@ object XmlUtil:
   val ctTable = "application/vnd.openxmlformats-officedocument.spreadsheetml.table+xml"
   val ctDrawing = "application/vnd.openxmlformats-officedocument.drawing+xml"
   val ctChart = "application/vnd.openxmlformats-officedocument.drawingml.chart+xml"
+  val ctTheme = "application/vnd.openxmlformats-officedocument.theme+xml"
   val ctRelationships = "application/vnd.openxmlformats-package.relationships+xml"
   val ctCoreProperties = "application/vnd.openxmlformats-package.core-properties+xml"
   val ctExtendedProperties =

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/xml.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/xml.scala
@@ -348,7 +348,8 @@ object XmlUtil:
    *   - <u/> → underline
    *   - <color rgb="RRGGBB"/> → font color (hex without # prefix)
    *   - <sz val="14.0"/> → size in points
-   *   - <name val="Arial"/> → font family
+   *   - <rFont val="Arial"/> → font family (CT_RPrElt spelling; legacy <name val=…/> read as
+   *     fallback, GH-383)
    *
    * @param rPrElem
    *   The <rPr> element to parse
@@ -380,11 +381,16 @@ object XmlUtil:
       .filter(_ > 0)
       .getOrElse(11.0)
 
-    val name = (rPrElem \ "name").headOption
-      .collect { case elem: Elem => elem }
-      .flatMap(e => getAttrOpt(e, "val"))
-      .filter(_.nonEmpty)
-      .getOrElse("Calibri")
+    // CT_RPrElt spells the font element <rFont val=…/> (real Excel files use it
+    // exclusively); older xl versions wrote the CT_Font spelling <name val=…/>,
+    // which stays readable as a fallback (GH-383).
+    def fontName(label: String): Option[String] =
+      (rPrElem \ label).headOption
+        .collect { case elem: Elem => elem }
+        .flatMap(e => getAttrOpt(e, "val"))
+        .filter(_.nonEmpty)
+
+    val name = fontName("rFont").orElse(fontName("name")).getOrElse("Calibri")
 
     Font(
       name = name,

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/CommentsSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/CommentsSpec.scala
@@ -542,5 +542,69 @@ class CommentsSpec extends FunSuite:
     assertEquals(rereadSheet.comments.get(ref"A1").flatMap(_.author), Some("Author"))
   }
 
+  test("GH-383: authored comment rPr emits <rFont> (CT_RPrElt), never <name>") {
+    // xl/commentsN.xml run properties are CT_RPrElt, whose font element is <rFont val=…/>.
+    // <name val=…/> is the CT_Font (styles.xml) spelling; strict parsers (openpyxl)
+    // reject the whole workbook over it. The author-prefix run makes every authored
+    // comment carry an rPr, so this exercises the exact GH-383 repro.
+    val sheet = Sheet("Sheet1").comment(
+      ref"A1",
+      Comment.plainText("Important note", Some("Report Author"))
+    )
+    val bytes = XlsxWriter.writeToBytes(Workbook(Vector(sheet))) match
+      case Right(b) => b
+      case Left(err) => fail(s"Write failed: $err")
+
+    val commentsXml = zipEntryString(bytes, "xl/comments1.xml")
+      .getOrElse(fail("Expected xl/comments1.xml part"))
+
+    assert(
+      commentsXml.contains("<rFont val="),
+      s"Author-prefix run must serialize its font as <rFont val=…>: $commentsXml"
+    )
+    assert(
+      !commentsXml.contains("<name val="),
+      s"CT_RPrElt forbids <name val=…> inside <rPr>: $commentsXml"
+    )
+  }
+
+  test("GH-383: comment run font name survives encode → parse round-trip") {
+    val richText = com.tjclp.xl.richtext.RichText(
+      Vector(
+        com.tjclp.xl.richtext.TextRun(
+          "Styled note",
+          Some(com.tjclp.xl.styles.font.Font(name = "Times New Roman", sizePt = 12.0, bold = true))
+        )
+      )
+    )
+    val comments = OoxmlComments(
+      authors = Vector("Author"),
+      comments = Vector(OoxmlComment(ref"A1", 0, richText))
+    )
+
+    val reparsed = OoxmlComments.fromXml(OoxmlComments.toXml(comments)) match
+      case Right(c) => c
+      case Left(err) => fail(s"Reparse failed: $err")
+
+    val run = reparsed.comments.headOption
+      .flatMap(_.text.runs.headOption)
+      .getOrElse(fail("Expected rich text run"))
+    assertEquals(run.font.map(_.name), Some("Times New Roman"))
+    assertEquals(run.font.map(_.bold), Some(true))
+  }
+
   private def extractShapeIds(vml: String): Set[Int] =
     "_x0000_s(\\d+)".r.findAllMatchIn(vml).map(_.group(1).toInt).toSet
+
+  private def zipEntryString(bytes: Array[Byte], entryName: String): Option[String] =
+    val zis = new java.util.zip.ZipInputStream(new java.io.ByteArrayInputStream(bytes))
+    try
+      Iterator
+        .continually(Option(zis.getNextEntry))
+        .takeWhile(_.isDefined)
+        .flatten
+        .collectFirst {
+          case entry if entry.getName == entryName =>
+            new String(zis.readAllBytes(), java.nio.charset.StandardCharsets.UTF_8)
+        }
+    finally zis.close()

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/ContentTypesReconcileSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/ContentTypesReconcileSpec.scala
@@ -250,7 +250,9 @@ class ContentTypesReconcileSpec extends FunSuite:
       s"legacyDrawing element must not reference a dropped VML rel:\n$sheetXml"
     )
 
-  test("GH-328: cell edit removing the last comment prunes CT override, sheet rels, legacyDrawing") {
+  test(
+    "GH-328: cell edit removing the last comment prunes CT override, sheet rels, legacyDrawing"
+  ) {
     // Excel-dialect source written by XL itself: comments1.xml + vmlDrawing1.vml
     val notes = Sheet(SheetName.unsafe("Notes"))
       .put(ref"A1" -> "hello")

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/ContentTypesReconcileSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/ContentTypesReconcileSpec.scala
@@ -5,7 +5,9 @@ import java.util.zip.{ZipEntry, ZipFile, ZipOutputStream}
 
 import scala.jdk.CollectionConverters.*
 
+import com.tjclp.xl.addressing.SheetName
 import com.tjclp.xl.api.*
+import com.tjclp.xl.cells.Comment
 import com.tjclp.xl.codec.CellCodec.given
 import com.tjclp.xl.macros.ref
 import munit.FunSuite
@@ -201,6 +203,158 @@ class ContentTypesReconcileSpec extends FunSuite:
 
     val reloaded = XlsxReader.read(output).fold(err => fail(s"Reload failed: $err"), identity)
     assertEquals(reloaded.sheetNames.map(_.value), Vector("Sheet1"))
+
+    Files.deleteIfExists(source)
+    Files.deleteIfExists(output)
+  }
+
+  // ========== GH-328: removing a sheet's LAST comment must not leave orphans behind ==========
+
+  private def sheetRelationships(path: Path, relsEntry: String): Seq[Relationship] =
+    if !zipEntryNames(path).contains(relsEntry) then Seq.empty
+    else
+      val xml = scala.xml.XML.loadString(new String(readEntry(path, relsEntry), "UTF-8"))
+      Relationships.fromXml(xml).fold(err => fail(s"rels parse failed: $err"), _.relationships)
+
+  private def assertNoCommentResidue(output: Path, commentPart: String, vmlPart: String): Unit =
+    val entries = zipEntryNames(output)
+    assert(!entries.contains(commentPart), s"removed comment part must not ship: $entries")
+    assert(!entries.contains(vmlPart), s"removed VML part must not ship: $entries")
+
+    val ct = parseContentTypes(output)
+    assertEquals(
+      ct.overrides.get(s"/$commentPart"),
+      None,
+      s"orphan comments override survived. Overrides: ${ct.overrides}"
+    )
+    assertEquals(
+      ct.overrides.get(s"/$vmlPart"),
+      None,
+      s"orphan VML override survived. Overrides: ${ct.overrides}"
+    )
+    val dangling = ct.overrides.keys.filterNot(p => entries.contains(p.stripPrefix("/")))
+    assert(
+      dangling.isEmpty,
+      s"overrides point at parts that do not ship: ${dangling.mkString(", ")}"
+    )
+
+    val sheetRels = sheetRelationships(output, "xl/worksheets/_rels/sheet1.xml.rels")
+    val commentish = sheetRels.filter(r =>
+      r.`type` == XmlUtil.relTypeComments || r.`type` == XmlUtil.relTypeVmlDrawing
+    )
+    assert(commentish.isEmpty, s"dangling comment/VML sheet rels survived: $commentish")
+
+    val sheetXml = new String(readEntry(output, "xl/worksheets/sheet1.xml"), "UTF-8")
+    assert(
+      !sheetXml.contains("<legacyDrawing"),
+      s"legacyDrawing element must not reference a dropped VML rel:\n$sheetXml"
+    )
+
+  test("GH-328: cell edit removing the last comment prunes CT override, sheet rels, legacyDrawing") {
+    // Excel-dialect source written by XL itself: comments1.xml + vmlDrawing1.vml
+    val notes = Sheet(SheetName.unsafe("Notes"))
+      .put(ref"A1" -> "hello")
+      .comment(ref"A1", Comment.plainText("note", Some("Ann")))
+    val source = Files.createTempFile("gh328-source", ".xlsx")
+    XlsxWriter
+      .write(Workbook(Vector(notes)), source)
+      .fold(err => fail(s"source write failed: $err"), identity)
+    assert(zipEntryNames(source).contains("xl/comments1.xml"), "fixture sanity: comments ship")
+
+    val wb = XlsxReader.read(source).fold(err => fail(s"Read failed: $err"), identity)
+    // Remove ALL comments + edit a cell: sheet modified, metadata stable → preserved-CT branch
+    val modified = wb
+      .update(SheetName.unsafe("Notes"), s => s.removeComment(ref"A1").put(ref"B1" -> 42))
+      .fold(err => fail(s"update failed: $err"), identity)
+
+    val output = Files.createTempFile("gh328-out", ".xlsx")
+    XlsxWriter.write(modified, output).fold(err => fail(s"Write failed: $err"), identity)
+
+    assertNoCommentResidue(output, "xl/comments1.xml", "xl/drawings/vmlDrawing1.vml")
+
+    val reloaded = XlsxReader.read(output).fold(err => fail(s"Reload failed: $err"), identity)
+    val sheet = reloaded("Notes").fold(err => fail(s"Sheet missing: $err"), identity)
+    assert(sheet.comments.isEmpty, s"comments must stay removed, got ${sheet.comments}")
+    assertEquals(sheet.cells.get(ref"B1").map(_.value.toString).isDefined, true)
+
+    Files.deleteIfExists(source)
+    Files.deleteIfExists(output)
+  }
+
+  test("GH-328: removing ONE of two comments keeps the part, its override, and its rels") {
+    val notes = Sheet(SheetName.unsafe("Notes"))
+      .put(ref"A1" -> "hello")
+      .comment(ref"A1", Comment.plainText("first", Some("Ann")))
+      .comment(ref"B2", Comment.plainText("second", Some("Bob")))
+    val source = Files.createTempFile("gh328-partial-source", ".xlsx")
+    XlsxWriter
+      .write(Workbook(Vector(notes)), source)
+      .fold(err => fail(s"source write failed: $err"), identity)
+
+    val wb = XlsxReader.read(source).fold(err => fail(s"Read failed: $err"), identity)
+    val modified = wb
+      .update(SheetName.unsafe("Notes"), _.removeComment(ref"A1"))
+      .fold(err => fail(s"update failed: $err"), identity)
+
+    val output = Files.createTempFile("gh328-partial-out", ".xlsx")
+    XlsxWriter.write(modified, output).fold(err => fail(s"Write failed: $err"), identity)
+
+    // The sheet still emits comments NOW → part, override, and rels all stay
+    val entries = zipEntryNames(output)
+    assert(entries.contains("xl/comments1.xml"), s"surviving comment part must ship: $entries")
+    val ct = parseContentTypes(output)
+    assertEquals(ct.overrides.get("/xl/comments1.xml"), Some(XmlUtil.ctComments))
+    val sheetRels = sheetRelationships(output, "xl/worksheets/_rels/sheet1.xml.rels")
+    assert(
+      sheetRels.exists(_.`type` == XmlUtil.relTypeComments),
+      s"comments rel must survive a partial removal: $sheetRels"
+    )
+
+    val reloaded = XlsxReader.read(output).fold(err => fail(s"Reload failed: $err"), identity)
+    val sheet = reloaded("Notes").fold(err => fail(s"Sheet missing: $err"), identity)
+    assertEquals(sheet.comments.keySet, Set(ref"B2"), "only the removed comment disappears")
+
+    Files.deleteIfExists(source)
+    Files.deleteIfExists(output)
+  }
+
+  test("GH-328: foreign-dialect (openpyxl) comment removal prunes by RESOLVED part path") {
+    val source = TestFixtures.copyToTemp("comments-hyperlinks.xlsx")
+    val wb = XlsxReader.read(source).fold(err => fail(s"Read failed: $err"), identity)
+
+    val hadComments = wb("Notes").fold(err => fail(s"Sheet missing: $err"), identity).comments
+    assert(hadComments.nonEmpty, "fixture sanity: the sheet starts with a comment")
+
+    val modified = wb
+      .update(
+        SheetName.unsafe("Notes"),
+        s => hadComments.keys.foldLeft(s)(_.removeComment(_)).put(ref"D4" -> "edited")
+      )
+      .fold(err => fail(s"update failed: $err"), identity)
+
+    val output = Files.createTempFile("gh328-openpyxl-out", ".xlsx")
+    XlsxWriter.write(modified, output).fold(err => fail(s"Write failed: $err"), identity)
+
+    // openpyxl names its parts xl/comments/comment1.xml + xl/drawings/commentsDrawing1.vml —
+    // pruning must key on the RESOLVED paths, not the legacy comments{n}.xml guess
+    assertNoCommentResidue(output, "xl/comments/comment1.xml", "xl/drawings/commentsDrawing1.vml")
+
+    // The model-owned EXTERNAL hyperlink keeps its rel (the internal one serializes inline
+    // via location=, no rel needed)
+    val sheetRels = sheetRelationships(output, "xl/worksheets/_rels/sheet1.xml.rels")
+    assertEquals(
+      sheetRels.count(_.`type` == XmlUtil.relTypeHyperlink),
+      1,
+      s"external hyperlink rel must survive: $sheetRels"
+    )
+
+    val reloaded = XlsxReader.read(output).fold(err => fail(s"Reload failed: $err"), identity)
+    val sheet = reloaded("Notes").fold(err => fail(s"Sheet missing: $err"), identity)
+    assert(sheet.comments.isEmpty, s"comments must stay removed, got ${sheet.comments}")
+    assert(
+      sheet.cells.get(ref"B1").exists(_.hyperlink.isDefined),
+      "hyperlink must survive the comment removal"
+    )
 
     Files.deleteIfExists(source)
     Files.deleteIfExists(output)

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/DirectSaxEmitterParitySpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/DirectSaxEmitterParitySpec.scala
@@ -221,7 +221,10 @@ class DirectSaxEmitterParitySpec extends FunSuite:
       .put(
         e1,
         // GH-378: cached DateTime must serialize identically on both backends
-        CellValue.Formula("EDATE(B2,1)", Some(CellValue.DateTime(LocalDateTime.of(2024, 2, 2, 3, 4))))
+        CellValue.Formula(
+          "EDATE(B2,1)",
+          Some(CellValue.DateTime(LocalDateTime.of(2024, 2, 2, 3, 4)))
+        )
       )
       .put(a2, CellValue.RichText(rich))
       .put(b2, CellValue.DateTime(LocalDateTime.of(2024, 1, 2, 3, 4)))

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/DirectSaxEmitterParitySpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/DirectSaxEmitterParitySpec.scala
@@ -126,6 +126,22 @@ class DirectSaxEmitterParitySpec extends FunSuite:
     Files.deleteIfExists(domPath)
   }
 
+  test("GH-383: rich text inline cell emits <rFont> under rPr and matches DOM writer") {
+    val a1 = ARef.from1(1, 1)
+    val rich = "Styled".fontFamily("Times New Roman") + " plain"
+    val sheet = Sheet(SheetName.unsafe("Sheet1")).put(a1, CellValue.RichText(rich))
+
+    val dom = OoxmlWorksheet.fromDomainWithSST(sheet, None, Map.empty, None).toXml
+    val sax = emitDirect(sheet, None)
+
+    for (label, xml) <- List("DOM" -> dom, "SAX" -> sax) do
+      val rPr = (xml \\ "rPr").headOption.getOrElse(fail(s"$label: expected <rPr> in: $xml"))
+      assertEquals((rPr \ "rFont" \ "@val").text, "Times New Roman", s"$label rPr was: $rPr")
+      assert((rPr \ "name").isEmpty, s"$label: CT_RPrElt forbids <name> inside <rPr>: $rPr")
+
+    assertEquals(normalize(dom), normalize(sax))
+  }
+
   private def zipEntryString(path: Path, entry: String): String =
     val zf = new ZipFile(path.toFile)
     try

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/DirectSaxEmitterParitySpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/DirectSaxEmitterParitySpec.scala
@@ -70,6 +70,25 @@ class DirectSaxEmitterParitySpec extends FunSuite:
     assertEquals(formulaElem.get.text, "SUM(B1:B10)")
   }
 
+  test("GH-378: formula with cached DateTime emits t=\"n\" and the Excel serial in <v>") {
+    val a1 = ARef.from1(1, 1)
+    // Jan 1, 2000 noon = serial 36526.5 exactly
+    val cached = LocalDateTime.of(2000, 1, 1, 12, 0, 0)
+    val sheet = Sheet(SheetName.unsafe("Test"))
+      .put(a1, CellValue.Formula("EOMONTH(A1,0)", Some(CellValue.DateTime(cached))))
+
+    val saxCell = (emitDirect(sheet, None) \\ "c").head
+    assertEquals(saxCell.attribute("t").map(_.text), Some("n"))
+    assertEquals((saxCell \ "f").text, "EOMONTH(A1,0)")
+    assertEquals((saxCell \ "v").map(_.text).toList, List("36526.5"))
+
+    // The DOM writer must emit the identical cached serial (backend parity)
+    val domCell =
+      (OoxmlWorksheet.fromDomainWithSST(sheet, None, Map.empty, None).toXml \\ "c").head
+    assertEquals(domCell.attribute("t").map(_.text), Some("n"))
+    assertEquals((domCell \ "v").map(_.text).toList, List("36526.5"))
+  }
+
   test("GH-265: direct SAX emission matches DOM writer for fresh-sheet metadata") {
     // Freeze panes, view settings, page setup (incl. even header + fitToPage), hyperlinks:
     // everything the DOM writer emits for a fresh sheet must come out of the streaming path too.
@@ -185,6 +204,7 @@ class DirectSaxEmitterParitySpec extends FunSuite:
     val b1 = ARef.from1(2, 1)
     val c1 = ARef.from1(3, 1)
     val d1 = ARef.from1(4, 1)
+    val e1 = ARef.from1(5, 1)
     val a2 = ARef.from1(1, 2)
     val b2 = ARef.from1(2, 2)
 
@@ -198,6 +218,11 @@ class DirectSaxEmitterParitySpec extends FunSuite:
         d1,
         CellValue.Formula("SUM(A1:B1)", Some(CellValue.Number(BigDecimal(3))))
       )
+      .put(
+        e1,
+        // GH-378: cached DateTime must serialize identically on both backends
+        CellValue.Formula("EDATE(B2,1)", Some(CellValue.DateTime(LocalDateTime.of(2024, 2, 2, 3, 4))))
+      )
       .put(a2, CellValue.RichText(rich))
       .put(b2, CellValue.DateTime(LocalDateTime.of(2024, 1, 2, 3, 4)))
       .merge(CellRange(ARef.from1(1, 3), ARef.from1(2, 3)))
@@ -206,6 +231,8 @@ class DirectSaxEmitterParitySpec extends FunSuite:
         Row.from1(2),
         RowProperties(height = Some(24.0), hidden = true, outlineLevel = Some(1), collapsed = true)
       )
+      // GH-381: property-only row (no cells in row 4) must survive on both backends
+      .setRowProperties(Row.from1(4), RowProperties(height = Some(5.25)))
       .setColumnProperties(
         Column.from1(1),
         ColumnProperties(width = Some(12.5), outlineLevel = Some(1))

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/OoxmlRoundTripSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/OoxmlRoundTripSpec.scala
@@ -17,7 +17,7 @@ import com.tjclp.xl.richtext.RichText.given
 import com.tjclp.xl.styles.CellStyle
 import com.tjclp.xl.sheets.styleSyntax.*
 import com.tjclp.xl.styles.dsl.*
-import java.util.zip.ZipInputStream
+import java.util.zip.{ZipFile, ZipInputStream}
 
 /** Round-trip tests for XLSX write → read */
 @SuppressWarnings(Array("org.wartremover.warts.OptionPartial"))
@@ -485,6 +485,48 @@ class OoxmlRoundTripSpec extends FunSuite:
         assertEquals(serial.toDouble, 36526.5, 0.001)
       case other =>
         fail(s"Expected Number, got: $other")
+  }
+
+  test("Formula cell with cached DateTime writes the Excel serial with t=\"n\" (GH-378)") {
+    import java.time.LocalDateTime
+
+    // Jan 1, 2000 noon = serial 36526.5 exactly (pinned by the DateTime literal test above)
+    val cached = LocalDateTime.of(2000, 1, 1, 12, 0, 0)
+    val initial = Workbook("Dates")
+    val sheet = initial
+      .sheets(0)
+      .put(ref"A1", CellValue.DateTime(cached))
+      .put(ref"B1", CellValue.Formula("EOMONTH(A1,0)", Some(CellValue.DateTime(cached))))
+
+    val wb =
+      initial.update(initial.sheets(0).name, _ => sheet).getOrElse(fail("Should create workbook"))
+
+    val outputPath = tempDir.resolve("formula-cached-datetime.xlsx")
+    XlsxWriter.write(wb, outputPath).getOrElse(fail("Write failed"))
+
+    // Raw XML: the formula cell must carry t="n" and the cached serial in <v>
+    val zip = new ZipFile(outputPath.toFile)
+    val sheetXml =
+      try
+        new String(
+          zip.getInputStream(zip.getEntry("xl/worksheets/sheet1.xml")).readAllBytes(),
+          StandardCharsets.UTF_8
+        )
+      finally zip.close()
+    val cellXml = """(?s)<c r="B1".*?</c>""".r
+      .findFirstIn(sheetXml)
+      .getOrElse(fail(s"B1 cell missing from worksheet XML:\n$sheetXml"))
+    assert(cellXml.contains("""t="n""""), cellXml)
+    assert(cellXml.contains("<v>36526.5</v>"), cellXml)
+
+    // Read back: cached value comes back as the serial Number (matching Excel's storage)
+    val readWb = XlsxReader.read(outputPath).getOrElse(fail("Read failed"))
+    readWb.sheets(0)(ref"B1").value match
+      case CellValue.Formula(expr, Some(CellValue.Number(serial))) =>
+        assertEquals(expr, "EOMONTH(A1,0)")
+        assertEquals(serial.toDouble, 36526.5, 0.000001)
+      case other =>
+        fail(s"Expected Formula with cached serial Number, got $other")
   }
 
   test("Full-feature workbook round-trips values, styles, merges, and bytes") {

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/RichTextXmlSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/RichTextXmlSpec.scala
@@ -72,14 +72,28 @@ class RichTextXmlSpec extends FunSuite:
     assert(xmlString.contains("val=\"18.0\""), "Should have size value")
   }
 
-  test("OoxmlCell: rich text with font family generates <name val=>") {
+  test("OoxmlCell: rich text with font family generates <rFont val=> (CT_RPrElt, GH-383)") {
     val richText = RichText("Text".fontFamily("Calibri"))
     val ooxmlCell = OoxmlCell(ref"A1", CellValue.RichText(richText), None, "inlineStr")
     val xml = ooxmlCell.toXml
 
     val xmlString = xml.toString
-    assert(xmlString.contains("<name"), "Should have name element")
+    assert(xmlString.contains("<rFont"), "Should have rFont element (CT_RPrElt)")
     assert(xmlString.contains("val=\"Calibri\""), "Should have font name")
+    assert(!xmlString.contains("<name"), "CT_RPrElt forbids <name> inside <rPr>")
+  }
+
+  test("OoxmlCell: SAX writeSax emits <rFont> for rich text runs (GH-383)") {
+    val richText = RichText("Text".fontFamily("Georgia"))
+    val ooxmlCell = OoxmlCell(ref"A1", CellValue.RichText(richText), None, "inlineStr")
+
+    val writer = ScalaXmlSaxWriter()
+    ooxmlCell.writeSax(writer)
+    val cellElem = writer.result.getOrElse(fail("Expected <c> root from SAX emission"))
+
+    val rPr = (cellElem \\ "rPr").headOption.getOrElse(fail(s"Expected <rPr> in: $cellElem"))
+    assertEquals((rPr \ "rFont" \ "@val").text, "Georgia", s"rPr was: $rPr")
+    assert((rPr \ "name").isEmpty, s"CT_RPrElt forbids <name> inside <rPr>: $rPr")
   }
 
   test("OoxmlCell: rich text with multiple runs generates multiple <r> elements") {

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/RowColumnOperationsSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/RowColumnOperationsSpec.scala
@@ -2,11 +2,13 @@ package com.tjclp.xl.ooxml
 
 import munit.FunSuite
 import java.nio.file.{Files, Path}
+import java.util.zip.ZipFile
 import com.tjclp.xl.addressing.{ARef, Column, Row}
 import com.tjclp.xl.api.*
 import com.tjclp.xl.cells.CellValue
 import com.tjclp.xl.dsl.*
 import com.tjclp.xl.macros.{col, ref}
+import com.tjclp.xl.ooxml.writer.{WriterConfig, XmlBackend}
 import com.tjclp.xl.patch.Patch
 import com.tjclp.xl.sheets.{ColumnProperties, RowProperties}
 
@@ -317,6 +319,53 @@ class RowColumnOperationsSpec extends FunSuite:
 
     assertEquals(readSheet.getRowProperties(Row.from0(3)).collapsed, true)
     assertEquals(readSheet.getRowProperties(Row.from0(3)).outlineLevel, Some(1))
+  }
+
+  // GH-381: rows carrying only properties (no cells in that row) must survive a scratch-build
+  // write on every backend. The SaxStax emitter already merged property-only rows into sheetData;
+  // the ScalaXml scratch branch dropped them entirely (no <row> element emitted).
+  List(
+    "ScalaXml" -> WriterConfig(backend = XmlBackend.ScalaXml),
+    "SaxStax" -> WriterConfig(backend = XmlBackend.SaxStax)
+  ).foreach { case (backendName, config) =>
+    test(s"GH-381: property-only row survives scratch-build write ($backendName)") {
+      val initial = Workbook("Test")
+      val sheet = initial
+        .sheets(0)
+        .put(ref"A1", CellValue.Text("Header"))
+        .setRowProperties(
+          Row.from1(5),
+          RowProperties(height = Some(5.25), hidden = true, outlineLevel = Some(1))
+        )
+      val wb =
+        initial.update(initial.sheets(0).name, _ => sheet).getOrElse(fail("Should create workbook"))
+
+      val outputPath = tempDir.resolve(s"property-only-row-$backendName.xlsx")
+      XlsxWriter.writeWith(wb, outputPath, config).getOrElse(fail("Write failed"))
+
+      val zip = new ZipFile(outputPath.toFile)
+      val sheetXml =
+        try
+          new String(
+            zip.getInputStream(zip.getEntry("xl/worksheets/sheet1.xml")).readAllBytes(),
+            "UTF-8"
+          )
+        finally zip.close()
+
+      val row5Xml = """<row\b[^>]*\br="5"[^>]*>""".r
+        .findFirstIn(sheetXml)
+        .getOrElse(fail(s"Property-only row 5 missing from scratch-built worksheet:\n$sheetXml"))
+      assert(row5Xml.contains("""ht="5.25""""), row5Xml)
+      assert(row5Xml.contains("""customHeight="1""""), row5Xml)
+      assert(row5Xml.contains("""hidden="1""""), row5Xml)
+      assert(row5Xml.contains("""outlineLevel="1""""), row5Xml)
+
+      val readWb = XlsxReader.read(outputPath).getOrElse(fail("Read failed"))
+      val readProps = readWb.sheets(0).getRowProperties(Row.from1(5))
+      assertEquals(readProps.height, Some(5.25))
+      assertEquals(readProps.hidden, true)
+      assertEquals(readProps.outlineLevel, Some(1))
+    }
   }
 
   test("multiple columns with different widths round-trip") {

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/SharedStringsSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/SharedStringsSpec.scala
@@ -108,3 +108,34 @@ class SharedStringsSpec extends FunSuite:
     assertEquals(sst.totalCount, 3)
     assertEquals(sst.strings.size, 3)
   }
+
+  test("GH-383: freshly-authored rich text emits <rFont val=> in DOM toXml, never <name val=>") {
+    // No rawRPrXml here (fresh authoring), so the rPr is built from the Font model:
+    // CT_RPrElt spells the font element <rFont val=…/>, not the CT_Font <name val=…/>.
+    val sst = SharedStrings.fromEntries(Vector(Right(freshRichText("Arial")): SSTEntry))
+    val xml = sst.toXml.toString
+
+    assert(xml.contains("<rFont val=\"Arial\""), s"Expected <rFont val=\"Arial\"> in: $xml")
+    assert(!xml.contains("<name val="), s"CT_RPrElt forbids <name val=…> inside <rPr>: $xml")
+  }
+
+  test("GH-383: freshly-authored rich text emits <rFont val=> in SAX writeSax, never <name val=>") {
+    val sst = SharedStrings.fromEntries(Vector(Right(freshRichText("Georgia")): SSTEntry))
+    val writer = ScalaXmlSaxWriter()
+    sst.writeSax(writer)
+    val root = writer.result.getOrElse(fail("Expected <sst> root from SAX emission"))
+
+    val rPr = (root \\ "rPr").headOption.getOrElse(fail(s"Expected <rPr> in: $root"))
+    assertEquals((rPr \ "rFont" \ "@val").text, "Georgia", s"rPr was: $rPr")
+    assert((rPr \ "name").isEmpty, s"CT_RPrElt forbids <name> inside <rPr>: $rPr")
+  }
+
+  private def freshRichText(fontName: String): com.tjclp.xl.richtext.RichText =
+    com.tjclp.xl.richtext.RichText(
+      Vector(
+        com.tjclp.xl.richtext.TextRun(
+          "Styled",
+          Some(com.tjclp.xl.styles.font.Font(name = fontName, sizePt = 10.0))
+        )
+      )
+    )

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/SheetIdentityMappingSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/SheetIdentityMappingSpec.scala
@@ -364,6 +364,118 @@ class SheetIdentityMappingSpec extends FunSuite:
     assertCommentPartsRegistered(out)
   }
 
+  // ===== GH-327: physical part numbering permuted vs logical order (Excel reorders on disk) =====
+
+  /**
+   * Rewrite the file so the PHYSICAL worksheet part names are permuted vs the logical `<sheets>`
+   * order: the two parts' bytes swap places and the workbook rels re-target, exactly like a file
+   * Excel has reordered and saved. workbook.xml (logical order) is untouched, so the reader
+   * resolves each sheet through the rels and records the permutation in sheetPathMapping. The
+   * permutation MUST be a property of the source file on disk — an in-session reorder marks
+   * metadata modified and regenerates everything, hiding the collision.
+   */
+  private def permutePhysicalSheetParts(path: Path): Unit =
+    val entries: Vector[(String, Array[Byte])] =
+      val zip = new ZipFile(path.toFile)
+      try
+        zip.entries().asScala.toVector.map { e =>
+          e.getName -> zip.getInputStream(e).readAllBytes()
+        }
+      finally zip.close()
+    val byName = entries.toMap
+    def part(entry: String): Array[Byte] =
+      byName.getOrElse(entry, fail(s"$entry missing from ${entries.map(_._1)}"))
+    val out = new java.util.zip.ZipOutputStream(Files.newOutputStream(path))
+    try
+      entries.foreach { case (entryName, bytes) =>
+        val content = entryName match
+          case "xl/worksheets/sheet1.xml" => part("xl/worksheets/sheet2.xml")
+          case "xl/worksheets/sheet2.xml" => part("xl/worksheets/sheet1.xml")
+          case "xl/_rels/workbook.xml.rels" =>
+            new String(bytes, "UTF-8")
+              .replace("worksheets/sheet1.xml", "worksheets/sheetSWAP.xml")
+              .replace("worksheets/sheet2.xml", "worksheets/sheet1.xml")
+              .replace("worksheets/sheetSWAP.xml", "worksheets/sheet2.xml")
+              .getBytes("UTF-8")
+          case _ => bytes
+        out.putNextEntry(new java.util.zip.ZipEntry(entryName))
+        out.write(content)
+        out.closeEntry()
+      }
+    finally out.close()
+
+  test("GH-327: cell edit on a sheet whose index name is an unmodified neighbor's source part") {
+    val alpha = Sheet(name("Alpha")).put(ref"A1" -> "AlphaContent")
+    val beta = Sheet(name("Beta")).put(ref"A1" -> "BetaContent")
+    val source = write(Workbook(Vector(alpha, beta)), "permuted-source")
+    permutePhysicalSheetParts(source)
+
+    val wb = reread(source)
+    // Sanity: the reader recorded the on-disk permutation by identity
+    val ctx = wb.sourceContext.getOrElse(fail("source context missing"))
+    assertEquals(ctx.sheetPathMapping.get(name("Alpha")), Some("xl/worksheets/sheet2.xml"))
+    assertEquals(ctx.sheetPathMapping.get(name("Beta")), Some("xl/worksheets/sheet1.xml"))
+    assertEquals(textAt(wb, "Alpha", ref"A1"), Some("AlphaContent"))
+
+    // Edit ONE cell on Alpha (index 0, source part sheet2.xml). Index naming would emit its
+    // output at sheet1.xml — the very part unmodified Beta rides verbatim copy to — and the
+    // duplicate zip entry killed the ENTIRE write with an IOError.
+    val edited = wb
+      .update(name("Alpha"), _.put(ref"B1" -> "Edited"))
+      .fold(e => fail(e.message), identity)
+    val out = write(edited, "permuted")
+
+    // No duplicate entries (ZipFile.entries reports raw central-directory rows)
+    val allEntries =
+      val zip = new ZipFile(out.toFile)
+      try zip.entries().asScala.toVector.map(_.getName)
+      finally zip.close()
+    assertEquals(allEntries.distinct.size, allEntries.size, s"duplicate entries: $allEntries")
+
+    // The modified sheet regenerated at its SOURCE part name; the neighbor kept its own
+    val sheet2Xml = entryText(out, "xl/worksheets/sheet2.xml")
+    assert(sheet2Xml.contains("Edited") || sheet2Xml.contains("t=\"s\""), s"got:\n$sheet2Xml")
+
+    val result = reread(out)
+    assertEquals(result.sheetNames.map(_.value), Vector("Alpha", "Beta"))
+    assertEquals(textAt(result, "Alpha", ref"A1"), Some("AlphaContent"))
+    assertEquals(textAt(result, "Alpha", ref"B1"), Some("Edited"))
+    assertEquals(textAt(result, "Beta", ref"A1"), Some("BetaContent"))
+    assertWorksheetRelsResolve(out)
+
+    // The workbook rels resolve: every worksheet rel target ships, one per live sheet
+    val wbRels = scala.xml.XML.loadString(entryText(out, "xl/_rels/workbook.xml.rels"))
+    val sheetTargets = (wbRels \ "Relationship")
+      .filter(r => (r \ "@Type").text.endsWith("/worksheet"))
+      .map(r => (r \ "@Target").text)
+    assertEquals(sheetTargets.size, 2)
+    sheetTargets.foreach { t =>
+      val resolved = if t.startsWith("/") then t.drop(1) else s"xl/$t"
+      assert(allEntries.contains(resolved), s"workbook rel target $t missing from $allEntries")
+    }
+  }
+
+  test("GH-327: permuted source + edit BOTH sheets — each regenerates at its own source part") {
+    val alpha = Sheet(name("Alpha")).put(ref"A1" -> "AlphaContent")
+    val beta = Sheet(name("Beta")).put(ref"A1" -> "BetaContent")
+    val source = write(Workbook(Vector(alpha, beta)), "permuted-both-source")
+    permutePhysicalSheetParts(source)
+
+    val wb = reread(source)
+    val edited = wb
+      .update(name("Alpha"), _.put(ref"B1" -> "EditedA"))
+      .flatMap(_.update(name("Beta"), _.put(ref"B1" -> "EditedB")))
+      .fold(e => fail(e.message), identity)
+    val out = write(edited, "permuted-both")
+
+    val result = reread(out)
+    assertEquals(textAt(result, "Alpha", ref"A1"), Some("AlphaContent"))
+    assertEquals(textAt(result, "Alpha", ref"B1"), Some("EditedA"))
+    assertEquals(textAt(result, "Beta", ref"A1"), Some("BetaContent"))
+    assertEquals(textAt(result, "Beta", ref"B1"), Some("EditedB"))
+    assertWorksheetRelsResolve(out)
+  }
+
   // ===== combined stress: every tracked structural+content operation in ONE write =====
 
   test("GH-315: delete middle + reorder + image edit + comment edit + fresh comment in ONE write") {

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/StyleParserHardeningSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/StyleParserHardeningSpec.scala
@@ -91,3 +91,30 @@ class StyleParserHardeningSpec extends FunSuite:
     assertEquals(font.sizePt, 9.5)
     assertEquals(font.name, "Consolas")
   }
+
+  // ---- GH-383: CT_RPrElt (rich runs in SST/inline strings/comments) spells the font
+  // ---- element <rFont val=…/>; real Excel files use it exclusively. Legacy xl-written
+  // ---- files used the CT_Font spelling <name val=…/>, kept as a read fallback.
+
+  test("GH-383: rich-run <rPr> reads <rFont val=> as the font name") {
+    val rPr = XML.loadString("""<rPr><rFont val="Times New Roman"/></rPr>""")
+    assertEquals(XmlUtil.parseRunProperties(rPr).name, "Times New Roman")
+  }
+
+  test("GH-383: rich-run <rPr> legacy <name val=> still parses as fallback") {
+    val rPr = XML.loadString("""<rPr><name val="Arial"/></rPr>""")
+    assertEquals(XmlUtil.parseRunProperties(rPr).name, "Arial")
+  }
+
+  test("GH-383: <rFont> wins over legacy <name> when both present") {
+    val rPr = XML.loadString("""<rPr><rFont val="Georgia"/><name val="Arial"/></rPr>""")
+    assertEquals(XmlUtil.parseRunProperties(rPr).name, "Georgia")
+  }
+
+  test("GH-383: empty <rFont> falls back to legacy <name>, then to default") {
+    val rPrBoth = XML.loadString("""<rPr><rFont val=""/><name val="Arial"/></rPr>""")
+    assertEquals(XmlUtil.parseRunProperties(rPrBoth).name, "Arial")
+
+    val rPrEmptyOnly = XML.loadString("""<rPr><rFont val=""/></rPr>""")
+    assertEquals(XmlUtil.parseRunProperties(rPrEmptyOnly).name, Font.default.name)
+  }

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/WriteFastSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/WriteFastSpec.scala
@@ -1,8 +1,10 @@
 package com.tjclp.xl.ooxml
 
 import munit.FunSuite
+import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Path}
 import java.time.{LocalDate, LocalDateTime}
+import java.util.zip.ZipFile
 import com.tjclp.xl.{*, given}
 import com.tjclp.xl.cells.CellValue
 import com.tjclp.xl.macros.ref
@@ -169,6 +171,44 @@ class WriteFastSpec extends FunSuite:
           assertEquals(expr, "SUM(A1:A2)")
           assertEquals(cached, Some(CellValue.Number(BigDecimal(30))))
         case other => fail(s"Expected Formula, got $other")
+    }
+  }
+
+  test("writeFast preserves formula cached DateTime as Excel serial with t=\"n\" (GH-378)") {
+    // Jan 1, 2000 noon = serial 36526.5 exactly
+    val cached = LocalDateTime.of(2000, 1, 1, 12, 0, 0)
+    val sheet = Sheet("Formulas")
+      .put(ref"A1" -> CellValue.DateTime(cached))
+      .put(ref"A2" -> CellValue.Formula("EDATE(A1,0)", Some(CellValue.DateTime(cached))))
+    val wb = Workbook(Vector(sheet))
+
+    val outputPath = tempDir.resolve("formula-cached-datetime-fast.xlsx")
+    val writeResult = XlsxWriter.writeWith(wb, outputPath, saxConfig)
+    assert(writeResult.isRight, s"writeFast failed: $writeResult")
+
+    // Raw XML: the formula cell must carry t="n" and the cached serial in <v>
+    val zip = new ZipFile(outputPath.toFile)
+    val sheetXml =
+      try
+        new String(
+          zip.getInputStream(zip.getEntry("xl/worksheets/sheet1.xml")).readAllBytes(),
+          StandardCharsets.UTF_8
+        )
+      finally zip.close()
+    val cellXml = """(?s)<c r="A2".*?</c>""".r
+      .findFirstIn(sheetXml)
+      .getOrElse(fail(s"A2 cell missing from worksheet XML:\n$sheetXml"))
+    assert(cellXml.contains("""t="n""""), cellXml)
+    assert(cellXml.contains("<v>36526.5</v>"), cellXml)
+
+    val readResult = XlsxReader.read(outputPath)
+    assert(readResult.isRight, s"Read failed: $readResult")
+    readResult.foreach { readWb =>
+      readWb.sheets.head(ref"A2").value match
+        case CellValue.Formula(expr, Some(CellValue.Number(serial))) =>
+          assertEquals(expr, "EDATE(A1,0)")
+          assertEquals(serial.toDouble, 36526.5, 0.000001)
+        case other => fail(s"Expected Formula with cached serial Number, got $other")
     }
   }
 

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/XlsxWriterCorruptionRegressionSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/XlsxWriterCorruptionRegressionSpec.scala
@@ -5,14 +5,16 @@ import java.nio.file.{Files, Path}
 import java.util.zip.{ZipEntry, ZipFile, ZipOutputStream}
 import javax.xml.parsers.DocumentBuilderFactory
 
+import com.tjclp.xl.addressing.SheetName
 import com.tjclp.xl.api.*
 import com.tjclp.xl.cells.CellValue
+import com.tjclp.xl.cf.{CfOperator, CfRule}
 import com.tjclp.xl.codec.CellCodec.given
 import com.tjclp.xl.macros.ref
 import com.tjclp.xl.ooxml.writer.{WriterConfig, XmlBackend}
 import com.tjclp.xl.richtext.RichText
 import com.tjclp.xl.sheets.styleSyntax.withCellStyle
-import com.tjclp.xl.styles.{CellStyle, Color, Fill}
+import com.tjclp.xl.styles.{Border, BorderSide, BorderStyle, CellStyle, Color, Dxf, Fill, Font, ThemeSlot}
 import munit.FunSuite
 
 /**
@@ -927,6 +929,130 @@ class XlsxWriterCorruptionRegressionSpec extends FunSuite:
     // Clean up
     outputZip.close()
     Files.deleteIfExists(source)
+    Files.deleteIfExists(output)
+  }
+
+  // ===== GH-387: scratch workbooks that reference theme colors must ship a theme part =====
+
+  /** Zip entry names + the three theme-registration surfaces of a written package. */
+  private def themeRegistration(output: Path): (Boolean, Boolean, Boolean) =
+    val zip = new ZipFile(output.toFile)
+    try
+      val hasPart = zip.getEntry("xl/theme/theme1.xml") != null
+      val ct = readEntryString(zip, zip.getEntry("[Content_Types].xml"))
+      val hasOverride = ct.contains("PartName=\"/xl/theme/theme1.xml\"")
+      val rels = readEntryString(zip, zip.getEntry("xl/_rels/workbook.xml.rels"))
+      val hasRel = rels.contains("/relationships/theme")
+      (hasPart, hasOverride, hasRel)
+    finally zip.close()
+
+  test("GH-387: scratch workbook with theme-colored styles ships a resolvable default theme") {
+    val style = CellStyle(
+      font = Font(color = Some(Color.Theme(ThemeSlot.Dark1, 0.0))),
+      fill = Fill.Solid(Color.Theme(ThemeSlot.Accent2, 0.25)),
+      border = Border(bottom = BorderSide(BorderStyle.Thin, Some(Color.Theme(ThemeSlot.Accent6, -0.1))))
+    )
+    val sheet = Sheet(SheetName.unsafe("Themed"))
+      .put(ref"A1" -> "themed")
+      .withCellStyle(ref"A1", style)
+
+    val output = Files.createTempFile("gh387-theme", ".xlsx")
+    XlsxWriter
+      .write(Workbook(Vector(sheet)), output)
+      .fold(err => fail(s"Failed to write: $err"), identity)
+
+    val zip = new ZipFile(output.toFile)
+    try
+      // The emitted styles carry theme="N" records — the reason the part must ship
+      val stylesXml = readEntryString(zip, zip.getEntry("xl/styles.xml"))
+      assert(stylesXml.contains("theme="), s"styles must reference theme colors:\n$stylesXml")
+
+      // (1) the part ships and parses to the SAME palette the reader assumes as fallback,
+      // so resolved colors are identical whether a consumer reads or defaults the part
+      val themeEntry = zip.getEntry("xl/theme/theme1.xml")
+      assert(themeEntry != null, "scratch workbook with theme colors must ship xl/theme/theme1.xml")
+      val themeXml = readEntryString(zip, themeEntry)
+      val palette = ThemeParser
+        .parse(themeXml)
+        .fold(err => fail(s"generated theme unparseable: $err"), identity)
+      assertEquals(palette.dark1, 0xff000000)
+      assertEquals(palette.light1, 0xffffffff)
+      assertEquals(palette.accent2, 0xffed7d31)
+      assertEquals(palette.accent6, 0xff70ad47)
+
+      // (2) [Content_Types].xml Override
+      val ct = readEntryString(zip, zip.getEntry("[Content_Types].xml"))
+      assert(
+        ct.contains("PartName=\"/xl/theme/theme1.xml\""),
+        s"missing theme Override:\n$ct"
+      )
+
+      // (3) workbook.xml.rels Relationship, resolvable, with a unique rId
+      val relsXml = readEntryString(zip, zip.getEntry("xl/_rels/workbook.xml.rels"))
+      val rels = Relationships
+        .fromXml(scala.xml.XML.loadString(relsXml))
+        .fold(err => fail(s"rels parse failed: $err"), identity)
+      val themeRels = rels.relationships.filter(_.`type`.endsWith("/relationships/theme"))
+      assertEquals(themeRels.size, 1, s"exactly one theme rel expected: ${rels.relationships}")
+      assertEquals(
+        themeRels.map(r => Relationships.resolveWorkbookTarget(r.target)),
+        Seq("xl/theme/theme1.xml")
+      )
+      val ids = rels.relationships.map(_.id)
+      assertEquals(ids.distinct.size, ids.size, s"duplicate rIds: $ids")
+    finally zip.close()
+
+    // Round trip: the theme colors survive (slot + tint), resolved against the shipped palette
+    val reloaded = XlsxReader.read(output).fold(err => fail(s"Reload failed: $err"), identity)
+    val reloadedSheet = reloaded.sheets(0)
+    val resolved = reloadedSheet.cells
+      .get(ref"A1")
+      .flatMap(_.styleId)
+      .flatMap(reloadedSheet.styleRegistry.get)
+      .getOrElse(fail("styled cell lost its style"))
+    assertEquals(resolved.fill, Fill.Solid(Color.Theme(ThemeSlot.Accent2, 0.25)))
+
+    Files.deleteIfExists(output)
+  }
+
+  test("GH-387: theme color only in a conditional-format dxf still triggers the theme part") {
+    val dxf = Dxf(fill = Some(Fill.Solid(Color.Theme(ThemeSlot.Accent4, 0.0))))
+    val sheet = Sheet(SheetName.unsafe("CfThemed"))
+      .put(ref"A1" -> 1)
+      .conditionalFormat(ref"A1:A9", CfRule.cellIs(CfOperator.GreaterThan, "0", dxf))
+
+    val output = Files.createTempFile("gh387-dxf", ".xlsx")
+    XlsxWriter
+      .write(Workbook(Vector(sheet)), output)
+      .fold(err => fail(s"Failed to write: $err"), identity)
+
+    val (hasPart, hasOverride, hasRel) = themeRegistration(output)
+    assert(hasPart, "dxf theme color must trigger the theme part")
+    assert(hasOverride, "dxf theme color must trigger the CT Override")
+    assert(hasRel, "dxf theme color must trigger the workbook rel")
+
+    Files.deleteIfExists(output)
+  }
+
+  test("GH-387: scratch workbook with only RGB/indexed colors ships NO theme part") {
+    val style = CellStyle(
+      font = Font(color = Some(Color.Rgb(0xff112233))),
+      fill = Fill.Solid(Color.Rgb(0xff4472c4))
+    )
+    val sheet = Sheet(SheetName.unsafe("Plain"))
+      .put(ref"A1" -> "plain")
+      .withCellStyle(ref"A1", style)
+
+    val output = Files.createTempFile("gh387-rgb", ".xlsx")
+    XlsxWriter
+      .write(Workbook(Vector(sheet)), output)
+      .fold(err => fail(s"Failed to write: $err"), identity)
+
+    val (hasPart, hasOverride, hasRel) = themeRegistration(output)
+    assert(!hasPart, "RGB-only scratch workbook must NOT gain a theme part")
+    assert(!hasOverride, "RGB-only scratch workbook must NOT gain a theme Override")
+    assert(!hasRel, "RGB-only scratch workbook must NOT gain a theme Relationship")
+
     Files.deleteIfExists(output)
   }
 

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/XlsxWriterCorruptionRegressionSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/XlsxWriterCorruptionRegressionSpec.scala
@@ -14,7 +14,17 @@ import com.tjclp.xl.macros.ref
 import com.tjclp.xl.ooxml.writer.{WriterConfig, XmlBackend}
 import com.tjclp.xl.richtext.RichText
 import com.tjclp.xl.sheets.styleSyntax.withCellStyle
-import com.tjclp.xl.styles.{Border, BorderSide, BorderStyle, CellStyle, Color, Dxf, Fill, Font, ThemeSlot}
+import com.tjclp.xl.styles.{
+  Border,
+  BorderSide,
+  BorderStyle,
+  CellStyle,
+  Color,
+  Dxf,
+  Fill,
+  Font,
+  ThemeSlot
+}
 import munit.FunSuite
 
 /**
@@ -950,7 +960,8 @@ class XlsxWriterCorruptionRegressionSpec extends FunSuite:
     val style = CellStyle(
       font = Font(color = Some(Color.Theme(ThemeSlot.Dark1, 0.0))),
       fill = Fill.Solid(Color.Theme(ThemeSlot.Accent2, 0.25)),
-      border = Border(bottom = BorderSide(BorderStyle.Thin, Some(Color.Theme(ThemeSlot.Accent6, -0.1))))
+      border =
+        Border(bottom = BorderSide(BorderStyle.Thin, Some(Color.Theme(ThemeSlot.Accent6, -0.1))))
     )
     val sheet = Sheet(SheetName.unsafe("Themed"))
       .put(ref"A1" -> "themed")


### PR DESCRIPTION
## Summary

The 0.12.7 "file integrity" wave: seven bug fixes from the tjc-modeling byte-exact replication campaign. Every workaround that campaign shipped as post-write zip surgery is now unnecessary — packages are self-consistent, schema-valid, and `recalculate()` is total.

- **#381** — property-only rows (height/hidden/outline, no cells) survive scratch-build writes on the default backend; backends now agree, pinned by cross-backend parity tests
- **#378** — formula cells keep cached DateTime results as Excel serials (`t="n"` + `<v>`) on all three writer backends; streaming writer also gained the missing cached-`Text` → `t="str"` mapping
- **#383** — comment/SST/inline rich runs emit schema-valid `<rFont>` (CT_RPrElt) instead of the styles-only `<name>` shape; openpyxl opens XL-authored comments again; reader accepts both new and legacy files
- **#327** — modified sheets keep their identity-resolved source part names; no duplicate-zip-entry `IOError` on Excel-reordered sources
- **#328** — removing a sheet's last comment prunes its CT overrides, sheet rels, and legacyDrawing reference (resolved-path-aware, openpyxl dialect included); other sheets' comments survive
- **#387** — scratch workbooks whose styles/dxfs reference theme colors ship a default Office theme part + CT override + workbook rel; RGB-only workbooks gain nothing; preservation path untouched
- **#388** — IRR Newton divergence (and the XIRR/XNPV/NPV + TVM overflow class) returns per-cell errors instead of throwing out of `recalculate()`; workbook-evaluator backstop guarantees totality

## Verification

Four worktree-isolated TDD implementers, each adversarially reviewed (revert-and-rerun refutation: every new test proven to fail against the pre-fix tree with the bug's exact signature). Reviews verified end-to-end with openpyxl 3.1.5 (comments load, `data_only` sees cached values, theme package facts, no duplicate entries on permuted-source writes). Integrated gates:

- `./mill __.checkFormat` 33/33
- `./mill __.test` 1028/1028 (4,107+ tests)
- `XL_ROUNDTRIP_MIN_SUCCESS=500 ./mill xl-ooxml.test` 239/239
- `scripts/test-examples.sh` ✓
- `scripts/verify-skill-snippets.sh --local` ✓

Closes #327
Closes #328
Closes #378
Closes #381
Closes #383
Closes #387
Closes #388

🤖 Generated with [Claude Code](https://claude.com/claude-code)