### PR TITLE
chore(release): Bump version to 0.12.7

### DIFF
--- a/.claude/workflows/issue-wave.js
+++ b/.claude/workflows/issue-wave.js
@@ -72,7 +72,7 @@ const HOUSE_RULES = `HOUSE RULES (xl repo, ${REPO}):
 - Purity charter: no null, no thrown exceptions in pure code, total functions returning Either/Option (XLResult), opaque types, enums with derives CanEqual. WartRemover enforces; .head/.tail and Option.get are warnings, var/while acceptable only in tests/macros.
 - NEVER re-inline extension methods or factories on opaque types (compiler landmines — see NOTE in xl-core addressing/ARef.scala). No default params on exported extension methods (use @targetName overloads).
 - Do NOT edit CHANGELOG.md or docs/plan/roadmap.md (the integrator owns them — avoids 6-way conflicts).
-- Style: ./mill <module>.reformat before committing; match surrounding code idiom; comments only for constraints code cannot express.
+- Style: ./mill mill.scalalib.scalafmt.ScalafmtModule/reformatAll __.sources before committing (module-scoped <module>.reformat MISSES test sources — CI runs checkFormatAll __.sources and will fail on them); match surrounding code idiom; comments only for constraints code cannot express.
 - Commit with --no-verify (you run the format/test gates explicitly instead of the slow pre-commit hook), conventional message ending with "Refs #<issue>" per issue (NOT "Closes" — the wave PR owns closing).`
 
 phase('Baseline')
@@ -125,7 +125,7 @@ ${HOUSE_RULES}
 METHOD (mandatory):
 1. TDD: for each issue, FIRST write the failing test that pins the bug/feature from the issue's repro, run it, SEE IT FAIL, then implement until green. Tests live in the module's existing spec files where the brief names them.
 2. Touch only files within this cluster's footprint. If a fix genuinely requires a file another cluster owns, STOP that part and report it as a gap instead.
-3. Local gates before declaring done: ./mill <module>.test for every module you touched (timeout 600000), ./mill __.checkFormat after ./mill <module>.reformat. All green.
+3. Local gates before declaring done: ./mill <module>.test for every module you touched (timeout 600000), then ./mill mill.scalalib.scalafmt.ScalafmtModule/reformatAll __.sources && ./mill mill.scalalib.scalafmt.ScalafmtModule/checkFormatAll __.sources (the CI form — module reformat/checkFormat miss test sources). All green.
 4. Commit (git commit --no-verify) with a conventional message; one commit per issue is ideal, a single clean cluster commit acceptable. Message body: "Refs #<n>" lines.
 5. Report: outcome (fixed | not-reproducible [only if the brief says verify-first and you proved it] | partial | blocked), sha (git rev-parse HEAD), branch (git branch --show-current), worktreePath (pwd), summary, filesChanged, testsAdded (test names), gateEvidence (the actual gate commands + tail of their output), gaps (anything discovered worth filing as a new issue — be specific).
 Your final structured output is consumed by an adversarial reviewer who will try to refute your work — include enough evidence that an honest reviewer can retrace every claim.`
@@ -157,7 +157,7 @@ REWORK INSTRUCTIONS: ${review.reworkInstructions || '(see findings)'}
 
 ${HOUSE_RULES}
 
-Fix, keep TDD discipline (failing test first for any finding that lacks one), rerun local gates (./mill <module>.test + ./mill __.checkFormat after reformat), commit on top (--no-verify), and report the same structured output as an implementer (outcome/sha/branch/worktreePath/summary/filesChanged/testsAdded/gateEvidence/gaps). The reviewer re-reviews after you.`
+Fix, keep TDD discipline (failing test first for any finding that lacks one), rerun local gates (./mill <module>.test + ./mill mill.scalalib.scalafmt.ScalafmtModule/reformatAll __.sources && ./mill mill.scalalib.scalafmt.ScalafmtModule/checkFormatAll __.sources), commit on top (--no-verify), and report the same structured output as an implementer (outcome/sha/branch/worktreePath/summary/filesChanged/testsAdded/gateEvidence/gaps). The reviewer re-reviews after you.`
 
 const results = await pipeline(
   CLUSTERS,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.7] "Integrity" - 2026-07-16
+
 File-integrity wave from the tjc-modeling byte-exact replication campaign
 (#327, #328, #378, #381, #383, #387, #388): every workaround that campaign
 shipped as post-write zip surgery is now unnecessary — packages are

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ```scala 3 raw
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.6
+//> using dep com.tjclp::xl:0.12.7
 
 import com.tjclp.xl.{*, given}
 
@@ -55,13 +55,13 @@ import com.tjclp.xl.{*, given}
 
 ```scala 3 ignore
 // build.mill — single dependency for everything
-def ivyDeps = Agg(ivy"com.tjclp::xl:0.12.6")
+def ivyDeps = Agg(ivy"com.tjclp::xl:0.12.7")
 
 // Or individual modules for minimal footprint:
-// ivy"com.tjclp::xl-core:0.12.6"        — Pure domain model only
-// ivy"com.tjclp::xl-ooxml:0.12.6"       — Add OOXML read/write
-// ivy"com.tjclp::xl-cats-effect:0.12.6" — Add IO streaming
-// ivy"com.tjclp::xl-evaluator:0.12.6"   — Add formula evaluation
+// ivy"com.tjclp::xl-core:0.12.7"        — Pure domain model only
+// ivy"com.tjclp::xl-ooxml:0.12.7"       — Add OOXML read/write
+// ivy"com.tjclp::xl-cats-effect:0.12.7" — Add IO streaming
+// ivy"com.tjclp::xl-evaluator:0.12.7"   — Add formula evaluation
 ```
 
 ### Basic Usage

--- a/build.mill
+++ b/build.mill
@@ -14,7 +14,7 @@ val organization = "com.tjclp"
 /** Shared build configuration constants */
 object BuildConfig {
   /** Project version: CI sets PUBLISH_VERSION; local builds use this fallback */
-  val version: String = sys.env.getOrElse("PUBLISH_VERSION", "0.12.6")
+  val version: String = sys.env.getOrElse("PUBLISH_VERSION", "0.12.7")
 
   /** JVM options to silence Scala 3 LazyVals sun.misc.Unsafe deprecation warnings (JDK 21+) */
   val lazyValsJvmArgs: Seq[String] = Seq(

--- a/docs/QUICK-START.md
+++ b/docs/QUICK-START.md
@@ -12,19 +12,19 @@ import mill._, scalalib._
 
 object myproject extends ScalaModule {
   def scalaVersion = "3.8.3"
-  def ivyDeps = Agg(ivy"com.tjclp::xl:0.12.6")
+  def ivyDeps = Agg(ivy"com.tjclp::xl:0.12.7")
 }
 ```
 
 ### With sbt (build.sbt)
 ```scala
 scalaVersion := "3.8.3"
-libraryDependencies += "com.tjclp" %% "xl" % "0.12.6"
+libraryDependencies += "com.tjclp" %% "xl" % "0.12.7"
 ```
 
 ### With Scala CLI
 ```scala
-//> using dep com.tjclp::xl:0.12.6
+//> using dep com.tjclp::xl:0.12.7
 ```
 
 ### Individual Modules (Optional)
@@ -44,7 +44,7 @@ For scripts, skip the build setup entirely: a two-line `scala-cli` header and ON
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.6
+//> using dep com.tjclp::xl:0.12.7
 
 import com.tjclp.xl.scripting.{*, given}
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,12 +1,21 @@
 # XL Project Status
 
-**Last Updated**: 2026-07-15 (0.12.6)
+**Last Updated**: 2026-07-16 (0.12.7)
 
 ## Current State
 
 > **For detailed phase completion status and roadmap, see [plan/roadmap.md](plan/roadmap.md)**
 
 ### What Works (Production-Ready)
+
+**New in 0.12.7** (2026-07-16):
+- ✅ **Property-only rows survive scratch writes** (#381) — rows with only `RowProperties` (no cells) emit `<row>` on the default backend; backend parity pinned by tests
+- ✅ **Cached DateTime on formula cells** (#378) — `=TODAY()`/`=EDATE()`/`=EOMONTH()` caches serialize as Excel serials (`t="n"` + `<v>`) on all three writer backends; streaming writer gained cached-Text `t="str"`
+- ✅ **Schema-valid comment rich runs** (#383) — `<rFont>` per CT_RPrElt (was styles-shape `<name>`); openpyxl opens XL-authored comments; reader accepts both dialects
+- ✅ **Identity-named modified-sheet parts** (#327) — no duplicate-zip-entry failure on Excel-reordered sources; physical writes, sheet rels, and workbook rels derive from one path
+- ✅ **Comment-removal package pruning** (#328) — dropping a sheet's last comment prunes CT overrides, sheet rels, and legacyDrawing (resolved-path-aware, openpyxl dialect included)
+- ✅ **Default theme part for scratch theme colors** (#387) — `Color.Theme` styles/dxfs ship `xl/theme/theme1.xml` + override + rel; RGB-only workbooks unaffected
+- ✅ **Total recalculate() under financial divergence** (#388) — IRR/XIRR/XNPV/NPV + TVM overflow class returns per-cell errors; workbook-evaluator NonFatal backstop guarantees totality
 
 **New in 0.12.6** (2026-07-15):
 - ✅ **External-workbook references** (#353) — `[2]Book1!A1` forms parse (dedicated AST node, exact printer round-trip, anchor-aware shifting), contribute no dependency edges, and `recalculate()` pins their Excel-written caches verbatim while dependents compute from them; uncached external cells report a clear per-cell error instead of `UnexpectedChar([`

--- a/docs/plan/roadmap.md
+++ b/docs/plan/roadmap.md
@@ -12,7 +12,7 @@
 
 **Current Status**: Production-ready with **107 formula functions** (incl. dynamic arrays SEQUENCE/SORT/UNIQUE/FILTER and OFFSET), **structural editing** (insert/delete rows & columns with formula rewriting), the **scripting prelude** (`com.tjclp.xl.scripting`), whole-workbook `recalculate`, named-range & hyperlink authoring, **typed charts + embedded pictures** (0.12.0), **conditional formatting** (0.12.1), SAX streaming (36% faster than POI), Excel tables, and full OOXML round-trip. 4,085 tests passing.
 
-**Current Version**: **0.12.6 "Fieldwork"** (released 2026-07-15)
+**Current Version**: **0.12.7 "Integrity"** (released 2026-07-16)
 
 ---
 
@@ -60,6 +60,10 @@ Phased: (a) verbatim chart/drawing preservation proven by the wave-2 fixture cor
 ### v0.12.1 "Clean Sweep" — wave 7 (Released 2026-06-11)
 
 Every remaining open issue closed in one wave. **Conditional formatting** ([#136](https://github.com/TJC-LP/xl/issues/136)) is the headline — typed cellIs/expression/colorScale/dataBar/top10/text rules + `dxf` differential formats, `sheet.conditionalFormat` authoring with auto-priority, structural-edit range shifting, unmodeled families preserved byte-faithfully — alongside twelve fidelity/writer fixes: openpyxl comment subdirectory dialect (#292), RichText SST keying (#303), exact surgical SST counts (#304), `[Content_Types]` preservation (#314), identity-keyed source mappings (#315), activeTab (#294), fitToPage tri-state (#284), `Cell.comment` deprecated→`Sheet.comments` (#295). Codec `put` paths 2.4x faster (#297).
+
+### v0.12.7 "Integrity" — wave 12 (Released 2026-07-16)
+
+File-integrity bugs from the tjc-modeling byte-exact replication campaign (PR #389, four worktree-isolated TDD clusters, each adversarially reviewed with revert-and-rerun refutation + openpyxl 3.1.5 cross-checks): property-only rows survive scratch writes ([#381](https://github.com/TJC-LP/xl/issues/381)), formula cells keep cached DateTime as Excel serials on all backends ([#378](https://github.com/TJC-LP/xl/issues/378)), schema-valid `<rFont>` comment/SST/inline rich runs + reader acceptance ([#383](https://github.com/TJC-LP/xl/issues/383)), identity-named modified-sheet parts on reordered sources ([#327](https://github.com/TJC-LP/xl/issues/327)), comment-removal CT/rels/legacyDrawing pruning ([#328](https://github.com/TJC-LP/xl/issues/328)), default theme part for scratch theme-color workbooks ([#387](https://github.com/TJC-LP/xl/issues/387)), and per-cell containment of financial-function divergence with a recalculate() totality backstop ([#388](https://github.com/TJC-LP/xl/issues/388)). Remaining campaign backlog: W2 parser unblockers (#374, #355) → W3 read/write parity (#372, #382, #358) → W4 authoring API (#373, #379, #380, #375, #361, #360) → W5 evaluator (#386, #385, #384) → W6 CLI/tooling (#356, #357, #324, #359) composing 0.13.0; then #344 as 0.14.0.
 
 ### v0.12.6 "Fieldwork" (Released 2026-07-15)
 

--- a/docs/reference/scripting.md
+++ b/docs/reference/scripting.md
@@ -33,7 +33,7 @@ release bump is a mechanical substitution):
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.6
+//> using dep com.tjclp::xl:0.12.7
 import com.tjclp.xl.scripting.{*, given}
 
 val sheet = Sheet("Demo").put(ref"A1", "Hello").put(ref"B1", 42)
@@ -51,7 +51,7 @@ read and write is pure values.
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.6
+//> using dep com.tjclp::xl:0.12.7
 import com.tjclp.xl.scripting.{*, given}
 
 val wb = Excel.read("input.xlsx")
@@ -135,7 +135,7 @@ throw — they are collected per cell.
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.6
+//> using dep com.tjclp::xl:0.12.7
 import com.tjclp.xl.scripting.{*, given}
 
 val title = CellStyle.default.bold.size(14.0).center
@@ -246,7 +246,7 @@ them explicitly:
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.6
+//> using dep com.tjclp::xl:0.12.7
 import com.tjclp.xl.scripting.{*, given}
 import com.tjclp.xl.sheets.{HeaderFooter, PageMargins, PageSetup, SheetView}
 
@@ -300,7 +300,7 @@ the whole workbook:
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.6
+//> using dep com.tjclp::xl:0.12.7
 import com.tjclp.xl.scripting.{*, given}
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global

--- a/examples/README.md
+++ b/examples/README.md
@@ -170,7 +170,7 @@ chmod +x examples/my_example.sc
 ./examples/my_example.sc
 ```
 
-The `project.scala` file centralizes dependencies (`com.tjclp::xl:0.12.6`) for all examples.
+The `project.scala` file centralizes dependencies (`com.tjclp::xl:0.12.7`) for all examples.
 
 ## Scripting Prelude & Skill
 

--- a/examples/project.scala
+++ b/examples/project.scala
@@ -2,4 +2,4 @@
 //> using repository ivy2Local
 
 // XL aggregate - includes all modules (core, ooxml, cats-effect, evaluator)
-//> using dep com.tjclp::xl:0.12.6
+//> using dep com.tjclp::xl:0.12.7

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "xl",
   "description": "LLM-friendly Excel tooling: the xl CLI for reading, writing, styling, and analyzing spreadsheets (xl-cli skill), plus type-safe Scala scripting against the xl library via scala-cli for bulk transformations, pipelines, and formula models (xl-scripting skill).",
-  "version": "0.12.6",
+  "version": "0.12.7",
   "author": {
     "name": "TJC L.P.",
     "url": "https://github.com/TJC-LP"

--- a/plugin/skills/xl-scripting/SKILL.md
+++ b/plugin/skills/xl-scripting/SKILL.md
@@ -38,7 +38,7 @@ The canonical header for every script (this is the single source of truth — re
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.6
+//> using dep com.tjclp::xl:0.12.7
 
 import com.tjclp.xl.scripting.{*, given}
 
@@ -100,7 +100,7 @@ wb.update("Sales", f).unsafe                       // throws structured XLExcept
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.6
+//> using dep com.tjclp::xl:0.12.7
 import com.tjclp.xl.scripting.{*, given}
 
 val wb = Excel.read("input.xlsx")
@@ -235,7 +235,7 @@ Or lean on totality so there is nothing to unwrap: literal refs, `upsert`, range
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.6
+//> using dep com.tjclp::xl:0.12.7
 import com.tjclp.xl.scripting.{*, given}
 import java.nio.file.{Files, Paths}
 import scala.jdk.CollectionConverters.*
@@ -257,7 +257,7 @@ println(s"merged ${inputs.size} files, ${merged.sheets.size} sheets")
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.6
+//> using dep com.tjclp::xl:0.12.7
 import com.tjclp.xl.scripting.{*, given}
 
 val data = List(("North", 125000.50), ("South", 98000.25), ("West", 143500.00))
@@ -285,7 +285,7 @@ println(if result.isClean then "✓ report written" else result.errors.map(_.ren
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.6
+//> using dep com.tjclp::xl:0.12.7
 import com.tjclp.xl.scripting.{*, given}
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global

--- a/plugin/skills/xl-scripting/reference/RECIPES.md
+++ b/plugin/skills/xl-scripting/reference/RECIPES.md
@@ -10,7 +10,7 @@ Apply a 5% price increase to column C of every workbook in a directory, in place
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.6
+//> using dep com.tjclp::xl:0.12.7
 import com.tjclp.xl.scripting.{*, given}
 import java.nio.file.{Files, Paths}
 import scala.jdk.CollectionConverters.*
@@ -42,7 +42,7 @@ Read rows into case classes; collect per-cell validation failures into a new Iss
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.6
+//> using dep com.tjclp::xl:0.12.7
 import com.tjclp.xl.scripting.{*, given}
 
 final case class Order(id: Int, customer: String, amount: BigDecimal)
@@ -76,7 +76,7 @@ Three-year projection with growth formulas; fail the script if any formula error
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.6
+//> using dep com.tjclp::xl:0.12.7
 import com.tjclp.xl.scripting.{*, given}
 
 val header = CellStyle.default.bold.size(12.0).center
@@ -111,7 +111,7 @@ Stack the data rows of every input file under one header.
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.6
+//> using dep com.tjclp::xl:0.12.7
 import com.tjclp.xl.scripting.{*, given}
 import java.nio.file.{Files, Paths}
 import scala.jdk.CollectionConverters.*
@@ -147,7 +147,7 @@ println(s"combined ${files.size} files, ${combined.cells.size} cells")
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.6
+//> using dep com.tjclp::xl:0.12.7
 import com.tjclp.xl.scripting.{*, given}
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
@@ -176,7 +176,7 @@ println("✓ filtered (constant memory)")
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.6
+//> using dep com.tjclp::xl:0.12.7
 import com.tjclp.xl.scripting.{*, given}
 
 val before = Excel.read("before.xlsx")
@@ -204,7 +204,7 @@ else
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.12.6
+//> using dep com.tjclp::xl:0.12.7
 import com.tjclp.xl.scripting.{*, given}
 import java.nio.file.{Files, Paths}
 import scala.jdk.CollectionConverters.*

--- a/xl-core/src/com/tjclp/xl/workbooks/WorkbookMetadata.scala
+++ b/xl-core/src/com/tjclp/xl/workbooks/WorkbookMetadata.scala
@@ -21,7 +21,7 @@ final case class WorkbookMetadata(
   modified: Option[java.time.LocalDateTime] = None,
   lastModifiedBy: Option[String] = None,
   application: Option[String] = Some("XL - Pure Scala 3.8 Excel Library"),
-  appVersion: Option[String] = Some("0.12.6"),
+  appVersion: Option[String] = Some("0.12.7"),
   theme: ThemePalette = ThemePalette.office,
   definedNames: Vector[DefinedName] = Vector.empty,
   sheetStates: Map[SheetName, Option[String]] = Map.empty,

--- a/xl/src/com/tjclp/xl/scripting.scala
+++ b/xl/src/com/tjclp/xl/scripting.scala
@@ -4,7 +4,7 @@ package com.tjclp.xl
  * Scripting prelude: everything a script needs in one import.
  *
  * {{{
- * //> using dep com.tjclp::xl:0.12.6
+ * //> using dep com.tjclp::xl:0.12.7
  * import com.tjclp.xl.scripting.{*, given}
  *
  * val wb = Excel.read("input.xlsx")


### PR DESCRIPTION
Release prep for **0.12.7 "Integrity"** — the file-integrity wave (PR #389: #327, #328, #378, #381, #383, #387, #388).

- Version pins `0.12.6` → `0.12.7`: `build.mill`, `WorkbookMetadata.appVersion`, `plugin.json`, README, QUICK-START, scripting docs/skill/RECIPES dep lines, examples
- CHANGELOG: `[0.12.7] "Integrity" - 2026-07-16` heading (release-notes source for the tag)
- STATUS.md + roadmap.md release bookkeeping (wave-12 section, remaining W2–W7 schedule)
- issue-wave workflow gates now use the CI scalafmt form (`checkFormatAll __.sources`) — module-scoped reformat missed test sources and cost PR #389 a CI round-trip

Gates run locally: compile 810/810, test 1028/1028, examples ✓, skill snippets ✓, no SNAPSHOT refs, `checkFormatAll __.sources` 25/25.

After merge: annotated tag `v0.12.7` on the squash commit (release notes from the CHANGELOG heading) triggers native binaries + Maven Central publish + GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)