### PR TITLE
Wave 13: parser + appearance parity — percent operator, preserved unary plus, freeze-pane read, scrolled panes, tab color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Excel percent postfix operator** (#355): `=A1*10%`, `=10%`, `=(1+5%)^2`
+  parse, evaluate (`10%` → exact `0.1`), broadcast over ranges (`=A1:C1%`),
+  and print back byte-identically (never rewritten to `/100`); precedence
+  matches Excel (`2^3%` ≡ `2^(3%)`), and deep `%` chains respect the
+  parser's nesting guard.
+- **Leading unary plus preserved through print** (#374): `=+A1`,
+  `=+Model!B2`, `=++A1`, `=2^+2` round-trip byte-for-byte via a dedicated
+  identity AST node — replicated formula text now matches professional-model
+  sources exactly. This deliberately reverses #271's printer normalization
+  (`=+A1` no longer prints as `=A1`); evaluation is unchanged (pure
+  identity), and references under `+`/`%` still shift on drag and
+  structural edits and contribute dependency edges.
+- **Freeze panes read into the model** (#372): the reader populates
+  `Sheet.freezePane` from `<pane>` (frozen and frozenSplit states), so
+  read→modify→write keeps freeze state through model regeneration and
+  typed dumps see it; `SheetView` gains `tabSelected`. Unmodified sheets
+  still round-trip byte-identically.
+- **Scrolled frozen panes** (#382): `FreezePane.At` carries an optional
+  scroll target (`freezeAt(anchor, scrolledTo)`), representing
+  `<pane ySplit="9" topLeftCell="F40"/>` — frozen at one row, scrolled to
+  another; structural edits shift both refs.
+- **Sheet tab color, model half** (#358): `Sheet.tabColor: Option[Color]`
+  (rgb and theme+tint forms) with `withTabColor`, read + write on both
+  writer backends with preserve-if-None semantics and schema-correct
+  `sheetPr` child order. CLI exposure remains open in #358.
+
 ## [0.12.7] "Integrity" - 2026-07-16
 
 File-integrity wave from the tjc-modeling byte-exact replication campaign

--- a/xl-core/src/com/tjclp/xl/sheets/FreezePane.scala
+++ b/xl-core/src/com/tjclp/xl/sheets/FreezePane.scala
@@ -12,8 +12,16 @@ import com.tjclp.xl.addressing.ARef
  *   - `At(ref"C1")` freezes columns A-B (no row freeze)
  */
 enum FreezePane derives CanEqual:
-  /** Freeze rows above and columns to the left of the given cell. */
-  case At(topLeftCell: ARef)
+  /**
+   * Freeze rows above and columns to the left of the given cell.
+   *
+   * NAMING WART: `topLeftCell` is the freeze ANCHOR — it maps to the pane's `xSplit`/`ySplit`
+   * attributes, NOT to the OOXML `topLeftCell` attribute. The OOXML `<pane topLeftCell=".."/>`
+   * attribute is the SCROLL target of the bottom-right pane, modeled here as [[scrolledTo]]
+   * (GH-382): a sheet frozen at row 10 but scrolled down to show row 40 carries
+   * `At(ref"A11", Some(ref"A40"))`. `None` means unscrolled — the pane attribute equals the anchor.
+   */
+  case At(topLeftCell: ARef, scrolledTo: Option[ARef] = None)
 
   /** Remove any existing freeze panes. */
   case Remove

--- a/xl-core/src/com/tjclp/xl/sheets/Sheet.scala
+++ b/xl-core/src/com/tjclp/xl/sheets/Sheet.scala
@@ -26,14 +26,18 @@ import scala.util.boundary, boundary.break
  *   - `Some(FreezePane.At(ref))`: inject/replace `<pane>` in sheetViews
  *   - `Some(FreezePane.Remove)`: strip any existing `<pane>` from sheetViews
  *
- * The distinction between `None` and `Some(Remove)` matters: `None` is the passive default
- * (round-trip preserves the original); `Some(Remove)` is the active intent to remove freeze panes
- * even when the source XML had them.
+ * The distinction between `None` and `Some(Remove)` matters: `None` is the passive default;
+ * `Some(Remove)` is the active intent to remove freeze panes even when the source XML had them.
+ * Since GH-372 the reader populates this from frozen `<pane>` elements (anchor from xSplit/ySplit,
+ * scroll target from the pane's topLeftCell attribute), so a read→modify→write regenerates the pane
+ * from the model and keeps the freeze through the rewrite. Plain SPLIT panes stay unmodeled
+ * (`None`) and ride the preserved XML.
  *
  * @param viewSettings
- *   Sheet view settings (gridline visibility, zoom). `None` preserves any existing `<sheetView>`
- *   attributes on write; `Some(view)` sets them. Freeze panes and view settings share a single
- *   `<sheetView>` element in the serialized XML.
+ *   Sheet view settings (gridline visibility, zoom, tab selection). `None` preserves any existing
+ *   `<sheetView>` attributes on write; `Some(view)` sets them. The reader populates this whenever a
+ *   modeled attribute is present in the source (GH-258/GH-372). Freeze panes and view settings
+ *   share a single `<sheetView>` element in the serialized XML.
  *
  * @param drawings
  *   Drawing objects (pictures and preserved fragments, GH-221). Document order is z-order is

--- a/xl-core/src/com/tjclp/xl/sheets/Sheet.scala
+++ b/xl-core/src/com/tjclp/xl/sheets/Sheet.scala
@@ -191,12 +191,16 @@ final case class Sheet(
       else Some(CellRange(rebuild(range.start, ns), rebuild(range.end, ne)))
     }
 
-    // Freeze pane: shift/clamp its anchor on the active axis (clamp a deleted anchor to `at`).
+    // Freeze pane: shift/clamp BOTH the anchor and the scroll target on the active axis
+    // (clamp a deleted ref to `at`) — dropping scrolledTo here would silently unscroll the
+    // pane on a structural edit (GH-382).
     val newFreeze = freezePane.map {
-      case FreezePane.At(ref) =>
-        val cur = axisOf(ref)
-        val ni = idx(cur).getOrElse(at)
-        FreezePane.At(rebuild(ref, ni))
+      case FreezePane.At(ref, scrolledTo) =>
+        val ni = idx(axisOf(ref)).getOrElse(at)
+        val newScrolled = scrolledTo.map { s =>
+          rebuild(s, idx(axisOf(s)).getOrElse(at))
+        }
+        FreezePane.At(rebuild(ref, ni), newScrolled)
       case other => other
     }
 
@@ -789,6 +793,13 @@ final case class Sheet(
 
   /** Freeze panes at the given cell (rows above and columns left are frozen). */
   def freezeAt(ref: ARef): Sheet = copy(freezePane = Some(FreezePane.At(ref)))
+
+  /**
+   * Freeze panes at `ref` with the scrollable pane scrolled so `scrolledTo` is its top-left visible
+   * cell (GH-382) — the OOXML `<pane topLeftCell=".."/>` attribute.
+   */
+  def freezeAt(ref: ARef, scrolledTo: ARef): Sheet =
+    copy(freezePane = Some(FreezePane.At(ref, Some(scrolledTo))))
 
   /** Remove freeze panes. */
   def unfreeze: Sheet = copy(freezePane = Some(FreezePane.Remove))

--- a/xl-core/src/com/tjclp/xl/sheets/Sheet.scala
+++ b/xl-core/src/com/tjclp/xl/sheets/Sheet.scala
@@ -8,6 +8,7 @@ import com.tjclp.xl.codec.{CellCodec, CellWritable, CellWriter}
 import com.tjclp.xl.drawings.{AnchorPoint, Drawing, DrawingAnchor, EditAs, Extent, ImageData}
 import com.tjclp.xl.error.{XLError, XLResult}
 import com.tjclp.xl.styles.{CellStyle, StyleRegistry}
+import com.tjclp.xl.styles.color.Color
 import com.tjclp.xl.styles.units.StyleId
 import com.tjclp.xl.tables.TableSpec
 
@@ -46,6 +47,12 @@ import scala.util.boundary, boundary.break
  * @param conditionalFormats
  *   Conditional-formatting blocks (GH-136). Document order is emission order; use
  *   [[conditionalFormat]] to append (it assigns priorities) rather than constructing directly.
+ *
+ * @param tabColor
+ *   Sheet tab color (GH-358), serialized as `<sheetPr><tabColor .../>`. `None` preserves any
+ *   existing tabColor XML on write (passive default, the viewSettings precedent); `Some(color)`
+ *   overlays it onto the preserved sheetPr. Both RGB and theme+tint colors are legal; the reader
+ *   populates it whenever the source color is in the typed subset (rgb / theme+tint / indexed).
  */
 final case class Sheet(
   name: SheetName,
@@ -62,7 +69,8 @@ final case class Sheet(
   freezePane: Option[FreezePane] = None,
   viewSettings: Option[SheetView] = None,
   drawings: Vector[Drawing] = Vector.empty,
-  conditionalFormats: Vector[ConditionalFormat] = Vector.empty
+  conditionalFormats: Vector[ConditionalFormat] = Vector.empty,
+  tabColor: Option[Color] = None
 ):
 
   /** Get cell at reference (returns empty cell if not present) */
@@ -830,6 +838,22 @@ final case class Sheet(
    * }}}
    */
   def withPageSetup(setup: PageSetup): Sheet = copy(pageSetup = Some(setup))
+
+  /**
+   * Set the sheet tab color (GH-358). Both RGB and theme colors are legal:
+   * {{{
+   * sheet.withTabColor(Color.Rgb(0xFF1F4E79))                 // navy
+   * sheet.withTabColor(Color.Theme(ThemeSlot.Accent2, 0.25))  // theme + tint
+   * }}}
+   */
+  def withTabColor(color: Color): Sheet = copy(tabColor = Some(color))
+
+  /**
+   * Clear the modeled tab color back to the passive default. NOTE: on write, `None` PRESERVES any
+   * tabColor already present in the source XML (preserve-if-None, the viewSettings precedent) — it
+   * does not actively strip a preserved color.
+   */
+  def withoutTabColor: Sheet = copy(tabColor = None)
 
   /** Count of non-empty cells */
   def cellCount: Int = cells.size

--- a/xl-core/src/com/tjclp/xl/sheets/SheetView.scala
+++ b/xl-core/src/com/tjclp/xl/sheets/SheetView.scala
@@ -8,16 +8,23 @@ package com.tjclp.xl.sheets
  * and the default gridlines visibly cheapen the artifact in Excel and in HTML/SVG/PNG exports.
  *
  * On write, view settings share a single `<sheetView>` element with freeze panes
- * ([[Sheet.freezePane]]), so setting both never produces duplicate view elements.
+ * ([[Sheet.freezePane]]), so setting both never produces duplicate view elements. The reader
+ * populates a SheetView whenever a modeled attribute is present on the first `<sheetView>`
+ * (GH-258/GH-372), so read→modify→write keeps these settings through model regeneration.
  *
  * @param showGridLines
  *   Whether Excel draws the default cell gridlines (default: true, Excel's default)
  * @param zoomScale
  *   Zoom percentage (10-400), or None for Excel's default (100)
+ * @param tabSelected
+ *   Whether this sheet's tab is selected in the UI (GH-372). Three-valued on write: `Some(_)`
+ *   overlays the attribute, `None` leaves any preserved `tabSelected` attribute untouched. Note
+ *   this is tab SELECTION (grouping), not the active sheet — that is `Workbook.activeSheetIndex`.
  */
 final case class SheetView(
   showGridLines: Boolean = true,
-  zoomScale: Option[Int] = None
+  zoomScale: Option[Int] = None,
+  tabSelected: Option[Boolean] = None
 ):
   require(
     zoomScale.forall(z => z >= 10 && z <= 400),

--- a/xl-core/test/src/com/tjclp/xl/Generators.scala
+++ b/xl-core/test/src/com/tjclp/xl/Generators.scala
@@ -508,7 +508,8 @@ object Generators:
     for
       gridLines <- Gen.oneOf(true, false)
       zoom <- Gen.option(Gen.oneOf(25, 75, 85, 100, 150, 200, 400))
-    yield SheetView(gridLines, zoom)
+      tabSelected <- Gen.option(Gen.oneOf(true, false))
+    yield SheetView(gridLines, zoom, tabSelected)
 
   /** Header/footer with at least one visible part or flag (all-default reads back as None) */
   val genHeaderFooter: Gen[HeaderFooter] =
@@ -562,17 +563,20 @@ object Generators:
       if ps == PageSetup() then ps.copy(orientation = Some("landscape")) else ps
 
   /**
-   * Freeze pane at a non-A1 cell (freezing at A1 is a no-op the writer elides). NOTE: freezePane
-   * has write-only three-valued semantics (None = preserve) — the reader never populates it, so
-   * generating it exercises the writer without participating in round-trip equality.
+   * Freeze pane at a non-A1 cell (freezing at A1 is a no-op the writer elides), optionally scrolled
+   * (GH-382). The reader populates freezePane from the pane XML since GH-372, so generated panes
+   * participate in round-trip equality; the scroll target sits strictly below the anchor so it
+   * never canonicalizes back to the unscrolled spelling on read.
    */
   val genFreezePane: Gen[FreezePane] =
     for
       col <- Gen.choose(0, 3)
       row <- Gen.choose(0, 5)
+      scrollRows <- Gen.option(Gen.choose(1, 30))
     yield
       val ref = if col == 0 && row == 0 then ARef.from0(1, 1) else ARef.from0(col, row)
-      FreezePane.At(ref)
+      val scrolledTo = scrollRows.map(dr => ARef.from0(ref.col.index0, ref.row.index0 + dr))
+      FreezePane.At(ref, scrolledTo)
 
   /** Cell reference within a compact grid (A1:H12) so merges/comments cluster realistically */
   val genGridRef: Gen[ARef] =

--- a/xl-core/test/src/com/tjclp/xl/Generators.scala
+++ b/xl-core/test/src/com/tjclp/xl/Generators.scala
@@ -958,6 +958,8 @@ object Generators:
       view <- Gen.option(genSheetView)
       pageSetup <- Gen.option(genPageSetup)
       freeze <- Gen.frequency(3 -> Gen.const(None), 1 -> genFreezePane.map(Some.apply))
+      // GH-358: tab color at freeze-like frequency (rgb and theme+tint both round-trip)
+      tabColor <- Gen.frequency(3 -> Gen.const(None), 1 -> genColor.map(Some.apply))
       // GH-221/GH-222: pictures at comment-like frequency, charts rarer still
       drawings <- Gen.frequency(
         3 -> Gen.const(Vector.empty[Drawing]),
@@ -982,7 +984,8 @@ object Generators:
         pageSetup = pageSetup,
         freezePane = freeze,
         drawings = drawings,
-        conditionalFormats = condFmts
+        conditionalFormats = condFmts,
+        tabColor = tabColor
       )
 
   /**

--- a/xl-core/test/src/com/tjclp/xl/SheetViewPageSetupSpec.scala
+++ b/xl-core/test/src/com/tjclp/xl/SheetViewPageSetupSpec.scala
@@ -33,6 +33,12 @@ class SheetViewPageSetupSpec extends FunSuite:
     assertEquals(sheet.viewSettings, Some(view))
   }
 
+  test("SheetView.tabSelected defaults to None and is settable (GH-372)") {
+    assertEquals(SheetView.default.tabSelected, None)
+    assertEquals(SheetView(tabSelected = Some(true)).tabSelected, Some(true))
+    assertEquals(SheetView(tabSelected = Some(false)).tabSelected, Some(false))
+  }
+
   // ===== FreezePane scroll state (GH-382) =====
 
   test("FreezePane.At defaults to an unscrolled pane (scrolledTo = None)") {

--- a/xl-core/test/src/com/tjclp/xl/SheetViewPageSetupSpec.scala
+++ b/xl-core/test/src/com/tjclp/xl/SheetViewPageSetupSpec.scala
@@ -3,6 +3,7 @@ package com.tjclp.xl
 import com.tjclp.xl.{*, given}
 import com.tjclp.xl.render.SvgRenderer
 import com.tjclp.xl.sheets.{FreezePane, HeaderFooter, PageMargins, PageSetup, SheetView}
+import com.tjclp.xl.styles.color.{Color, ThemeSlot}
 import munit.FunSuite
 
 /**
@@ -37,6 +38,21 @@ class SheetViewPageSetupSpec extends FunSuite:
     assertEquals(SheetView.default.tabSelected, None)
     assertEquals(SheetView(tabSelected = Some(true)).tabSelected, Some(true))
     assertEquals(SheetView(tabSelected = Some(false)).tabSelected, Some(false))
+  }
+
+  // ===== Tab color (GH-358) =====
+
+  test("Sheet.tabColor defaults to None; withTabColor sets it; withoutTabColor clears it") {
+    val navy = Color.Rgb(0xff1f4e79)
+    assertEquals(Sheet("S").tabColor, None)
+    val sheet = Sheet("S").withTabColor(navy)
+    assertEquals(sheet.tabColor, Some(navy))
+    assertEquals(sheet.withoutTabColor.tabColor, None)
+  }
+
+  test("Sheet.tabColor supports theme colors with tint (GH-358)") {
+    val theme = Color.Theme(ThemeSlot.Accent2, 0.25)
+    assertEquals(Sheet("S").withTabColor(theme).tabColor, Some(theme))
   }
 
   // ===== FreezePane scroll state (GH-382) =====

--- a/xl-core/test/src/com/tjclp/xl/SheetViewPageSetupSpec.scala
+++ b/xl-core/test/src/com/tjclp/xl/SheetViewPageSetupSpec.scala
@@ -2,7 +2,7 @@ package com.tjclp.xl
 
 import com.tjclp.xl.{*, given}
 import com.tjclp.xl.render.SvgRenderer
-import com.tjclp.xl.sheets.{HeaderFooter, PageMargins, PageSetup, SheetView}
+import com.tjclp.xl.sheets.{FreezePane, HeaderFooter, PageMargins, PageSetup, SheetView}
 import munit.FunSuite
 
 /**
@@ -31,6 +31,33 @@ class SheetViewPageSetupSpec extends FunSuite:
     val view = SheetView(showGridLines = false, zoomScale = Some(85))
     val sheet = Sheet("S").withViewSettings(view)
     assertEquals(sheet.viewSettings, Some(view))
+  }
+
+  // ===== FreezePane scroll state (GH-382) =====
+
+  test("FreezePane.At defaults to an unscrolled pane (scrolledTo = None)") {
+    assertEquals(FreezePane.At(ref"B2"), FreezePane.At(ref"B2", None))
+  }
+
+  test("Sheet.freezeAt(anchor, scrolledTo) records the scroll target (GH-382)") {
+    val sheet = Sheet("S").freezeAt(ref"C11", ref"F40")
+    assertEquals(sheet.freezePane, Some(FreezePane.At(ref"C11", Some(ref"F40"))))
+  }
+
+  test("Sheet.freezeAt(anchor) keeps the unscrolled default") {
+    assertEquals(Sheet("S").freezeAt(ref"B2").freezePane, Some(FreezePane.At(ref"B2", None)))
+  }
+
+  test("insertRows shifts BOTH the freeze anchor and the scroll target (GH-382)") {
+    val sheet = Sheet("S").freezeAt(ref"B3", ref"B10")
+    val shifted = sheet.insertRows(at = 0, count = 2)
+    assertEquals(shifted.freezePane, Some(FreezePane.At(ref"B5", Some(ref"B12"))))
+  }
+
+  test("deleteColumns shifts the scroll target with the anchor (GH-382)") {
+    val sheet = Sheet("S").freezeAt(ref"C11", ref"F40")
+    val shifted = sheet.deleteColumns(at = 0, count = 1)
+    assertEquals(shifted.freezePane, Some(FreezePane.At(ref"B11", Some(ref"E40"))))
   }
 
   // ===== PageSetup extensions (GH-259) =====

--- a/xl-evaluator/src/com/tjclp/xl/formula/ast/TExpr.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/ast/TExpr.scala
@@ -203,6 +203,18 @@ enum TExpr[A] derives CanEqual:
    */
   case UnaryPlus[A](expr: TExpr[A]) extends TExpr[A]
 
+  /**
+   * GH-355: postfix percent — `=A1*10%`, Excel's tightest-binding operator (value ÷ 100).
+   *
+   * Binds tighter than `^` and unary minus: `2^3%` ≡ `2^(3%)`, `-2%` ≡ `-(2%)` = -0.02; chained
+   * percents nest (`10%%` = 0.001). Preserved through print (never rewritten to `/100`). Evaluation
+   * routes through the array arithmetic machinery (like the binary operators), so a range operand
+   * broadcasts elementwise: `=A1:A3%` divides each cell by 100.
+   *
+   * Law: eval(Percent(x)) == eval(Div(x, Lit(100)))
+   */
+  case Percent(expr: TExpr[BigDecimal]) extends TExpr[BigDecimal]
+
   // String operators
 
   /**

--- a/xl-evaluator/src/com/tjclp/xl/formula/ast/TExpr.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/ast/TExpr.scala
@@ -191,6 +191,18 @@ enum TExpr[A] derives CanEqual:
    */
   case Pow(x: TExpr[BigDecimal], y: TExpr[BigDecimal]) extends TExpr[BigDecimal]
 
+  /**
+   * GH-374: unary plus — `=+A1`, the Lotus-era leading-plus idiom endemic in professional models.
+   *
+   * Semantically the identity (Excel evaluates `+x` as `x`, whatever x's type), but carried as an
+   * explicit type-preserving node — not erased at parse — so the printer replicates the source
+   * formula text byte-for-byte (`=+Model!B2` round-trips as `=+Model!B2`). Transparent wrapper in
+   * the ToInt/Coerced mold: analysis, shifting, and dependency extraction recurse through it.
+   *
+   * Law: eval(UnaryPlus(x)) == eval(x)
+   */
+  case UnaryPlus[A](expr: TExpr[A]) extends TExpr[A]
+
   // String operators
 
   /**

--- a/xl-evaluator/src/com/tjclp/xl/formula/ast/TExprAnalysis.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/ast/TExprAnalysis.scala
@@ -43,6 +43,8 @@ trait TExprAnalysis:
     // Error handling
     // Type conversion
     case ToInt(e) => containsDateFunction(e)
+    // GH-374: unary plus is transparent for analysis
+    case UnaryPlus(e) => containsDateFunction(e)
     // GH-193: LET — check binding values (the body may reference them) and the body
     case Let(bindings, body) =>
       bindings.exists((_, value) => containsDateFunction(value)) || containsDateFunction(body)
@@ -81,6 +83,8 @@ trait TExprAnalysis:
     // Error handling
     // Type conversion
     case ToInt(e) => containsTimeFunction(e)
+    // GH-374: unary plus is transparent for analysis
+    case UnaryPlus(e) => containsTimeFunction(e)
     // GH-193: LET — check binding values (the body may reference them) and the body
     case Let(bindings, body) =>
       bindings.exists((_, value) => containsTimeFunction(value)) || containsTimeFunction(body)
@@ -125,6 +129,7 @@ trait TExprAnalysis:
     case Gt(l, r) => containsExternalRef(l) || containsExternalRef(r)
     case Gte(l, r) => containsExternalRef(l) || containsExternalRef(r)
     case ToInt(e) => containsExternalRef(e)
+    case UnaryPlus(e) => containsExternalRef(e)
     case DateToSerial(e) => containsExternalRef(e)
     case DateTimeToSerial(e) => containsExternalRef(e)
     case Let(bindings, body) =>
@@ -169,6 +174,8 @@ trait TExprAnalysis:
     case Gte(l, r) => collectRanges(l) ++ collectRanges(r)
     // Type conversion
     case ToInt(e) => collectRanges(e)
+    // GH-374: unary plus is transparent — nested ranges still get bounded
+    case UnaryPlus(e) => collectRanges(e)
     // GH-193: LET — ranges from binding values and the body
     case Let(bindings, body) =>
       bindings.flatMap((_, value) => collectRanges(value)) ++ collectRanges(body)
@@ -221,6 +228,9 @@ trait TExprAnalysis:
       // Type conversion
       case ToInt(e) =>
         ToInt(transformRanges(e, f))
+      // GH-374: unary plus is transparent — transform ranges under it
+      case UnaryPlus(e) =>
+        UnaryPlus(transformRanges(e, f))
       // GH-193: LET — transform ranges in binding values and the body
       case Let(bindings, body) =>
         Let(

--- a/xl-evaluator/src/com/tjclp/xl/formula/ast/TExprAnalysis.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/ast/TExprAnalysis.scala
@@ -43,8 +43,9 @@ trait TExprAnalysis:
     // Error handling
     // Type conversion
     case ToInt(e) => containsDateFunction(e)
-    // GH-374: unary plus is transparent for analysis
+    // GH-374/GH-355: unary plus and percent are transparent for analysis
     case UnaryPlus(e) => containsDateFunction(e)
+    case Percent(e) => containsDateFunction(e)
     // GH-193: LET — check binding values (the body may reference them) and the body
     case Let(bindings, body) =>
       bindings.exists((_, value) => containsDateFunction(value)) || containsDateFunction(body)
@@ -83,8 +84,9 @@ trait TExprAnalysis:
     // Error handling
     // Type conversion
     case ToInt(e) => containsTimeFunction(e)
-    // GH-374: unary plus is transparent for analysis
+    // GH-374/GH-355: unary plus and percent are transparent for analysis
     case UnaryPlus(e) => containsTimeFunction(e)
+    case Percent(e) => containsTimeFunction(e)
     // GH-193: LET — check binding values (the body may reference them) and the body
     case Let(bindings, body) =>
       bindings.exists((_, value) => containsTimeFunction(value)) || containsTimeFunction(body)
@@ -130,6 +132,7 @@ trait TExprAnalysis:
     case Gte(l, r) => containsExternalRef(l) || containsExternalRef(r)
     case ToInt(e) => containsExternalRef(e)
     case UnaryPlus(e) => containsExternalRef(e)
+    case Percent(e) => containsExternalRef(e)
     case DateToSerial(e) => containsExternalRef(e)
     case DateTimeToSerial(e) => containsExternalRef(e)
     case Let(bindings, body) =>
@@ -174,8 +177,9 @@ trait TExprAnalysis:
     case Gte(l, r) => collectRanges(l) ++ collectRanges(r)
     // Type conversion
     case ToInt(e) => collectRanges(e)
-    // GH-374: unary plus is transparent — nested ranges still get bounded
+    // GH-374/GH-355: unary plus and percent are transparent — nested ranges still get bounded
     case UnaryPlus(e) => collectRanges(e)
+    case Percent(e) => collectRanges(e)
     // GH-193: LET — ranges from binding values and the body
     case Let(bindings, body) =>
       bindings.flatMap((_, value) => collectRanges(value)) ++ collectRanges(body)
@@ -228,9 +232,11 @@ trait TExprAnalysis:
       // Type conversion
       case ToInt(e) =>
         ToInt(transformRanges(e, f))
-      // GH-374: unary plus is transparent — transform ranges under it
+      // GH-374/GH-355: unary plus and percent are transparent — transform ranges under them
       case UnaryPlus(e) =>
         UnaryPlus(transformRanges(e, f))
+      case Percent(e) =>
+        Percent(transformRanges(e, f))
       // GH-193: LET — transform ranges in binding values and the body
       case Let(bindings, body) =>
         Let(

--- a/xl-evaluator/src/com/tjclp/xl/formula/ast/TExprCoercions.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/ast/TExprCoercions.scala
@@ -20,7 +20,9 @@ trait TExprCoercions:
    */
   private def isRuntimePolymorphic(expr: TExpr[?]): Boolean = expr match
     case _: TExpr.Call[?] | _: TExpr.Let[?] | _: TExpr.Aggregate | _: TExpr.Coerced[?] => true
-    case _: TExpr.Add | _: TExpr.Sub | _: TExpr.Mul | _: TExpr.Div | _: TExpr.Pow => true
+    case _: TExpr.Add | _: TExpr.Sub | _: TExpr.Mul | _: TExpr.Div | _: TExpr.Pow |
+        _: TExpr.Percent =>
+      true
     case _: TExpr.Concat => true
     case _: TExpr.Eq[?] | _: TExpr.Neq[?] | _: TExpr.Lt[?] | _: TExpr.Lte[?] | _: TExpr.Gt[?] |
         _: TExpr.Gte[?] =>
@@ -113,7 +115,8 @@ trait TExprCoercions:
     // Arithmetic expressions return BigDecimal — wrap in ToInt to avoid
     // a runtime ClassCastException when used in Int-arg positions
     // (e.g. =MID(A1, FIND("@", A1) + 1, 100)).
-    case _: TExpr.Add | _: TExpr.Sub | _: TExpr.Mul | _: TExpr.Div | _: TExpr.Pow =>
+    case _: TExpr.Add | _: TExpr.Sub | _: TExpr.Mul | _: TExpr.Div | _: TExpr.Pow |
+        _: TExpr.Percent =>
       ToInt(expr.asInstanceOf[TExpr[BigDecimal]])
     case agg: TExpr.Aggregate => ToInt(agg)
     // GH-302/GH-306: non-numeric call results (text, boolean, arrays, IF branches) coerce at
@@ -148,7 +151,7 @@ trait TExprCoercions:
     case call: TExpr.Call[?] if call.spec.flags.returnsNumeric =>
       call.asInstanceOf[TExpr[BigDecimal]]
     case _: TExpr.Add | _: TExpr.Sub | _: TExpr.Mul | _: TExpr.Div | _: TExpr.Pow |
-        _: TExpr.Aggregate | _: TExpr.DateToSerial | _: TExpr.DateTimeToSerial =>
+        _: TExpr.Percent | _: TExpr.Aggregate | _: TExpr.DateToSerial | _: TExpr.DateTimeToSerial =>
       expr.asInstanceOf[TExpr[BigDecimal]]
     // GH-302/GH-306: text/boolean/array call results coerce at evaluation time (numeric text
     // parses, booleans are 1/0, 1×1 arrays collapse; arrays still broadcast in operand positions)

--- a/xl-evaluator/src/com/tjclp/xl/formula/ast/TExprCoercions.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/ast/TExprCoercions.scala
@@ -40,6 +40,9 @@ trait TExprCoercions:
   @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
   def asStringExpr(expr: TExpr[?]): TExpr[String] = expr match
     case PolyRef(at, anchor) => Ref(at, anchor, decodeAsString)
+    // GH-374: unary plus is a type-preserving transparent wrapper — push the coercion through
+    // so wrapped PolyRefs still resolve (and the node survives for byte-faithful printing)
+    case UnaryPlus(inner) => UnaryPlus(asStringExpr(inner))
     case SheetPolyRef(sheet, at, anchor) => SheetRef(sheet, at, anchor, decodeAsString)
     // GH-193: LET bindings are Any-typed — coerce totally at evaluation time
     case BindingRef(name) => CoercedBindingRef[String](name, BindingCoercion.Text)
@@ -63,6 +66,8 @@ trait TExprCoercions:
   @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
   def asDateExpr(expr: TExpr[?]): TExpr[java.time.LocalDate] = expr match
     case PolyRef(at, anchor) => Ref(at, anchor, decodeAsDate)
+    // GH-374: push through the transparent unary-plus wrapper (see asStringExpr)
+    case UnaryPlus(inner) => UnaryPlus(asDateExpr(inner))
     case SheetPolyRef(sheet, at, anchor) => SheetRef(sheet, at, anchor, decodeAsDate)
     // GH-193: LET bindings are Any-typed — coerce totally at evaluation time (bound dates from
     // cells are stored as Excel serial numbers, which the Date target converts back)
@@ -90,6 +95,8 @@ trait TExprCoercions:
   @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
   def asIntExpr(expr: TExpr[?]): TExpr[Int] = expr match
     case PolyRef(at, anchor) => Ref(at, anchor, decodeAsInt)
+    // GH-374: push through the transparent unary-plus wrapper (see asStringExpr)
+    case UnaryPlus(inner) => UnaryPlus(asIntExpr(inner))
     case SheetPolyRef(sheet, at, anchor) => SheetRef(sheet, at, anchor, decodeAsInt)
     // GH-193: LET bindings are Any-typed — coerce totally at evaluation time
     case BindingRef(name) => CoercedBindingRef[Int](name, BindingCoercion.Integer)
@@ -122,6 +129,8 @@ trait TExprCoercions:
   @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
   def asNumericExpr(expr: TExpr[?]): TExpr[BigDecimal] = expr match
     case PolyRef(at, anchor) => Ref(at, anchor, decodeNumeric)
+    // GH-374: push through the transparent unary-plus wrapper (see asStringExpr)
+    case UnaryPlus(inner) => UnaryPlus(asNumericExpr(inner))
     case SheetPolyRef(sheet, at, anchor) => SheetRef(sheet, at, anchor, decodeNumeric)
     // GH-193: LET bindings are Any-typed — coerce totally at evaluation time
     case BindingRef(name) => CoercedBindingRef[BigDecimal](name, BindingCoercion.Numeric)
@@ -160,6 +169,9 @@ trait TExprCoercions:
   def asNumericOrRangeExpr(expr: TExpr[?]): TExpr[BigDecimal] = expr match
     case r: TExpr.RangeRef => r.asInstanceOf[TExpr[BigDecimal]] // Preserve for array eval
     case sr: TExpr.SheetRange => sr.asInstanceOf[TExpr[BigDecimal]] // Preserve for array eval
+    // GH-374: push through the transparent unary-plus wrapper so a wrapped range stays
+    // range-shaped for array arithmetic (=+A1:A3*10 broadcasts)
+    case UnaryPlus(inner) => UnaryPlus(asNumericOrRangeExpr(inner))
     case other => asNumericExpr(other)
 
   /**
@@ -170,6 +182,8 @@ trait TExprCoercions:
   @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
   def asBooleanExpr(expr: TExpr[?]): TExpr[Boolean] = expr match
     case PolyRef(at, anchor) => Ref(at, anchor, decodeBool)
+    // GH-374: push through the transparent unary-plus wrapper (see asStringExpr)
+    case UnaryPlus(inner) => UnaryPlus(asBooleanExpr(inner))
     case SheetPolyRef(sheet, at, anchor) => SheetRef(sheet, at, anchor, decodeBool)
     // GH-193: LET bindings are Any-typed — coerce totally at evaluation time
     case BindingRef(name) => CoercedBindingRef[Boolean](name, BindingCoercion.Bool)
@@ -197,6 +211,8 @@ trait TExprCoercions:
   @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
   def asCellValueExpr(expr: TExpr[?]): TExpr[CellValue] = expr match
     case PolyRef(at, anchor) => Ref(at, anchor, decodeCellValue)
+    // GH-374: push through the transparent unary-plus wrapper (see asStringExpr)
+    case UnaryPlus(inner) => UnaryPlus(asCellValueExpr(inner))
     case SheetPolyRef(sheet, at, anchor) => SheetRef(sheet, at, anchor, decodeCellValue)
     case other =>
       other.asInstanceOf[TExpr[CellValue]] // Safe: non-PolyRef already has correct type
@@ -210,6 +226,8 @@ trait TExprCoercions:
   @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
   def asResolvedValueExpr(expr: TExpr[?]): TExpr[CellValue] = expr match
     case PolyRef(at, anchor) => Ref(at, anchor, decodeResolvedValue)
+    // GH-374: push through the transparent unary-plus wrapper (see asStringExpr)
+    case UnaryPlus(inner) => UnaryPlus(asResolvedValueExpr(inner))
     case SheetPolyRef(sheet, at, anchor) => SheetRef(sheet, at, anchor, decodeResolvedValue)
     case other =>
       other.asInstanceOf[TExpr[CellValue]] // Safe: non-PolyRef already has correct type
@@ -224,6 +242,8 @@ trait TExprCoercions:
   @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
   def asComparableValueExpr(expr: TExpr[?]): TExpr[CellValue] = expr match
     case PolyRef(at, anchor) => Ref(at, anchor, decodeComparableValue)
+    // GH-374: push through the transparent unary-plus wrapper (see asStringExpr)
+    case UnaryPlus(inner) => UnaryPlus(asComparableValueExpr(inner))
     case SheetPolyRef(sheet, at, anchor) => SheetRef(sheet, at, anchor, decodeComparableValue)
     case other =>
       other.asInstanceOf[TExpr[CellValue]] // Safe: non-PolyRef already has correct type

--- a/xl-evaluator/src/com/tjclp/xl/formula/eval/Evaluator.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/eval/Evaluator.scala
@@ -481,6 +481,12 @@ private class EvaluatorImpl(
         evalArithmetic(x, y, ArrayArithmetic.pow, sheet, clock, workbook, currentCell)
           .asInstanceOf[Either[EvalError, A]]
 
+      // GH-374: unary plus is the identity — preserved in the AST only so the printer can
+      // replicate source text byte-for-byte; at evaluation time the operand's value (scalar,
+      // array, whatever) passes through untouched.
+      case TExpr.UnaryPlus(e) =>
+        eval(e, sheet, clock, workbook, currentCell)
+
       // ===== String Operators =====
       case TExpr.Concat(x, y) =>
         // Concatenate: join two strings. Operands are statically String, but erased upstream
@@ -831,6 +837,10 @@ private class EvaluatorImpl(
             workbook
           )
           .map(targetSheet => ArrayArithmetic.rangeToArray(range, targetSheet))
+      // GH-374: unary plus is transparent in operand positions — =+A1:A3*10 broadcasts
+      // exactly like =A1:A3*10
+      case TExpr.UnaryPlus(inner) =>
+        evalMaybeArray(inner, sheet, clock, workbook, currentCell)
       // GH-302: coerced nodes in OPERAND positions pass ArrayResults through (so
       // =INDIRECT("A1:A3")*10 broadcasts exactly like =A1:A3*10) and coerce scalars totally
       // (so ="16"&"" or a text call result still enters arithmetic per the Numeric table).

--- a/xl-evaluator/src/com/tjclp/xl/formula/eval/Evaluator.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/eval/Evaluator.scala
@@ -487,6 +487,20 @@ private class EvaluatorImpl(
       case TExpr.UnaryPlus(e) =>
         eval(e, sheet, clock, workbook, currentCell)
 
+      // GH-355: postfix percent is ÷100 routed through the same array machinery as the binary
+      // operators, so range operands broadcast elementwise (=A1:A3% divides each cell by 100)
+      // and scalars stay exact (BigDecimal(10)/100 = 0.1).
+      case TExpr.Percent(e) =>
+        evalArithmetic(
+          e,
+          TExpr.Lit(BigDecimal(100)),
+          ArrayArithmetic.div,
+          sheet,
+          clock,
+          workbook,
+          currentCell
+        ).asInstanceOf[Either[EvalError, A]]
+
       // ===== String Operators =====
       case TExpr.Concat(x, y) =>
         // Concatenate: join two strings. Operands are statically String, but erased upstream

--- a/xl-evaluator/src/com/tjclp/xl/formula/eval/FormulaFormatting.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/eval/FormulaFormatting.scala
@@ -162,6 +162,7 @@ object FormulaFormatting:
         // Unary wrappers
         case TExpr.ToInt(inner) => loop(inner)
         case TExpr.UnaryPlus(inner) => loop(inner)
+        case TExpr.Percent(inner) => loop(inner)
         case TExpr.DateToSerial(inner) => loop(inner)
         case TExpr.DateTimeToSerial(inner) => loop(inner)
 

--- a/xl-evaluator/src/com/tjclp/xl/formula/eval/FormulaFormatting.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/eval/FormulaFormatting.scala
@@ -161,6 +161,7 @@ object FormulaFormatting:
 
         // Unary wrappers
         case TExpr.ToInt(inner) => loop(inner)
+        case TExpr.UnaryPlus(inner) => loop(inner)
         case TExpr.DateToSerial(inner) => loop(inner)
         case TExpr.DateTimeToSerial(inner) => loop(inner)
 

--- a/xl-evaluator/src/com/tjclp/xl/formula/graph/DependencyGraph.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/graph/DependencyGraph.scala
@@ -171,6 +171,7 @@ object DependencyGraph:
 
       // Unary operators
       case TExpr.ToInt(e) => containsCellReferences(e)
+      case TExpr.UnaryPlus(e) => containsCellReferences(e)
       case TExpr.DateToSerial(e) => containsCellReferences(e)
       case TExpr.DateTimeToSerial(e) => containsCellReferences(e)
 
@@ -218,6 +219,7 @@ object DependencyGraph:
       case TExpr.Gt(l, r) => containsDynamicReference(l) || containsDynamicReference(r)
       case TExpr.Gte(l, r) => containsDynamicReference(l) || containsDynamicReference(r)
       case TExpr.ToInt(e) => containsDynamicReference(e)
+      case TExpr.UnaryPlus(e) => containsDynamicReference(e)
       case TExpr.DateToSerial(e) => containsDynamicReference(e)
       case TExpr.DateTimeToSerial(e) => containsDynamicReference(e)
       // GH-306: runtime coercion wrapper — a coerced INDIRECT/OFFSET is still dynamic
@@ -347,6 +349,7 @@ object DependencyGraph:
 
       // Unary operators
       case TExpr.ToInt(e) => containsUnqualifiedCellReferences(e)
+      case TExpr.UnaryPlus(e) => containsUnqualifiedCellReferences(e)
       case TExpr.DateToSerial(e) => containsUnqualifiedCellReferences(e)
       case TExpr.DateTimeToSerial(e) => containsUnqualifiedCellReferences(e)
 
@@ -429,6 +432,8 @@ object DependencyGraph:
       case TExpr.Gte(l, r) => extractDependencies(l) ++ extractDependencies(r)
       case TExpr.ToInt(expr) =>
         extractDependencies(expr) // Type conversion - extract from wrapped expr
+      // GH-374: unary plus is transparent — dependencies under it feed recalc edges
+      case TExpr.UnaryPlus(expr) => extractDependencies(expr)
       case TExpr.Aggregate(_, location) => location.localCells
 
       // GH-193: LET — union of binding-value and body dependencies; BindingRef has none
@@ -511,6 +516,7 @@ object DependencyGraph:
       case TExpr.Gte(l, r) =>
         extractDependenciesBounded(l, bounds) ++ extractDependenciesBounded(r, bounds)
       case TExpr.ToInt(expr) => extractDependenciesBounded(expr, bounds)
+      case TExpr.UnaryPlus(expr) => extractDependenciesBounded(expr, bounds)
       case TExpr.Aggregate(_, location) => location.localCellsBounded(bounds)
 
       case call: TExpr.Call[?] =>
@@ -1078,6 +1084,7 @@ object DependencyGraph:
         case TExpr.Gte(l, r) => go(l) ++ go(r)
         // Unary operators
         case TExpr.ToInt(x) => go(x)
+        case TExpr.UnaryPlus(x) => go(x)
 
         // Reference functions
         case TExpr.Aggregate(_, location) => locCells(location)

--- a/xl-evaluator/src/com/tjclp/xl/formula/graph/DependencyGraph.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/graph/DependencyGraph.scala
@@ -172,6 +172,7 @@ object DependencyGraph:
       // Unary operators
       case TExpr.ToInt(e) => containsCellReferences(e)
       case TExpr.UnaryPlus(e) => containsCellReferences(e)
+      case TExpr.Percent(e) => containsCellReferences(e)
       case TExpr.DateToSerial(e) => containsCellReferences(e)
       case TExpr.DateTimeToSerial(e) => containsCellReferences(e)
 
@@ -220,6 +221,7 @@ object DependencyGraph:
       case TExpr.Gte(l, r) => containsDynamicReference(l) || containsDynamicReference(r)
       case TExpr.ToInt(e) => containsDynamicReference(e)
       case TExpr.UnaryPlus(e) => containsDynamicReference(e)
+      case TExpr.Percent(e) => containsDynamicReference(e)
       case TExpr.DateToSerial(e) => containsDynamicReference(e)
       case TExpr.DateTimeToSerial(e) => containsDynamicReference(e)
       // GH-306: runtime coercion wrapper — a coerced INDIRECT/OFFSET is still dynamic
@@ -350,6 +352,7 @@ object DependencyGraph:
       // Unary operators
       case TExpr.ToInt(e) => containsUnqualifiedCellReferences(e)
       case TExpr.UnaryPlus(e) => containsUnqualifiedCellReferences(e)
+      case TExpr.Percent(e) => containsUnqualifiedCellReferences(e)
       case TExpr.DateToSerial(e) => containsUnqualifiedCellReferences(e)
       case TExpr.DateTimeToSerial(e) => containsUnqualifiedCellReferences(e)
 
@@ -434,6 +437,8 @@ object DependencyGraph:
         extractDependencies(expr) // Type conversion - extract from wrapped expr
       // GH-374: unary plus is transparent — dependencies under it feed recalc edges
       case TExpr.UnaryPlus(expr) => extractDependencies(expr)
+      // GH-355: postfix percent — dependencies under it feed recalc edges
+      case TExpr.Percent(expr) => extractDependencies(expr)
       case TExpr.Aggregate(_, location) => location.localCells
 
       // GH-193: LET — union of binding-value and body dependencies; BindingRef has none
@@ -517,6 +522,7 @@ object DependencyGraph:
         extractDependenciesBounded(l, bounds) ++ extractDependenciesBounded(r, bounds)
       case TExpr.ToInt(expr) => extractDependenciesBounded(expr, bounds)
       case TExpr.UnaryPlus(expr) => extractDependenciesBounded(expr, bounds)
+      case TExpr.Percent(expr) => extractDependenciesBounded(expr, bounds)
       case TExpr.Aggregate(_, location) => location.localCellsBounded(bounds)
 
       case call: TExpr.Call[?] =>
@@ -1085,6 +1091,7 @@ object DependencyGraph:
         // Unary operators
         case TExpr.ToInt(x) => go(x)
         case TExpr.UnaryPlus(x) => go(x)
+        case TExpr.Percent(x) => go(x)
 
         // Reference functions
         case TExpr.Aggregate(_, location) => locCells(location)

--- a/xl-evaluator/src/com/tjclp/xl/formula/parser/FormulaParser.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/parser/FormulaParser.scala
@@ -23,7 +23,7 @@ import scala.annotation.tailrec
  *   - Ranges: A1:B10
  *   - External-workbook references (GH-353): [2]Book1!A1, [2]Book1!A1:B2, '[3]Sheet Name'!B2
  *     (unresolvable — carried as ExternalRef/ExternalRange for closed-workbook cache semantics)
- *   - Operators: +, -, *, /, =, <>, <, <=, >, >=, &
+ *   - Operators: +, -, *, /, ^, =, <>, <, <=, >, >=, &, postfix % (GH-355)
  *   - Functions: SUM, COUNT, IF, AND, OR, NOT, etc.
  *   - Parentheses for grouping
  *
@@ -39,14 +39,15 @@ import scala.annotation.tailrec
  * Operator precedence (highest to lowest, Excel-compatible):
  *   1. Parentheses ()
  *   2. Function calls
- *   3. Exponentiation ^ (right-associative)
- *   4. Unary minus -
- *   5. Multiplication *, Division /
- *   6. Addition +, Subtraction -
- *   7. Concatenation &
- *   8. Comparison =, <>, <, <=, >, >=
- *   9. Logical AND
- *   10. Logical OR
+ *   3. Postfix percent % (GH-355: binds tighter than ^, 2^3% = 2^(3%))
+ *   4. Exponentiation ^ (right-associative)
+ *   5. Unary minus -, unary plus +
+ *   6. Multiplication *, Division /
+ *   7. Addition +, Subtraction -
+ *   8. Concatenation &
+ *   9. Comparison =, <>, <, <=, >, >=
+ *   10. Logical AND
+ *   11. Logical OR
  *
  * @note
  *   Suppression rationale:
@@ -481,7 +482,7 @@ object FormulaParser:
    * than unary minus, so -2^2 = -(2^2) = -4 But the exponent can have unary minus: 2^-1 = 0.5
    */
   private def parsePow(state: ParserState): ParseResult[TExpr[?]] =
-    parsePrimary(state).flatMap { case (left, s1) =>
+    parsePostfix(state).flatMap { case (left, s1) =>
       val s2 = skipWhitespace(s1)
       s2.currentChar match
         case Some('^') =>
@@ -500,6 +501,30 @@ object FormulaParser:
             }
           }
         case _ => Right((left, s2))
+    }
+
+  /**
+   * GH-355: parse postfix percent — Excel's tightest-binding operator (value ÷ 100).
+   *
+   * Sits between parsePow and parsePrimary in the precedence ladder so `%` binds tighter than `^`
+   * (2^3% ≡ 2^(3%)) and tighter than unary minus (-2% ≡ -(2%)). A loop consumes chained percents
+   * (10%% = 0.001), each wrapping in TExpr.Percent and counting against the depth budget (chained
+   * postfixes nest the AST like chained '+' terms, GH-56). The operand coerces numerically with
+   * ranges preserved so `=A1:A3%` broadcasts through the array machinery.
+   */
+  private def parsePostfix(state: ParserState): ParseResult[TExpr[?]] =
+    parsePrimary(state).flatMap { case (first, s1) =>
+      @tailrec
+      def loop(acc: TExpr[?], s: ParserState): ParseResult[TExpr[?]] =
+        val s2 = skipWhitespace(s)
+        s2.currentChar match
+          case Some('%') =>
+            descend(s2) match
+              case Left(err) => Left(err)
+              case Right(sd) =>
+                loop(TExpr.Percent(TExpr.asNumericOrRangeExpr(acc)), sd.advance())
+          case _ => Right((acc, s2))
+      loop(first, s1)
     }
 
   /**

--- a/xl-evaluator/src/com/tjclp/xl/formula/parser/FormulaParser.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/parser/FormulaParser.scala
@@ -118,6 +118,8 @@ object FormulaParser:
    */
   private def resolveTopLevelPolyRef(expr: TExpr[?]): TExpr[?] = expr match
     case _: TExpr.PolyRef | _: TExpr.SheetPolyRef => TExpr.asResolvedValueExpr(expr)
+    // GH-374: unary plus is a transparent wrapper — a bare `=+A1` must resolve exactly like `=A1`
+    case TExpr.UnaryPlus(inner) => TExpr.UnaryPlus(resolveTopLevelPolyRef(inner))
     case other => other
 
   /**
@@ -502,7 +504,8 @@ object FormulaParser:
 
   /**
    * Parse the exponent of a power expression, allowing unary minus and plus. This handles cases
-   * like 2^-1 = 0.5 while keeping -2^2 = -(2^2) = -4. Unary plus is identity (GH-271).
+   * like 2^-1 = 0.5 while keeping -2^2 = -(2^2) = -4. Unary plus wraps in TExpr.UnaryPlus so
+   * `=2^+2` prints back byte-identically (GH-271 acceptance, GH-374 preservation).
    */
   private def parsePowExponent(state: ParserState): ParseResult[TExpr[?]] =
     val s = skipWhitespace(state)
@@ -521,7 +524,7 @@ object FormulaParser:
         descend(s).flatMap { sd =>
           val s2 = skipWhitespace(sd.advance())
           parsePowExponent(s2).map { case (expr, s3) =>
-            (expr, s3.copy(depth = s.depth))
+            (TExpr.UnaryPlus(expr), s3.copy(depth = s.depth))
           }
         }
       case _ => parsePow(s)
@@ -531,8 +534,9 @@ object FormulaParser:
    *
    * Excel precedence: unary minus has lower precedence than ^, so -2^2 = -(2^2) = -4
    *
-   * Unary plus (GH-271: =+A1, the pervasive banker idiom) is identity: it parses to the same AST as
-   * the operand alone, so the printer normalizes it away while parse∘print=id holds on the AST.
+   * Unary plus (GH-271: =+A1, the pervasive banker idiom) is semantically the identity, but since
+   * GH-374 it parses to an explicit TExpr.UnaryPlus node so the printer preserves the source text
+   * byte-for-byte (replicated model formulas must match their source). Chained pluses nest.
    */
   @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
   private def parseUnary(state: ParserState): ParseResult[TExpr[?]] =
@@ -554,7 +558,7 @@ object FormulaParser:
         descend(s).flatMap { sd =>
           val s2 = skipWhitespace(sd.advance())
           parseUnary(s2).map { case (expr, s3) =>
-            (expr, s3.copy(depth = s.depth))
+            (TExpr.UnaryPlus(expr), s3.copy(depth = s.depth))
           }
         }
       case Some('N') | Some('n') if isKeywordAt(s, "NOT") =>

--- a/xl-evaluator/src/com/tjclp/xl/formula/printer/FormulaPrinter.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/printer/FormulaPrinter.scala
@@ -126,6 +126,14 @@ object FormulaPrinter:
         val result = s"$base^$exponent"
         parenthesizeIf(result, precedence > Precedence.Pow)
 
+      // GH-374: unary plus is preserved byte-for-byte. The operand prints at Pow context — the
+      // loosest level the parser's unary-plus operand slot accepts without parens — so `=+2^3`
+      // and `=+-2` replicate their source exactly (parseUnary recurses through unary chains into
+      // parsePow).
+      case TExpr.UnaryPlus(e) =>
+        val result = s"+${printExpr(e, Precedence.Pow)}"
+        parenthesizeIf(result, precedence > Precedence.Unary)
+
       // String operators
       case TExpr.Concat(x, y) =>
         val result = s"${printExpr(x, Precedence.Concat)}&${printExpr(y, Precedence.Concat)}"
@@ -273,6 +281,8 @@ object FormulaPrinter:
     unwrapTransparent(expr) match
       case TExpr.Pow(_, _) => true
       case TExpr.Sub(TExpr.Lit(n: BigDecimal), _) if n == BigDecimal(0) => true
+      // GH-374: a bare `+2^3` re-parses as +(2^3), so a UnaryPlus BASE needs parens: (+2)^3
+      case TExpr.UnaryPlus(_) => true
       case _ => false
 
   private def unwrapTransparent(expr: TExpr[?]): TExpr[?] =
@@ -388,6 +398,8 @@ object FormulaPrinter:
         s"Div(${printWithTypes(x)}, ${printWithTypes(y)})"
       case TExpr.Pow(x, y) =>
         s"Pow(${printWithTypes(x)}, ${printWithTypes(y)})"
+      case TExpr.UnaryPlus(e) =>
+        s"UnaryPlus(${printWithTypes(e)})"
       case TExpr.Concat(x, y) =>
         s"Concat(${printWithTypes(x)}, ${printWithTypes(y)})"
       case TExpr.Eq(x, y) =>

--- a/xl-evaluator/src/com/tjclp/xl/formula/printer/FormulaPrinter.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/printer/FormulaPrinter.scala
@@ -56,7 +56,9 @@ object FormulaPrinter:
     val MulDiv = 6
     val Pow = 7
     val Unary = 8
-    val Primary = 9
+    // GH-355: postfix % binds tighter than ^ AND tighter than unary minus (-2% = -(2%))
+    val Percent = 9
+    val Primary = 10
 
   /**
    * Print expression with appropriate parentheses based on precedence.
@@ -133,6 +135,14 @@ object FormulaPrinter:
       case TExpr.UnaryPlus(e) =>
         val result = s"+${printExpr(e, Precedence.Pow)}"
         parenthesizeIf(result, precedence > Precedence.Unary)
+
+      // GH-355: postfix percent is preserved (never rewritten to /100). The operand prints at
+      // Percent context, so anything looser — including unary minus and ^ — parenthesizes:
+      // Percent(Sub(0,2)) prints (-2)%, Percent(Pow(2,3)) prints (2^3)%, while chained percents
+      // stay flat (10%%). Percent itself never needs outer parens (tightest operator).
+      case TExpr.Percent(e) =>
+        val result = s"${printExpr(e, Precedence.Percent)}%"
+        parenthesizeIf(result, precedence > Precedence.Percent)
 
       // String operators
       case TExpr.Concat(x, y) =>
@@ -400,6 +410,8 @@ object FormulaPrinter:
         s"Pow(${printWithTypes(x)}, ${printWithTypes(y)})"
       case TExpr.UnaryPlus(e) =>
         s"UnaryPlus(${printWithTypes(e)})"
+      case TExpr.Percent(e) =>
+        s"Percent(${printWithTypes(e)})"
       case TExpr.Concat(x, y) =>
         s"Concat(${printWithTypes(x)}, ${printWithTypes(y)})"
       case TExpr.Eq(x, y) =>

--- a/xl-evaluator/src/com/tjclp/xl/formula/printer/FormulaShifter.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/printer/FormulaShifter.scala
@@ -145,6 +145,10 @@ object FormulaShifter:
       case UnaryPlus(e) =>
         UnaryPlus(shiftInternal(e, colDelta, rowDelta))
 
+      // GH-355: postfix percent — recurse so refs under it drag
+      case Percent(e) =>
+        Percent(shiftInternal(e, colDelta, rowDelta)).asInstanceOf[TExpr[A]]
+
       // Arithmetic range functions (now using RangeLocation)
       case Aggregate(aggregatorId, location) =>
         Aggregate(aggregatorId, shiftLocation(location, colDelta, rowDelta)).asInstanceOf[TExpr[A]]
@@ -412,6 +416,8 @@ object FormulaShifter:
       case ToInt(e) => go(e).map(se => ToInt(se).asInstanceOf[TExpr[A]])
       // GH-374: unary plus is transparent — recurse so refs under it move/void structurally
       case UnaryPlus(e) => go(e).map(UnaryPlus.apply)
+      // GH-355: postfix percent — recurse so refs under it move/void structurally
+      case Percent(e) => go(e).map(se => Percent(se).asInstanceOf[TExpr[A]])
       case Aggregate(aggId, location) =>
         shiftLocationStructural(location, shiftLocal, editedSheet, isRow, at, delta)
           .map(l => Aggregate(aggId, l).asInstanceOf[TExpr[A]])

--- a/xl-evaluator/src/com/tjclp/xl/formula/printer/FormulaShifter.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/printer/FormulaShifter.scala
@@ -141,6 +141,10 @@ object FormulaShifter:
       case ToInt(e) =>
         ToInt(shiftInternal(e, colDelta, rowDelta)).asInstanceOf[TExpr[A]]
 
+      // GH-374: unary plus is transparent — recurse so refs under it drag
+      case UnaryPlus(e) =>
+        UnaryPlus(shiftInternal(e, colDelta, rowDelta))
+
       // Arithmetic range functions (now using RangeLocation)
       case Aggregate(aggregatorId, location) =>
         Aggregate(aggregatorId, shiftLocation(location, colDelta, rowDelta)).asInstanceOf[TExpr[A]]
@@ -406,6 +410,8 @@ object FormulaShifter:
       case Gt(x, y) => for sx <- go(x); sy <- go(y) yield Gt(sx, sy).asInstanceOf[TExpr[A]]
       case Gte(x, y) => for sx <- go(x); sy <- go(y) yield Gte(sx, sy).asInstanceOf[TExpr[A]]
       case ToInt(e) => go(e).map(se => ToInt(se).asInstanceOf[TExpr[A]])
+      // GH-374: unary plus is transparent — recurse so refs under it move/void structurally
+      case UnaryPlus(e) => go(e).map(UnaryPlus.apply)
       case Aggregate(aggId, location) =>
         shiftLocationStructural(location, shiftLocal, editedSheet, isRow, at, delta)
           .map(l => Aggregate(aggId, l).asInstanceOf[TExpr[A]])

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/ArrayArithmeticSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/ArrayArithmeticSpec.scala
@@ -188,6 +188,39 @@ class ArrayArithmeticSpec extends FunSuite:
     assertEquals(updatedSheet(ref"G1").value, CellValue.Number(30))
   }
 
+  test("GH-355: postfix percent broadcasts over a range (=A1:C1%)") {
+    val sheet = Sheet("Test")
+      .put(ref"A1", CellValue.Number(10))
+      .put(ref"B1", CellValue.Number(20))
+      .put(ref"C1", CellValue.Number(30))
+
+    val result = sheet.evaluateArrayFormula("=A1:C1%", ref"E1")
+
+    assert(result.isRight, s"Expected Right, got $result")
+    val (updatedSheet, spillRange) = result.toOption.get
+
+    assertEquals(spillRange.width, 3)
+    assertEquals(spillRange.height, 1)
+    assertEquals(updatedSheet(ref"E1").value, CellValue.Number(BigDecimal("0.1")))
+    assertEquals(updatedSheet(ref"F1").value, CellValue.Number(BigDecimal("0.2")))
+    assertEquals(updatedSheet(ref"G1").value, CellValue.Number(BigDecimal("0.3")))
+  }
+
+  test("GH-355: range * percent literal broadcasts (=A1:C1*10%)") {
+    val sheet = Sheet("Test")
+      .put(ref"A1", CellValue.Number(10))
+      .put(ref"B1", CellValue.Number(20))
+      .put(ref"C1", CellValue.Number(30))
+
+    val result = sheet.evaluateArrayFormula("=A1:C1*10%", ref"E1")
+
+    assert(result.isRight, s"Expected Right, got $result")
+    val (updatedSheet, _) = result.toOption.get
+    assertEquals(updatedSheet(ref"E1").value, CellValue.Number(BigDecimal(1)))
+    assertEquals(updatedSheet(ref"F1").value, CellValue.Number(BigDecimal(2)))
+    assertEquals(updatedSheet(ref"G1").value, CellValue.Number(BigDecimal(3)))
+  }
+
   test("range * TRANSPOSE(range) via evaluateArrayFormula") {
     // This is the key SpreadsheetBench 52292 pattern!
     // 1x3 row * TRANSPOSE(3x1 col) = 1x3 * 1x3 = 1x3 element-wise

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/DependencyGraphSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/DependencyGraphSpec.scala
@@ -48,6 +48,18 @@ class DependencyGraphSpec extends ScalaCheckSuite:
     assertEquals(DependencyGraph.extractDependencies(expr), Set(ref"A1", ref"B1"))
   }
 
+  test("GH-374: extractDependencies walks through unary plus (=+A1+B1)") {
+    FormulaParser.parse("=+A1+B1") match
+      case Right(expr) =>
+        assertEquals(DependencyGraph.extractDependencies(expr), Set(ref"A1", ref"B1"))
+        assertEquals(
+          DependencyGraph.extractDependenciesBounded(expr, None),
+          Set(ref"A1", ref"B1")
+        )
+        assert(DependencyGraph.containsCellReferences(expr))
+      case Left(err) => fail(s"=+A1+B1 should parse: $err")
+  }
+
   test("extractDependencies: range arguments expand to all cells in range") {
     val range = parseRange("A1:A3")
     val expr = TExpr.sum(range)

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/DependencyGraphSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/DependencyGraphSpec.scala
@@ -60,6 +60,22 @@ class DependencyGraphSpec extends ScalaCheckSuite:
       case Left(err) => fail(s"=+A1+B1 should parse: $err")
   }
 
+  test("GH-355: extractDependencies walks through postfix percent (=A1%)") {
+    FormulaParser.parse("=A1%") match
+      case Right(expr) =>
+        assertEquals(DependencyGraph.extractDependencies(expr), Set(ref"A1"))
+        assertEquals(DependencyGraph.extractDependenciesBounded(expr, None), Set(ref"A1"))
+        assert(DependencyGraph.containsCellReferences(expr))
+      case Left(err) => fail(s"=A1% should parse: $err")
+  }
+
+  test("GH-355/GH-374: dependencies survive percent nested under unary plus (=+A1%)") {
+    FormulaParser.parse("=+A1%") match
+      case Right(expr) =>
+        assertEquals(DependencyGraph.extractDependencies(expr), Set(ref"A1"))
+      case Left(err) => fail(s"=+A1% should parse: $err")
+  }
+
   test("extractDependencies: range arguments expand to all cells in range") {
     val range = parseRange("A1:A3")
     val expr = TExpr.sum(range)

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/FormulaFormattingSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/FormulaFormattingSpec.scala
@@ -49,6 +49,12 @@ class FormulaFormattingSpec extends FunSuite:
     assertEquals(inferred, Some(NumFmt.Currency))
   }
 
+  test("GH-374: format inheritance walks through a leading unary plus (=+B2*2)") {
+    val sheet = base.put(ref"B2", 100, currency)
+    val inferred = FormulaFormatting.inferFormatFromReferences(parseOrFail("=+B2*2"), sheet)
+    assertEquals(inferred, Some(NumFmt.Currency))
+  }
+
   test("multiple references with identical format inherit that format") {
     val sheet = base
       .put(ref"B2", 1000000, currency)

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/FormulaParserSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/FormulaParserSpec.scala
@@ -218,60 +218,178 @@ class FormulaParserSpec extends ScalaCheckSuite:
     }
   }
 
-  // ==================== GH-271: Leading unary plus ====================
-  // Excel accepts a leading unary plus (=+E43, =+SUM(...)) — a pervasive banker idiom.
-  // Unary plus is identity: it parses to the SAME AST as the formula without it, so the
-  // printer normalizes it away and the parse∘print=id round-trip law stays intact.
+  // ==================== GH-374 (supersedes GH-271): leading unary plus ====================
+  // Excel accepts a leading unary plus (=+E43, =+SUM(...)) — the Lotus-era banker idiom,
+  // endemic in professional models. GH-271 parsed '+' as identity and NORMALIZED it away on
+  // print; GH-374 deliberately reverses that spec: the plus is preserved as TExpr.UnaryPlus
+  // so parse→print replicates the source formula text byte-for-byte.
 
-  test("GH-271: unary plus parses to the same AST as without it (=+A1)") {
-    val plus = FormulaParser.parse("=+A1")
-    assert(plus.isRight, s"=+A1 should parse, got $plus")
-    assertEquals(plus, FormulaParser.parse("=A1"))
+  private def assertPreserved(source: String): Unit =
+    FormulaParser.parse(source) match
+      case Right(expr) => assertEquals(FormulaPrinter.print(expr), source)
+      case Left(err) => fail(s"$source should parse: $err")
+
+  test("GH-374: leading unary plus is preserved byte-for-byte (=+A1)") {
+    assertPreserved("=+A1")
   }
 
-  test("GH-271: unary plus before function call (=+SUM(A1:B2))") {
-    val plus = FormulaParser.parse("=+SUM(A1:B2)")
-    assert(plus.isRight, s"=+SUM(A1:B2) should parse, got $plus")
-    assertEquals(plus, FormulaParser.parse("=SUM(A1:B2)"))
+  test("GH-374: unary plus before function call is preserved (=+SUM(A1:B2))") {
+    assertPreserved("=+SUM(A1:B2)")
   }
 
-  test("GH-271: chained unary plus (=++A1)") {
-    val plus = FormulaParser.parse("=++A1")
-    assert(plus.isRight, s"=++A1 should parse, got $plus")
-    assertEquals(plus, FormulaParser.parse("=A1"))
+  test("GH-374: chained unary plus is preserved (=++A1)") {
+    assertPreserved("=++A1")
   }
 
-  test("GH-271: unary plus followed by binary plus (=+1+2)") {
-    val plus = FormulaParser.parse("=+1+2")
-    assert(plus.isRight, s"=+1+2 should parse, got $plus")
-    assertEquals(plus, FormulaParser.parse("=1+2"))
+  test("GH-374: unary plus followed by binary plus is preserved (=+1+2)") {
+    assertPreserved("=+1+2")
   }
 
-  test("GH-271: unary plus mixes with unary minus (=+-2)") {
-    val plus = FormulaParser.parse("=+-2")
-    assert(plus.isRight, s"=+-2 should parse, got $plus")
-    assertEquals(plus, FormulaParser.parse("=-2"))
+  test("GH-374: unary plus mixed with unary minus is preserved (=+-2)") {
+    assertPreserved("=+-2")
   }
 
-  test("GH-271: unary plus in power exponent (=2^+2)") {
-    val plus = FormulaParser.parse("=2^+2")
-    assert(plus.isRight, s"=2^+2 should parse, got $plus")
-    assertEquals(plus, FormulaParser.parse("=2^2"))
+  test("GH-374: unary plus in power exponent is preserved (=2^+2)") {
+    assertPreserved("=2^+2")
   }
 
-  test("GH-271: printer normalizes unary plus away (=+A1 prints as =A1)") {
-    FormulaParser.parse("=+A1") match
-      case Right(expr) => assertEquals(FormulaPrinter.print(expr), "=A1")
-      case Left(err) => fail(s"=+A1 should parse: $err")
+  test("GH-374: unary plus before sheet-qualified ref is preserved (=+Model!B2)") {
+    assertPreserved("=+Model!B2")
   }
 
-  test("GH-271: unary plus formula evaluates (=+1+2 = 3)") {
+  test("GH-374: unary plus before IF call is preserved (=+IF(A1=2, 3, 4))") {
+    // Call arguments print with the pre-existing canonical ", " separator; the leading plus
+    // itself must survive (canonical-source formulas round-trip byte-identically).
+    FormulaParser.parse("=+IF(A1=2,3,4)") match
+      case Right(expr) => assertEquals(FormulaPrinter.print(expr), "=+IF(A1=2, 3, 4)")
+      case Left(err) => fail(s"=+IF(A1=2,3,4) should parse: $err")
+    assertPreserved("=+IF(A1=2, 3, 4)")
+  }
+
+  test("GH-374: unary plus before parenthesized expression is preserved (=+(A1+B2))") {
+    assertPreserved("=+(A1+B2)")
+  }
+
+  test("GH-374: unary plus before numeric literal is preserved (=+123)") {
+    assertPreserved("=+123")
+  }
+
+  test("GH-374: unary plus before power expression is preserved (=+2^3)") {
+    assertPreserved("=+2^3")
+  }
+
+  test("GH-374: unary plus formula evaluates (=+1+2 = 3)") {
     val sheet = Sheet("Test")
     val result = for
       expr <- FormulaParser.parse("=+1+2")
       value <- Evaluator.eval(expr, sheet)
     yield value
     assertEquals(result, Right(BigDecimal(3)))
+  }
+
+  test("GH-374: =+A1 parses to UnaryPlus wrapping a resolved Ref") {
+    FormulaParser.parse("=+A1") match
+      case Right(TExpr.UnaryPlus(TExpr.Ref(at, _, _))) => assertEquals(at.toA1, "A1")
+      case other => fail(s"Expected UnaryPlus(Ref(A1)), got $other")
+  }
+
+  test("GH-374: =++A1 parses to nested UnaryPlus") {
+    FormulaParser.parse("=++A1") match
+      case Right(TExpr.UnaryPlus(TExpr.UnaryPlus(TExpr.Ref(at, _, _)))) =>
+        assertEquals(at.toA1, "A1")
+      case other => fail(s"Expected UnaryPlus(UnaryPlus(Ref(A1))), got $other")
+  }
+
+  test("GH-374: =+1+2 parses to Add with UnaryPlus on the left operand only") {
+    FormulaParser.parse("=+1+2") match
+      case Right(TExpr.Add(TExpr.UnaryPlus(TExpr.Lit(x: BigDecimal)), TExpr.Lit(y: BigDecimal))) =>
+        assertEquals(x, BigDecimal(1))
+        assertEquals(y, BigDecimal(2))
+      case other => fail(s"Expected Add(UnaryPlus(Lit(1)), Lit(2)), got $other")
+  }
+
+  test("GH-374: =2^+2 parses to Pow with UnaryPlus exponent") {
+    FormulaParser.parse("=2^+2") match
+      case Right(TExpr.Pow(_, TExpr.UnaryPlus(TExpr.Lit(e: BigDecimal)))) =>
+        assertEquals(e, BigDecimal(2))
+      case other => fail(s"Expected Pow(2, UnaryPlus(Lit(2))), got $other")
+  }
+
+  test("GH-374: unary plus is the identity at evaluation (=+A1 = A1's value)") {
+    val sheet = Sheet("Test").put(ref"A1", CellValue.Number(BigDecimal(42)))
+    val result = for
+      expr <- FormulaParser.parse("=+A1")
+      value <- Evaluator.eval(expr, sheet)
+    yield value
+    assertEquals(result, Right(CellValue.Number(BigDecimal(42))))
+  }
+
+  test("GH-374: unary plus before function call evaluates (=+SUM(A1:B1))") {
+    val sheet = Sheet("Test")
+      .put(ref"A1", CellValue.Number(BigDecimal(2)))
+      .put(ref"B1", CellValue.Number(BigDecimal(3)))
+    val result = for
+      expr <- FormulaParser.parse("=+SUM(A1:B1)")
+      value <- Evaluator.eval(expr, sheet)
+    yield value
+    assertEquals(result, Right(BigDecimal(5)))
+  }
+
+  test("GH-374: unary plus operand participates in arithmetic (=+A1*2)") {
+    val sheet = Sheet("Test").put(ref"A1", CellValue.Number(BigDecimal(21)))
+    val result = for
+      expr <- FormulaParser.parse("=+A1*2")
+      value <- Evaluator.eval(expr, sheet)
+    yield value
+    assertEquals(result, Right(BigDecimal(42)))
+  }
+
+  test("GH-374: unary plus round-trips inside larger formulas (=B1*+A1)") {
+    assertPreserved("=B1*+A1")
+  }
+
+  test("GH-374: parenthesized unary plus as pow base round-trips ((+2)^3)") {
+    FormulaParser.parse("=(+2)^3") match
+      case Right(expr) =>
+        assertEquals(FormulaPrinter.print(expr), "=(+2)^3")
+        assertEquals(FormulaParser.parse(FormulaPrinter.print(expr)), Right(expr))
+      case Left(err) => fail(s"=(+2)^3 should parse: $err")
+  }
+
+  property("GH-374: print ∘ parse is byte-identity for leading-plus refs") {
+    forAll(genARef) { r =>
+      val source = s"=+${r.toA1}"
+      FormulaParser.parse(source).map(FormulaPrinter.print(_)) == Right(source)
+    }
+  }
+
+  property("GH-374: parse ∘ print = id for UnaryPlus ASTs over integer literals") {
+    forAll(Gen.choose(0, 1000000)) { n =>
+      val expr = TExpr.UnaryPlus(TExpr.Lit(BigDecimal(n)))
+      FormulaParser.parse(FormulaPrinter.print(expr)) == Right(expr)
+    }
+  }
+
+  test("GH-374: formula drag shifts references under unary plus (=+A1*$B$1)") {
+    val result =
+      for expr <- FormulaParser.parse("=+A1*$B$1")
+      yield FormulaPrinter.print(FormulaShifter.shift(expr, colDelta = 0, rowDelta = 1))
+    assertEquals(result, Right("=+A2*$B$1"))
+  }
+
+  test("GH-374: structural row insert shifts references under unary plus") {
+    val result = for
+      expr <- FormulaParser.parse("=+A5")
+      shifted = FormulaShifter.shiftStructural(
+        expr,
+        shiftLocal = true,
+        editedSheet = "Test",
+        isRow = true,
+        at = 0,
+        delta = 2
+      )
+    yield shifted.map(FormulaPrinter.print(_))
+    assertEquals(result, Right(Some("=+A7")))
   }
 
   // ==================== GH-263: cell-ref-shaped sheet names ====================

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/FormulaParserSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/FormulaParserSpec.scala
@@ -392,6 +392,143 @@ class FormulaParserSpec extends ScalaCheckSuite:
     assertEquals(result, Right(Some("=+A7")))
   }
 
+  // ==================== GH-355: postfix percent operator ====================
+  // Excel treats % as a postfix operator (value ÷ 100) binding tighter than ^ (and every
+  // other operator): =A1*10% ≡ A1*(0.1), =2^3% ≡ 2^(0.03), =(1+5%)^2 ≡ 1.05².
+  // Round-trip must preserve the % (no rewrite to /100).
+
+  private def evalIn(sheet: Sheet, source: String): Either[Any, Any] =
+    for
+      expr <- FormulaParser.parse(source)
+      value <- Evaluator.eval(expr, sheet)
+    yield value
+
+  test("GH-355: =10% parses and evaluates to 0.1") {
+    assertEquals(evalIn(Sheet("Test"), "=10%"), Right(BigDecimal("0.1")))
+  }
+
+  test("GH-355: =A1*10% evaluates against a cell (A1=50 → 5)") {
+    val sheet = Sheet("Test").put(ref"A1", CellValue.Number(BigDecimal(50)))
+    assertEquals(evalIn(sheet, "=A1*10%"), Right(BigDecimal(5)))
+  }
+
+  test("GH-355: =A1% applies percent directly to a cell (A1=50 → 0.5)") {
+    val sheet = Sheet("Test").put(ref"A1", CellValue.Number(BigDecimal(50)))
+    assertEquals(evalIn(sheet, "=A1%"), Right(BigDecimal("0.5")))
+  }
+
+  test("GH-355: =(1+5%)^2 evaluates to 1.1025") {
+    assertEquals(evalIn(Sheet("Test"), "=(1+5%)^2"), Right(BigDecimal("1.1025")))
+  }
+
+  test("GH-355: percent binds tighter than ^ (=2^3% = 2^(3%))") {
+    val result = evalIn(Sheet("Test"), "=2^3%")
+    val expected = BigDecimal(scala.math.pow(2.0, 0.03))
+    result match
+      case Right(value: BigDecimal) =>
+        assert((value - expected).abs < BigDecimal("1e-12"), s"got $value, expected ~$expected")
+      case other => fail(s"Expected numeric result, got $other")
+  }
+
+  test("GH-355: percent binds tighter than unary minus (=-2% = -0.02)") {
+    assertEquals(evalIn(Sheet("Test"), "=-2%"), Right(BigDecimal("-0.02")))
+  }
+
+  test("GH-355: chained percent (=10%% = 0.001)") {
+    assertEquals(evalIn(Sheet("Test"), "=10%%"), Right(BigDecimal("0.001")))
+  }
+
+  test("GH-355: percent of a parenthesized sum (=(1+5)% = 0.06)") {
+    assertEquals(evalIn(Sheet("Test"), "=(1+5)%"), Right(BigDecimal("0.06")))
+  }
+
+  test("GH-355: percent inside a function argument (=SUM(1, 50%) = 1.5)") {
+    assertEquals(evalIn(Sheet("Test"), "=SUM(1, 50%)"), Right(BigDecimal("1.5")))
+  }
+
+  test("GH-355: percent interacts with unary plus (=+A1% = 0.5)") {
+    val sheet = Sheet("Test").put(ref"A1", CellValue.Number(BigDecimal(50)))
+    assertEquals(evalIn(sheet, "=+A1%"), Right(BigDecimal("0.5")))
+  }
+
+  test("GH-355: percent round-trips byte-identically (no rewrite to /100)") {
+    List("=10%", "=A1*10%", "=(1+5%)^2", "=2^3%", "=-2%", "=10%%", "=B2%+C3%")
+      .foreach(assertPreserved)
+  }
+
+  test("GH-355: parenthesized pow under percent round-trips (=(2^3)%)") {
+    assertPreserved("=(2^3)%")
+  }
+
+  test("GH-355: division by zero through percent still errors (=1/0%)") {
+    FormulaParser.parse("=1/0%") match
+      case Right(expr) =>
+        Evaluator.eval(expr, Sheet("Test")) match
+          case Left(_: com.tjclp.xl.formula.eval.EvalError.DivByZero) => ()
+          case other => fail(s"Expected DivByZero, got $other")
+      case Left(err) => fail(s"=1/0% should parse: $err")
+  }
+
+  test("GH-355: =A1*10% parses to Mul with Percent on the right operand") {
+    FormulaParser.parse("=A1*10%") match
+      case Right(TExpr.Mul(TExpr.Ref(at, _, _), TExpr.Percent(TExpr.Lit(n: BigDecimal)))) =>
+        assertEquals(at.toA1, "A1")
+        assertEquals(n, BigDecimal(10))
+      case other => fail(s"Expected Mul(Ref(A1), Percent(Lit(10))), got $other")
+  }
+
+  test("GH-355: =2^3% parses to Pow with Percent exponent (binds tighter than ^)") {
+    FormulaParser.parse("=2^3%") match
+      case Right(TExpr.Pow(TExpr.Lit(b: BigDecimal), TExpr.Percent(TExpr.Lit(e: BigDecimal)))) =>
+        assertEquals(b, BigDecimal(2))
+        assertEquals(e, BigDecimal(3))
+      case other => fail(s"Expected Pow(Lit(2), Percent(Lit(3))), got $other")
+  }
+
+  test("GH-355: =-2% parses to unary minus OVER percent (-(2%))") {
+    FormulaParser.parse("=-2%") match
+      case Right(
+            TExpr.Sub(TExpr.Lit(zero: BigDecimal), TExpr.Percent(TExpr.Lit(n: BigDecimal)))
+          ) =>
+        assertEquals(zero, BigDecimal(0))
+        assertEquals(n, BigDecimal(2))
+      case other => fail(s"Expected Sub(Lit(0), Percent(Lit(2))), got $other")
+  }
+
+  test("GH-355: =10%% parses to nested Percent") {
+    FormulaParser.parse("=10%%") match
+      case Right(TExpr.Percent(TExpr.Percent(TExpr.Lit(n: BigDecimal)))) =>
+        assertEquals(n, BigDecimal(10))
+      case other => fail(s"Expected Percent(Percent(Lit(10))), got $other")
+  }
+
+  test("GH-355: =A1:B1% preserves the range under Percent for array broadcast") {
+    FormulaParser.parse("=A1:B1%") match
+      case Right(TExpr.Percent(_: TExpr.RangeRef)) => ()
+      case other => fail(s"Expected Percent(RangeRef(A1:B1)), got $other")
+  }
+
+  property("GH-355: parse ∘ print = id for Percent ASTs over integer literals") {
+    forAll(Gen.choose(0, 1000000)) { n =>
+      val expr = TExpr.Percent(TExpr.Lit(BigDecimal(n)))
+      FormulaParser.parse(FormulaPrinter.print(expr)) == Right(expr)
+    }
+  }
+
+  test("GH-355: formula drag shifts references under percent (=A1%*$B$1)") {
+    val result =
+      for expr <- FormulaParser.parse("=A1%*$B$1")
+      yield FormulaPrinter.print(FormulaShifter.shift(expr, colDelta = 0, rowDelta = 1))
+    assertEquals(result, Right("=A2%*$B$1"))
+  }
+
+  property("GH-355: print ∘ parse is byte-identity for ref*10% sources") {
+    forAll(genARef) { r =>
+      val source = s"=${r.toA1}*10%"
+      FormulaParser.parse(source).map(FormulaPrinter.print(_)) == Right(source)
+    }
+  }
+
   // ==================== GH-263: cell-ref-shaped sheet names ====================
   // A sheet named Q1/A1/R1C1 must be single-quoted by the printer or the generated
   // formula is spec-invalid (Excel would read Q1!A1 as something else entirely).

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/FormulaParserSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/FormulaParserSpec.scala
@@ -529,6 +529,15 @@ class FormulaParserSpec extends ScalaCheckSuite:
     }
   }
 
+  test("GH-355: percent works inside comparisons (=50%=0.5 → TRUE)") {
+    assertEquals(evalIn(Sheet("Test"), "=50%=0.5"), Right(true))
+    assertEquals(evalIn(Sheet("Test"), "=200%>1"), Right(true))
+  }
+
+  test("GH-374: unary plus before quoted sheet ref round-trips (=+'Q1 Report'!B2)") {
+    assertPreserved("=+'Q1 Report'!B2")
+  }
+
   // ==================== GH-263: cell-ref-shaped sheet names ====================
   // A sheet named Q1/A1/R1C1 must be single-quoted by the printer or the generated
   // formula is spec-invalid (Excel would read Q1!A1 as something else entirely).

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/RecursionGuardSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/RecursionGuardSpec.scala
@@ -36,6 +36,13 @@ class RecursionGuardSpec extends FunSuite:
       case other => fail(s"expected NestingTooDeep, got $other")
   }
 
+  test("GH-355: deeply chained percent → NestingTooDeep, not StackOverflowError") {
+    val formula = "=1" + ("%" * 300)
+    FormulaParser.parse(formula) match
+      case Left(_: ParseError.NestingTooDeep) => ()
+      case other => fail(s"expected NestingTooDeep, got $other")
+  }
+
   test("deeply nested function calls → NestingTooDeep") {
     val formula = "=" + ("ABS(" * 300) + "1" + (")" * 300)
     FormulaParser.parse(formula) match

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/DirectSaxEmitter.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/DirectSaxEmitter.scala
@@ -76,8 +76,8 @@ object DirectSaxEmitter:
     // OoxmlWorksheet.fromDomainWithMetadata. The tiny metadata Elems reuse the SAME builders as the
     // DOM writer (parity by construction); only the bulk sheetData stays hand-emitted for speed.
     SaxWriter.withAttributes(writer, "xmlns" -> nsSpreadsheetML, "xmlns:r" -> nsRelationships) {
-      // sheetPr carries the pageSetUpPr fitToPage flag (GH-266)
-      mergeSheetPrElem(None, sheet.pageSetup).foreach(writer.writeElem)
+      // sheetPr carries the pageSetUpPr fitToPage flag (GH-266) and tabColor (GH-358)
+      mergeSheetPrElem(None, sheet.pageSetup, sheet.tabColor).foreach(writer.writeElem)
 
       // Calculate dimension from cells
       emitDimension(writer, sheet)

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/XlsxReader.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/XlsxReader.scala
@@ -5,6 +5,7 @@ import com.tjclp.xl.cells.{Cell, CellError, CellValue}
 import com.tjclp.xl.api.{Sheet, Workbook}
 import com.tjclp.xl.sheets.{
   ColumnProperties,
+  FreezePane,
   HeaderFooter,
   PageMargins,
   PageSetup,
@@ -1051,8 +1052,11 @@ object XlsxReader:
     val pageSetup =
       parsePageSetup(ooxmlSheet.pageSetup, ooxmlSheet.pageMargins, ooxmlSheet.headerFooter)
 
-    // Parse view settings (gridlines, zoom) from <sheetViews> — GH-258
+    // Parse view settings (gridlines, zoom, tabSelected) from <sheetViews> — GH-258/GH-372
     val viewSettings = parseSheetView(ooxmlSheet.sheetViews)
+
+    // Parse frozen panes into the model (GH-372) so read→modify→write keeps them
+    val freezePane = parseFreezePane(ooxmlSheet.sheetViews)
 
     // Parse conditional formatting into the typed model (GH-136); dxfId attrs resolve through
     // the styles.xml <dxfs> table. Total: unmodeled content rides through Preserved.
@@ -1070,6 +1074,7 @@ object XlsxReader:
         columnProperties = columnProperties,
         rowProperties = rowProperties,
         pageSetup = pageSetup,
+        freezePane = freezePane,
         viewSettings = viewSettings,
         drawings = drawings,
         conditionalFormats = conditionalFormats
@@ -1208,12 +1213,12 @@ object XlsxReader:
     if parsed == HeaderFooter() then None else Some(parsed)
 
   /**
-   * Parse sheet view settings (GH-258) from the first <sheetView>.
+   * Parse sheet view settings (GH-258/GH-372) from the first <sheetView>.
    *
-   * Returns Some only when a modeled attribute (showGridLines, zoomScale) is present, so typical
-   * files keep viewSettings = None and the raw sheetViews XML rides through unchanged on rewrite
-   * (passive preserve, mirroring freezePane semantics). Out-of-range zoom values are dropped rather
-   * than violating the SheetView invariant.
+   * Returns Some only when a modeled attribute (showGridLines, zoomScale, tabSelected) is present,
+   * so typical files keep viewSettings = None and the raw sheetViews XML rides through unchanged on
+   * rewrite (passive preserve). Out-of-range zoom values are dropped rather than violating the
+   * SheetView invariant.
    */
   private def parseSheetView(sheetViewsElem: Option[Elem]): Option[SheetView] =
     for
@@ -1222,8 +1227,46 @@ object XlsxReader:
       attrs = view.attributes.asAttrMap
       showGridLines = attrs.get("showGridLines").map(v => v != "0" && v != "false")
       zoomScale = attrs.get("zoomScale").flatMap(_.toIntOption).filter(z => z >= 10 && z <= 400)
-      if showGridLines.isDefined || zoomScale.isDefined
-    yield SheetView(showGridLines = showGridLines.getOrElse(true), zoomScale = zoomScale)
+      tabSelected = attrs.get("tabSelected").map(v => v == "1" || v == "true")
+      if showGridLines.isDefined || zoomScale.isDefined || tabSelected.isDefined
+    yield SheetView(
+      showGridLines = showGridLines.getOrElse(true),
+      zoomScale = zoomScale,
+      tabSelected = tabSelected
+    )
+
+  /**
+   * Parse the freeze pane (GH-372) from the first <sheetView>'s <pane> child.
+   *
+   * Only FROZEN panes (state="frozen"/"frozenSplit") enter the model: for those, xSplit/ySplit
+   * count frozen columns/rows, so the freeze anchor derives as (col=xSplit, row=ySplit). Plain
+   * split panes (state="split", the schema default) measure the split in 1/20 pt and stay unmodeled
+   * — they ride the preserved sheetViews XML. The pane's topLeftCell attribute is the SCROLL
+   * target, captured as scrolledTo when it differs from the derived anchor (GH-382) — without it
+   * the first read→write of a scrolled pane would lose the scroll.
+   *
+   * Total: a missing, degenerate (no split), or out-of-range pane yields None — the passive
+   * default, never Some(Remove).
+   */
+  private def parseFreezePane(sheetViewsElem: Option[Elem]): Option[FreezePane] =
+    for
+      views <- sheetViewsElem
+      view <- (views \ "sheetView").collectFirst { case e: Elem => e }
+      pane <- (view \ "pane").collectFirst { case e: Elem => e }
+      attrs = pane.attributes.asAttrMap
+      state <- attrs.get("state")
+      if state == "frozen" || state == "frozenSplit"
+      xSplit = attrs.get("xSplit").flatMap(_.toIntOption).getOrElse(0)
+      ySplit = attrs.get("ySplit").flatMap(_.toIntOption).getOrElse(0)
+      if xSplit > 0 || ySplit > 0
+      if xSplit >= 0 && xSplit <= Column.MaxIndex0 && ySplit >= 0 && ySplit <= Row.MaxIndex0
+    yield
+      val anchor = ARef.from0(xSplit, ySplit)
+      val scrolledTo = attrs
+        .get("topLeftCell")
+        .flatMap(t => ARef.parse(t).toOption)
+        .filter(_ != anchor)
+      FreezePane.At(anchor, scrolledTo)
 
   /**
    * Assemble final workbook with optional SourceContext for surgical modification.

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/XlsxReader.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/XlsxReader.scala
@@ -1058,6 +1058,9 @@ object XlsxReader:
     // Parse frozen panes into the model (GH-372) so read→modify→write keeps them
     val freezePane = parseFreezePane(ooxmlSheet.sheetViews)
 
+    // Parse the tab color from <sheetPr><tabColor .../> — GH-358
+    val tabColor = parseTabColor(ooxmlSheet.sheetPr)
+
     // Parse conditional formatting into the typed model (GH-136); dxfId attrs resolve through
     // the styles.xml <dxfs> table. Total: unmodeled content rides through Preserved.
     val conditionalFormats =
@@ -1077,7 +1080,8 @@ object XlsxReader:
         freezePane = freezePane,
         viewSettings = viewSettings,
         drawings = drawings,
-        conditionalFormats = conditionalFormats
+        conditionalFormats = conditionalFormats,
+        tabColor = tabColor
       )
     )
 
@@ -1267,6 +1271,19 @@ object XlsxReader:
         .flatMap(t => ARef.parse(t).toOption)
         .filter(_ != anchor)
       FreezePane.At(anchor, scrolledTo)
+
+  /**
+   * Parse the sheet tab color (GH-358) from `<sheetPr><tabColor .../>`, reusing the strict dxf
+   * color parser (rgb / theme+tint / indexed-with-palette-mapping). Colors outside that subset
+   * (`auto`, unmapped indexed, foreign attrs) yield None and ride the preserved sheetPr XML — the
+   * preserve-if-None writer never loses them.
+   */
+  private def parseTabColor(sheetPrElem: Option[Elem]): Option[com.tjclp.xl.styles.color.Color] =
+    for
+      sheetPr <- sheetPrElem
+      tabColorElem <- (sheetPr \ "tabColor").collectFirst { case e: Elem => e }
+      color <- com.tjclp.xl.ooxml.style.DxfCodec.parseColor(tabColorElem)
+    yield color
 
   /**
    * Assemble final workbook with optional SourceContext for surgical modification.

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/OoxmlWorksheet.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/OoxmlWorksheet.scala
@@ -545,7 +545,8 @@ object OoxmlWorksheet extends com.tjclp.xl.ooxml.XmlReadable[OoxmlWorksheet]:
           sheet.mergedRanges,
           // Preserve all metadata from original, but use recalculated dimension.
           // GH-266: fitToWidth/fitToHeight require sheetPr/pageSetUpPr fitToPage="1"
-          mergeSheetPrElem(preserved.sheetPr, sheet.pageSetup),
+          // GH-358: modeled tabColor overlays the preserved sheetPr
+          mergeSheetPrElem(preserved.sheetPr, sheet.pageSetup, sheet.tabColor),
           calculatedDimension.orElse(
             preserved.dimension
           ), // Use calculated dimension, fallback to preserved
@@ -579,7 +580,8 @@ object OoxmlWorksheet extends com.tjclp.xl.ooxml.XmlReadable[OoxmlWorksheet]:
         OoxmlWorksheet(
           allRows, // GH-381: include property-only rows (rowProperties without cells)
           sheet.mergedRanges,
-          sheetPr = mergeSheetPrElem(None, sheet.pageSetup), // GH-266: fitToPage flag
+          // GH-266: fitToPage flag; GH-358: tabColor
+          sheetPr = mergeSheetPrElem(None, sheet.pageSetup, sheet.tabColor),
           dimension = calculatedDimension,
           sheetViews = buildSheetViewsElem(None, sheet.freezePane, sheet.viewSettings),
           cols = generatedCols,

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/WorksheetHelpers.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/WorksheetHelpers.scala
@@ -5,6 +5,7 @@ import scala.xml.*
 import com.tjclp.xl.addressing.{ARef, Column}
 import com.tjclp.xl.ooxml.XmlUtil
 import com.tjclp.xl.ooxml.XmlUtil.nsSpreadsheetML
+import com.tjclp.xl.ooxml.style.DxfCodec
 import com.tjclp.xl.sheets.{
   ColumnProperties,
   FreezePane,
@@ -13,6 +14,7 @@ import com.tjclp.xl.sheets.{
   Sheet,
   SheetView
 }
+import com.tjclp.xl.styles.color.Color
 
 // Default namespaces for generated worksheets. Real files capture the original scope/attributes to
 // avoid redundant declarations and preserve mc/x14/xr bindings from the source sheet.
@@ -629,8 +631,8 @@ private[ooxml] def mergeHeaderFooterElem(
       if flagged.child.isEmpty && flagged.attributes == Null then None else Some(flagged)
 
 /**
- * Reconcile `<sheetPr><pageSetUpPr fitToPage="1"/></sheetPr>` with the model (GH-266, GH-284):
- * Excel ignores pageSetup's fitToWidth/fitToHeight without this flag.
+ * Reconcile `<sheetPr>` with the model: the pageSetUpPr fitToPage flag (GH-266, GH-284 — Excel
+ * ignores pageSetup's fitToWidth/fitToHeight without it) and the tab color (GH-358).
  *
  * `PageSetup.fitToPage` is a write-only tri-state (GH-284):
  *   - Some(true): force the flag (even without fitTo* fields)
@@ -641,16 +643,46 @@ private[ooxml] def mergeHeaderFooterElem(
  *     preserved element rides through verbatim. Absence of the model fields is not evidence the
  *     source flag should be cleared (fitToWidth/fitToHeight default to 1 in OOXML, so a bare flag
  *     without pageSetup attributes is still meaningful).
+ *
+ * `tabColor` overlays a `<tabColor>` child when Some (replacing an existing one in place,
+ * PREPENDING otherwise — tabColor is FIRST in the CT_SheetPr child sequence, unlike pageSetUpPr
+ * which is last; misplacing it makes Excel show a repair prompt) and leaves the preserved sheetPr
+ * untouched when None (preserve-if-None, the viewSettings precedent).
  */
 private[ooxml] def mergeSheetPrElem(
   existing: Option[Elem],
-  pageSetup: Option[PageSetup]
+  pageSetup: Option[PageSetup],
+  tabColor: Option[Color]
 ): Option[Elem] =
   val derivedFit = pageSetup.exists(ps => ps.fitToWidth.isDefined || ps.fitToHeight.isDefined)
-  pageSetup.flatMap(_.fitToPage) match
+  val withFit = pageSetup.flatMap(_.fitToPage) match
     case Some(false) => stripFitToPage(existing)
     case Some(true) => ensureFitToPage(existing)
     case None => if derivedFit then ensureFitToPage(existing) else existing
+  applyTabColor(withFit, tabColor)
+
+/** Overlay the modeled tab color onto sheetPr (GH-358); None preserves the input untouched. */
+private def applyTabColor(existing: Option[Elem], tabColor: Option[Color]): Option[Elem] =
+  tabColor match
+    case None => existing
+    case Some(color) =>
+      // Theme colors keep their theme/tint attrs (DxfCodec.colorToXml), relabeled per the
+      // fgColor/bgColor pattern
+      val colorElem = DxfCodec.colorToXml(color).copy(label = "tabColor")
+      val base = existing.getOrElse(XmlUtil.elem("sheetPr")())
+      val hasTabColor = base.child.exists {
+        case e: Elem => e.label == "tabColor"
+        case _ => false
+      }
+      val children =
+        if hasTabColor then
+          base.child.map {
+            case e: Elem if e.label == "tabColor" => colorElem
+            case other => other
+          }
+        // CT_SheetPr's child sequence STARTS with tabColor — prepend (pageSetUpPr appends)
+        else colorElem +: base.child
+      Some(base.copy(child = children))
 
 /** Set fitToPage="1", creating sheetPr/pageSetUpPr as needed (GH-266 behavior). */
 private def ensureFitToPage(existing: Option[Elem]): Option[Elem] =

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/WorksheetHelpers.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/WorksheetHelpers.scala
@@ -408,10 +408,11 @@ private[ooxml] def buildSheetViewsElem(
  * Apply sheet view settings to sheetViews XML.
  *
  * When `None`, preserves existing sheetViews unchanged (passive default, mirroring freezePane).
- * When `Some(view)`, sets `showGridLines` ("1"/"0", always written so the setting round-trips) and
- * `zoomScale` (written when defined, removed when None) on every `<sheetView>` element, creating a
- * minimal `<sheetViews><sheetView workbookViewId="0"/></sheetViews>` when absent. Unmodeled
- * attributes (tabSelected, topLeftCell, view, ...) are preserved.
+ * When `Some(view)`, sets `showGridLines` ("1"/"0", always written so the setting round-trips),
+ * `zoomScale` (written when defined, removed when None), and `tabSelected` (GH-372: overlaid when
+ * defined, LEFT AS PRESERVED when None) on every `<sheetView>` element, creating a minimal
+ * `<sheetViews><sheetView workbookViewId="0"/></sheetViews>` when absent. Unmodeled attributes
+ * (rightToLeft, topLeftCell, view, workbookViewId, ...) are preserved.
  */
 private def applyViewSettingsOverride(
   existing: Option[Elem],
@@ -444,9 +445,16 @@ private def applyViewAttrs(sheetView: Elem, view: SheetView): Elem =
     if view.showGridLines then "1" else "0",
     Null
   )
-  view.zoomScale match
+  val withZoom = view.zoomScale match
     case Some(zoom) => withGrid % new UnprefixedAttribute("zoomScale", zoom.toString, Null)
     case None => withGrid.copy(attributes = withGrid.attributes.remove("zoomScale"))
+  view.tabSelected match
+    case Some(selected) =>
+      withZoom % new UnprefixedAttribute("tabSelected", if selected then "1" else "0", Null)
+    // Three-valued (GH-372): None means "not modeled" — a preserved tabSelected attribute
+    // must ride through, so it is never removed here (unlike zoomScale, where the reader
+    // always models an in-range source value)
+    case None => withZoom
 
 /**
  * Apply freeze pane override to sheetViews XML.

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/WorksheetHelpers.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/WorksheetHelpers.scala
@@ -473,7 +473,7 @@ private def applyFreezePaneOverride(
         }
         sv.copy(child = newChildren)
       }
-    case Some(FreezePane.At(ref)) =>
+    case Some(FreezePane.At(ref, scrolledTo)) =>
       val colSplit = ref.col.index0
       val rowSplit = ref.row.index0
       if colSplit == 0 && rowSplit == 0 then existing
@@ -488,7 +488,9 @@ private def applyFreezePaneOverride(
           (if colSplit > 0 then Vector("xSplit" -> colSplit.toString) else Vector.empty) ++
             (if rowSplit > 0 then Vector("ySplit" -> rowSplit.toString) else Vector.empty) ++
             Vector(
-              "topLeftCell" -> ref.toA1,
+              // The OOXML topLeftCell attribute is the SCROLL target of the scrollable pane;
+              // unscrolled panes point it at the freeze anchor (GH-382)
+              "topLeftCell" -> scrolledTo.getOrElse(ref).toA1,
               "activePane" -> activePane,
               "state" -> "frozen"
             )

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/DirectSaxEmitterParitySpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/DirectSaxEmitterParitySpec.scala
@@ -117,7 +117,12 @@ class DirectSaxEmitterParitySpec extends FunSuite:
 
     val xml = zipEntryString(saxPath, "xl/worksheets/sheet1.xml")
     assert(xml.contains("<pane "), s"freeze pane missing from streaming output: $xml")
+    assert(
+      xml.contains("topLeftCell=\"D20\""),
+      s"scrolled pane topLeftCell (GH-382) missing from streaming output: $xml"
+    )
     assert(xml.contains("showGridLines=\"0\""), s"view settings missing: $xml")
+    assert(xml.contains("tabSelected=\"1\""), s"tabSelected (GH-372) missing: $xml")
     assert(xml.contains("orientation=\"landscape\""), s"pageSetup missing: $xml")
     assert(xml.contains("<pageMargins "), s"pageMargins missing: $xml")
     assert(xml.contains("<evenHeader>"), s"even header (GH-266) missing: $xml")
@@ -174,8 +179,11 @@ class DirectSaxEmitterParitySpec extends FunSuite:
     val b2 = ARef.from1(2, 2)
     buildSheet()
       .put(Cell(ARef.from1(4, 2), CellValue.Text("link")).withHyperlink("https://example.com"))
-      .freezeAt(b2)
-      .withViewSettings(SheetView(showGridLines = false, zoomScale = Some(85)))
+      // GH-382: scrolled freeze — both backends must emit the scroll target as topLeftCell
+      .freezeAt(b2, ARef.from1(4, 20))
+      .withViewSettings(
+        SheetView(showGridLines = false, zoomScale = Some(85), tabSelected = Some(true))
+      )
       .withPageSetup(
         PageSetup(
           orientation = Some("landscape"),

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/DirectSaxEmitterParitySpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/DirectSaxEmitterParitySpec.scala
@@ -127,6 +127,12 @@ class DirectSaxEmitterParitySpec extends FunSuite:
     assert(xml.contains("<pageMargins "), s"pageMargins missing: $xml")
     assert(xml.contains("<evenHeader>"), s"even header (GH-266) missing: $xml")
     assert(xml.contains("fitToPage=\"1\""), s"sheetPr fitToPage flag missing: $xml")
+    // StAX writes <tabColor ...></tabColor>, the DOM writer self-closes — match the open tag only
+    assert(xml.contains("<tabColor rgb=\"FF1F4E79\""), s"tabColor (GH-358) missing: $xml")
+    assert(
+      xml.indexOf("<tabColor ") < xml.indexOf("<pageSetUpPr "),
+      s"CT_SheetPr order: tabColor before pageSetUpPr: $xml"
+    )
     // Schema order (ECMA-376 18.3.1.99): sheetPr < sheetViews < cols < sheetData < page*
     val order = Seq(
       "<sheetPr>",
@@ -184,6 +190,8 @@ class DirectSaxEmitterParitySpec extends FunSuite:
       .withViewSettings(
         SheetView(showGridLines = false, zoomScale = Some(85), tabSelected = Some(true))
       )
+      // GH-358: tabColor must come out of the streaming path too, first among sheetPr children
+      .withTabColor(com.tjclp.xl.styles.color.Color.Rgb(0xff1f4e79))
       .withPageSetup(
         PageSetup(
           orientation = Some("landscape"),

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/OoxmlGenerativeRoundTripSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/OoxmlGenerativeRoundTripSpec.scala
@@ -34,8 +34,9 @@ import com.tjclp.xl.styles.numfmt.NumFmt
  * text, author); hyperlinks equal; merges set-equal; viewSettings/pageSetup equal; docProps
  * metadata fields equal (GH-242). Explicitly ignored serialization noise: styleId numbering, SST
  * ordering, activeSheetIndex (not serialized), dimension/defaultColWidth-style derived props,
- * write-only freezePane, cached formula values, and Rgb alpha-00 ≡ alpha-FF (the parser
- * deliberately canonicalizes 00 alpha to opaque, matching Excel/openpyxl's 00RRGGBB convention).
+ * cached formula values, and Rgb alpha-00 ≡ alpha-FF (the parser deliberately canonicalizes 00
+ * alpha to opaque, matching Excel/openpyxl's 00RRGGBB convention). freezePane compares under the
+ * writer-canonical mapping since GH-372 (the reader populates it from the pane XML).
  *
  * Determinism: the suite fixes the ScalaCheck initial seed so CI failures are reproducible.
  * Locally, crank the run count to shake out new bugs:
@@ -151,7 +152,7 @@ class OoxmlGenerativeRoundTripSpec extends ScalaCheckSuite:
             margins = Some(PageMargins(0.5, 0.5, 0.75, 0.75, 0.3, 0.3))
           )
         ),
-        freezePane = Some(FreezePane.At(ref"B2"))
+        freezePane = Some(FreezePane.At(ref"B2", Some(ref"B40")))
       )
     val wb = Workbook(Vector(sheet))
     val diffs = roundTripDiff(wb)

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/OoxmlGenerativeRoundTripSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/OoxmlGenerativeRoundTripSpec.scala
@@ -152,7 +152,8 @@ class OoxmlGenerativeRoundTripSpec extends ScalaCheckSuite:
             margins = Some(PageMargins(0.5, 0.5, 0.75, 0.75, 0.3, 0.3))
           )
         ),
-        freezePane = Some(FreezePane.At(ref"B2", Some(ref"B40")))
+        freezePane = Some(FreezePane.At(ref"B2", Some(ref"B40"))),
+        tabColor = Some(Color.Theme(ThemeSlot.Accent4, -0.25))
       )
     val wb = Workbook(Vector(sheet))
     val diffs = roundTripDiff(wb)

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/PageSetupRoundTripSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/PageSetupRoundTripSpec.scala
@@ -8,6 +8,7 @@ import com.tjclp.xl.api.*
 import com.tjclp.xl.codec.CellCodec.given
 import com.tjclp.xl.macros.ref
 import com.tjclp.xl.sheets.{HeaderFooter, PageMargins, PageSetup, SheetView}
+import com.tjclp.xl.styles.color.{Color, ThemeSlot}
 import com.tjclp.xl.workbooks.DefinedName
 import munit.FunSuite
 
@@ -15,6 +16,9 @@ import munit.FunSuite
  * GH-259: PageSetup print extensions round-trip — scale/orientation/fit via `<pageSetup>`, margins
  * via `<pageMargins>`, header/footer via `<headerFooter>`, and print area / repeat title rows via
  * sheet-scoped workbook defined names (`_xlnm.Print_Area` / `_xlnm.Print_Titles`).
+ *
+ * GH-358: `Sheet.tabColor` ⇄ `<sheetPr><tabColor .../>` with preserve-if-None merge semantics (the
+ * sheetPr overlay lives beside the fitToPage reconciliation, hence this spec).
  */
 class PageSetupRoundTripSpec extends FunSuite:
 
@@ -441,7 +445,8 @@ class PageSetupRoundTripSpec extends FunSuite:
         .fold(e => fail(s"parse failed: $e"), identity)
     val merged = com.tjclp.xl.ooxml.worksheet.mergeSheetPrElem(
       Some(preserved),
-      Some(PageSetup(fitToPage = Some(false)))
+      Some(PageSetup(fitToPage = Some(false))),
+      None
     )
     val elem = merged.getOrElse(fail("sheetPr with codeName/tabColor must survive the strip"))
     assertEquals(elem \@ "codeName", "Sheet1", "codeName attribute lost")
@@ -452,9 +457,134 @@ class PageSetupRoundTripSpec extends FunSuite:
   test("GH-284: Some(false) with nothing preserved emits no sheetPr at all") {
     val merged = com.tjclp.xl.ooxml.worksheet.mergeSheetPrElem(
       None,
-      Some(PageSetup(fitToPage = Some(false)))
+      Some(PageSetup(fitToPage = Some(false))),
+      None
     )
     assertEquals(merged, None)
+  }
+
+  // ===== Tab color (GH-358, model half) =====
+
+  test("GH-358: rgb tabColor round-trips (write → read → equality + XML shape)") {
+    val navy = Color.Rgb(0xff1f4e79)
+    val wb = Workbook(Sheet("Sheet1").put(ref"A1" -> 1).withTabColor(navy))
+    val (reread, out) = writeRead(wb)
+
+    val sheet = reread("Sheet1").fold(e => fail(s"sheet missing: $e"), identity)
+    assertEquals(sheet.tabColor, Some(navy))
+
+    val xml = zipEntryString(out, "xl/worksheets/sheet1.xml")
+    assert(xml.contains("<sheetPr>"), s"sheetPr missing: $xml")
+    assert(xml.contains("<tabColor rgb=\"FF1F4E79\"/>"), s"tabColor element missing: $xml")
+    Files.deleteIfExists(out)
+  }
+
+  test("GH-358: theme tabColor (slot + tint) round-trips") {
+    val theme = Color.Theme(ThemeSlot.Accent2, 0.25)
+    val wb = Workbook(Sheet("Sheet1").put(ref"A1" -> 1).withTabColor(theme))
+    val (reread, out) = writeRead(wb)
+    val sheet = reread("Sheet1").fold(e => fail(s"sheet missing: $e"), identity)
+    assertEquals(sheet.tabColor, Some(theme))
+    Files.deleteIfExists(out)
+  }
+
+  test("GH-358: workbook without tabColor reads back None") {
+    val wb = Workbook(Sheet("Sheet1").put(ref"A1" -> 1))
+    val (reread, out) = writeRead(wb)
+    val sheet = reread("Sheet1").fold(e => fail(s"sheet missing: $e"), identity)
+    assertEquals(sheet.tabColor, None)
+    Files.deleteIfExists(out)
+  }
+
+  test("GH-358: tabColor + fitToPage keep CT_SheetPr child order (tabColor FIRST)") {
+    val wb = Workbook(
+      Sheet("Sheet1")
+        .put(ref"A1" -> 1)
+        .withTabColor(Color.Rgb(0xffff0000))
+        .withPageSetup(PageSetup(fitToWidth = Some(1)))
+    )
+    val (_, out) = writeRead(wb)
+    val xml = zipEntryString(out, "xl/worksheets/sheet1.xml")
+    val tabColorIdx = xml.indexOf("<tabColor ")
+    val pageSetUpPrIdx = xml.indexOf("<pageSetUpPr ")
+    assert(tabColorIdx >= 0, s"tabColor missing: $xml")
+    assert(pageSetUpPrIdx >= 0, s"pageSetUpPr missing: $xml")
+    assert(
+      tabColorIdx < pageSetUpPrIdx,
+      s"CT_SheetPr sequence: tabColor must precede pageSetUpPr or Excel repairs the file: $xml"
+    )
+    Files.deleteIfExists(out)
+  }
+
+  test("GH-358: tabColor overlay REPLACES an existing tabColor child in place") {
+    import scala.xml.*
+    val preserved =
+      XmlSecurity
+        .parseSafe(
+          """<sheetPr codeName="Sheet1"><tabColor rgb="FF00FF00"/><pageSetUpPr fitToPage="1"/></sheetPr>""",
+          "test sheetPr"
+        )
+        .fold(e => fail(s"parse failed: $e"), identity)
+    val merged = com.tjclp.xl.ooxml.worksheet.mergeSheetPrElem(
+      Some(preserved),
+      None,
+      Some(Color.Rgb(0xff1f4e79))
+    )
+    val elem = merged.getOrElse(fail("merged sheetPr missing"))
+    assertEquals(elem \@ "codeName", "Sheet1", "codeName attribute lost")
+    val tabColors = (elem \ "tabColor").collect { case e: Elem => e }
+    assertEquals(tabColors.length, 1, s"exactly one tabColor expected: $elem")
+    assertEquals(tabColors.headOption.map(_ \@ "rgb"), Some("FF1F4E79"))
+    assert((elem \ "pageSetUpPr").nonEmpty, "unrelated pageSetUpPr child lost")
+  }
+
+  test("GH-358: tabColor overlay PREPENDS when the preserved sheetPr has no tabColor") {
+    import scala.xml.*
+    val preserved =
+      XmlSecurity
+        .parseSafe(
+          """<sheetPr><outlinePr summaryBelow="0"/><pageSetUpPr fitToPage="1"/></sheetPr>""",
+          "test sheetPr"
+        )
+        .fold(e => fail(s"parse failed: $e"), identity)
+    val merged = com.tjclp.xl.ooxml.worksheet.mergeSheetPrElem(
+      Some(preserved),
+      None,
+      Some(Color.Rgb(0xffff0000))
+    )
+    val elem = merged.getOrElse(fail("merged sheetPr missing"))
+    val childLabels = elem.child.collect { case e: Elem => e.label }
+    assertEquals(
+      childLabels.headOption,
+      Some("tabColor"),
+      s"tabColor must be the FIRST CT_SheetPr child (schema order): $childLabels"
+    )
+    assertEquals(childLabels, Seq("tabColor", "outlinePr", "pageSetUpPr"))
+  }
+
+  test("GH-358: tabColor = None leaves a preserved sheetPr untouched (preserve-if-None)") {
+    import scala.xml.*
+    val preserved =
+      XmlSecurity
+        .parseSafe(
+          """<sheetPr codeName="S1"><tabColor theme="5" tint="0.25"/></sheetPr>""",
+          "test sheetPr"
+        )
+        .fold(e => fail(s"parse failed: $e"), identity)
+    val merged =
+      com.tjclp.xl.ooxml.worksheet.mergeSheetPrElem(Some(preserved), None, None)
+    assertEquals(merged, Some(preserved), "None must not touch the preserved sheetPr")
+  }
+
+  test("GH-358: theme tabColor emits theme/tint attributes (not a resolved rgb)") {
+    val theme = Color.Theme(ThemeSlot.Accent1, 0.5)
+    val wb = Workbook(Sheet("Sheet1").put(ref"A1" -> 1).withTabColor(theme))
+    val (_, out) = writeRead(wb)
+    val xml = zipEntryString(out, "xl/worksheets/sheet1.xml")
+    assert(xml.contains("<tabColor "), s"tabColor missing: $xml")
+    assert(xml.contains("theme=\"4\""), s"theme index missing (Accent1 = 4): $xml")
+    assert(xml.contains("tint=\"0.5\""), s"tint missing: $xml")
+    Files.deleteIfExists(out)
   }
 
   test("GH-284: fitToPage=Some(true) forces the flag without fitToWidth/fitToHeight") {

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/SheetViewRoundTripSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/SheetViewRoundTripSpec.scala
@@ -94,6 +94,18 @@ class SheetViewRoundTripSpec extends FunSuite:
     Files.deleteIfExists(out)
   }
 
+  test("GH-382: scrolled frozen pane writes anchor-derived splits and the scroll topLeftCell") {
+    val wb = Workbook(Sheet("Sheet1").put(ref"A1" -> 1).freezeAt(ref"C11", ref"F40"))
+    val out = Files.createTempFile("scrolled-pane", ".xlsx")
+    XlsxWriter.write(wb, out).fold(e => fail(s"write failed: $e"), identity)
+    val xml = zipEntryString(out, "xl/worksheets/sheet1.xml")
+    assert(xml.contains("xSplit=\"2\""), s"xSplit derived from the anchor missing: $xml")
+    assert(xml.contains("ySplit=\"10\""), s"ySplit derived from the anchor missing: $xml")
+    assert(xml.contains("topLeftCell=\"F40\""), s"scroll target must win topLeftCell: $xml")
+    assert(xml.contains("state=\"frozen\""), s"frozen state missing: $xml")
+    Files.deleteIfExists(out)
+  }
+
   test("GH-258: surgical write (cell edit) preserves view settings from the source file") {
     val view = SheetView(showGridLines = false, zoomScale = Some(75))
     val wb0 = Workbook(Sheet("Sheet1").put(ref"A1" -> 1).withViewSettings(view))

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/SheetViewRoundTripSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/SheetViewRoundTripSpec.scala
@@ -192,6 +192,50 @@ class SheetViewRoundTripSpec extends FunSuite:
     Files.deleteIfExists(out)
   }
 
+  // ===== GH-358: foreign sheetPr / tabColor shapes =====
+
+  test("GH-358: unparseable tabColor (auto) stays out of the model and rides preservation") {
+    val src = rawWorksheetFixture("""<sheetPr><tabColor auto="1"/></sheetPr>""")
+    val wb = XlsxReader.read(src).fold(e => fail(s"read failed: $e"), identity)
+    val sheet = wb("Sheet1").fold(e => fail(s"sheet missing: $e"), identity)
+    assertEquals(sheet.tabColor, None, "auto tabColor is outside the typed color subset")
+
+    val out = Files.createTempFile("tabcolor-auto", ".xlsx")
+    XlsxWriter
+      .write(wb.put(sheet.put(ref"B1" -> 2)), out)
+      .fold(e => fail(s"write failed: $e"), identity)
+    val xml = zipEntryString(out, "xl/worksheets/sheet1.xml")
+    assert(xml.contains("<tabColor auto=\"1\"/>"), s"foreign tabColor lost on rewrite: $xml")
+    Files.deleteIfExists(src)
+    Files.deleteIfExists(out)
+  }
+
+  test("GH-358: setting tabColor on a read sheet keeps foreign sheetPr attrs and children") {
+    val src = rawWorksheetFixture(
+      """<sheetPr codeName="Hoja1" filterMode="1"><outlinePr summaryBelow="0"/></sheetPr>"""
+    )
+    val recolored = for
+      wb <- XlsxReader.read(src)
+      updated <- wb.updateAt(0, _.withTabColor(com.tjclp.xl.styles.color.Color.Rgb(0xff1f4e79)))
+    yield updated
+    val wb1 = recolored.fold(e => fail(s"edit failed: $e"), identity)
+
+    val out = Files.createTempFile("tabcolor-foreign", ".xlsx")
+    XlsxWriter.write(wb1, out).fold(e => fail(s"write failed: $e"), identity)
+    val xml = zipEntryString(out, "xl/worksheets/sheet1.xml")
+    assert(xml.contains("<tabColor rgb=\"FF1F4E79\"/>"), s"tabColor missing: $xml")
+    assert(xml.contains("codeName=\"Hoja1\""), s"foreign sheetPr attr lost: $xml")
+    assert(xml.contains("filterMode=\"1\""), s"foreign sheetPr attr lost: $xml")
+    assert(xml.contains("summaryBelow=\"0\""), s"foreign sheetPr child lost: $xml")
+    // CT_SheetPr sequence: tabColor precedes outlinePr
+    assert(
+      xml.indexOf("<tabColor ") < xml.indexOf("<outlinePr "),
+      s"tabColor must be prepended before other sheetPr children: $xml"
+    )
+    Files.deleteIfExists(src)
+    Files.deleteIfExists(out)
+  }
+
   // ===== GH-372: tabSelected =====
 
   test("GH-372: tabSelected round-trips (write → read)") {

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/SheetViewRoundTripSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/SheetViewRoundTripSpec.scala
@@ -2,12 +2,12 @@ package com.tjclp.xl.ooxml
 
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Path}
-import java.util.zip.ZipFile
+import java.util.zip.{ZipEntry, ZipFile, ZipOutputStream}
 
 import com.tjclp.xl.api.*
 import com.tjclp.xl.codec.CellCodec.given
 import com.tjclp.xl.macros.ref
-import com.tjclp.xl.sheets.SheetView
+import com.tjclp.xl.sheets.{FreezePane, SheetView}
 import com.tjclp.xl.unsafe.*
 import munit.FunSuite
 
@@ -15,6 +15,10 @@ import munit.FunSuite
  * GH-258: sheet view settings (showGridLines, zoomScale) serialize into
  * `<sheetViews><sheetView .../>` and parse back. Freeze panes and view settings must share ONE
  * sheetView element.
+ *
+ * GH-372: the reader populates `Sheet.freezePane` from frozen `<pane>` elements and
+ * `SheetView.tabSelected` from the sheetView attribute, so read→modify→write keeps view state
+ * through model regeneration.
  */
 class SheetViewRoundTripSpec extends FunSuite:
 
@@ -106,6 +110,137 @@ class SheetViewRoundTripSpec extends FunSuite:
     Files.deleteIfExists(out)
   }
 
+  // ===== GH-372: freeze panes read back into the model =====
+
+  test("GH-372: freeze pane reads back into the model (write → read)") {
+    val wb = Workbook(Sheet("Sheet1").put(ref"A1" -> 1).freezeAt(ref"B2"))
+    val (reread, out) = writeRead(wb)
+    val sheet = reread("Sheet1").fold(e => fail(s"sheet missing: $e"), identity)
+    assertEquals(sheet.freezePane, Some(FreezePane.At(ref"B2", None)))
+    Files.deleteIfExists(out)
+  }
+
+  test("GH-372/GH-382: scrolled frozen pane round-trips through the model") {
+    val wb = Workbook(Sheet("Sheet1").put(ref"A1" -> 1).freezeAt(ref"C11", ref"F40"))
+    val (reread, out) = writeRead(wb)
+    val sheet = reread("Sheet1").fold(e => fail(s"sheet missing: $e"), identity)
+    assertEquals(sheet.freezePane, Some(FreezePane.At(ref"C11", Some(ref"F40"))))
+    Files.deleteIfExists(out)
+  }
+
+  test("GH-372: workbook without freeze panes reads back None (never Some(Remove))") {
+    val wb = Workbook(Sheet("Sheet1").put(ref"A1" -> 1))
+    val (reread, out) = writeRead(wb)
+    val sheet = reread("Sheet1").fold(e => fail(s"sheet missing: $e"), identity)
+    assertEquals(sheet.freezePane, None)
+    Files.deleteIfExists(out)
+  }
+
+  test("GH-372: read → edit cell → write retains a foreign scrolled pane (model regeneration)") {
+    val src = rawWorksheetFixture(
+      """<sheetViews><sheetView rightToLeft="1" workbookViewId="0"><pane xSplit="2" ySplit="10" topLeftCell="C40" activePane="bottomRight" state="frozen"/></sheetView></sheetViews>"""
+    )
+    val wb = XlsxReader.read(src).fold(e => fail(s"read failed: $e"), identity)
+    val sheet0 = wb("Sheet1").fold(e => fail(s"sheet missing: $e"), identity)
+    assertEquals(
+      sheet0.freezePane,
+      Some(FreezePane.At(ref"C11", Some(ref"C40"))),
+      "anchor derives from xSplit/ySplit; pane topLeftCell is the scroll target"
+    )
+
+    val out = Files.createTempFile("pane-retain", ".xlsx")
+    XlsxWriter
+      .write(wb.put(sheet0.put(ref"B1" -> 2)), out)
+      .fold(e => fail(s"write failed: $e"), identity)
+    val xml = zipEntryString(out, "xl/worksheets/sheet1.xml")
+    assert(xml.contains("xSplit=\"2\""), s"xSplit lost on rewrite: $xml")
+    assert(xml.contains("ySplit=\"10\""), s"ySplit lost on rewrite: $xml")
+    assert(xml.contains("topLeftCell=\"C40\""), s"scroll target lost on rewrite: $xml")
+    assert(xml.contains("state=\"frozen\""), s"frozen state lost on rewrite: $xml")
+    assert(xml.contains("rightToLeft=\"1\""), s"foreign sheetView attr lost on rewrite: $xml")
+    Files.deleteIfExists(src)
+    Files.deleteIfExists(out)
+  }
+
+  test("GH-372: unscrolled foreign pane reads back with scrolledTo = None") {
+    val src = rawWorksheetFixture(
+      """<sheetViews><sheetView workbookViewId="0"><pane xSplit="2" ySplit="10" topLeftCell="C11" activePane="bottomRight" state="frozen"/></sheetView></sheetViews>"""
+    )
+    val wb = XlsxReader.read(src).fold(e => fail(s"read failed: $e"), identity)
+    val sheet = wb("Sheet1").fold(e => fail(s"sheet missing: $e"), identity)
+    assertEquals(sheet.freezePane, Some(FreezePane.At(ref"C11", None)))
+    Files.deleteIfExists(src)
+  }
+
+  test("GH-372: plain split panes stay unmodeled and ride preservation on edit") {
+    // No state attribute → state defaults to "split": xSplit/ySplit are 1/20 pt, not row/col
+    // counts, so the pane must NOT enter the model — and must survive a cell edit verbatim.
+    val src = rawWorksheetFixture(
+      """<sheetViews><sheetView workbookViewId="0"><pane xSplit="2310" ySplit="990" topLeftCell="C11" activePane="bottomRight"/></sheetView></sheetViews>"""
+    )
+    val wb = XlsxReader.read(src).fold(e => fail(s"read failed: $e"), identity)
+    val sheet = wb("Sheet1").fold(e => fail(s"sheet missing: $e"), identity)
+    assertEquals(sheet.freezePane, None, "split panes are out of the modeled subset")
+
+    val out = Files.createTempFile("split-pane", ".xlsx")
+    XlsxWriter
+      .write(wb.put(sheet.put(ref"B1" -> 2)), out)
+      .fold(e => fail(s"write failed: $e"), identity)
+    val xml = zipEntryString(out, "xl/worksheets/sheet1.xml")
+    assert(xml.contains("xSplit=\"2310\""), s"split pane lost on rewrite: $xml")
+    Files.deleteIfExists(src)
+    Files.deleteIfExists(out)
+  }
+
+  // ===== GH-372: tabSelected =====
+
+  test("GH-372: tabSelected round-trips (write → read)") {
+    val view = SheetView(showGridLines = false, tabSelected = Some(true))
+    val wb = Workbook(Sheet("Sheet1").put(ref"A1" -> 1).withViewSettings(view))
+    val (reread, out) = writeRead(wb)
+    val sheet = reread("Sheet1").fold(e => fail(s"sheet missing: $e"), identity)
+    assertEquals(sheet.viewSettings, Some(view))
+
+    val xml = zipEntryString(out, "xl/worksheets/sheet1.xml")
+    assert(xml.contains("tabSelected=\"1\""), s"tabSelected attr missing: $xml")
+    Files.deleteIfExists(out)
+  }
+
+  test("GH-372: parseSheetView fires when ONLY tabSelected is present") {
+    val src = rawWorksheetFixture(
+      """<sheetViews><sheetView tabSelected="1" workbookViewId="0"/></sheetViews>"""
+    )
+    val wb = XlsxReader.read(src).fold(e => fail(s"read failed: $e"), identity)
+    val sheet = wb("Sheet1").fold(e => fail(s"sheet missing: $e"), identity)
+    assertEquals(
+      sheet.viewSettings,
+      Some(SheetView(showGridLines = true, zoomScale = None, tabSelected = Some(true)))
+    )
+    Files.deleteIfExists(src)
+  }
+
+  test("GH-372: tabSelected = None leaves a preserved tabSelected attribute untouched") {
+    val src = rawWorksheetFixture(
+      """<sheetViews><sheetView tabSelected="1" workbookViewId="0"/></sheetViews>"""
+    )
+    val edited = for
+      wb <- XlsxReader.read(src)
+      updated <- wb.updateAt(0, _.withViewSettings(SheetView(showGridLines = false)))
+    yield updated
+    val wb1 = edited.fold(e => fail(s"edit failed: $e"), identity)
+
+    val out = Files.createTempFile("tabsel-preserve", ".xlsx")
+    XlsxWriter.write(wb1, out).fold(e => fail(s"write failed: $e"), identity)
+    val xml = zipEntryString(out, "xl/worksheets/sheet1.xml")
+    assert(xml.contains("showGridLines=\"0\""), s"modeled attr not overlaid: $xml")
+    assert(
+      xml.contains("tabSelected=\"1\""),
+      s"tabSelected=None must leave the preserved attribute: $xml"
+    )
+    Files.deleteIfExists(src)
+    Files.deleteIfExists(out)
+  }
+
   test("GH-258: surgical write (cell edit) preserves view settings from the source file") {
     val view = SheetView(showGridLines = false, zoomScale = Some(75))
     val wb0 = Workbook(Sheet("Sheet1").put(ref"A1" -> 1).withViewSettings(view))
@@ -151,3 +286,71 @@ class SheetViewRoundTripSpec extends FunSuite:
     Files.deleteIfExists(src)
     Files.deleteIfExists(out)
   }
+
+  // ========== helpers ==========
+
+  private def writeEntry(out: ZipOutputStream, name: String, content: String): Unit =
+    out.putNextEntry(new ZipEntry(name))
+    out.write(content.getBytes("UTF-8"))
+    out.closeEntry()
+
+  /**
+   * Minimal Excel-shaped single-sheet fixture with the given raw worksheet XML injected before
+   * `<sheetData>` (the ActiveTabRoundTripSpec pattern) — for feeding foreign `<sheetViews>` /
+   * `<sheetPr>` shapes the XL writer never produces.
+   */
+  private def rawWorksheetFixture(preSheetDataXml: String): Path =
+    val path = Files.createTempFile("sheetview-fixture", ".xlsx")
+    val out = new ZipOutputStream(Files.newOutputStream(path))
+    out.setLevel(1)
+    try
+      writeEntry(
+        out,
+        "[Content_Types].xml",
+        """<?xml version="1.0"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+  <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+</Types>"""
+      )
+      writeEntry(
+        out,
+        "_rels/.rels",
+        """<?xml version="1.0"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>"""
+      )
+      writeEntry(
+        out,
+        "xl/workbook.xml",
+        """<?xml version="1.0"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <sheets>
+    <sheet name="Sheet1" sheetId="1" r:id="rId1"/>
+  </sheets>
+</workbook>"""
+      )
+      writeEntry(
+        out,
+        "xl/_rels/workbook.xml.rels",
+        """<?xml version="1.0"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+</Relationships>"""
+      )
+      writeEntry(
+        out,
+        "xl/worksheets/sheet1.xml",
+        s"""<?xml version="1.0"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  $preSheetDataXml
+  <sheetData>
+    <row r="1"><c r="A1"><v>1</v></c></row>
+  </sheetData>
+</worksheet>"""
+      )
+    finally out.close()
+    path

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/WorkbookEquivalence.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/WorkbookEquivalence.scala
@@ -39,7 +39,7 @@ import com.tjclp.xl.styles.fill.Fill
  *     XML and reads back None by design — generators only produce visible ones); freezePane equal
  *     after WRITER-CANONICAL mapping (GH-372: the reader populates it from the pane XML) — an A1
  *     anchor or Remove emits no pane and reads back None, a scroll target equal to the anchor reads
- *     back None
+ *     back None; tabColor equal after color canonicalization (GH-358)
  *   - (d) workbook-level: docProps metadata fields equal (GH-242 — creator, lastModifiedBy,
  *     application, appVersion exact; created/modified at W3CDTF second precision)
  *
@@ -150,8 +150,16 @@ object WorkbookEquivalence:
             s"(authored ${expected.freezePane}), actual ${actual.freezePane}"
         )
       else Nil
+    val tabColorDiffs =
+      if expected.tabColor.map(normalizeColor) != actual.tabColor.map(normalizeColor) then
+        List(
+          s"$name: tabColor mismatch (GH-358): expected ${expected.tabColor}, " +
+            s"actual ${actual.tabColor}"
+        )
+      else Nil
     refDiffs ++ cellDiffs ++ commentDiffs ++ mergeDiffs ++ viewDiffs ++ pageSetupDiffs ++
-      freezeDiffs ++ drawingsDiff(name, expected, actual) ++ cfDiff(name, expected, actual)
+      freezeDiffs ++ tabColorDiffs ++ drawingsDiff(name, expected, actual) ++
+      cfDiff(name, expected, actual)
 
   /**
    * Writer-canonical freeze pane (GH-372): the reader populates freezePane from the pane XML, so it

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/WorkbookEquivalence.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/WorkbookEquivalence.scala
@@ -5,6 +5,7 @@ import java.time.Duration
 import com.tjclp.xl.api.*
 import com.tjclp.xl.addressing.ARef
 import com.tjclp.xl.cells.{Cell, CellValue}
+import com.tjclp.xl.sheets.FreezePane
 import com.tjclp.xl.styles.CellStyle
 import com.tjclp.xl.styles.border.{Border, BorderSide}
 import com.tjclp.xl.styles.color.Color
@@ -35,7 +36,10 @@ import com.tjclp.xl.styles.fill.Fill
  *   - merged ranges set-equal
  *   - (c) sheet-level: viewSettings equal; pageSetup equal (an authored PageSetup always
  *     round-trips when it has at least one visible field; all-default PageSetup serializes to no
- *     XML and reads back None by design — generators only produce visible ones)
+ *     XML and reads back None by design — generators only produce visible ones); freezePane equal
+ *     after WRITER-CANONICAL mapping (GH-372: the reader populates it from the pane XML) — an A1
+ *     anchor or Remove emits no pane and reads back None, a scroll target equal to the anchor reads
+ *     back None
  *   - (d) workbook-level: docProps metadata fields equal (GH-242 — creator, lastModifiedBy,
  *     application, appVersion exact; created/modified at W3CDTF second precision)
  *
@@ -45,8 +49,6 @@ import com.tjclp.xl.styles.fill.Fill
  *   - metadata theme/definedNames/sheetStates (separate parts with their own round-trip specs);
  *     activeSheetIndex compares since GH-294 (bookViews/activeTab serializes both directions)
  *   - the worksheet dimension element and derived defaults (defaultColWidth etc.)
- *   - freezePane (three-valued write-only override: None means "preserve", so the reader never
- *     populates it)
  *   - Cell.comment / rich-text comment formatting (Sheet.comments is the comment model; the
  *     author-prefix run the writer adds is presentation, so comments compare by plain text)
  *   - cached formula values (see Formula rule above)
@@ -140,8 +142,29 @@ object WorkbookEquivalence:
           s"$name: pageSetup mismatch: expected ${expected.pageSetup}, actual ${actual.pageSetup}"
         )
       else Nil
+    val freezeDiffs =
+      val canonical = canonicalFreeze(expected.freezePane)
+      if canonical != actual.freezePane then
+        List(
+          s"$name: freezePane mismatch (GH-372): expected $canonical " +
+            s"(authored ${expected.freezePane}), actual ${actual.freezePane}"
+        )
+      else Nil
     refDiffs ++ cellDiffs ++ commentDiffs ++ mergeDiffs ++ viewDiffs ++ pageSetupDiffs ++
-      drawingsDiff(name, expected, actual) ++ cfDiff(name, expected, actual)
+      freezeDiffs ++ drawingsDiff(name, expected, actual) ++ cfDiff(name, expected, actual)
+
+  /**
+   * Writer-canonical freeze pane (GH-372): the reader populates freezePane from the pane XML, so it
+   * participates in ≈ mapped through what the writer actually emits — an A1 anchor is a no-op the
+   * writer elides, Remove strips the pane, and a scroll target equal to the anchor is the
+   * unscrolled spelling; all three read back as the model's passive default.
+   */
+  private def canonicalFreeze(freeze: Option[FreezePane]): Option[FreezePane] = freeze match
+    case Some(FreezePane.At(anchor, scrolledTo)) =>
+      if anchor == ARef.from0(0, 0) then None
+      else Some(FreezePane.At(anchor, scrolledTo.filter(_ != anchor)))
+    case Some(FreezePane.Remove) => None
+    case None => None
 
   /**
    * Conditional-format equality (GH-136): PLAIN structural equality — typed blocks/rules compare by


### PR DESCRIPTION
## Summary

W2+W3 of the replication-campaign roadmap, composing toward 0.13.0.

**Parser (xl-evaluator)**
- **#355** — Excel percent postfix operator: `=A1*10%`, `=10%` → exact `0.1`, `=(1+5%)^2`, range broadcast (`=A1:C1%`), Excel precedence (`2^3%` ≡ `2^(3%)`), byte-identical print round-trip (never rewritten to `/100`), nesting-guard on deep `%` chains
- **#374** — leading unary plus preserved through print via a dedicated identity `UnaryPlus` AST node: `=+A1`, `=+Model!B2`, `=++A1`, `=2^+2` replicate byte-for-byte. **Deliberate spec reversal** of #271's printer normalization (called out in the commit); evaluation unchanged; drag/structural shift and dependency extraction recurse through both new nodes

**Appearance (xl-core + xl-ooxml)**
- **#382** — `FreezePane.At` carries an optional scroll target (`freezeAt(anchor, scrolledTo)`): `<pane ySplit="9" topLeftCell="F40"/>` is now representable; structural edits shift both refs
- **#372** — the reader populates `Sheet.freezePane` (frozen/frozenSplit) and models `SheetView.tabSelected`, so read→modify→write keeps freeze state through regeneration; unmodified sheets remain byte-identical
- **#358 (model half)** — `Sheet.tabColor: Option[Color]` (rgb + theme/tint) with `withTabColor`, both writer backends, preserve-if-None, schema-correct `sheetPr` child order. CLI half stays open for the tooling wave

## Verification

Two worktree-isolated TDD implementers, each adversarially reviewed. Parser review: three independent source reverts proved the 49 new tests pin the bugs; 32-formula byte-identity battery; original CLI repro (`eval "=A1*10%"` → 5). Appearance review: openpyxl 3.1.5 cross-validation in both directions; byte-identity of untouched sheets with exotic panes; generative round-trip law extended (scrolled panes, tabSelected, tabColor now generated + compared at `XL_ROUNDTRIP_MIN_SUCCESS=500`).

Integrated gates: `checkFormatAll __.sources` 25/25, `./mill __.test` 1028/1028 (4,188 cases), roundtrip corpus 239/239, examples ✓, skill snippets ✓.

Skill-recipe updates for the new APIs (percent gotcha removal, freeze/tabColor recipes) ride the 0.13.0 release-prep, when the published pin catches up.

Closes #355
Closes #374
Closes #372
Closes #382
Refs #358 (model half here; CLI exposure remains open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)