### PR TITLE
Wave 14: authoring API — data validation, calcPr, Patch comment/CF, text rotation, runtime columns, recalculating write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Data-validation authoring** (#375): typed list dropdowns —
+  `sheet.withDataValidation(range, DataValidation.list("\"Yes,No\""))` or a
+  range-ref formula — with allowBlank/showDropdown (OOXML's inverted
+  `showDropDown` handled), multi-range sqref, structural-edit range
+  shifting, and read-side parse into the model (read→edit→write keeps
+  validations on rewritten sheets); unmodeled validation kinds survive
+  byte-faithfully as `Preserved`, mirroring conditional formatting.
+- **calcPr authoring** (#373, part a): `WorkbookMetadata.calcPr` /
+  `Workbook.withCalcPr(CalcPr(iterativeCalculation, maxIterations,
+  maxChange))` emits `<calcPr iterate iterateCount iterateDelta/>` on
+  scratch builds and overlays onto preserved calcPr (calcId/refMode
+  survive) — from-scratch replicas of circular models open in Excel with
+  iterative calc ON. Bounded iterative evaluation (part b) remains open.
+- **Patch comment + conditional-format cases** (#379):
+  `Patch.SetComment` / `Patch.SetConditionalFormat` with DSL operators
+  (`ref.comment(...)`, `range.conditionalFormat(rule)`) — section builders
+  composed as patches can now attach provenance comments and CF rules;
+  auto-priority stamping routes through `Sheet.conditionalFormat`.
+- **Text rotation** (#380): `Align.textRotation` (0–180 + 255 stacked, with
+  `CellStyle.rotated(deg)` accepting Excel-UI negative degrees) — rotated
+  sensitivity-grid captions author, serialize on both backends, stream
+  through `StylePatcher`, and participate in style dedup correctly.
+- **Runtime column handles** (#361): `Column.parse("D")` and a total
+  `RefType.col` — column-oriented builders can fold over runtime letters
+  (`Column.parse(c)` → `setColumnProperties`) with no compile-time literal.
+- **Recalculating write** (#360): `Excel.writeRecalculated(wb, path)` (xl
+  aggregator/scripting prelude) recalculates, writes the cached workbook,
+  and returns the `RecalcResult` — the one-call answer to the
+  "wrote blanks because nothing recalculated" footgun; formula errors are
+  data (the file still writes; inspect `result.errors`).
+
 - **Excel percent postfix operator** (#355): `=A1*10%`, `=10%`, `=(1+5%)^2`
   parse, evaluate (`10%` → exact `0.1`), broadcast over ranges (`=A1:C1%`),
   and print back byte-identically (never rewritten to `/100`); precedence

--- a/docs/reference/scripting.md
+++ b/docs/reference/scripting.md
@@ -68,6 +68,25 @@ Excel.write(updated, "output.xlsx")
   replacement (no ZIP corruption on a crashed write).
 - `Excel.write` also accepts an `XLResult[Workbook]` directly.
 
+> **Formulas are written with whatever cache they carry — recalculate first.** A freshly built
+> `fx"…"` cell has no cached value, so a plain `Excel.write` produces a file whose formulas show
+> up **blank** in every cached-value consumer (openpyxl `data_only`, pandas, previewers, Excel
+> before its first recalc). If the workbook contains formulas, write it with
+> `Excel.writeRecalculated` (since 0.13.0) instead — one call recalculates and writes, returning
+> the `RecalcResult` so failures are visible instead of silent:
+>
+> ```scala
+> val result = Excel.writeRecalculated(updated, "output.xlsx") // recalc → write → report
+> if !result.isClean then result.errors.foreach(e => println(e.render))
+> ```
+>
+> The file is written even when some formulas fail — errors are data conditions; failed cells
+> stay uncached and Excel recalculates them on open. Overloads take an explicit `Clock`
+> (deterministic `TODAY`/`NOW`), a `Clock` + `Rng` (reproducible `RAND`/`RANDBETWEEN`), or an
+> `XLResult[Workbook]` directly. For full control (e.g. fail-hard pipelines), drop to
+> `wb.recalculate()` and write `result.workbook` yourself — see
+> [Formulas: build, recalculate, inspect](#formulas-build-recalculate-inspect).
+
 ## Compile-time vs runtime refs (and the `fx` rule)
 
 Literal refs and formulas are validated **at compile time** — a typo fails the build, not the
@@ -106,6 +125,19 @@ base.shift(1, 2) // B4   (colOffset, rowOffset)
 
 Navigation is total but **unchecked at the sheet edges**: `ref"A1".up()` produces the
 non-existent "A0", which corrupts output if written. Keep loop bounds inside your data extent.
+
+For **runtime column handles** (since 0.13.0) — column-oriented builders that fold over letters
+computed at runtime — use `Column.parse` instead of special-casing macro literals; a runtime
+`RefType` also exposes `.col` (the cell's column, or the range's starting column):
+
+```scala
+Vector("C" -> 14.0, "D" -> 22.0).foldLeft(sheet) { case (s, (letter, w)) =>
+  val col = Column.parse(letter).getOrElse(sys.error(s"bad column: $letter"))
+  s.setColumnProperties(col, ColumnProperties(width = Some(w)))
+}
+Column.parse("D1")                      // Right(D) — trailing row digits tolerated
+RefType.parse("Sales!C2:E9").map(_.col) // Right(C) — starting column of the range
+```
 
 ## Range fill and the patch DSL
 
@@ -192,6 +224,11 @@ For Excel-style format inheritance on formula entry, use the opt-in
 Reference cycles are **isolated**: the participants and their downstream dependents are reported
 (e.g. `Model!A7: Formula error in '=B7': Circular reference` via `CellEvalError.render`) while
 the acyclic remainder still evaluates and caches.
+
+When the very next step is a write, `Excel.writeRecalculated(wb, path)` (since 0.13.0) fuses the
+two — recalculate, write the cached workbook (even on partial failure), return the same
+`RecalcResult`. Use the explicit `recalculate().toEither` pattern above when a dirty result must
+abort *before* anything lands on disk.
 
 For one-off questions, `wb.evaluateFormula("=SUM(Data!A1:A9)", "Summary")` returns
 `XLResult[CellValue]` with cross-sheet context wired automatically (107 functions supported —

--- a/xl-cats-effect/src/com/tjclp/xl/io/streaming/StylePatcher.scala
+++ b/xl-cats-effect/src/com/tjclp/xl/io/streaming/StylePatcher.scala
@@ -136,7 +136,10 @@ object StylePatcher:
         val wrap = overlay.align.wrapText || existing.align.wrapText
         val indent =
           if overlay.align.indent > 0 then overlay.align.indent else existing.align.indent
-        Align(h, v, wrap, indent)
+        val rotation =
+          if overlay.align.textRotation != 0 then overlay.align.textRotation
+          else existing.align.textRotation
+        Align(h, v, wrap, indent, rotation)
 
     CellStyle(mergedFont, mergedFill, mergedBorder, mergedNumFmt, align = mergedAlign)
 
@@ -470,6 +473,7 @@ object StylePatcher:
       attrs += "vertical" -> vAlignStr
     if align.wrapText then attrs += "wrapText" -> "1"
     if align.indent > 0 then attrs += "indent" -> align.indent.toString
+    if align.textRotation != 0 then attrs += "textRotation" -> align.textRotation.toString
 
     val attrMeta = attrs.foldRight(Null: MetaData) { case ((k, v), acc) =>
       new UnprefixedAttribute(k, v, acc)
@@ -605,7 +609,11 @@ object StylePatcher:
       // OOXML indent is an unsigned int; ignore negative values from malformed files so the
       // streaming path stays total (Align requires indent >= 0), matching the DOM StyleParser
       val indent = (alignment \ "@indent").text.toIntOption.filter(_ >= 0).getOrElse(0)
-      Align(h, v, wrap, indent)
+      // ST_TextRotation admits 0-180 plus 255; drop anything else, matching the DOM StyleParser
+      val rotation = (alignment \ "@textRotation").text.toIntOption
+        .filter(v => (v >= 0 && v <= 180) || v == Align.VerticalTextRotation)
+        .getOrElse(0)
+      Align(h, v, wrap, indent, rotation)
 
   private def extractColor(nodes: NodeSeq): Option[Color] =
     nodes.headOption.flatMap { c =>

--- a/xl-cats-effect/test/src/com/tjclp/xl/io/streaming/StreamingErrorSpec.scala
+++ b/xl-cats-effect/test/src/com/tjclp/xl/io/streaming/StreamingErrorSpec.scala
@@ -4,7 +4,7 @@ import munit.FunSuite
 import com.tjclp.xl.ooxml.XmlSecurity
 import com.tjclp.xl.ooxml.style.WorkbookStyles
 import com.tjclp.xl.styles.CellStyle
-import com.tjclp.xl.styles.alignment.HAlign
+import com.tjclp.xl.styles.alignment.{Align, HAlign}
 import com.tjclp.xl.styles.font.Font
 import com.tjclp.xl.styles.fill.Fill
 import com.tjclp.xl.styles.color.Color
@@ -162,6 +162,85 @@ class StreamingErrorSpec extends FunSuite:
     result match
       case Right(Some(style)) => assertEquals(style.align.indent, 3)
       case other => fail(s"Expected Right(Some(style)), got: $other")
+  }
+
+  test("StylePatcher.getStyle: out-of-range textRotation is ignored, not thrown (GH-380)") {
+    // ST_TextRotation admits 0-180 plus 255; 181-254, negatives, and junk must fall back to 0
+    for bad <- List("181", "200", "-10", "junk") do
+      val xml = stylesXmlWith(
+        defaultFontsXml,
+        s"""<xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0" applyAlignment="1"><alignment horizontal="left" textRotation="$bad"/></xf>"""
+      )
+
+      val result = StylePatcher.getStyle(xml, 1)
+      result match
+        case Right(Some(style)) =>
+          assertEquals(style.align.textRotation, 0, s"for textRotation=$bad")
+          assertEquals(style.align.horizontal, HAlign.Left, "fallback must only affect rotation")
+        case other => fail(s"Expected Right(Some(style)) for textRotation=$bad, got: $other")
+  }
+
+  test("StylePatcher.getStyle: valid textRotation values are preserved (GH-380)") {
+    for (attr, expected) <- List("90" -> 90, "135" -> 135, "180" -> 180, "255" -> 255) do
+      val xml = stylesXmlWith(
+        defaultFontsXml,
+        s"""<xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0" applyAlignment="1"><alignment horizontal="left" textRotation="$attr"/></xf>"""
+      )
+
+      val result = StylePatcher.getStyle(xml, 1)
+      result match
+        case Right(Some(style)) =>
+          assertEquals(style.align.textRotation, expected, s"for textRotation=$attr")
+        case other => fail(s"Expected Right(Some(style)) for textRotation=$attr, got: $other")
+  }
+
+  test("StylePatcher.getStyle: out-of-range textRotation behaves identically to DOM StyleParser") {
+    val xml = stylesXmlWith(
+      defaultFontsXml,
+      """<xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0" applyAlignment="1"><alignment horizontal="left" textRotation="200"/></xf>"""
+    )
+
+    val streamingAlign = StylePatcher.getStyle(xml, 1).toOption.flatten.map(_.align)
+    val domAlign = XmlSecurity
+      .parseSafe(xml, "styles.xml")
+      .toOption
+      .flatMap(elem => WorkbookStyles.fromXml(elem).toOption)
+      .flatMap(_.styleAt(1))
+      .map(_.align)
+
+    assert(streamingAlign.isDefined, "streaming path should produce an alignment")
+    assert(domAlign.isDefined, "DOM path should produce an alignment")
+    assertEquals(streamingAlign, domAlign)
+  }
+
+  test("StylePatcher: textRotation round-trips through addStyle + getStyle (GH-380)") {
+    val rotated =
+      CellStyle.default.withAlign(Align(horizontal = HAlign.Left, textRotation = 90))
+
+    val result =
+      for
+        added <- StylePatcher.addStyle(minimalStylesXml, rotated)
+        (updatedXml, id) = added
+        parsed <- StylePatcher.getStyle(updatedXml, id)
+      yield parsed
+
+    result match
+      case Right(Some(style)) => assertEquals(style.align.textRotation, 90)
+      case other => fail(s"Expected Right(Some(style)), got: $other")
+  }
+
+  test("StylePatcher.mergeStyles: textRotation follows overlay-wins-when-set semantics (GH-380)") {
+    val existing = CellStyle.default.withAlign(Align(horizontal = HAlign.Left, textRotation = 90))
+
+    // Default overlay preserves the existing rotation
+    val keptRotation = StylePatcher.mergeStyles(existing, CellStyle.default)
+    assertEquals(keptRotation.align.textRotation, 90)
+
+    // Non-default overlay rotation wins
+    val overlay = CellStyle.default.withAlign(Align(textRotation = 135))
+    val merged = StylePatcher.mergeStyles(existing, overlay)
+    assertEquals(merged.align.textRotation, 135)
+    assertEquals(merged.align.horizontal, HAlign.Left, "unset overlay components inherit existing")
   }
 
   test("StylePatcher.getStyle: non-positive font size falls back to default, not thrown") {

--- a/xl-core/src/com/tjclp/xl/addressing/Column.scala
+++ b/xl-core/src/com/tjclp/xl/addressing/Column.scala
@@ -28,6 +28,22 @@ object Column:
       if index < 0 || index > MaxIndex0 then Left(s"Column index out of range: $index")
       else Right(index)
 
+  /**
+   * Parse a column from Excel letter notation at runtime (`"D"`, `"aa"` — case-insensitive).
+   *
+   * Runtime counterpart of the compile-time `ref` literal for code that computes column letters
+   * dynamically (e.g. folding over `Vector("C", "D")` to set widths). Trailing row digits are
+   * tolerated and discarded (`"D1"` parses as column D) so full A1 refs can be passed directly; any
+   * other suffix (anchors, ranges, mixed letters) is rejected. Strict letters-only parsing is
+   * [[fromLetter]].
+   */
+  def parse(input: String): Either[String, Column] =
+    val normalized = input.toUpperCase(Locale.ROOT)
+    val (letters, rest) = normalized.span(c => c >= 'A' && c <= 'Z')
+    if letters.isEmpty then Left(s"No column letters in: $input")
+    else if !rest.forall(c => c >= '0' && c <= '9') then Left(s"Invalid column: $input")
+    else fromLetter(letters)
+
   extension (col: Column)
     /** Get 0-based index (0 = A, 1 = B, ...) */
     def index0: Int = col

--- a/xl-core/src/com/tjclp/xl/addressing/RefType.scala
+++ b/xl-core/src/com/tjclp/xl/addressing/RefType.scala
@@ -71,6 +71,17 @@ enum RefType derives CanEqual:
     case QualifiedRange(sheet, range) =>
       s"${SheetName.quoteForFormula(sheet.value)}!${range.toA1}"
 
+  /**
+   * Column handle (GH-361): the cell's column, or the range's starting (leftmost) column. Total —
+   * gives runtime-parsed refs the same `.col` ergonomics as the compile-time `ref` literal (e.g.
+   * `RefType.parse(s).map(rt => sheet.setColumnProperties(rt.col, props))`).
+   */
+  def col: Column = this match
+    case Cell(ref) => ref.col
+    case Range(range) => range.start.col
+    case QualifiedCell(_, ref) => ref.col
+    case QualifiedRange(_, range) => range.start.col
+
 end RefType
 
 object RefType:

--- a/xl-core/src/com/tjclp/xl/api.scala
+++ b/xl-core/src/com/tjclp/xl/api.scala
@@ -72,7 +72,7 @@ object api:
   export patch.Patch
 
   // Workbook types
-  export workbooks.{Workbook, WorkbookMetadata}
+  export workbooks.{Workbook, WorkbookMetadata, CalcPr}
 
   // Context types (for surgical modification)
   export context.{SourceContext, SourceFingerprint}

--- a/xl-core/src/com/tjclp/xl/api.scala
+++ b/xl-core/src/com/tjclp/xl/api.scala
@@ -46,7 +46,7 @@ object api:
   export richtext.{TextRun, RichText}
 
   // Sheet types
-  export sheets.{Sheet, ColumnProperties, RowProperties}
+  export sheets.{Sheet, ColumnProperties, RowProperties, DataValidation, DvKind}
 
   // Drawing types (GH-221) — case classes/enums, so plain export forwarders are safe.
   // NEVER export anything named `Anchor` here (taken by addressing above).

--- a/xl-core/src/com/tjclp/xl/dsl/syntax.scala
+++ b/xl-core/src/com/tjclp/xl/dsl/syntax.scala
@@ -1,7 +1,8 @@
 package com.tjclp.xl.dsl
 
 import com.tjclp.xl.addressing.{ARef, CellRange, RefType}
-import com.tjclp.xl.cells.CellValue
+import com.tjclp.xl.cells.{CellValue, Comment}
+import com.tjclp.xl.cf.CfRule
 import com.tjclp.xl.patch.Patch
 import com.tjclp.xl.styles.CellStyle
 import com.tjclp.xl.styles.border.{Border, BorderSide, BorderStyle}
@@ -64,6 +65,12 @@ object syntax:
      * The style will be auto-registered in the sheet's StyleRegistry when applied.
      */
     def styled(style: CellStyle): Patch = Patch.SetCellStyle(ref, style)
+
+    /**
+     * Create a SetComment patch attaching a comment to this cell (later comments to the same ref
+     * win when composed).
+     */
+    def comment(c: Comment): Patch = Patch.SetComment(ref, c)
 
     /** Create a SetStyle patch using a StyleId (for pre-registered styles) */
     def styleId(id: StyleId): Patch = Patch.SetStyle(ref, id)
@@ -143,6 +150,19 @@ object syntax:
 
     /** Create a Merge patch */
     def merge: Patch = Patch.Merge(range)
+
+    /**
+     * Create a SetConditionalFormat patch: ONE conditional-formatting block applying `rule` (and
+     * `more`) to this range. Applying appends the block via `Sheet.conditionalFormat`, which stamps
+     * [[com.tjclp.xl.cf.CfRule.AutoPriority]] rules above every priority already on the sheet.
+     *
+     * Deliberately NOT named `cf`: the package-level `export syntax.*` in com.tjclp.xl would then
+     * mint a term forwarder named `cf`, which collides with the `com.tjclp.xl.cf` PACKAGE and fails
+     * compilation. Mirroring the Sheet method name is the export-safe (and more discoverable)
+     * choice.
+     */
+    def conditionalFormat(rule: CfRule, more: CfRule*): Patch =
+      Patch.SetConditionalFormat(Vector(range), (rule +: more).toVector)
 
     /** Create an Unmerge patch */
     def unmerge: Patch = Patch.Unmerge(range)
@@ -232,8 +252,9 @@ object syntax:
    *   yield (rangeRef := 0)            // fills A1:B5 with 0
    * }}}
    *
-   * `styled`, `merge`, and `remove` also work on both cells and ranges (merge of a single cell is
-   * meaningless and returns the empty patch).
+   * `styled`, `merge`, `remove`, `comment`, and `conditionalFormat` also work across cells and
+   * ranges where meaningful: merge of a single cell and comment of a range are meaningless and
+   * return the empty patch; `conditionalFormat` of a single cell becomes a 1x1-range block.
    */
   extension (refType: RefType)
     /** Create Put patch from RefType (delegates to underlying ARef) */
@@ -307,6 +328,21 @@ object syntax:
       case RefType.QualifiedCell(_, aref) => aref.styled(style)
       case RefType.Range(range) => range.styled(style)
       case RefType.QualifiedRange(_, range) => range.styled(style)
+
+    /** Comment RefType (only works for cells; comments anchor to one cell, ranges yield empty) */
+    @annotation.targetName("refTypeComment")
+    def comment(c: Comment): Patch = refType match
+      case RefType.Cell(aref) => aref.comment(c)
+      case RefType.QualifiedCell(_, aref) => aref.comment(c)
+      case _ => Patch.empty // A range can't carry a single comment
+
+    /** Conditional-format RefType (works for both; a cell becomes a 1x1-range block) */
+    @annotation.targetName("refTypeConditionalFormat")
+    def conditionalFormat(rule: CfRule, more: CfRule*): Patch = refType match
+      case RefType.Cell(aref) => CellRange(aref, aref).conditionalFormat(rule, more*)
+      case RefType.QualifiedCell(_, aref) => CellRange(aref, aref).conditionalFormat(rule, more*)
+      case RefType.Range(range) => range.conditionalFormat(rule, more*)
+      case RefType.QualifiedRange(_, range) => range.conditionalFormat(rule, more*)
 
     /** Merge RefType (only works for ranges, returns empty for cells) */
     @annotation.targetName("refTypeMerge")

--- a/xl-core/src/com/tjclp/xl/patch/Patch.scala
+++ b/xl-core/src/com/tjclp/xl/patch/Patch.scala
@@ -2,7 +2,8 @@ package com.tjclp.xl.patch
 
 import cats.Monoid
 import com.tjclp.xl.addressing.{ARef, CellRange, Column, Row}
-import com.tjclp.xl.cells.{Cell, CellValue}
+import com.tjclp.xl.cells.{Cell, CellValue, Comment}
+import com.tjclp.xl.cf.CfRule
 import com.tjclp.xl.codec.CellCodec.given
 import com.tjclp.xl.error.XLResult
 import com.tjclp.xl.sheets.{ColumnProperties, RowProperties, Sheet}
@@ -20,7 +21,9 @@ import com.tjclp.xl.styles.units.StyleId
  * Laws:
  *   - Associativity: (p1 |+| p2) |+| p3 == p1 |+| (p2 |+| p3)
  *   - Identity: Patch.empty |+| p == p == p |+| Patch.empty
- *   - Idempotence: Applying the same patch twice yields the same result
+ *   - Idempotence: Applying the same patch twice yields the same result (SetConditionalFormat
+ *     excepted — it appends one CF block per application, matching Sheet.conditionalFormat's
+ *     append-only authoring semantics)
  */
 enum Patch:
   /** Put a cell value at a reference */
@@ -68,6 +71,21 @@ enum Patch:
 
   /** Put a grid of values starting at origin (for array formula spill) */
   case PutArray(origin: ARef, values: Vector[Vector[CellValue]])
+
+  /**
+   * Attach a comment to a cell (later comments to the same ref win). Comments live on
+   * `Sheet.comments`, so no cell is materialized.
+   */
+  case SetComment(ref: ARef, comment: Comment)
+
+  /**
+   * Append ONE conditional-formatting block applying `rules` to `ranges` (multi-range sqref).
+   *
+   * Applied via [[com.tjclp.xl.sheets.Sheet.conditionalFormat]], which owns auto-priority stamping:
+   * rules left at [[CfRule.AutoPriority]] are assigned above every priority already on the sheet.
+   * Append-only like the Sheet method — applying the same patch twice appends two blocks.
+   */
+  case SetConditionalFormat(ranges: Vector[CellRange], rules: Vector[CfRule])
 
   /** Batch multiple patches together */
   case Batch(patches: Vector[Patch])
@@ -162,6 +180,13 @@ object Patch:
         }
       }
       sheet.copy(cells = newCells)
+
+    case SetComment(ref, cmt) =>
+      sheet.comment(ref, cmt)
+
+    case SetConditionalFormat(ranges, rules) =>
+      // Route through Sheet.conditionalFormat — it owns AutoPriority stamping
+      sheet.conditionalFormat(ranges, rules)
 
     case Batch(patches) =>
       patches.foldLeft(sheet) { (acc, p) =>

--- a/xl-core/src/com/tjclp/xl/sheets/DataValidation.scala
+++ b/xl-core/src/com/tjclp/xl/sheets/DataValidation.scala
@@ -1,0 +1,75 @@
+package com.tjclp.xl.sheets
+
+import com.tjclp.xl.addressing.CellRange
+
+/**
+ * Data validation (GH-375): one worksheet `<dataValidation>` entry.
+ *
+ * Document order in `Sheet.dataValidations` is emission order inside the single `<dataValidations>`
+ * container. The typed envelope (sqref ranges) shifts under structural edits even while foreign
+ * entries ride through as [[DataValidation.Preserved]] — the [[com.tjclp.xl.cf.ConditionalFormat]]
+ * pattern.
+ */
+enum DataValidation derives CanEqual:
+  /**
+   * One typed validation: `kind` applies to every range in `ranges`.
+   *
+   * An entry with empty `ranges` is unexpressible in OOXML and is dropped at emission (the
+   * authoring API cannot construct one).
+   *
+   * @param allowBlank
+   *   Blank cells always pass validation (Excel's "Ignore blank", `allowBlank="1"`). The OOXML
+   *   schema default is false; Excel's UI default is true.
+   * @param showDropdown
+   *   Show the in-cell dropdown arrow for list validations. NOTE the OOXML INVERSION: the
+   *   serialized attribute `showDropDown="1"` SUPPRESSES the dropdown, so this friendly field emits
+   *   the attribute only when false.
+   */
+  case Rules(
+    ranges: Vector[CellRange],
+    kind: DvKind,
+    allowBlank: Boolean = true,
+    showDropdown: Boolean = true
+  )
+
+  /**
+   * Whole-entry fallback for an unmodeled `<dataValidation>` (whole/decimal/date/custom types,
+   * operators, prompt/error messages, unknown attrs). CONTRACT =
+   * [[com.tjclp.xl.cf.ConditionalFormat.Preserved]]: constructed only by xl-ooxml's reader; the
+   * payload is the scope-self-contained canonical XML of one whole element, re-emitted verbatim.
+   * Users must not construct this case; a hand-built payload that is not canonical XML is silently
+   * dropped at emission.
+   */
+  case Preserved(xml: String)
+
+object DataValidation:
+  /**
+   * List-dropdown validation. `formula` is stored VERBATIM as the `<formula1>` text: either an
+   * inline list with literal quotes (`"\"Low,Med,High\""`) or a range reference (`"$Z$1:$Z$3"`,
+   * `"Lists!$A$1:$A$5"`). Attach ranges via `Sheet.withDataValidation`.
+   */
+  def list(
+    formula: String,
+    allowBlank: Boolean = true,
+    showDropdown: Boolean = true
+  ): DataValidation.Rules =
+    Rules(Vector.empty, DvKind.List(formula), allowBlank, showDropdown)
+
+  /**
+   * List-dropdown validation from inline values: `listOf("Yes", "No")` stores `"Yes,No"` (the
+   * quoted comma-separated form Excel uses). Quotes in values are doubled per formula
+   * string-literal rules; values containing commas are inexpressible inline — use a range reference
+   * via [[list]] instead.
+   */
+  def listOf(first: String, rest: String*): DataValidation.Rules =
+    val joined = (first +: rest).map(_.replace("\"", "\"\"")).mkString(",")
+    list("\"" + joined + "\"")
+
+/**
+ * Validation kind for [[DataValidation.Rules]] — minimal but extensible (GH-375): list dropdowns
+ * first; whole/decimal/date/textLength bounds are future cases. Formula text is stored verbatim,
+ * never parsed (the [[com.tjclp.xl.cf.CfRule]] convention).
+ */
+enum DvKind derives CanEqual:
+  /** `type="list"`: `formula` is the `<formula1>` text (inline quoted list or range reference). */
+  case List(formula: String)

--- a/xl-core/src/com/tjclp/xl/sheets/Sheet.scala
+++ b/xl-core/src/com/tjclp/xl/sheets/Sheet.scala
@@ -53,6 +53,11 @@ import scala.util.boundary, boundary.break
  *   existing tabColor XML on write (passive default, the viewSettings precedent); `Some(color)`
  *   overlays it onto the preserved sheetPr. Both RGB and theme+tint colors are legal; the reader
  *   populates it whenever the source color is in the typed subset (rgb / theme+tint / indexed).
+ *
+ * @param dataValidations
+ *   Data-validation entries (GH-375). Document order is emission order inside the single
+ *   `<dataValidations>` container; use [[withDataValidation]] to append. Unmodeled entries ride
+ *   through as [[DataValidation.Preserved]] (the conditionalFormats pattern).
  */
 final case class Sheet(
   name: SheetName,
@@ -70,7 +75,8 @@ final case class Sheet(
   viewSettings: Option[SheetView] = None,
   drawings: Vector[Drawing] = Vector.empty,
   conditionalFormats: Vector[ConditionalFormat] = Vector.empty,
-  tabColor: Option[Color] = None
+  tabColor: Option[Color] = None,
+  dataValidations: Vector[DataValidation] = Vector.empty
 ):
 
   /** Get cell at reference (returns empty cell if not present) */
@@ -189,8 +195,10 @@ final case class Sheet(
           idx(col.index0).map(ni => Column.from0(ni) -> p)
         }
 
-    // Merged ranges: clamp the active-axis span; drop if it collapses entirely into the deletion.
-    val newMerges = mergedRanges.flatMap { range =>
+    // Shared range algebra on the active axis: clamp the span; None when it collapses entirely
+    // into the deletion. Used by merged ranges, conditional-format envelopes, and data
+    // validations — the three sqref-shaped structures that must shift identically.
+    def shiftRangeOnAxis(range: CellRange): Option[CellRange] =
       val s = axisOf(range.start)
       val e = axisOf(range.end)
       val (ns, ne) =
@@ -201,7 +209,9 @@ final case class Sheet(
           (ns0, ne0)
       if ns > ne then None
       else Some(CellRange(rebuild(range.start, ns), rebuild(range.end, ne)))
-    }
+
+    // Merged ranges: clamp the active-axis span; drop if it collapses entirely into the deletion.
+    val newMerges = mergedRanges.flatMap(shiftRangeOnAxis)
 
     // Freeze pane: shift/clamp BOTH the anchor and the scroll target on the active axis
     // (clamp a deleted ref to `at`) — dropping scrolledTo here would silently unscroll the
@@ -250,21 +260,21 @@ final case class Sheet(
     // xl-evaluator's StructuralEditor. ConditionalFormat.Preserved blocks are untouched.
     val newCondFmts = conditionalFormats.flatMap {
       case ConditionalFormat.Rules(ranges, rules, pivot) =>
-        val shiftedRanges = ranges.flatMap { range =>
-          val s = axisOf(range.start)
-          val e = axisOf(range.end)
-          val (ns, ne) =
-            if !deleting then (if s >= at then s + count else s, if e >= at then e + count else e)
-            else
-              val ns0 = if s < at then s else if s >= at + count then s - count else at
-              val ne0 = if e < at then e else if e >= at + count then e - count else at - 1
-              (ns0, ne0)
-          if ns > ne then None
-          else Some(CellRange(rebuild(range.start, ns), rebuild(range.end, ne)))
-        }
+        val shiftedRanges = ranges.flatMap(shiftRangeOnAxis)
         if shiftedRanges.isEmpty then None
         else Some(ConditionalFormat.Rules(shiftedRanges, rules, pivot))
       case preserved: ConditionalFormat.Preserved => Some(preserved)
+    }
+
+    // Data validations (GH-375): same envelope algebra — without it, dropdowns detach from their
+    // cells on row/column insert or delete. An entry whose ranges all drop is removed (Excel
+    // deletes validations whose entire range is deleted); Preserved entries are untouched.
+    val newDataValidations = dataValidations.flatMap {
+      case DataValidation.Rules(ranges, kind, allowBlank, showDropdown) =>
+        val shiftedRanges = ranges.flatMap(shiftRangeOnAxis)
+        if shiftedRanges.isEmpty then None
+        else Some(DataValidation.Rules(shiftedRanges, kind, allowBlank, showDropdown))
+      case preserved: DataValidation.Preserved => Some(preserved)
     }
 
     copy(
@@ -275,7 +285,8 @@ final case class Sheet(
       mergedRanges = newMerges,
       freezePane = newFreeze,
       drawings = newDrawings,
-      conditionalFormats = newCondFmts
+      conditionalFormats = newCondFmts,
+      dataValidations = newDataValidations
     )
 
   /** Put CellValue at reference (always succeeds - CellValue is pre-validated) */
@@ -738,6 +749,35 @@ final case class Sheet(
   /** All typed conditional-format blocks in document order (Preserved fragments excluded). */
   def typedConditionalFormats: Vector[ConditionalFormat.Rules] =
     conditionalFormats.collect { case r: ConditionalFormat.Rules => r }
+
+  // ===== Data validation (GH-375) =====
+
+  /**
+   * Append ONE data validation applying `dv` to `range` — list dropdowns first:
+   * {{{
+   * sheet.withDataValidation(ref"B2:B10", DataValidation.listOf("Low", "Med", "High"))
+   * sheet.withDataValidation(ref"C2:C10", DataValidation.list("$Z$1:$Z$3", allowBlank = false))
+   * }}}
+   * Authoring always appends a new entry (Excel accepts several validations per sheet); any ranges
+   * already on `dv` are replaced by `range`.
+   */
+  def withDataValidation(range: CellRange, dv: DataValidation.Rules): Sheet =
+    withDataValidation(Vector(range), dv)
+
+  /** Multi-range variant of [[withDataValidation]]: one entry, several sqref ranges. */
+  def withDataValidation(ranges: Vector[CellRange], dv: DataValidation.Rules): Sheet =
+    if ranges.isEmpty then this
+    else copy(dataValidations = dataValidations :+ dv.copy(ranges = ranges))
+
+  /** Remove the data validation at `index` (document order); identity when out of range. */
+  def removeDataValidation(index: Int): Sheet =
+    if dataValidations.isDefinedAt(index) then
+      copy(dataValidations = dataValidations.patch(index, Nil, 1))
+    else this
+
+  /** All typed data validations in document order (Preserved entries excluded). */
+  def typedDataValidations: Vector[DataValidation.Rules] =
+    dataValidations.collect { case r: DataValidation.Rules => r }
 
   /** Add or update table in sheet */
   def withTable(table: TableSpec): Sheet =

--- a/xl-core/src/com/tjclp/xl/styles/alignment/Align.scala
+++ b/xl-core/src/com/tjclp/xl/styles/alignment/Align.scala
@@ -12,19 +12,48 @@ package com.tjclp.xl.styles.alignment
  * @param indent
  *   Excel's alignment indent level (~3 characters per level); 0 means no indent and is omitted from
  *   OOXML output. Indentation travels with the style rather than the value, unlike leading spaces.
+ * @param textRotation
+ *   Raw OOXML ST_TextRotation value: 0 is horizontal (omitted from output), 1-90 rotates
+ *   counter-clockwise by that many degrees (90 = straight up), 91-180 encodes DOWNWARD rotation as
+ *   90 + the clockwise angle (135 = 45 degrees down), and 255 stacks letters vertically. The
+ *   [[Align.normalizeRotation]] helper (and the `.rotated` style DSL) accepts Excel-UI-style
+ *   negative degrees and maps them onto this encoding.
  */
 final case class Align(
   horizontal: HAlign = HAlign.General,
   vertical: VAlign = VAlign.Bottom,
   wrapText: Boolean = false,
-  indent: Int = 0
+  indent: Int = 0,
+  textRotation: Int = 0
 ):
   require(indent >= 0, s"Indent must be non-negative, got: $indent")
+  require(
+    (textRotation >= 0 && textRotation <= 180) || textRotation == Align.VerticalTextRotation,
+    s"textRotation must be 0-180 or 255 (ST_TextRotation), got: $textRotation"
+  )
 
   def withHAlign(h: HAlign): Align = copy(horizontal = h)
   def withVAlign(v: VAlign): Align = copy(vertical = v)
   def withWrap(w: Boolean = true): Align = copy(wrapText = w)
   def withIndent(i: Int): Align = copy(indent = i)
+  def withRotation(deg: Int): Align = copy(textRotation = deg)
 
 object Align:
   val default: Align = Align()
+
+  /** ST_TextRotation sentinel for vertically stacked letters. */
+  val VerticalTextRotation: Int = 255
+
+  /**
+   * Normalize a user-facing rotation into a valid ST_TextRotation value (total, never throws).
+   *
+   * Excel-UI-style degrees are accepted: positive 1-90 rotates counter-clockwise (90 = straight
+   * up), negative -1 to -90 rotates clockwise and is encoded per OOXML as `90 + |deg|` (91-180),
+   * and 255 stacks letters vertically. Raw values 91-180 (the downward encoding) pass through
+   * unchanged; anything else is clamped to the nearest valid rotation.
+   */
+  def normalizeRotation(deg: Int): Int =
+    if deg == VerticalTextRotation then VerticalTextRotation
+    else
+      val clamped = math.max(-90, math.min(180, deg))
+      if clamped < 0 then 90 - clamped else clamped

--- a/xl-core/src/com/tjclp/xl/styles/cellstyle.scala
+++ b/xl-core/src/com/tjclp/xl/styles/cellstyle.scala
@@ -57,7 +57,7 @@ final case class CellStyle(
       s"B:${border.left},${border.right},${border.top},${border.bottom}"
     val numFmtKey = s"N:${numFmt}"
     val alignKey =
-      s"A:${align.horizontal},${align.vertical},${align.wrapText},${align.indent}"
+      s"A:${align.horizontal},${align.vertical},${align.wrapText},${align.indent},${align.textRotation}"
     s"$fontKey|$fillKey|$borderKey|$numFmtKey|$alignKey"
 
 object CellStyle:

--- a/xl-core/src/com/tjclp/xl/styles/dsl.scala
+++ b/xl-core/src/com/tjclp/xl/styles/dsl.scala
@@ -199,6 +199,18 @@ object dsl:
     inline def indent(n: Int): CellStyle =
       style.withAlign(style.align.withIndent(math.max(0, n)))
 
+    /**
+     * Set the text rotation (Excel's alignment `textRotation` attribute) — the rotated axis
+     * captions of sensitivity grids and tall merged header cells.
+     *
+     * Accepts Excel-UI-style degrees: positive 1-90 rotates counter-clockwise (90 = straight up),
+     * negative -1 to -90 rotates clockwise (encoded per OOXML ST_TextRotation as `90 + |deg|`), and
+     * 255 stacks letters vertically. Raw OOXML values 91-180 (the downward encoding) pass through
+     * unchanged; out-of-range values are clamped to the nearest valid rotation.
+     */
+    inline def rotated(deg: Int): CellStyle =
+      style.withAlign(style.align.withRotation(Align.normalizeRotation(deg)))
+
     // ========== Borders ==========
 
     /** Set all borders to thin */

--- a/xl-core/src/com/tjclp/xl/workbooks/CalcPr.scala
+++ b/xl-core/src/com/tjclp/xl/workbooks/CalcPr.scala
@@ -1,0 +1,24 @@
+package com.tjclp.xl.workbooks
+
+/**
+ * Workbook calculation properties: the iterative-calculation subset of `<calcPr>` (GH-373).
+ *
+ * Professional financial models are routinely circular by design (interest on average debt
+ * balances) and ship with iterative calculation enabled; a replica without it opens with circular
+ * warnings the original never shows. The model uses friendly names — OOXML CT_CalcPr spells the
+ * attributes `iterate` / `iterateCount` / `iterateDelta` and the codec maps between them. Unmodeled
+ * calcPr attributes (calcId, fullCalcOnLoad, refMode, ...) are preserved on write and never surface
+ * here.
+ *
+ * @param iterativeCalculation
+ *   True enables bounded iterative evaluation of circular references (`iterate="1"`)
+ * @param maxIterations
+ *   Iteration cap (`iterateCount`, Excel default 100 when absent)
+ * @param maxChange
+ *   Convergence threshold between iterations (`iterateDelta`, Excel default 0.001 when absent)
+ */
+final case class CalcPr(
+  iterativeCalculation: Boolean = false,
+  maxIterations: Option[Int] = None,
+  maxChange: Option[BigDecimal] = None
+)

--- a/xl-core/src/com/tjclp/xl/workbooks/Workbook.scala
+++ b/xl-core/src/com/tjclp/xl/workbooks/Workbook.scala
@@ -408,6 +408,35 @@ final case class Workbook(
     val newMetadata = metadata.copy(definedNames = others :+ dn)
     copy(metadata = newMetadata, sourceContext = sourceContext.map(_.markMetadataModified))
 
+  /**
+   * Set the workbook's iterative-calculation properties (GH-373), serialized as `<calcPr>`
+   * attributes (`iterate` / `iterateCount` / `iterateDelta`). Unmodeled calcPr attributes of a
+   * source file (calcId, fullCalcOnLoad, refMode, ...) ride through unchanged. Marks metadata
+   * modified so a surgical write regenerates workbook.xml instead of copying the source verbatim
+   * (which would silently drop the change — the GH-294 setActiveSheet precedent).
+   *
+   * Example (the circular-LBO shape: bounded iteration like Excel's UI defaults):
+   * {{{
+   * wb.withCalcPr(CalcPr(iterativeCalculation = true, maxIterations = Some(100), maxChange = Some(BigDecimal("0.001"))))
+   * }}}
+   */
+  def withCalcPr(calcPr: CalcPr): Workbook =
+    copy(
+      metadata = metadata.copy(calcPr = Some(calcPr)),
+      sourceContext = sourceContext.map(_.markMetadataModified)
+    )
+
+  /**
+   * Clear the modeled iterative-calculation settings (GH-373): the three iterate attributes are
+   * stripped from `<calcPr>` on write while unmodeled attributes (calcId, refMode, ...) survive.
+   * Marks metadata modified (see [[withCalcPr]]).
+   */
+  def removeCalcPr: Workbook =
+    copy(
+      metadata = metadata.copy(calcPr = None),
+      sourceContext = sourceContext.map(_.markMetadataModified)
+    )
+
   /** Remove a workbook-scoped defined name by identifier (GH-236). Marks metadata modified. */
   def removeDefinedName(name: String): Workbook =
     val newMetadata =

--- a/xl-core/src/com/tjclp/xl/workbooks/WorkbookMetadata.scala
+++ b/xl-core/src/com/tjclp/xl/workbooks/WorkbookMetadata.scala
@@ -14,6 +14,11 @@ import com.tjclp.xl.styles.color.ThemePalette
  *   Excel): date serials count days since 1904-01-01 instead of the default 1900 system (GH-243).
  *   Read from workbookPr and preserved on write; DateTime cells are serialized with the matching
  *   epoch (see `CellValue.dateTimeToExcelSerial(dt, date1904)`).
+ * @param calcPr
+ *   Iterative-calculation settings of `<calcPr>` (GH-373). None reflects a file whose calcPr
+ *   carries no iterate attributes (or has no calcPr at all); unmodeled calcPr attributes (calcId,
+ *   fullCalcOnLoad, refMode, ...) ride through on write either way. Author via
+ *   `Workbook.withCalcPr` so surgical writes see the change.
  */
 final case class WorkbookMetadata(
   creator: Option[String] = None,
@@ -25,5 +30,6 @@ final case class WorkbookMetadata(
   theme: ThemePalette = ThemePalette.office,
   definedNames: Vector[DefinedName] = Vector.empty,
   sheetStates: Map[SheetName, Option[String]] = Map.empty,
-  date1904: Boolean = false
+  date1904: Boolean = false,
+  calcPr: Option[CalcPr] = None
 )

--- a/xl-core/test/src/com/tjclp/xl/Generators.scala
+++ b/xl-core/test/src/com/tjclp/xl/Generators.scala
@@ -394,7 +394,13 @@ object Generators:
       v <- Gen.oneOf(VAlign.values.toIndexedSeq)
       wrap <- Gen.oneOf(true, false)
       indent <- Gen.frequency(3 -> Gen.const(0), 1 -> Gen.choose(1, 15))
-    yield Align(h, v, wrap, indent)
+      // ST_TextRotation: 0-180 (91-180 = downward encoding) or 255 (vertical stacked)
+      rotation <- Gen.frequency(
+        3 -> Gen.const(0),
+        1 -> Gen.choose(1, 180),
+        1 -> Gen.const(255)
+      )
+    yield Align(h, v, wrap, indent, rotation)
 
   /** Generate complete cell style (numFmtId left writer-assigned) */
   val genCellStyle: Gen[CellStyle] =

--- a/xl-core/test/src/com/tjclp/xl/PatchSpec.scala
+++ b/xl-core/test/src/com/tjclp/xl/PatchSpec.scala
@@ -7,13 +7,15 @@ import Generators.given
 import com.tjclp.xl.patch.Patch
 import com.tjclp.xl.patch.Patch.{*, given}
 import com.tjclp.xl.api.*
-import com.tjclp.xl.addressing.{ARef, CellRange, Column, Row, SheetName}
-import com.tjclp.xl.cells.{Cell, CellValue}
+import com.tjclp.xl.addressing.{ARef, CellRange, Column, RefType, Row, SheetName}
+import com.tjclp.xl.cells.{Cell, CellValue, Comment}
+import com.tjclp.xl.cf.{CfRule, ConditionalFormat}
 import com.tjclp.xl.codec.CellCodec.given
+import com.tjclp.xl.dsl.syntax.*
 import com.tjclp.xl.macros.ref
 // Removed: BatchPutMacro is dead code (shadowed by Sheet.put member)  // For batch put extension
 import com.tjclp.xl.sheets.syntax.*
-import com.tjclp.xl.styles.CellStyle
+import com.tjclp.xl.styles.{CellStyle, Dxf}
 import com.tjclp.xl.styles.color.Color
 import com.tjclp.xl.styles.fill.Fill
 import com.tjclp.xl.styles.font.Font
@@ -207,6 +209,98 @@ class PatchSpec extends ScalaCheckSuite:
     assertEquals(updated.getRowProperties(row), props)
   }
 
+  test("SetComment patch attaches a comment to a cell (GH-379)") {
+    val sheet = emptySheet.put(ref"A1", CellValue.Text("Revenue"))
+    val comment = Comment.plainText("Q1 2025 data", Some("Analyst"))
+    val patch = Patch.SetComment(ref"A1", comment)
+
+    val updated = Patch.applyPatch(sheet, patch)
+    assertEquals(updated.getComment(ref"A1"), Some(comment))
+  }
+
+  test("SetComment works on a cell with no value (comments live on Sheet.comments)") {
+    val patch = Patch.SetComment(ref"B2", Comment.plainText("provenance"))
+    val updated = Patch.applyPatch(emptySheet, patch)
+
+    assertEquals(updated.getComment(ref"B2").map(_.text.toPlainText), Some("provenance"))
+    assert(!updated.contains(ref"B2"), "SetComment must not materialize a cell")
+  }
+
+  test("SetConditionalFormat patch appends one CF block via Sheet.conditionalFormat (GH-379)") {
+    val rule = CfRule.expression("A1>10", Dxf.fill(Color.Rgb(0xffff0000)))
+    val patch = Patch.SetConditionalFormat(Vector(ref"A1:B10"), Vector(rule))
+
+    val updated = Patch.applyPatch(emptySheet, patch)
+    updated.conditionalFormats match
+      case Vector(ConditionalFormat.Rules(ranges, rules, _)) =>
+        assertEquals(ranges, Vector[CellRange](ref"A1:B10"))
+        assertEquals(rules.size, 1)
+      case other => fail(s"Expected one Rules block, got: $other")
+  }
+
+  test("SetConditionalFormat stamps auto priorities through the patch path (GH-379)") {
+    // Two AutoPriority rules in one patched block must come out stamped 1, 2 — the arm must
+    // route through Sheet.conditionalFormat (which owns allocation), not a raw copy.
+    val dxf = Dxf.fill(Color.Rgb(0xffffcc00))
+    val patch = Patch.SetConditionalFormat(
+      Vector(ref"A1:A10"),
+      Vector(CfRule.expression("A1>10", dxf), CfRule.expression("A1>20", dxf))
+    )
+
+    val updated = Patch.applyPatch(emptySheet, patch)
+    val priorities = updated.conditionalFormats.flatMap {
+      case ConditionalFormat.Rules(_, rules, _) => rules.flatMap(CfRule.priorityOf)
+      case _ => Vector.empty
+    }
+    assertEquals(priorities, Vector(1, 2))
+  }
+
+  // ========== DSL Tests (GH-379) ==========
+
+  test("ARef.comment DSL builds a SetComment patch") {
+    val comment = Comment.plainText("note", Some("Author"))
+    val patch = ref"C3".comment(comment)
+    assertEquals(patch, Patch.SetComment(ref"C3", comment): Patch)
+
+    val updated = Patch.applyPatch(emptySheet, patch)
+    assertEquals(updated.getComment(ref"C3"), Some(comment))
+  }
+
+  test("CellRange.conditionalFormat DSL builds a single-block SetConditionalFormat patch") {
+    val dxf = Dxf.fill(Color.Rgb(0xff00ff00))
+    val r1 = CfRule.expression("A1>1", dxf)
+    val r2 = CfRule.expression("A1>2", dxf)
+
+    val patch = ref"A1:A10".conditionalFormat(r1, r2)
+    assertEquals(
+      patch,
+      Patch.SetConditionalFormat(Vector[CellRange](ref"A1:A10"), Vector(r1, r2)): Patch
+    )
+  }
+
+  test("RefType comment and conditionalFormat mirror the ARef/CellRange DSL (runtime refs)") {
+    val comment = Comment.plainText("dynamic")
+    val dxf = Dxf.fill(Color.Rgb(0xff0000ff))
+    val rule = CfRule.expression("A1>5", dxf)
+
+    val cellRef: RefType = RefType.Cell(ref"A1")
+    val rangeRef: RefType = RefType.Range(ref"A1:B2")
+
+    assertEquals(cellRef.comment(comment), Patch.SetComment(ref"A1", comment): Patch)
+    // Comments anchor to a single cell; a range comment is meaningless and yields the empty patch
+    assertEquals(rangeRef.comment(comment), Patch.empty)
+
+    assertEquals(
+      rangeRef.conditionalFormat(rule),
+      Patch.SetConditionalFormat(Vector[CellRange](ref"A1:B2"), Vector(rule)): Patch
+    )
+    // A CF on a single cell is meaningful: it becomes a 1x1-range block
+    assertEquals(
+      cellRef.conditionalFormat(rule),
+      Patch.SetConditionalFormat(Vector(CellRange(ref"A1", ref"A1")), Vector(rule)): Patch
+    )
+  }
+
   test("Batch patch applies multiple patches in order") {
     val sheet = emptySheet
     val r1 = ARef.from1(1, 1)
@@ -291,6 +385,34 @@ class PatchSpec extends ScalaCheckSuite:
     val updated = Patch.applyPatch(sheet, patch)
 
     assertEquals(updated(ref).styleId, Some(StyleId(2)))
+  }
+
+  test("Later SetComment overrides earlier SetComment to same ref (last-wins, GH-379)") {
+    val first = Comment.plainText("first draft")
+    val second = Comment.plainText("final note")
+
+    val patch =
+      (Patch.SetComment(ref"A1", first): Patch) |+| (Patch.SetComment(ref"A1", second): Patch)
+    val updated = Patch.applyPatch(emptySheet, patch)
+
+    assertEquals(updated.getComment(ref"A1"), Some(second))
+  }
+
+  test("SetConditionalFormat patches append blocks under Batch composition (GH-379)") {
+    // CF authoring is append-only (Excel accepts multiple blocks); the second block's auto
+    // priorities continue above the first block's.
+    val dxf = Dxf.fill(Color.Rgb(0xffffcc00))
+    val p1 = Patch.SetConditionalFormat(Vector(ref"A1:A10"), Vector(CfRule.expression("A1>1", dxf)))
+    val p2 = Patch.SetConditionalFormat(Vector(ref"B1:B10"), Vector(CfRule.expression("B1>2", dxf)))
+
+    val updated = Patch.applyPatch(emptySheet, (p1: Patch) |+| (p2: Patch))
+    assertEquals(updated.conditionalFormats.size, 2)
+
+    val priorities = updated.conditionalFormats.flatMap {
+      case ConditionalFormat.Rules(_, rules, _) => rules.flatMap(CfRule.priorityOf)
+      case _ => Vector.empty
+    }
+    assertEquals(priorities, Vector(1, 2))
   }
 
   // ========== Extension Method Tests ==========

--- a/xl-core/test/src/com/tjclp/xl/StyleSpec.scala
+++ b/xl-core/test/src/com/tjclp/xl/StyleSpec.scala
@@ -135,7 +135,12 @@ class StyleSpec extends ScalaCheckSuite:
     v <- genVAlign
     wrap <- Gen.oneOf(true, false)
     indent <- Gen.choose(0, 10)
-  yield Align(h, v, wrap, indent)
+    rotation <- Gen.frequency(
+      3 -> Gen.const(0),
+      1 -> Gen.choose(1, 180),
+      1 -> Gen.const(255)
+    )
+  yield Align(h, v, wrap, indent, rotation)
 
   val genCellStyle: Gen[CellStyle] = for
     font <- genFont
@@ -425,6 +430,18 @@ class StyleSpec extends ScalaCheckSuite:
     assertNotEquals(indent0.canonicalKey, indent1.canonicalKey)
     assertNotEquals(indent1.canonicalKey, indent2.canonicalKey)
     assertNotEquals(indent0.canonicalKey, indent2.canonicalKey)
+  }
+
+  test("CellStyle.canonicalKey distinguishes styles differing only by textRotation (GH-380)") {
+    // Style dedup must account for textRotation: two styles that differ only by rotation
+    // would otherwise collapse to one xf in styles.xml, losing the rotation.
+    val flat = CellStyle.default.withAlign(Align(horizontal = HAlign.Left))
+    val up = CellStyle.default.withAlign(Align(horizontal = HAlign.Left, textRotation = 90))
+    val stacked = CellStyle.default.withAlign(Align(horizontal = HAlign.Left, textRotation = 255))
+
+    assertNotEquals(flat.canonicalKey, up.canonicalKey)
+    assertNotEquals(up.canonicalKey, stacked.canonicalKey)
+    assertNotEquals(flat.canonicalKey, stacked.canonicalKey)
   }
 
   property("CellStyle.canonicalKey: equal styles have equal keys") {

--- a/xl-core/test/src/com/tjclp/xl/addressing/ColumnSpec.scala
+++ b/xl-core/test/src/com/tjclp/xl/addressing/ColumnSpec.scala
@@ -1,0 +1,83 @@
+package com.tjclp.xl.addressing
+
+import com.tjclp.xl.Generators.given
+import munit.ScalaCheckSuite
+import org.scalacheck.Prop.*
+
+/**
+ * Runtime column parsing (GH-361): `Column.parse` is the discoverable runtime counterpart of the
+ * compile-time `ref` literal for scripts that compute column letters dynamically.
+ */
+class ColumnSpec extends ScalaCheckSuite:
+
+  // ========== Column.parse: bare letters ==========
+
+  test("parse accepts a bare letter"):
+    assertEquals(Column.parse("D"), Right(Column.from0(3)))
+
+  test("parse accepts multi-letter columns"):
+    assertEquals(Column.parse("AA"), Right(Column.from0(26)))
+    assertEquals(Column.parse("XFD"), Right(Column.from0(Column.MaxIndex0)))
+
+  test("parse is case-insensitive"):
+    assertEquals(Column.parse("d"), Right(Column.from0(3)))
+    assertEquals(Column.parse("aA"), Right(Column.from0(26)))
+
+  test("parse tolerates a trailing row number (full A1 refs work directly)"):
+    assertEquals(Column.parse("D1"), Right(Column.from0(3)))
+    assertEquals(Column.parse("xfd1048576"), Right(Column.from0(Column.MaxIndex0)))
+
+  // ========== Column.parse: rejections ==========
+
+  test("parse rejects empty input"):
+    assert(Column.parse("").isLeft)
+
+  test("parse rejects digits-only input"):
+    assert(Column.parse("12").isLeft)
+
+  test("parse rejects letters after the row digits"):
+    assert(Column.parse("D1D").isLeft)
+
+  test("parse rejects absolute anchors and other punctuation"):
+    assert(Column.parse("$D").isLeft)
+    assert(Column.parse("D$1").isLeft)
+    assert(Column.parse("D:D").isLeft)
+
+  test("parse rejects columns past XFD"):
+    assert(Column.parse("XFE").isLeft)
+    assert(Column.parse("ZZZZ").isLeft)
+
+  test("parse rejects non-ASCII letters and unicode digits"):
+    assert(Column.parse("Δ").isLeft)
+    assert(Column.parse("D١").isLeft) // Arabic-Indic digit is not a row number
+
+  // ========== fromLetter edge cases (sibling of parse) ==========
+
+  test("fromLetter rejects empty, mixed, and overflow inputs"):
+    assert(Column.fromLetter("").isLeft)
+    assert(Column.fromLetter("D1").isLeft) // strict: letters only
+    assert(Column.fromLetter("XFE").isLeft)
+    assertEquals(Column.fromLetter("xfd"), Right(Column.from0(Column.MaxIndex0)))
+
+  // ========== Laws ==========
+
+  property("parse . toLetter = Right (round-trip for every valid column)") {
+    forAll { (col: Column) =>
+      assertEquals(Column.parse(col.toLetter), Right(col))
+      true
+    }
+  }
+
+  property("parse tolerates any appended 1-based row number") {
+    forAll { (col: Column, row: Row) =>
+      assertEquals(Column.parse(s"${col.toLetter}${row.index1}"), Right(col))
+      true
+    }
+  }
+
+  property("parse agrees with fromLetter on letters-only input") {
+    forAll { (col: Column) =>
+      assertEquals(Column.parse(col.toLetter), Column.fromLetter(col.toLetter))
+      true
+    }
+  }

--- a/xl-core/test/src/com/tjclp/xl/addressing/RefTypeSpec.scala
+++ b/xl-core/test/src/com/tjclp/xl/addressing/RefTypeSpec.scala
@@ -80,6 +80,29 @@ class RefTypeSpec extends ScalaCheckSuite:
     }
   }
 
+  // ========== Column handle (GH-361) ==========
+
+  property("col is total: the cell's column, or the range's starting column") {
+    forAll { (rt: RefType) =>
+      val expected = rt match
+        case RefType.Cell(ref) => ref.col
+        case RefType.QualifiedCell(_, ref) => ref.col
+        case RefType.Range(range) => range.start.col
+        case RefType.QualifiedRange(_, range) => range.start.col
+      assertEquals(rt.col, expected)
+      true
+    }
+  }
+
+  test("col on a parsed runtime ref recovers the column") {
+    RefType.parse("D7") match
+      case Right(rt) => assertEquals(rt.col.toLetter, "D")
+      case Left(err) => fail(s"Failed to parse D7: $err")
+    RefType.parse("Sales!C2:E9") match
+      case Right(rt) => assertEquals(rt.col.toLetter, "C")
+      case Left(err) => fail(s"Failed to parse Sales!C2:E9: $err")
+  }
+
   // ========== Parsing Tests ==========
 
   test("Parse simple cell: A1") {

--- a/xl-core/test/src/com/tjclp/xl/sheets/DataValidationSpec.scala
+++ b/xl-core/test/src/com/tjclp/xl/sheets/DataValidationSpec.scala
@@ -1,0 +1,130 @@
+package com.tjclp.xl.sheets
+
+import com.tjclp.xl.{*, given}
+import com.tjclp.xl.addressing.CellRange
+import munit.FunSuite
+
+/**
+ * GH-375: typed data-validation model — factories, Sheet authoring API, and structural shifts (the
+ * conditionalFormats clamp/split/drop algebra: without it, dropdowns detach from their cells on
+ * row/column insert or delete).
+ */
+class DataValidationSpec extends FunSuite:
+
+  // ===== factories =====
+
+  test("list stores the formula verbatim (inline quoted list or range reference)") {
+    assertEquals(
+      DataValidation.list("\"Low,Med,High\""),
+      DataValidation.Rules(Vector.empty, DvKind.List("\"Low,Med,High\""))
+    )
+    assertEquals(
+      DataValidation.list("$Z$1:$Z$3", allowBlank = false, showDropdown = false),
+      DataValidation.Rules(
+        Vector.empty,
+        DvKind.List("$Z$1:$Z$3"),
+        allowBlank = false,
+        showDropdown = false
+      )
+    )
+  }
+
+  test("listOf quotes inline values and doubles embedded quotes") {
+    assertEquals(
+      DataValidation.listOf("Yes", "No").kind,
+      DvKind.List("\"Yes,No\"")
+    )
+    assertEquals(
+      DataValidation.listOf("say \"hi\"").kind,
+      DvKind.List("\"say \"\"hi\"\"\"")
+    )
+  }
+
+  // ===== Sheet authoring =====
+
+  test("withDataValidation appends one entry with the given range") {
+    val s = Sheet("DV")
+      .withDataValidation(ref"B2:B10", DataValidation.listOf("1", "2", "3"))
+      .withDataValidation(ref"C2:C10", DataValidation.list("$Z$1:$Z$3"))
+    assertEquals(s.dataValidations.size, 2)
+    assertEquals(
+      s.dataValidations(0),
+      DataValidation.Rules(Vector(ref"B2:B10": CellRange), DvKind.List("\"1,2,3\""))
+    )
+    assertEquals(
+      s.dataValidations(1),
+      DataValidation.Rules(Vector(ref"C2:C10": CellRange), DvKind.List("$Z$1:$Z$3"))
+    )
+  }
+
+  test("withDataValidation multi-range variant keeps one entry; empty ranges are identity") {
+    val s = Sheet("DV").withDataValidation(
+      Vector(ref"A1:A5": CellRange, ref"C1:C5": CellRange),
+      DataValidation.listOf("a", "b")
+    )
+    assertEquals(s.dataValidations.size, 1)
+    assertEquals(s.typedDataValidations.map(_.ranges.map(_.toA1)), Vector(Vector("A1:A5", "C1:C5")))
+    assertEquals(
+      Sheet("DV").withDataValidation(Vector.empty, DataValidation.listOf("a")),
+      Sheet("DV")
+    )
+  }
+
+  test("removeDataValidation mirrors removeConditionalFormat (identity out of range)") {
+    val s = Sheet("DV")
+      .withDataValidation(ref"A1:A5", DataValidation.listOf("x"))
+      .withDataValidation(ref"B1:B5", DataValidation.listOf("y"))
+    assertEquals(s.removeDataValidation(0).dataValidations.size, 1)
+    assertEquals(
+      s.removeDataValidation(0).dataValidations(0),
+      s.dataValidations(1)
+    )
+    assertEquals(s.removeDataValidation(7), s)
+    assertEquals(s.removeDataValidation(-1), s)
+  }
+
+  test("typedDataValidations excludes Preserved entries") {
+    val s = Sheet("DV")
+      .copy(dataValidations = Vector(DataValidation.Preserved("<dataValidation/>")))
+      .withDataValidation(ref"A1:A2", DataValidation.listOf("x"))
+    assertEquals(s.dataValidations.size, 2)
+    assertEquals(s.typedDataValidations.size, 1)
+  }
+
+  // ===== structural shifts (the mergedRanges/cf clamp/split/drop algebra) =====
+
+  private def dvRanges(s: Sheet): Vector[Vector[String]] =
+    s.typedDataValidations.map(_.ranges.map(_.toA1))
+
+  test("insertRows shifts validation ranges below the cut (dropdowns stay attached)") {
+    val s = Sheet("DV").withDataValidation(ref"B2:B4", DataValidation.listOf("1", "2"))
+    assertEquals(dvRanges(s.insertRows(at = 0, count = 2)), Vector(Vector("B4:B6")))
+  }
+
+  test("deleteRows clamps a validation range spanning the cut") {
+    val s = Sheet("DV").withDataValidation(ref"A1:A4", DataValidation.listOf("x"))
+    assertEquals(dvRanges(s.deleteRows(at = 1, count = 2)), Vector(Vector("A1:A2")))
+  }
+
+  test("deleteColumns drops a fully-deleted range and removes an emptied entry") {
+    val s = Sheet("DV")
+      .withDataValidation(ref"B1:B5", DataValidation.listOf("x"))
+      .withDataValidation(
+        Vector(ref"B2:B3": CellRange, ref"D2:D3": CellRange),
+        DataValidation.listOf("y")
+      )
+    val r = s.deleteColumns(at = 1, count = 1) // delete column B
+    // first entry: only range fully deleted -> whole entry removed
+    // second entry: B2:B3 dropped, D2:D3 -> C2:C3
+    assertEquals(dvRanges(r), Vector(Vector("C2:C3")))
+  }
+
+  test("structural shifts leave Preserved entries untouched") {
+    val preserved = DataValidation.Preserved("""<dataValidation type="whole" sqref="Z9"/>""")
+    val s = Sheet("DV")
+      .copy(dataValidations = Vector(preserved))
+      .withDataValidation(ref"A2:A4", DataValidation.listOf("x"))
+    val r = s.insertRows(at = 0, count = 1)
+    assertEquals(r.dataValidations(0), preserved)
+    assertEquals(dvRanges(r), Vector(Vector("A3:A5")))
+  }

--- a/xl-core/test/src/com/tjclp/xl/styles/StyleDslSpec.scala
+++ b/xl-core/test/src/com/tjclp/xl/styles/StyleDslSpec.scala
@@ -217,6 +217,41 @@ class StyleDslSpec extends ScalaCheckSuite:
     assertEquals(style.align, Align.default)
   }
 
+  // ========== Text Rotation Tests (GH-380) ==========
+
+  test("rotated sets alignment textRotation") {
+    val style = CellStyle.default.rotated(90)
+    assertEquals(style.align.textRotation, 90)
+  }
+
+  test("rotated preserves other alignment properties") {
+    val style = CellStyle.default.left.wrap.rotated(45)
+    assertEquals(style.align.horizontal, HAlign.Left)
+    assert(style.align.wrapText)
+    assertEquals(style.align.textRotation, 45)
+  }
+
+  test("rotated maps Excel-UI negative degrees to the OOXML downward encoding") {
+    // Excel UI -45 (45 degrees clockwise, slanting down) is ST_TextRotation 90 + 45 = 135
+    assertEquals(CellStyle.default.rotated(-45).align.textRotation, 135)
+    assertEquals(CellStyle.default.rotated(-90).align.textRotation, 180)
+  }
+
+  test("rotated(255) sets vertical stacked text") {
+    assertEquals(CellStyle.default.rotated(255).align.textRotation, 255)
+  }
+
+  test("rotated clamps out-of-range values (total, never throws)") {
+    assertEquals(CellStyle.default.rotated(200).align.textRotation, 180)
+    assertEquals(CellStyle.default.rotated(-120).align.textRotation, 180)
+  }
+
+  test("rotated(0) clears an existing rotation") {
+    val style = CellStyle.default.rotated(90).rotated(0)
+    assertEquals(style.align.textRotation, 0)
+    assertEquals(style.align, Align.default)
+  }
+
   // ========== Border Tests ==========
 
   test("bordered sets all borders to thin") {

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/Workbook.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/Workbook.scala
@@ -11,7 +11,7 @@ private val defaultWorkbookScope =
   NamespaceBinding(null, nsSpreadsheetML, NamespaceBinding("r", nsRelationships, TopScope))
 import com.tjclp.xl.addressing.SheetName
 import com.tjclp.xl.api.Workbook
-import com.tjclp.xl.workbooks.DefinedName
+import com.tjclp.xl.workbooks.{CalcPr, DefinedName}
 
 /**
  * Sheet reference in workbook.xml
@@ -81,6 +81,9 @@ case class OoxmlWorkbook(
    * serials then count days since 1904-01-01 instead of the default 1900 system.
    */
   def date1904: Boolean = OoxmlWorkbook.parseDate1904(workbookPr)
+
+  /** The typed iterative-calculation settings of the raw `<calcPr>` element (GH-373). */
+  def calcPrSettings: Option[CalcPr] = OoxmlWorkbook.parseCalcPr(calcPr)
 
   /**
    * Overlay the model's active tab onto the bookViews element (GH-294, model wins). See
@@ -267,7 +270,8 @@ object OoxmlWorkbook extends XmlReadable[OoxmlWorkbook]:
           .withActiveTab(clampActiveTab(wb.activeSheetIndex, wb.sheets.size))
           .copy(
             workbookPr = reconcileDate1904(p.workbookPr, wb.metadata.date1904),
-            definedNames = reconcileDefinedNames(p.definedNames, PrintNames.effective(wb))
+            definedNames = reconcileDefinedNames(p.definedNames, PrintNames.effective(wb)),
+            calcPr = reconcileCalcPr(p.calcPr, wb.metadata.calcPr)
           )
       case None =>
         val sheetRefs = wb.sheets.zipWithIndex.map { case (sheet, idx) =>
@@ -288,7 +292,10 @@ object OoxmlWorkbook extends XmlReadable[OoxmlWorkbook]:
           workbookPr = workbookPr,
           // GH-294: fresh workbooks always ship bookViews/activeTab (Excel always writes bookViews)
           bookViews = buildBookViews(None, clampActiveTab(wb.activeSheetIndex, wb.sheets.size)),
-          definedNames = buildDefinedNames(PrintNames.effective(wb))
+          definedNames = buildDefinedNames(PrintNames.effective(wb)),
+          // GH-373: scratch builds emit authored iterative-calculation settings (no calcId needed,
+          // the LibreOffice precedent)
+          calcPr = reconcileCalcPr(None, wb.metadata.calcPr)
         )
 
   /**
@@ -315,6 +322,56 @@ object OoxmlWorkbook extends XmlReadable[OoxmlWorkbook]:
         case (Some(pr), false) => Some(pr.copy(attributes = pr.attributes.remove("date1904")))
         case (None, true) => Some(elem("workbookPr", "date1904" -> "1")())
         case (None, false) => None
+
+  /**
+   * Parse the iterative-calculation attributes of a raw `<calcPr>` element (GH-373). OOXML
+   * CT_CalcPr spells them `iterate` / `iterateCount` / `iterateDelta`; the model uses friendly
+   * names. Some only when at least one of the three attributes is present — a calcPr carrying only
+   * unmodeled attributes (calcId, refMode, ...) parses to None and rides through on write. Lenient:
+   * malformed numeric values contribute no field (a read must never fail on them).
+   */
+  def parseCalcPr(calcPr: Option[Elem]): Option[CalcPr] =
+    calcPr.flatMap { e =>
+      val attrs = e.attributes.asAttrMap
+      val iterate = attrs.get("iterate")
+      val iterateCount = attrs.get("iterateCount")
+      val iterateDelta = attrs.get("iterateDelta")
+      Option.when(iterate.isDefined || iterateCount.isDefined || iterateDelta.isDefined)(
+        CalcPr(
+          iterativeCalculation = iterate.exists(v => v == "1" || v == "true"),
+          maxIterations = iterateCount.flatMap(_.toIntOption),
+          maxChange = iterateDelta.flatMap(s => scala.util.Try(BigDecimal(s.trim)).toOption)
+        )
+      )
+    }
+
+  /**
+   * Reconcile the `<calcPr>` iterative-calculation attributes with the model (model wins, GH-373 —
+   * the reconcileDate1904 pattern) while every unmodeled preserved attribute (calcId,
+   * fullCalcOnLoad, refMode, ...) rides through. Byte-identical when the model agrees with the
+   * preserved spelling; a fresh element is built when nothing is preserved (no calcId needed — the
+   * LibreOffice precedent). A model of None strips the three modeled attributes and keeps the rest.
+   */
+  def reconcileCalcPr(preservedPr: Option[Elem], model: Option[CalcPr]): Option[Elem] =
+    if parseCalcPr(preservedPr) == model then preservedPr
+    else
+      val modelAttrs: Seq[(String, String)] = model.toList.flatMap { cp =>
+        (if cp.iterativeCalculation then List("iterate" -> "1") else Nil) ++
+          cp.maxIterations.map(n => "iterateCount" -> n.toString).toList ++
+          cp.maxChange.map(d => "iterateDelta" -> d.toString).toList
+      }
+      preservedPr match
+        case None =>
+          // model must be Some here (the equal-guard covers None/None); an all-default CalcPr
+          // carries no attributes and emits nothing
+          if modelAttrs.isEmpty then None else Some(elem("calcPr", modelAttrs*)())
+        case Some(pr) =>
+          val stripped =
+            pr.attributes.remove("iterate").remove("iterateCount").remove("iterateDelta")
+          val overlaid = modelAttrs.foldRight(stripped) { case ((k, v), acc) =>
+            new UnprefixedAttribute(k, v, acc)
+          }
+          Some(pr.copy(attributes = overlaid))
 
   /** Clamp an active-tab index into [0, sheetCount-1] (write side; the reader clamps too). */
   def clampActiveTab(index: Int, sheetCount: Int): Int =

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/XlsxReader.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/XlsxReader.scala
@@ -472,6 +472,7 @@ object XlsxReader:
         sheetStates,
         commentPathMapping,
         date1904 = ooxmlWb.date1904,
+        calcPr = ooxmlWb.calcPrSettings,
         activeSheetIndex = activeSheetIndex,
         docProps,
         drawingPathMapping = parsedSheets.drawingPathMapping,
@@ -1308,6 +1309,8 @@ object XlsxReader:
    *   "xl/comments1.xml")
    * @param date1904
    *   True when workbookPr declares the 1904 date system (GH-243)
+   * @param calcPr
+   *   Iterative-calculation settings parsed from `<calcPr>` (GH-373)
    * @param activeSheetIndex
    *   Active tab parsed from bookViews, already clamped to the sheet count (GH-294)
    * @param docProps
@@ -1325,6 +1328,7 @@ object XlsxReader:
     sheetStates: Map[SheetName, Option[String]],
     commentPathMapping: Map[SheetName, String],
     date1904: Boolean,
+    calcPr: Option[com.tjclp.xl.workbooks.CalcPr],
     activeSheetIndex: Int,
     docProps: DocProps.Data,
     drawingPathMapping: Map[SheetName, String],
@@ -1374,7 +1378,8 @@ object XlsxReader:
           theme = theme,
           definedNames = remainingNames,
           sheetStates = sheetStates,
-          date1904 = date1904
+          date1904 = date1904,
+          calcPr = calcPr
         )
       sourceContextEither.map(ctx =>
         Workbook(

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/XlsxReader.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/XlsxReader.scala
@@ -1067,6 +1067,11 @@ object XlsxReader:
     val conditionalFormats =
       com.tjclp.xl.ooxml.worksheet.CfCodec.parseAll(ooxmlSheet.conditionalFormatting, styles.dxfs)
 
+    // Parse data validations into the typed model (GH-375). Total: unmodeled entries ride
+    // through Preserved, so read→edit→write keeps them on rewritten sheets.
+    val dataValidations =
+      com.tjclp.xl.ooxml.worksheet.DataValidationCodec.parseAll(ooxmlSheet.dataValidations)
+
     Right(
       Sheet(
         name = name,
@@ -1082,7 +1087,8 @@ object XlsxReader:
         viewSettings = viewSettings,
         drawings = drawings,
         conditionalFormats = conditionalFormats,
-        tabColor = tabColor
+        tabColor = tabColor,
+        dataValidations = dataValidations
       )
     )
 

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/XlsxWriter.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/XlsxWriter.scala
@@ -1406,6 +1406,32 @@ object XlsxWriter:
     CfWritePlan(condFmt, dxfPlan.merged)
 
   /**
+   * Pre-pass for the data-validation slot (GH-375, the planCfWrites contract): per regenerated
+   * sheet, CLEAN (reparse of the preserved container equals the model — pass the source element
+   * through verbatim, zero trust regression) or DIRTY (emit from the model via DataValidationCodec,
+   * overlaying unmodeled container attributes of the source). A cleared model compares dirty and
+   * emits nothing (no resurrection).
+   */
+  private def planDvWrites(
+    workbook: Workbook,
+    sheetsToRegenerate: Set[Int],
+    preservedWorksheets: Map[Int, XLResult[Option[OoxmlWorksheet]]]
+  ): Map[Int, Option[Elem]] =
+    import com.tjclp.xl.ooxml.worksheet.DataValidationCodec
+    sheetsToRegenerate.toVector.sorted
+      .flatMap(idx => workbook.sheets.lift(idx).map(idx -> _))
+      .map { case (idx, sheet) =>
+        val sourceDv: Option[Elem] =
+          preservedWorksheets.get(idx).flatMap(_.toOption).flatten.flatMap(_.dataValidations)
+        sourceDv match
+          case Some(src) if DataValidationCodec.parseAll(Some(src)) == sheet.dataValidations =>
+            idx -> Some(src)
+          case _ if sheet.dataValidations.isEmpty => idx -> None
+          case _ => idx -> DataValidationCodec.toElem(sheet.dataValidations, sourceDv)
+      }
+      .toMap
+
+  /**
    * Unified write: intelligently regenerates only what changed, preserves the rest.
    *
    * Strategy:
@@ -1626,6 +1652,10 @@ object XlsxWriter:
     // GH-136: plan conditional-formatting emission + dxf-table merge BEFORE writeStyles —
     // styles.xml is written before the sheet loop, so dxf indices must be assigned up front.
     val cfPlan = planCfWrites(workbook, sheetsToRegenerate, preservedWorksheets, preservedDxfs)
+
+    // GH-375: plan the per-sheet data-validation slot (clean → verbatim source container,
+    // dirty/fresh → DataValidationCodec emission)
+    val dvPlan = planDvWrites(workbook, sheetsToRegenerate, preservedWorksheets)
 
     val styles =
       OoxmlStyles(styleIndex, preservedStylesAttrs, preservedStylesScope, cfPlan.mergedDxfs)
@@ -2033,9 +2063,11 @@ object XlsxWriter:
           // (bypasses intermediate OOXML types for 5-7x performance improvement).
           // GH-221: sheets with drawings force the OoxmlWorksheet path — DirectSaxEmitter has no
           // <drawing> support yet (deferred). GH-136: same for conditional formats.
+          // GH-375: same for data validations.
           (config.backend, preservedMetadata) match
             case (XmlBackend.SaxStax, None)
-                if sheet.drawings.isEmpty && sheet.conditionalFormats.isEmpty =>
+                if sheet.drawings.isEmpty && sheet.conditionalFormats.isEmpty &&
+                  sheet.dataValidations.isEmpty =>
               writeWorksheetDirect(
                 zip,
                 sheetOutputPaths(idx),
@@ -2056,7 +2088,8 @@ object XlsxWriter:
                   tablePartsXml,
                   escapeFormulas,
                   drawingPlan.drawingRefs.get(idx),
-                  condFmt = Some(cfPlan.condFmtBySheet.getOrElse(idx, Seq.empty))
+                  condFmt = Some(cfPlan.condFmtBySheet.getOrElse(idx, Seq.empty)),
+                  dataValidations = Some(dvPlan.getOrElse(idx, None))
                 )
               writeWorksheet(zip, sheetOutputPaths(idx), ooxmlSheet, config)
 

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/style/StyleParser.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/style/StyleParser.scala
@@ -250,12 +250,20 @@ object WorkbookStyles:
           .flatMap(attr => attr.text.toIntOption)
           .filter(_ >= 0)
           .getOrElse(Align.default.indent)
+        // ST_TextRotation admits 0-180 plus 255 (vertical stacked); drop anything else from
+        // malformed files so the parser stays total (Align requires the same range)
+        val textRotation = alignElem
+          .attribute("textRotation")
+          .flatMap(attr => attr.text.toIntOption)
+          .filter(v => (v >= 0 && v <= 180) || v == Align.VerticalTextRotation)
+          .getOrElse(Align.default.textRotation)
         Some(
           Align(
             horizontal = horizontal.getOrElse(Align.default.horizontal),
             vertical = vertical.getOrElse(Align.default.vertical),
             wrapText = wrap,
-            indent = indent
+            indent = indent,
+            textRotation = textRotation
           )
         )
       case Some(_) => None

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/style/StyleSerializer.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/style/StyleSerializer.scala
@@ -353,7 +353,7 @@ final case class OoxmlStyles(
    * REQUIRES: align is valid Align instance ENSURES:
    *   - Returns None if align == Align.default (optimization)
    *   - Returns Some(<alignment .../>) if any property differs from default
-   *   - Only emits non-default attributes (horizontal, vertical, wrapText, indent)
+   *   - Only emits non-default attributes (horizontal, vertical, wrapText, indent, textRotation)
    *   - Attribute values match OOXML spec enum names (lowercase)
    *   - VAlign.Middle serializes as "center" per OOXML spec
    *   - wrapText serializes as "1" (true) or "0" (false)
@@ -390,6 +390,9 @@ final case class OoxmlStyles(
 
       if align.indent != Align.default.indent then attrs += ("indent" -> align.indent.toString)
 
+      if align.textRotation != Align.default.textRotation then
+        attrs += ("textRotation" -> align.textRotation.toString)
+
       val attrSeq = attrs.result()
       // If no attributes, don't emit element (though this shouldn't happen since align != default)
       if attrSeq.isEmpty then None
@@ -417,6 +420,9 @@ final case class OoxmlStyles(
           attrs += ("wrapText" -> (if align.wrapText then "1" else "0"))
 
         if align.indent != Align.default.indent then attrs += ("indent" -> align.indent.toString)
+
+        if align.textRotation != Align.default.textRotation then
+          attrs += ("textRotation" -> align.textRotation.toString)
 
         val attrSeq = attrs.result()
         if attrSeq.nonEmpty then

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/CfCodec.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/CfCodec.scala
@@ -76,15 +76,16 @@ object CfCodec:
    * WorksheetReader hoists used prefixes onto the block root and cleans descendant scopes, so a
    * RULE captured in isolation must resolve x14/xm (the dataBar extLst pairing) against its parent
    * block's scope or the stored payload is unbound XML that parsePreserved silently drops at dirty
-   * emission.
+   * emission. Shared with DataValidationCodec (GH-375), which captures entries below a rebound
+   * container the same way.
    */
-  private def preservedXml(e: Elem, inheritedScope: NamespaceBinding): String =
+  private[worksheet] def preservedXml(e: Elem, inheritedScope: NamespaceBinding): String =
     XmlUtil.compact(rebindUsedNamespaces(e, includeDefault = true, inheritedScope))
 
-  private def attrKeys(e: Elem): Set[String] = e.attributes.asAttrMap.keySet
+  private[worksheet] def attrKeys(e: Elem): Set[String] = e.attributes.asAttrMap.keySet
 
   /** Element children; Left when any non-whitespace non-element content is present. */
-  private def childElems(e: Elem): Either[Unit, Vector[Elem]] =
+  private[worksheet] def childElems(e: Elem): Either[Unit, Vector[Elem]] =
     val nonWs = e.child.filterNot {
       case Text(t) => t.forall(_.isWhitespace)
       case _ => false
@@ -92,7 +93,7 @@ object CfCodec:
     val elems = nonWs.collect { case c: Elem => c }.toVector
     if elems.sizeIs == nonWs.size then Right(elems) else Left(())
 
-  private def parseBool(value: String): Option[Boolean] = value match
+  private[worksheet] def parseBool(value: String): Option[Boolean] = value match
     case "1" | "true" => Some(true)
     case "0" | "false" => Some(false)
     case _ => None
@@ -114,7 +115,7 @@ object CfCodec:
     typed.getOrElse(ConditionalFormat.Preserved(preservedXml(block, TopScope)))
 
   /** Space-split sqref; a single-cell token becomes a 1×1 range. None on any corrupt token. */
-  private def parseSqref(sqref: String): Option[Vector[CellRange]] =
+  private[worksheet] def parseSqref(sqref: String): Option[Vector[CellRange]] =
     val tokens = sqref.trim.split("\\s+").toVector.filter(_.nonEmpty)
     if tokens.isEmpty then None
     else

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/DataValidationCodec.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/DataValidationCodec.scala
@@ -1,0 +1,99 @@
+package com.tjclp.xl.ooxml.worksheet
+
+import scala.xml.*
+
+import com.tjclp.xl.ooxml.{XmlSecurity, XmlUtil}
+import com.tjclp.xl.ooxml.XmlUtil.{elem, elemOrdered}
+import com.tjclp.xl.sheets.{DataValidation, DvKind}
+
+/**
+ * Total data-validation codec (GH-375): the `<dataValidations>` container ↔ the typed
+ * [[DataValidation]] model — the CfCodec contract applied to validations.
+ *
+ * Parse is TOTAL: an entry outside the typed subset (any type other than `list`, operators,
+ * prompt/error messages, formula2, unknown attrs/children) falls back to
+ * [[DataValidation.Preserved]] whose payload is scope-self-contained canonical XML re-emitted
+ * verbatim. THE INVERSION: the OOXML attribute `showDropDown="1"` SUPPRESSES the in-cell dropdown;
+ * the friendly model field `showDropdown` is its negation, so the attribute is emitted only when
+ * the model says false.
+ *
+ * Unlike conditional formatting (one element per block), OOXML allows a single
+ * `<dataValidations count="N">` container: emission always regenerates ONE container holding typed
+ * emissions and Preserved payloads together, overlaying `count` while any unmodeled container
+ * attributes of the source (disablePrompts, xWindow, ...) ride through via `base`.
+ */
+object DataValidationCodec:
+
+  private val typedAttrs = Set("type", "sqref", "allowBlank", "showDropDown")
+
+  // ===== parse =====
+
+  /** Parse the (single) `<dataValidations>` container (total — never fails the read). */
+  def parseAll(container: Option[Elem]): Vector[DataValidation] =
+    container.toList.toVector.flatMap { dvs =>
+      dvs.child.collect { case e: Elem => e }.map(parseEntry(_, dvs.scope))
+    }
+
+  /** Per-entry typed parse with the list-family whitelist; falls back to Preserved. */
+  private def parseEntry(entry: Elem, containerScope: NamespaceBinding): DataValidation =
+    val typed: Option[DataValidation.Rules] =
+      for
+        _ <- Option.when(entry.label == "dataValidation")(())
+        _ <- Option.when(CfCodec.attrKeys(entry).subsetOf(typedAttrs))(())
+        _ <- Option.when(entry.attribute("type").map(_.text).contains("list"))(())
+        sqref <- entry.attribute("sqref").map(_.text)
+        ranges <- CfCodec.parseSqref(sqref)
+        allowBlank <- entry.attribute("allowBlank").map(_.text) match
+          case None => Some(false) // OOXML schema default
+          case Some(v) => CfCodec.parseBool(v)
+        suppressDropdown <- entry.attribute("showDropDown").map(_.text) match
+          case None => Some(false) // absent attr = dropdown SHOWN
+          case Some(v) => CfCodec.parseBool(v)
+        children <- CfCodec.childElems(entry).toOption
+        formula <- children match
+          case Vector(f1) if f1.label == "formula1" =>
+            Some(XmlUtil.getTextPreservingWhitespace(f1))
+          case _ => None
+      yield DataValidation.Rules(
+        ranges,
+        DvKind.List(formula),
+        allowBlank = allowBlank,
+        showDropdown = !suppressDropdown
+      )
+    typed.getOrElse(DataValidation.Preserved(CfCodec.preservedXml(entry, containerScope)))
+
+  // ===== emission =====
+
+  /**
+   * Canonical emission: ONE `<dataValidations count="N">` container with entries in vector order
+   * (typed emissions and Preserved payloads together); None when nothing emits. Empty-ranges typed
+   * entries are dropped (unexpressible in OOXML); a Preserved payload that fails to re-parse drops
+   * silently (the CfCodec contract). `base` carries the preserved source container so unmodeled
+   * container attributes ride through a dirty write; `count` is always restamped.
+   */
+  def toElem(dvs: Vector[DataValidation], base: Option[Elem]): Option[Elem] =
+    val children: Vector[Elem] = dvs.flatMap {
+      case DataValidation.Rules(ranges, kind, allowBlank, showDropdown) if ranges.nonEmpty =>
+        kind match
+          case DvKind.List(formula) =>
+            val attrs = Seq("type" -> "list") ++
+              (if allowBlank then Seq("allowBlank" -> "1") else Seq.empty) ++
+              // THE INVERSION: showDropDown="1" suppresses the dropdown
+              (if showDropdown then Seq.empty else Seq("showDropDown" -> "1")) ++
+              Seq("sqref" -> ranges.map(_.toA1).mkString(" "))
+            Some(elemOrdered("dataValidation", attrs*)(elem("formula1")(Text(formula))))
+      case _: DataValidation.Rules => None
+      case DataValidation.Preserved(xml) => parsePreserved(xml)
+    }
+    Option.when(children.nonEmpty) {
+      val baseAttrs = base.map(_.attributes.remove("count")).getOrElse(Null)
+      val attrs = new UnprefixedAttribute("count", children.size.toString, baseAttrs)
+      base match
+        case Some(b) => b.copy(attributes = attrs, child = children)
+        case None =>
+          Elem(null, "dataValidations", attrs, TopScope, minimizeEmpty = false, children*)
+    }
+
+  /** Preserved payloads re-parse to Elems; a non-canonical hand-built payload drops silently. */
+  private def parsePreserved(xml: String): Option[Elem] =
+    XmlSecurity.parseSafe(xml, "preserved data validation").toOption

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/OoxmlWorksheet.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/OoxmlWorksheet.scala
@@ -60,6 +60,9 @@ case class OoxmlWorksheet(
   sheetFormatPr: Option[Elem] = None,
   cols: Option[Elem] = None,
   conditionalFormatting: Seq[Elem] = Seq.empty,
+  // GH-375: the single <dataValidations> container (modeled — emitted between
+  // conditionalFormatting and the preserved hyperlinks, its ECMA-376 18.3.1.99 slot)
+  dataValidations: Option[Elem] = None,
   printOptions: Option[Elem] = None,
   rowBreaks: Option[Elem] = None,
   colBreaks: Option[Elem] = None,
@@ -112,7 +115,8 @@ case class OoxmlWorksheet(
       oleObjects,
       controls,
       tableParts,
-      extLst
+      extLst,
+      dataValidations
     ).flatten ++ conditionalFormatting ++
       preservedKnown.toSeq.sortBy(_._1).map(_._2) ++ otherElements
 
@@ -173,7 +177,8 @@ case class OoxmlWorksheet(
 
       conditionalFormatting.foreach(writer.writeElem)
 
-      // GH-232: dataValidations, hyperlinks (after conditionalFormatting)
+      // GH-375: dataValidations (modeled), then GH-232: hyperlinks (schema order)
+      dataValidations.foreach(writer.writeElem)
       preservedAfterCondFmt.foreach(l => preservedKnown.get(l).foreach(writer.writeElem))
 
       printOptions.foreach(writer.writeElem)
@@ -245,7 +250,8 @@ case class OoxmlWorksheet(
     // Conditional formatting (multiple allowed)
     conditionalFormatting.foreach(e => children += cleanNamespaces(e))
 
-    // GH-232: dataValidations, hyperlinks (after conditionalFormatting)
+    // GH-375: dataValidations (modeled), then GH-232: hyperlinks (schema order)
+    dataValidations.foreach(e => children += cleanNamespaces(e))
     preservedAfterCondFmt.foreach(l =>
       preservedKnown.get(l).foreach(e => children += cleanNamespaces(e))
     )
@@ -337,7 +343,8 @@ object OoxmlWorksheet extends com.tjclp.xl.ooxml.XmlReadable[OoxmlWorksheet]:
     styleRemapping: Map[Int, Int] = Map.empty,
     tableParts: Option[Elem] = None,
     escapeFormulas: Boolean = false,
-    condFmt: Option[Seq[Elem]] = None
+    condFmt: Option[Seq[Elem]] = None,
+    dataValidations: Option[Option[Elem]] = None
   ): OoxmlWorksheet =
     fromDomainWithMetadata(
       sheet,
@@ -346,7 +353,8 @@ object OoxmlWorksheet extends com.tjclp.xl.ooxml.XmlReadable[OoxmlWorksheet]:
       None,
       tableParts,
       escapeFormulas,
-      condFmt = condFmt
+      condFmt = condFmt,
+      dataValidations = dataValidations
     )
 
   /**
@@ -376,6 +384,11 @@ object OoxmlWorksheet extends com.tjclp.xl.ooxml.XmlReadable[OoxmlWorksheet]:
    *   always passes `Some(elems)` from its cf plan (cf-clean → preserved source elements verbatim,
    *   cf-dirty/fresh → CfCodec-generated; `Some(Seq.empty)` actively clears). `None` falls back to
    *   the preserved elements (legacy direct-caller behavior).
+   * @param dataValidations
+   *   Data-validation slot (GH-375, the condFmt shape): `Some(container)` is the planned emission
+   *   (dv-clean → preserved source element verbatim, dv-dirty/fresh → DataValidationCodec;
+   *   `Some(None)` actively clears); `None` falls back to the preserved element (legacy
+   *   direct-caller behavior).
    */
   def fromDomainWithMetadata(
     sheet: Sheet,
@@ -385,7 +398,8 @@ object OoxmlWorksheet extends com.tjclp.xl.ooxml.XmlReadable[OoxmlWorksheet]:
     tableParts: Option[Elem] = None,
     escapeFormulas: Boolean = false,
     drawingRef: Option[Elem] = None,
-    condFmt: Option[Seq[Elem]] = None
+    condFmt: Option[Seq[Elem]] = None,
+    dataValidations: Option[Option[Elem]] = None
   ): OoxmlWorksheet =
     // Build a map of row indices to preserved row attributes
     val preservedRowAttrs = preservedMetadata
@@ -554,6 +568,7 @@ object OoxmlWorksheet extends com.tjclp.xl.ooxml.XmlReadable[OoxmlWorksheet]:
           preserved.sheetFormatPr,
           generatedCols.orElse(preserved.cols), // Prefer domain props over preserved XML
           condFmt.getOrElse(preserved.conditionalFormatting), // GH-136: planned slot wins
+          dataValidations.getOrElse(preserved.dataValidations), // GH-375: planned slot wins
           preserved.printOptions,
           preserved.rowBreaks,
           preserved.colBreaks,
@@ -586,6 +601,7 @@ object OoxmlWorksheet extends com.tjclp.xl.ooxml.XmlReadable[OoxmlWorksheet]:
           sheetViews = buildSheetViewsElem(None, sheet.freezePane, sheet.viewSettings),
           cols = generatedCols,
           conditionalFormatting = condFmt.getOrElse(Seq.empty), // GH-136: fresh workbooks get cf
+          dataValidations = dataValidations.flatten, // GH-375: fresh workbooks get validations
           pageMargins = buildPageMarginsElem(sheet.pageSetup),
           pageSetup = mergePageSetupElem(None, sheet.pageSetup),
           headerFooter = mergeHeaderFooterElem(None, sheet.pageSetup),

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/WorksheetHelpers.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/WorksheetHelpers.scala
@@ -215,7 +215,9 @@ private[worksheet] val preservedAfterSheetData: Seq[String] =
     "customSheetViews"
   )
 private[worksheet] val preservedAfterMergeCells: Seq[String] = Seq("phoneticPr")
-private[worksheet] val preservedAfterCondFmt: Seq[String] = Seq("dataValidations", "hyperlinks")
+// GH-375: dataValidations graduated from this group to a dedicated modeled field on
+// OoxmlWorksheet (emitted between conditionalFormatting and hyperlinks, its schema slot).
+private[worksheet] val preservedAfterCondFmt: Seq[String] = Seq("hyperlinks")
 private[worksheet] val preservedAfterCustomProps: Seq[String] =
   Seq("cellWatches", "ignoredErrors", "smartTags")
 private[worksheet] val preservedAfterLegacyDrawing: Seq[String] = Seq("legacyDrawingHF")

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/WorksheetReader.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/WorksheetReader.scala
@@ -55,6 +55,10 @@ object WorksheetReader extends XmlReadable[OoxmlWorksheet]:
       conditionalFormatting = elem.child.collect {
         case e: Elem if e.label == "conditionalFormatting" => rebindUsedNamespaces(e)
       }
+      // GH-375: the single <dataValidations> container gets a dedicated field (was preservedKnown)
+      dataValidations = (elem \ "dataValidations").headOption.collect { case e: Elem =>
+        rebindUsedNamespaces(e)
+      }
       printOptions = (elem \ "printOptions").headOption.collect { case e: Elem =>
         rebindUsedNamespaces(e)
       }
@@ -113,6 +117,7 @@ object WorksheetReader extends XmlReadable[OoxmlWorksheet]:
       sheetFormatPr,
       cols,
       conditionalFormatting,
+      dataValidations,
       printOptions,
       rowBreaks,
       colBreaks,

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/AlignmentSerializationSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/AlignmentSerializationSpec.scala
@@ -1,5 +1,7 @@
 package com.tjclp.xl.ooxml
 
+import scala.xml.XML
+
 import munit.FunSuite
 import com.tjclp.xl.addressing.ARef
 import com.tjclp.xl.cells.CellValue
@@ -60,7 +62,13 @@ class AlignmentSerializationSpec extends FunSuite:
 
   test("alignment serializes to <alignment> in cellXfs") {
     val style = CellStyle.default.withAlign(
-      Align(horizontal = HAlign.Right, vertical = VAlign.Top, wrapText = true, indent = 2)
+      Align(
+        horizontal = HAlign.Right,
+        vertical = VAlign.Top,
+        wrapText = true,
+        indent = 2,
+        textRotation = 90
+      )
     )
     val index = StyleIndex(
       fonts = Vector.empty,
@@ -84,11 +92,13 @@ class AlignmentSerializationSpec extends FunSuite:
     val vertical = (alignmentElem \ "@vertical").text
     val wrapText = (alignmentElem \ "@wrapText").text
     val indent = (alignmentElem \ "@indent").text
+    val textRotation = (alignmentElem \ "@textRotation").text
 
     assertEquals(horizontal, "right", "horizontal should be 'right'")
     assertEquals(vertical, "top", "vertical should be 'top'")
     assertEquals(wrapText, "1", "wrapText should be '1'")
     assertEquals(indent, "2", "indent should be '2'")
+    assertEquals(textRotation, "90", "textRotation should be '90'")
   }
 
   test("alignment with only horizontal changed emits only horizontal attribute") {
@@ -112,10 +122,12 @@ class AlignmentSerializationSpec extends FunSuite:
     val vertical = (alignmentElem \ "@vertical").text
     val wrapText = (alignmentElem \ "@wrapText").text
     val indent = (alignmentElem \ "@indent").text
+    val textRotation = (alignmentElem \ "@textRotation").text
 
     assertEquals(vertical, "", "vertical should not be present (default)")
     assertEquals(wrapText, "", "wrapText should not be present (default false)")
     assertEquals(indent, "", "indent should not be present (default 0)")
+    assertEquals(textRotation, "", "textRotation should not be present (default 0)")
   }
 
   test("alignment round-trips through write/read cycle") {
@@ -123,7 +135,8 @@ class AlignmentSerializationSpec extends FunSuite:
       horizontal = HAlign.Justify,
       vertical = VAlign.Middle,
       wrapText = true,
-      indent = 3
+      indent = 3,
+      textRotation = 135
     )
     val style = CellStyle.default.withAlign(originalAlign)
     val index = StyleIndex(
@@ -211,6 +224,98 @@ class AlignmentSerializationSpec extends FunSuite:
     assertEquals(ids.distinct.size, 2, "indent-only style variants must not collapse")
     assertEquals(readSheet.getCellStyle(ref"A1").map(_.align.indent), Some(1))
     assertEquals(readSheet.getCellStyle(ref"A2").map(_.align.indent), Some(2))
+  }
+
+  test("workbook with rotated captions round-trips textRotation through write/read (GH-380)") {
+    // Sensitivity-grid row-axis labels are 90-degree rotated text in a tall merged cell; the
+    // rotation must survive a full workbook write -> read cycle.
+    val up = CellStyle.default.center.rotated(90)
+    val down = CellStyle.default.center.rotated(-45) // ST_TextRotation 135 (downward encoding)
+    val stacked = CellStyle.default.center.rotated(255)
+
+    val sheet = Sheet("Rotation")
+      .put(ref"A1", CellValue.Text("Exit Multiple"))
+      .put(ref"A2", CellValue.Text("Down"))
+      .put(ref"A3", CellValue.Text("Stacked"))
+      .withCellStyle(ref"A1", up)
+      .withCellStyle(ref"A2", down)
+      .withCellStyle(ref"A3", stacked)
+    val wb = Workbook(Vector(sheet))
+
+    val bytes = XlsxWriter.writeToBytes(wb) match
+      case Right(b) => b
+      case Left(err) => fail(s"Write failed: $err")
+    val readWb = XlsxReader.readFromBytes(bytes) match
+      case Right(w) => w
+      case Left(err) => fail(s"Read failed: $err")
+
+    val readSheet = readWb.sheets(0)
+    def rotationOf(r: ARef): Int =
+      readSheet.getCellStyle(r).map(_.align.textRotation).getOrElse(-1)
+
+    assertEquals(rotationOf(ref"A1"), 90, "upward rotation should round-trip")
+    assertEquals(rotationOf(ref"A2"), 135, "downward rotation should round-trip")
+    assertEquals(rotationOf(ref"A3"), 255, "vertical stacked should round-trip")
+  }
+
+  test(
+    "style dedup keeps styles differing only by textRotation distinct after round-trip (GH-380)"
+  ) {
+    // canonicalKey accounts for textRotation: two styles identical except for rotation must map
+    // to distinct xf entries in styles.xml, not collapse into one.
+    val rotated1 = CellStyle.default.left.rotated(45)
+    val rotated2 = CellStyle.default.left.rotated(90)
+
+    val sheet = Sheet("DedupRot")
+      .put(ref"A1", CellValue.Text("one"))
+      .put(ref"A2", CellValue.Text("two"))
+      .withCellStyle(ref"A1", rotated1)
+      .withCellStyle(ref"A2", rotated2)
+    val wb = Workbook(Vector(sheet))
+
+    val bytes = XlsxWriter.writeToBytes(wb) match
+      case Right(b) => b
+      case Left(err) => fail(s"Write failed: $err")
+    val readWb = XlsxReader.readFromBytes(bytes) match
+      case Right(w) => w
+      case Left(err) => fail(s"Read failed: $err")
+
+    val readSheet = readWb.sheets(0)
+    val ids = Vector(ref"A1", ref"A2").flatMap(r => readSheet.cells.get(r).flatMap(_.styleId))
+    assertEquals(ids.size, 2, "both cells should carry a style after round-trip")
+    assertEquals(ids.distinct.size, 2, "rotation-only style variants must not collapse")
+    assertEquals(readSheet.getCellStyle(ref"A1").map(_.align.textRotation), Some(45))
+    assertEquals(readSheet.getCellStyle(ref"A2").map(_.align.textRotation), Some(90))
+  }
+
+  test("reader keeps valid textRotation values and drops invalid ones (GH-380)") {
+    // ST_TextRotation admits 0-180 plus 255 (vertical stacked); anything else from a malformed
+    // file is dropped so the parser stays total (Align requires the same range).
+    def parsedRotation(attr: String): Int =
+      val xml = XML.loadString(
+        s"""<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+           |  <fonts count="1"><font><sz val="11"/><name val="Calibri"/></font></fonts>
+           |  <fills count="1"><fill><patternFill patternType="none"/></fill></fills>
+           |  <borders count="1"><border/></borders>
+           |  <cellXfs count="1">
+           |    <xf numFmtId="0" fontId="0" fillId="0" borderId="0" applyAlignment="1">
+           |      <alignment horizontal="left" textRotation="$attr"/>
+           |    </xf>
+           |  </cellXfs>
+           |</styleSheet>""".stripMargin
+      )
+      WorkbookStyles.fromXml(xml) match
+        case Right(styles) =>
+          styles.cellStyles.headOption.map(_.align.textRotation).getOrElse(fail("no style parsed"))
+        case Left(err) => fail(s"styles parse must not fail: $err")
+
+    assertEquals(parsedRotation("90"), 90, "in-range rotation kept")
+    assertEquals(parsedRotation("180"), 180, "boundary rotation kept")
+    assertEquals(parsedRotation("255"), 255, "vertical stacked sentinel kept")
+    assertEquals(parsedRotation("181"), 0, "181-254 gap is invalid and dropped")
+    assertEquals(parsedRotation("200"), 0, "invalid rotation dropped")
+    assertEquals(parsedRotation("-10"), 0, "negative rotation dropped")
+    assertEquals(parsedRotation("junk"), 0, "unparseable rotation dropped")
   }
 
   test("all HAlign enum values serialize correctly") {

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/CalcPrRoundTripSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/CalcPrRoundTripSpec.scala
@@ -1,0 +1,339 @@
+package com.tjclp.xl.ooxml
+
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path}
+import java.util.zip.{ZipEntry, ZipInputStream, ZipOutputStream}
+
+import scala.xml.Elem
+
+import munit.FunSuite
+
+import com.tjclp.xl.api.{CalcPr, Workbook}
+import com.tjclp.xl.codec.CellCodec.given
+import com.tjclp.xl.macros.ref
+
+/**
+ * GH-373 (a): `WorkbookMetadata.calcPr` ⇄ `<calcPr>` iterative-calculation attributes.
+ *
+ * Contract (the GH-243 date1904 / GH-294 activeTab machinery):
+ *   - The reader parses `iterate` / `iterateCount` / `iterateDelta` into the friendly-named
+ *     [[CalcPr]] model; a calcPr with only unmodeled attributes (calcId, refMode, ...) parses to
+ *     None and rides through on write.
+ *   - `Workbook.withCalcPr` marks metadata modified so a surgical write regenerates workbook.xml —
+ *     without it the untouched fast path copies preserved bytes and silently drops the change.
+ *   - Reconcile is model-wins for the three modeled attributes ONLY: unmodeled preserved attributes
+ *     survive an overlay; the preserved element rides byte-stable when the model agrees.
+ *   - Scratch builds emit `<calcPr>` with just the modeled attributes (no calcId — the LibreOffice
+ *     precedent), in CT_Workbook schema position (after sheets/definedNames, before extLst).
+ */
+class CalcPrRoundTripSpec extends FunSuite:
+
+  private val contentTypesXml =
+    """<?xml version="1.0" encoding="UTF-8"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+  <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+</Types>"""
+
+  private val rootRelationshipsXml =
+    """<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>"""
+
+  private val workbookRelationshipsXml =
+    """<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+</Relationships>"""
+
+  /** workbook.xml with a configurable raw calcPr element (schema position: after sheets). */
+  private def workbookXml(calcPr: String): String =
+    s"""<?xml version="1.0" encoding="UTF-8"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+          xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <sheets>
+    <sheet name="Model" sheetId="1" r:id="rId1"/>
+  </sheets>
+  $calcPr
+</workbook>"""
+
+  private val worksheetXml =
+    """<?xml version="1.0" encoding="UTF-8"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <sheetData>
+    <row r="1">
+      <c r="A1"><v>42</v></c>
+    </row>
+  </sheetData>
+</worksheet>"""
+
+  private def buildCalcPrWorkbook(calcPr: String): Array[Byte] =
+    writeZip(
+      Map(
+        "[Content_Types].xml" -> contentTypesXml,
+        "_rels/.rels" -> rootRelationshipsXml,
+        "xl/workbook.xml" -> workbookXml(calcPr),
+        "xl/_rels/workbook.xml.rels" -> workbookRelationshipsXml,
+        "xl/worksheets/sheet1.xml" -> worksheetXml
+      )
+    )
+
+  private def writeZip(parts: Map[String, String]): Array[Byte] =
+    val baos = new ByteArrayOutputStream()
+    val zip = new ZipOutputStream(baos)
+    parts.foreach { case (name, content) =>
+      zip.putNextEntry(new ZipEntry(name))
+      zip.write(content.getBytes(StandardCharsets.UTF_8))
+      zip.closeEntry()
+    }
+    zip.close()
+    baos.toByteArray
+
+  /** Extract one entry from an xlsx byte array as UTF-8 text. */
+  @SuppressWarnings(Array("org.wartremover.warts.Var", "org.wartremover.warts.While"))
+  private def zipEntryText(bytes: Array[Byte], entryName: String): Option[String] =
+    val zip = new ZipInputStream(new ByteArrayInputStream(bytes))
+    try
+      var entry = zip.getNextEntry
+      var found: Option[String] = None
+      while entry != null && found.isEmpty do
+        if entry.getName == entryName then
+          found = Some(new String(zip.readAllBytes(), StandardCharsets.UTF_8))
+        entry = zip.getNextEntry
+      found
+    finally zip.close()
+
+  private def readBytes(bytes: Array[Byte]): Workbook =
+    XlsxReader.readFromBytes(bytes).fold(e => fail(s"read failed: ${e.message}"), identity)
+
+  private def calcPrElemOf(workbookXml: String): Option[Elem] =
+    val root = XmlSecurity
+      .parseSafe(workbookXml, "xl/workbook.xml")
+      .fold(e => fail(e.message), identity)
+    (root \ "calcPr").headOption.collect { case e: Elem => e }
+
+  private def parseElem(xml: String): Elem =
+    XmlSecurity.parseSafe(xml, "test").fold(e => fail(e.message), identity)
+
+  private val houseCalcPr =
+    CalcPr(
+      iterativeCalculation = true,
+      maxIterations = Some(100),
+      maxChange = Some(BigDecimal("0.001"))
+    )
+
+  // ---------------------------------------------------------------------------
+  // The wither MUST mark metadata modified (the silent-drop fast path)
+  // ---------------------------------------------------------------------------
+
+  test("GH-373: withCalcPr on a read workbook survives a file→file write (model wins)") {
+    val src = Files.createTempFile("calcpr-src", ".xlsx")
+    val out = Files.createTempFile("calcpr-out", ".xlsx")
+    try
+      Files.write(src, buildCalcPrWorkbook("""<calcPr calcId="191029"/>"""))
+
+      val wb = XlsxReader.read(src).fold(e => fail(s"read failed: ${e.message}"), identity)
+      assertEquals(wb.metadata.calcPr, None, "calcId-only calcPr must parse to None")
+
+      // The ONLY change is calcPr — without markMetadataModified the untouched fast path
+      // copies the source bytes verbatim and the authored setting silently vanishes.
+      val authored = wb.withCalcPr(houseCalcPr)
+      XlsxWriter.write(authored, out).fold(e => fail(s"write failed: ${e.message}"), identity)
+
+      val reread = XlsxReader.read(out).fold(e => fail(s"reread failed: ${e.message}"), identity)
+      assertEquals(
+        reread.metadata.calcPr,
+        Some(houseCalcPr),
+        "calcPr-only change was dropped on write"
+      )
+
+      val calcPr = calcPrElemOf(
+        zipEntryText(Files.readAllBytes(out), "xl/workbook.xml").getOrElse(
+          fail("workbook.xml missing")
+        )
+      ).getOrElse(fail("calcPr element missing"))
+      assertEquals(calcPr \@ "iterate", "1")
+      assertEquals(calcPr \@ "iterateCount", "100")
+      assertEquals(calcPr \@ "iterateDelta", "0.001")
+      assertEquals(calcPr \@ "calcId", "191029", "unmodeled calcId must survive the overlay")
+    finally
+      Files.deleteIfExists(src)
+      Files.deleteIfExists(out)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Scratch authoring (the from-scratch replica case)
+  // ---------------------------------------------------------------------------
+
+  test("GH-373: scratch workbook emits authored calcPr and round-trips") {
+    val wb = Workbook(com.tjclp.xl.api.Sheet("Model").put(ref"A1" -> 1))
+      .withCalcPr(
+        CalcPr(
+          iterativeCalculation = true,
+          maxIterations = Some(100),
+          maxChange = Some(BigDecimal("0.0001"))
+        )
+      )
+
+    val bytes = XlsxWriter.writeToBytes(wb).fold(e => fail(s"write failed: ${e.message}"), identity)
+    val workbookOut = zipEntryText(bytes, "xl/workbook.xml").getOrElse(fail("workbook.xml missing"))
+
+    val calcPr = calcPrElemOf(workbookOut).getOrElse(fail(s"calcPr missing: $workbookOut"))
+    assertEquals(calcPr \@ "iterate", "1")
+    assertEquals(calcPr \@ "iterateCount", "100")
+    assertEquals(calcPr \@ "iterateDelta", "0.0001")
+    assertEquals(calcPr \@ "calcId", "", "scratch emission needs no calcId (LO precedent)")
+
+    // CT_Workbook schema order: sheets before calcPr
+    val sheetsIdx = workbookOut.indexOf("<sheets>")
+    val calcPrIdx = workbookOut.indexOf("<calcPr")
+    assert(sheetsIdx >= 0 && calcPrIdx >= 0, workbookOut)
+    assert(sheetsIdx < calcPrIdx, "calcPr must follow sheets (CT_Workbook sequence)")
+
+    val reread = readBytes(bytes)
+    assertEquals(
+      reread.metadata.calcPr,
+      Some(CalcPr(true, Some(100), Some(BigDecimal("0.0001"))))
+    )
+  }
+
+  test("GH-373: workbooks without authored calcPr emit none (scratch default unchanged)") {
+    val wb = Workbook(com.tjclp.xl.api.Sheet("Plain").put(ref"A1" -> 1))
+    val bytes = XlsxWriter.writeToBytes(wb).fold(e => fail(s"write failed: ${e.message}"), identity)
+    val workbookOut = zipEntryText(bytes, "xl/workbook.xml").getOrElse(fail("workbook.xml missing"))
+    assert(!workbookOut.contains("<calcPr"), s"no calcPr expected: $workbookOut")
+    assertEquals(readBytes(bytes).metadata.calcPr, None)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Reader forms
+  // ---------------------------------------------------------------------------
+
+  test("GH-373: reader parses the OOXML attribute spellings into friendly names") {
+    // xsd:boolean form
+    assertEquals(
+      readBytes(
+        buildCalcPrWorkbook("""<calcPr iterate="true" iterateCount="50"/>""")
+      ).metadata.calcPr,
+      Some(CalcPr(iterativeCalculation = true, maxIterations = Some(50), maxChange = None))
+    )
+    // the LibreOffice fixture shape: iterate explicitly false, count+delta present
+    assertEquals(
+      readBytes(
+        buildCalcPrWorkbook(
+          """<calcPr iterateCount="100" refMode="A1" iterate="false" iterateDelta="0.0001"/>"""
+        )
+      ).metadata.calcPr,
+      Some(
+        CalcPr(
+          iterativeCalculation = false,
+          maxIterations = Some(100),
+          maxChange = Some(BigDecimal("0.0001"))
+        )
+      )
+    )
+    // unmodeled-only calcPr parses to None (and rides through on write elsewhere)
+    assertEquals(
+      readBytes(
+        buildCalcPrWorkbook("""<calcPr calcId="191029" fullCalcOnLoad="1"/>""")
+      ).metadata.calcPr,
+      None
+    )
+    // absent element
+    assertEquals(readBytes(buildCalcPrWorkbook("")).metadata.calcPr, None)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Metadata-modified writes: preserved calcPr rides through when the model agrees
+  // ---------------------------------------------------------------------------
+
+  test("GH-373: a metadata write keeps the preserved calcPr when the model agrees") {
+    val src = Files.createTempFile("calcpr-agree-src", ".xlsx")
+    val out = Files.createTempFile("calcpr-agree-out", ".xlsx")
+    try
+      Files.write(
+        src,
+        buildCalcPrWorkbook(
+          """<calcPr calcId="191029" iterate="1" iterateCount="50" iterateDelta="0.01" refMode="A1"/>"""
+        )
+      )
+      val wb = XlsxReader.read(src).fold(e => fail(s"read failed: ${e.message}"), identity)
+      assertEquals(wb.metadata.calcPr, Some(CalcPr(true, Some(50), Some(BigDecimal("0.01")))))
+
+      // trigger the metadata-modified (fromDomain) path with an unrelated authoring action
+      val named = wb.withDefinedName("MyRange", "Model!$A$1")
+      XlsxWriter.write(named, out).fold(e => fail(s"write failed: ${e.message}"), identity)
+
+      val calcPr = calcPrElemOf(
+        zipEntryText(Files.readAllBytes(out), "xl/workbook.xml").getOrElse(
+          fail("workbook.xml missing")
+        )
+      ).getOrElse(fail("calcPr dropped on metadata write"))
+      assertEquals(calcPr \@ "calcId", "191029")
+      assertEquals(calcPr \@ "refMode", "A1")
+      assertEquals(calcPr \@ "iterate", "1")
+      assertEquals(calcPr \@ "iterateCount", "50")
+      assertEquals(calcPr \@ "iterateDelta", "0.01")
+    finally
+      Files.deleteIfExists(src)
+      Files.deleteIfExists(out)
+  }
+
+  // ---------------------------------------------------------------------------
+  // reconcileCalcPr unit laws (model wins on the three modeled attrs only)
+  // ---------------------------------------------------------------------------
+
+  test("GH-373: reconcileCalcPr is the identity when the model agrees with the preserved bytes") {
+    val pr =
+      parseElem("""<calcPr calcId="191029" iterate="1" iterateCount="50" iterateDelta="0.01"/>""")
+    val model = OoxmlWorkbook.parseCalcPr(Some(pr))
+    assert(
+      OoxmlWorkbook.reconcileCalcPr(Some(pr), model).exists(_ eq pr),
+      "must return the preserved element untouched"
+    )
+    assertEquals(OoxmlWorkbook.reconcileCalcPr(None, None), None)
+  }
+
+  test("GH-373: reconcileCalcPr overlays the model in place (foreign attrs survive)") {
+    val pr =
+      parseElem("""<calcPr calcId="191029" iterate="false" iterateCount="100" refMode="A1"/>""")
+    val model = Some(
+      CalcPr(
+        iterativeCalculation = true,
+        maxIterations = Some(200),
+        maxChange = Some(BigDecimal("0.05"))
+      )
+    )
+    val result =
+      OoxmlWorkbook.reconcileCalcPr(Some(pr), model).getOrElse(fail("expected an element"))
+    assertEquals(result \@ "calcId", "191029")
+    assertEquals(result \@ "refMode", "A1")
+    assertEquals(result \@ "iterate", "1")
+    assertEquals(result \@ "iterateCount", "200")
+    assertEquals(result \@ "iterateDelta", "0.05")
+  }
+
+  test("GH-373: reconcileCalcPr with a cleared model strips only the modeled attrs") {
+    val pr = parseElem("""<calcPr calcId="191029" iterate="1" iterateCount="100" refMode="A1"/>""")
+    val result =
+      OoxmlWorkbook.reconcileCalcPr(Some(pr), None).getOrElse(fail("expected an element"))
+    assertEquals(result \@ "calcId", "191029")
+    assertEquals(result \@ "refMode", "A1")
+    assertEquals(result.attribute("iterate"), None)
+    assertEquals(result.attribute("iterateCount"), None)
+    assertEquals(result.attribute("iterateDelta"), None)
+  }
+
+  test("GH-373: reconcileCalcPr emits false-with-bounds without an iterate attribute") {
+    // iterativeCalculation=false is the schema default: the attribute is omitted, not spelled out
+    val model =
+      Some(CalcPr(iterativeCalculation = false, maxIterations = Some(10), maxChange = None))
+    val result = OoxmlWorkbook.reconcileCalcPr(None, model).getOrElse(fail("expected an element"))
+    assertEquals(result.attribute("iterate"), None)
+    assertEquals(result \@ "iterateCount", "10")
+    // and it parses back to the same model (round-trip)
+    assertEquals(OoxmlWorkbook.parseCalcPr(Some(result)), model)
+  }

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/DataValidationPreservationSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/DataValidationPreservationSpec.scala
@@ -1,0 +1,357 @@
+package com.tjclp.xl.ooxml
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path}
+import java.util.zip.{ZipEntry, ZipFile, ZipOutputStream}
+
+import munit.FunSuite
+
+import com.tjclp.xl.api.*
+import com.tjclp.xl.cells.CellValue
+import com.tjclp.xl.macros.ref
+import com.tjclp.xl.ooxml.writer.WriterConfig
+
+/**
+ * GH-375 preservation laws (the CfPreservationSpec contract applied to `<dataValidations>`):
+ *
+ *   - (a) read → author a validation → write → re-read: every preserved entry exactly once,
+ *     authored entry appended, container count correct
+ *   - (b) dv-CLEAN cell edit: the emitted dataValidations element equals the source element (the
+ *     dirty-gate proof) — the read→edit→write ask of the GH-372 family
+ *   - (c) cleared model emits no dataValidations (no resurrection)
+ *   - (d) fresh authoring: scratch list dropdowns emit and round-trip typed (incl. the showDropDown
+ *     INVERSION and multi-range sqref)
+ *   - (e) both writer backends emit identical dataValidations
+ */
+class DataValidationPreservationSpec extends FunSuite:
+
+  private def writeTo(wb: Workbook, label: String, config: WriterConfig = WriterConfig()): Path =
+    val out = Files.createTempFile(s"xl-dv-$label-", ".xlsx")
+    out.toFile.deleteOnExit()
+    XlsxWriter
+      .writeWith(wb, out, config)
+      .fold(err => fail(s"$label write failed: ${err.message}"), _ => ())
+    out
+
+  private def reread(path: Path): Workbook =
+    XlsxReader.read(path).fold(err => fail(s"re-read failed: ${err.message}"), identity)
+
+  private def entryText(path: Path, name: String): String =
+    val zip = new ZipFile(path.toFile)
+    try
+      Option(zip.getEntry(name)) match
+        case Some(e) =>
+          new String(zip.getInputStream(e).readAllBytes(), StandardCharsets.UTF_8)
+        case None => fail(s"zip entry $name not found in $path")
+    finally zip.close()
+
+  private def occurrences(haystack: String, needle: String): Int =
+    java.util.regex.Pattern.quote(needle).r.findAllMatchIn(haystack).size
+
+  // ===== fixtures: an Excel-typical validation the typed model does NOT cover (Preserved) =====
+
+  private def writeEntry(out: ZipOutputStream, name: String, content: String): Unit =
+    out.putNextEntry(new ZipEntry(name))
+    out.write(content.getBytes("UTF-8"))
+    out.closeEntry()
+
+  /**
+   * Minimal single-sheet fixture whose worksheet carries the given raw `<dataValidations>` block
+   * (may be empty). The decimal entry carries an operator + prompts — outside the typed subset, so
+   * it must ride [[com.tjclp.xl.sheets.DataValidation.Preserved]].
+   */
+  private def rawDvFixture(dataValidationsXml: String): Path =
+    val path = Files.createTempFile("dv-fixture", ".xlsx")
+    val out = new ZipOutputStream(Files.newOutputStream(path))
+    out.setLevel(1)
+    try
+      writeEntry(
+        out,
+        "[Content_Types].xml",
+        """<?xml version="1.0"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+  <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+</Types>"""
+      )
+      writeEntry(
+        out,
+        "_rels/.rels",
+        """<?xml version="1.0"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>"""
+      )
+      writeEntry(
+        out,
+        "xl/workbook.xml",
+        """<?xml version="1.0"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <sheets>
+    <sheet name="Inputs" sheetId="1" r:id="rId1"/>
+  </sheets>
+</workbook>"""
+      )
+      writeEntry(
+        out,
+        "xl/_rels/workbook.xml.rels",
+        """<?xml version="1.0"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+</Relationships>"""
+      )
+      writeEntry(
+        out,
+        "xl/worksheets/sheet1.xml",
+        s"""<?xml version="1.0"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <sheetData>
+    <row r="1"><c r="A1"><v>1</v></c></row>
+  </sheetData>
+  $dataValidationsXml
+</worksheet>"""
+      )
+    finally out.close()
+    path
+
+  private val foreignDecimalDv =
+    """<dataValidations count="1">
+    <dataValidation type="decimal" operator="between" allowBlank="1" showInputMessage="1" showErrorMessage="1" errorTitle="Range" error="0 to 1 only" sqref="D2:D9"><formula1>0</formula1><formula2>1</formula2></dataValidation>
+  </dataValidations>"""
+
+  private def readDvFixture(dvXml: String): (Path, Workbook) =
+    val path = rawDvFixture(dvXml)
+    val wb = XlsxReader.read(path).fold(e => fail(s"fixture read failed: ${e.message}"), identity)
+    (path, wb)
+
+  // ===== (d) fresh authoring: the from-scratch replica case =====
+
+  private def freshDvWorkbook: Workbook =
+    val sheet = Sheet(SheetName.unsafe("Case"))
+      .put(ref"B2", CellValue.Number(BigDecimal(1)))
+      .withDataValidation(ref"B2:B10", DataValidation.listOf("1", "2", "3"))
+      .withDataValidation(ref"C2:C10", DataValidation.list("$Z$1:$Z$3", allowBlank = false))
+    Workbook(Vector(sheet))
+
+  test("(d) fresh workbook: authored list dropdowns emit on a no-source write and round-trip") {
+    val wb = freshDvWorkbook
+    val out = writeTo(wb, "fresh")
+    val sheetXml = entryText(out, "xl/worksheets/sheet1.xml")
+    assert(sheetXml.contains("<dataValidations count=\"2\">"), sheetXml.take(800))
+    assert(sheetXml.contains("type=\"list\""), sheetXml.take(800))
+    // inline values keep their literal quotes (scala.xml text-escapes them as &quot;);
+    // the range ref rides verbatim
+    assert(sheetXml.contains("<formula1>&quot;1,2,3&quot;</formula1>"), sheetXml.take(800))
+    assert(sheetXml.contains("<formula1>$Z$1:$Z$3</formula1>"), sheetXml.take(800))
+    // default flags: allowBlank=true emits, showDropdown=true emits NO attribute (inversion!)
+    assert(sheetXml.contains("allowBlank=\"1\""), sheetXml.take(800))
+    assert(!sheetXml.contains("showDropDown"), s"dropdown must not be suppressed: $sheetXml")
+    assertEquals(reread(out).sheets(0).dataValidations, wb.sheets(0).dataValidations)
+  }
+
+  test("(d) the OOXML showDropDown INVERSION: model showDropdown=false emits showDropDown=\"1\"") {
+    val sheet = Sheet(SheetName.unsafe("Case"))
+      .withDataValidation(ref"B2:B4", DataValidation.list("\"a,b\"", showDropdown = false))
+    val out = writeTo(Workbook(Vector(sheet)), "inversion")
+    val sheetXml = entryText(out, "xl/worksheets/sheet1.xml")
+    assert(sheetXml.contains("showDropDown=\"1\""), s"suppression attr missing: $sheetXml")
+    val back = reread(out).sheets(0).typedDataValidations
+    assertEquals(back.map(_.showDropdown), Vector(false))
+  }
+
+  test("(d) multi-range sqref emits space-separated and round-trips") {
+    val sheet = Sheet(SheetName.unsafe("Case"))
+      .withDataValidation(
+        Vector(ref"B2:B4": CellRange, ref"D2:D4": CellRange),
+        DataValidation.listOf("x", "y")
+      )
+    val out = writeTo(Workbook(Vector(sheet)), "multirange")
+    val sheetXml = entryText(out, "xl/worksheets/sheet1.xml")
+    assert(sheetXml.contains("sqref=\"B2:B4 D2:D4\""), sheetXml.take(800))
+    assertEquals(
+      reread(out).sheets(0).typedDataValidations.map(_.ranges.map(_.toA1)),
+      Vector(Vector("B2:B4", "D2:D4"))
+    )
+  }
+
+  test("(d) schema position: dataValidations sits after sheetData, before pageMargins/hyperlinks") {
+    val sheet = Sheet(SheetName.unsafe("Case"))
+      .put(ref"A1", CellValue.Text("v"))
+      .withDataValidation(ref"A2:A5", DataValidation.listOf("a"))
+      .withPageSetup(
+        com.tjclp.xl.sheets.PageSetup(margins = Some(com.tjclp.xl.sheets.PageMargins.default))
+      )
+    val out = writeTo(Workbook(Vector(sheet)), "order")
+    val sheetXml = entryText(out, "xl/worksheets/sheet1.xml")
+    val sheetData = sheetXml.indexOf("<sheetData>")
+    val dv = sheetXml.indexOf("<dataValidations")
+    val margins = sheetXml.indexOf("<pageMargins")
+    assert(sheetData >= 0 && dv >= 0 && margins >= 0, sheetXml)
+    assert(sheetData < dv && dv < margins, s"schema order violated: $sheetXml")
+  }
+
+  // ===== (a) authored + preserved coexistence =====
+
+  test("(a) author on top of a foreign (Preserved) validation: no duplication, no loss") {
+    val (_, wb) = readDvFixture(foreignDecimalDv)
+    val before = wb.sheets(0).dataValidations
+    assertEquals(before.size, 1)
+    assert(
+      before(0).isInstanceOf[com.tjclp.xl.sheets.DataValidation.Preserved],
+      s"decimal+operator+prompts must ride Preserved: $before"
+    )
+
+    val updated = wb
+      .update(
+        wb.sheets(0).name,
+        _.withDataValidation(ref"B2:B9", DataValidation.listOf("Low", "Med", "High"))
+      )
+      .fold(err => fail(s"update failed: $err"), identity)
+    val out = writeTo(updated, "author")
+    val sheetXml = entryText(out, "xl/worksheets/sheet1.xml")
+    assertEquals(occurrences(sheetXml, "<dataValidations"), 1, "exactly ONE container")
+    assert(sheetXml.contains("count=\"2\""), s"container count must be 2: $sheetXml")
+    assertEquals(occurrences(sheetXml, "type=\"decimal\""), 1, "preserved entry exactly once")
+    assertEquals(occurrences(sheetXml, "errorTitle=\"Range\""), 1, "foreign attrs survive")
+    assertEquals(occurrences(sheetXml, "<formula1>&quot;Low,Med,High&quot;</formula1>"), 1)
+
+    val back = reread(out).sheets(0).dataValidations
+    assertEquals(back.size, 2)
+    assertEquals(back.take(1), before, "preserved entry must ride through unchanged")
+    assertEquals(back.lastOption, updated.sheets(0).dataValidations.lastOption)
+  }
+
+  // ===== (b) the dirty-gate proof (the GH-372-family read→edit→write ask) =====
+
+  test("(b) dv-CLEAN cell edit keeps validations on the REWRITTEN sheet (slot passthrough)") {
+    val (in, wb) = readDvFixture(foreignDecimalDv)
+    val edited = wb
+      .update(wb.sheets(0).name, _.put(ref"A5", CellValue.Text("unrelated edit")))
+      .fold(err => fail(s"update failed: $err"), identity)
+    val out = writeTo(edited, "clean-edit")
+    def dvElem(p: Path): Option[String] =
+      val ws = XmlSecurity
+        .parseSafe(entryText(p, "xl/worksheets/sheet1.xml"), "ws")
+        .fold(e => fail(e.message), identity)
+      (ws \ "dataValidations").headOption.map(_.toString)
+    assert(dvElem(out).isDefined, "validations dropped by the rewrite")
+    assertEquals(dvElem(out), dvElem(in), "clean slot must pass the source element through")
+    assertEquals(reread(out).sheets(0).dataValidations, wb.sheets(0).dataValidations)
+  }
+
+  // ===== (c) deletion honored =====
+
+  test("(c) cleared model emits NO dataValidations (no resurrection)") {
+    val (_, wb) = readDvFixture(foreignDecimalDv)
+    val cleared = wb
+      .update(wb.sheets(0).name, _.copy(dataValidations = Vector.empty))
+      .fold(err => fail(s"update failed: $err"), identity)
+    val out = writeTo(cleared, "cleared")
+    val sheetXml = entryText(out, "xl/worksheets/sheet1.xml")
+    assert(!sheetXml.contains("<dataValidations"), "dataValidations must not resurrect")
+    assertEquals(
+      reread(out).sheets(0).dataValidations,
+      Vector.empty[com.tjclp.xl.sheets.DataValidation]
+    )
+  }
+
+  test("(c) removing one entry keeps the other (removeDataValidation)") {
+    val (_, wb) = readDvFixture(foreignDecimalDv)
+    val updated = wb
+      .update(
+        wb.sheets(0).name,
+        _.withDataValidation(ref"B2:B9", DataValidation.listOf("a", "b")).removeDataValidation(0)
+      )
+      .fold(err => fail(s"update failed: $err"), identity)
+    val out = writeTo(updated, "remove-one")
+    val sheetXml = entryText(out, "xl/worksheets/sheet1.xml")
+    assert(!sheetXml.contains("type=\"decimal\""), "removed entry must not resurrect")
+    assert(sheetXml.contains("count=\"1\""), sheetXml)
+    assertEquals(
+      reread(out).sheets(0).typedDataValidations.map(_.ranges.map(_.toA1)),
+      Vector(Vector("B2:B9"))
+    )
+  }
+
+  // ===== (e) backend parity =====
+
+  test("(e) backend parity: ScalaXml and SaxStax emit structurally identical dataValidations") {
+    val wb = freshDvWorkbook
+    val domOut = writeTo(wb, "dom", WriterConfig.scalaXml)
+    val saxOut = writeTo(wb, "sax", WriterConfig.saxStax)
+    def normalize(n: scala.xml.Node): String =
+      def attrsOf(e: scala.xml.Elem): String =
+        e.attributes.asAttrMap.toSeq.sorted.map((k, v) => s"$k=$v").mkString(" ")
+      n match
+        case e: scala.xml.Elem =>
+          val kids = e.child.collect { case c: scala.xml.Elem => normalize(c) }.mkString
+          val text = e.child.collect { case t: scala.xml.Text => t.data }.mkString.trim
+          s"<${e.label} ${attrsOf(e)}>$text$kids</${e.label}>"
+        case other => other.text.trim
+    def dvSection(p: Path): Seq[String] =
+      val ws = XmlSecurity
+        .parseSafe(entryText(p, "xl/worksheets/sheet1.xml"), "ws")
+        .fold(e => fail(e.message), identity)
+      (ws \ "dataValidations").map(normalize)
+    assert(dvSection(domOut).nonEmpty, "DOM backend emitted no dataValidations")
+    assertEquals(dvSection(saxOut), dvSection(domOut), "backends must emit identical dv")
+    assertEquals(reread(saxOut).sheets(0).dataValidations, wb.sheets(0).dataValidations)
+    assertEquals(reread(domOut).sheets(0).dataValidations, wb.sheets(0).dataValidations)
+  }
+
+  // ===== structural edits keep dropdowns attached through a full write cycle =====
+
+  test("insert-above shifts the emitted sqref (dropdowns stay attached end to end)") {
+    val sheet = Sheet(SheetName.unsafe("Case"))
+      .withDataValidation(ref"B2:B4", DataValidation.listOf("1", "2"))
+      .insertRows(at = 0, count = 2)
+    val out = writeTo(Workbook(Vector(sheet)), "shifted")
+    assert(entryText(out, "xl/worksheets/sheet1.xml").contains("sqref=\"B4:B6\""))
+    assertEquals(
+      reread(out).sheets(0).typedDataValidations.map(_.ranges.map(_.toA1)),
+      Vector(Vector("B4:B6"))
+    )
+  }
+
+  // ===== openpyxl smoke: the authored dropdown is visible to a foreign reader =====
+
+  test("openpyxl reads the authored list validation (subprocess smoke)") {
+    assume(pythonWithOpenpyxl, "python3 with openpyxl not available")
+    val out = writeTo(freshDvWorkbook, "openpyxl")
+    val script =
+      s"""import openpyxl
+         |wb = openpyxl.load_workbook(${pyString(out.toString)})
+         |ws = wb["Case"]
+         |dvs = ws.data_validations.dataValidation
+         |print(len(dvs))
+         |print(sorted((dv.formula1 or "") for dv in dvs))
+         |""".stripMargin
+    val output = runPython(script)
+    assert(output.contains("2"), s"openpyxl lost the validations: $output")
+    assert(output.contains("\"1,2,3\""), s"openpyxl lost the inline list: $output")
+    assert(output.contains("$Z$1:$Z$3"), s"openpyxl lost the range ref: $output")
+  }
+
+  private lazy val pythonWithOpenpyxl: Boolean =
+    scala.util
+      .Try {
+        val p = new ProcessBuilder("python3", "-c", "import openpyxl")
+          .redirectErrorStream(true)
+          .start()
+        p.waitFor() == 0
+      }
+      .getOrElse(false)
+
+  private def pyString(s: String): String =
+    "\"" + s.replace("\\", "\\\\").replace("\"", "\\\"") + "\""
+
+  private def runPython(script: String): String =
+    val pb = new ProcessBuilder("python3", "-c", script).redirectErrorStream(true)
+    pb.environment().put("PYTHONIOENCODING", "utf-8")
+    val p = pb.start()
+    val output = new String(p.getInputStream.readAllBytes(), StandardCharsets.UTF_8)
+    val exit = p.waitFor()
+    assertEquals(exit, 0, s"python exited $exit:\n$output")
+    output

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/WorkbookRelsRegenerationSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/WorkbookRelsRegenerationSpec.scala
@@ -266,6 +266,54 @@ class WorkbookRelsRegenerationSpec extends FunSuite:
     assertEquals(back.sheets(0)(ref"A2").value, CellValue.Text("héllo wörld"))
   }
 
+  test("GH-373: authoring iterate onto formulas-lo.xlsx flips iterate and keeps refMode") {
+    val (_, wb) = readFixture("formulas-lo.xlsx")
+    // the LO fixture ships <calcPr iterateCount="100" refMode="A1" iterate="false" iterateDelta="0.0001"/>
+    assertEquals(
+      wb.metadata.calcPr,
+      Some(
+        CalcPr(
+          iterativeCalculation = false,
+          maxIterations = Some(100),
+          maxChange = Some(BigDecimal("0.0001"))
+        )
+      )
+    )
+    val authored = wb.withCalcPr(
+      CalcPr(
+        iterativeCalculation = true,
+        maxIterations = Some(100),
+        maxChange = Some(BigDecimal("0.0001"))
+      )
+    )
+    val out = writeTo(authored, "lo-calcpr")
+    val calcPr = (parseEntry(out, "xl/workbook.xml") \ "calcPr").headOption
+      .getOrElse(fail("calcPr dropped"))
+    assertEquals(calcPr \@ "iterate", "1", "authored iterate must flip on")
+    assertEquals(calcPr \@ "iterateCount", "100")
+    assertEquals(calcPr \@ "iterateDelta", "0.0001")
+    assertEquals(calcPr \@ "refMode", "A1", "unmodeled refMode dropped by the overlay")
+    // preserved siblings still ride through on this metadata write (the GH-320 carry-through)
+    val workbookElem = parseEntry(out, "xl/workbook.xml")
+    assert((workbookElem \ "fileVersion").nonEmpty, "fileVersion dropped")
+    assert(
+      (workbookElem \ "extLst").exists(_.toString.contains("extCalcPr")),
+      "loext extLst dropped"
+    )
+    val back = reread(out)
+    assertEquals(
+      back.metadata.calcPr,
+      Some(
+        CalcPr(
+          iterativeCalculation = true,
+          maxIterations = Some(100),
+          maxChange = Some(BigDecimal("0.0001"))
+        )
+      )
+    )
+    assertEquals(back.sheets(0)(ref"A5").value, CellValue.Number(BigDecimal(50)))
+  }
+
   // ===== new sheets allocate fresh non-colliding ids =====
 
   test("GH-320: adding a sheet to small-values-lo.xlsx allocates a fresh rId above the max") {

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/worksheet/DataValidationCodecSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/worksheet/DataValidationCodecSpec.scala
@@ -1,0 +1,175 @@
+package com.tjclp.xl.ooxml.worksheet
+
+import scala.xml.Elem
+
+import munit.FunSuite
+
+import com.tjclp.xl.api.*
+import com.tjclp.xl.macros.ref
+import com.tjclp.xl.ooxml.XmlSecurity
+import com.tjclp.xl.sheets.{DataValidation, DvKind}
+
+/**
+ * GH-375: total data-validation codec — typed parse of the list family with entry-level Preserved
+ * fallback, canonical single-container emission, and `parseAll(toElem(dvs)) == dvs` for typed
+ * content (the CfCodecSpec contract).
+ */
+class DataValidationCodecSpec extends FunSuite:
+
+  private def xml(s: String): Elem =
+    XmlSecurity.parseSafe(s, "test").fold(e => fail(s"parse failed: ${e.message}"), identity)
+
+  private def roundTrip(dvs: Vector[DataValidation]): Vector[DataValidation] =
+    DataValidationCodec.parseAll(DataValidationCodec.toElem(dvs, None).map(e => xml(e.toString)))
+
+  private def typedList(
+    range: String,
+    formula: String,
+    allowBlank: Boolean = true,
+    showDropdown: Boolean = true
+  ): DataValidation.Rules =
+    DataValidation.Rules(
+      Vector(CellRange.parse(range).fold(e => fail(s"bad range: $e"), identity)),
+      DvKind.List(formula),
+      allowBlank,
+      showDropdown
+    )
+
+  // ===== typed round-trips =====
+
+  test("list round-trips: inline values, range ref, flag combinations") {
+    val dvs: Vector[DataValidation] = Vector(
+      typedList("B2:B10", "\"Low,Med,High\""),
+      typedList("C2:C10", "$Z$1:$Z$3", allowBlank = false),
+      typedList("D2:D10", "Lists!$A$1:$A$5", showDropdown = false),
+      typedList("E2:E10", "\"1,2\"", allowBlank = false, showDropdown = false)
+    )
+    assertEquals(roundTrip(dvs), dvs)
+  }
+
+  test("multi-range sqref round-trips (space-separated)") {
+    val dv = DataValidation.Rules(
+      Vector(ref"A1:A5": CellRange, ref"C1:C5": CellRange),
+      DvKind.List("\"x\"")
+    )
+    assertEquals(roundTrip(Vector(dv)), Vector(dv))
+    val emitted = DataValidationCodec.toElem(Vector(dv), None).getOrElse(fail("no container"))
+    assertEquals((emitted \ "dataValidation").headOption.map(_ \@ "sqref"), Some("A1:A5 C1:C5"))
+  }
+
+  test("the showDropDown INVERSION maps both directions") {
+    // raw attr present=1 -> model false; absent -> model true
+    val container = xml(
+      """<dataValidations count="2">
+        |  <dataValidation type="list" sqref="A1:A3" showDropDown="1"><formula1>"a"</formula1></dataValidation>
+        |  <dataValidation type="list" sqref="B1:B3"><formula1>"b"</formula1></dataValidation>
+        |</dataValidations>""".stripMargin
+    )
+    val parsed = DataValidationCodec.parseAll(Some(container))
+    assertEquals(
+      parsed.collect { case r: DataValidation.Rules => r.showDropdown },
+      Vector(false, true)
+    )
+    // model false -> attr "1"; model true -> attr absent
+    val emitted = DataValidationCodec.toElem(parsed, None).getOrElse(fail("no container"))
+    val entries = (emitted \ "dataValidation").collect { case e: Elem => e }
+    assertEquals(entries.map(e => e.attribute("showDropDown").map(_.text)), Seq(Some("1"), None))
+  }
+
+  test("single-cell sqref promotes to a 1x1 range") {
+    val container = xml(
+      """<dataValidations count="1"><dataValidation type="list" sqref="A1"><formula1>"Yes,No"</formula1></dataValidation></dataValidations>"""
+    )
+    DataValidationCodec.parseAll(Some(container)) match
+      case Vector(DataValidation.Rules(ranges, DvKind.List(f), allowBlank, showDropdown)) =>
+        assertEquals(ranges.map(_.toA1), Vector("A1:A1"))
+        assertEquals(f, "\"Yes,No\"")
+        assertEquals(allowBlank, false) // schema default when the attribute is absent
+        assertEquals(showDropdown, true)
+      case other => fail(s"expected one typed list, got $other")
+  }
+
+  // ===== Preserved fallback (total parse) =====
+
+  test("unmodeled entries ride Preserved: foreign type, extra attrs, formula2, no formula") {
+    val container = xml(
+      """<dataValidations count="4">
+        |  <dataValidation type="whole" operator="between" sqref="A1"><formula1>1</formula1><formula2>9</formula2></dataValidation>
+        |  <dataValidation type="list" allowBlank="1" showInputMessage="1" showErrorMessage="1" sqref="B1"><formula1>"a,b"</formula1></dataValidation>
+        |  <dataValidation type="list" sqref="C1"><formula1>"a"</formula1><formula2>"b"</formula2></dataValidation>
+        |  <dataValidation type="list" sqref="D1"/>
+        |</dataValidations>""".stripMargin
+    )
+    val parsed = DataValidationCodec.parseAll(Some(container))
+    assertEquals(parsed.size, 4)
+    assert(
+      parsed.forall(_.isInstanceOf[DataValidation.Preserved]),
+      s"all four must degrade to Preserved: $parsed"
+    )
+    // and they re-emit verbatim (payload is canonical self-contained XML)
+    val emitted = DataValidationCodec.toElem(parsed, None).getOrElse(fail("no container"))
+    assertEquals((emitted \ "dataValidation").size, 4)
+    assertEquals(emitted \@ "count", "4")
+    assert(emitted.toString.contains("showInputMessage=\"1\""), emitted.toString)
+    assertEquals(DataValidationCodec.parseAll(Some(xml(emitted.toString))), parsed)
+  }
+
+  test("corrupt sqref degrades to Preserved (never fails the read)") {
+    val container = xml(
+      """<dataValidations count="1"><dataValidation type="list" sqref="NOT A REF"><formula1>"a"</formula1></dataValidation></dataValidations>"""
+    )
+    DataValidationCodec.parseAll(Some(container)) match
+      case Vector(p: DataValidation.Preserved) => assert(p.xml.contains("NOT A REF"))
+      case other => fail(s"expected Preserved, got $other")
+  }
+
+  // ===== emission =====
+
+  test("empty model emits no container; empty-ranges typed entries are dropped") {
+    assertEquals(DataValidationCodec.toElem(Vector.empty, None), None)
+    assertEquals(
+      DataValidationCodec.toElem(Vector(DataValidation.list("\"a\"")), None),
+      None,
+      "an entry with no ranges is unexpressible and must drop"
+    )
+  }
+
+  test("a hand-built non-XML Preserved payload drops silently (CfCodec contract)") {
+    val dvs: Vector[DataValidation] =
+      Vector(DataValidation.Preserved("not xml <<<"), typedList("A1:A2", "\"a\""))
+    val emitted = DataValidationCodec.toElem(dvs, None).getOrElse(fail("no container"))
+    assertEquals((emitted \ "dataValidation").size, 1)
+    assertEquals(emitted \@ "count", "1")
+  }
+
+  test("dirty rebuild overlays unmodeled container attrs from the source and restamps count") {
+    val base = xml(
+      """<dataValidations count="7" disablePrompts="1" xWindow="120"><dataValidation type="list" sqref="A1"><formula1>"a"</formula1></dataValidation></dataValidations>"""
+    )
+    val emitted = DataValidationCodec
+      .toElem(Vector(typedList("B2:B4", "\"x,y\"")), Some(base))
+      .getOrElse(fail("no container"))
+    assertEquals(emitted \@ "count", "1", "count restamped to the emitted children")
+    assertEquals(emitted \@ "disablePrompts", "1", "unmodeled container attr dropped")
+    assertEquals(emitted \@ "xWindow", "120", "unmodeled container attr dropped")
+    assertEquals((emitted \ "dataValidation").size, 1)
+    assertEquals((emitted \ "dataValidation").headOption.map(_ \@ "sqref"), Some("B2:B4"))
+  }
+
+  test("allowBlank defaults: absent attr parses false; model true emits allowBlank=\"1\"") {
+    val emitted = DataValidationCodec
+      .toElem(Vector(typedList("A1:A2", "\"a\"", allowBlank = true)), None)
+      .getOrElse(fail("no container"))
+    assertEquals(
+      (emitted \ "dataValidation").headOption.map(_ \@ "allowBlank"),
+      Some("1")
+    )
+    val emittedFalse = DataValidationCodec
+      .toElem(Vector(typedList("A1:A2", "\"a\"", allowBlank = false)), None)
+      .getOrElse(fail("no container"))
+    assertEquals(
+      (emittedFalse \ "dataValidation").flatMap(_.attribute("allowBlank")).isEmpty,
+      true,
+      "false is the schema default and must omit the attribute"
+    )
+  }

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/worksheet/WorksheetPreservationInvariantSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/worksheet/WorksheetPreservationInvariantSpec.scala
@@ -28,6 +28,7 @@ class WorksheetPreservationInvariantSpec extends FunSuite:
     "sheetData",
     "mergeCells",
     "conditionalFormatting",
+    "dataValidations", // GH-375: dedicated OoxmlWorksheet field (was preservedKnown)
     "printOptions",
     "rowBreaks",
     "colBreaks",

--- a/xl/src/com/tjclp/xl/io/ExcelRecalc.scala
+++ b/xl/src/com/tjclp/xl/io/ExcelRecalc.scala
@@ -1,0 +1,79 @@
+package com.tjclp.xl.io
+
+import com.tjclp.xl.error.{XLException, XLResult}
+import com.tjclp.xl.formula.eval.RecalcResult
+import com.tjclp.xl.formula.eval.WorkbookEvaluator.*
+import com.tjclp.xl.formula.{Clock, Rng}
+import com.tjclp.xl.workbooks.Workbook
+
+/**
+ * Recalculating write for the sync `Excel` facade (GH-360).
+ *
+ * `Excel.write` serializes formulas with whatever cached value they carry — a freshly built `fx"…"`
+ * cell has none, so downstream cached-value consumers (openpyxl `data_only`, pandas, previewers,
+ * Excel before its first recalc) see blanks. `Excel.writeRecalculated` closes that footgun: one
+ * call recalculates the whole workbook (dependency-ordered, cross-sheet aware) and writes the
+ * cached result.
+ *
+ * The workbook is written even when some formulas fail — errors are data conditions, reported in
+ * the returned [[com.tjclp.xl.formula.eval.RecalcResult]]; failed cells stay uncached and Excel
+ * recalculates them on open. Scripts that must not proceed on partial results use `result.toEither`
+ * / `result.errors`:
+ *
+ * {{{
+ * import com.tjclp.xl.scripting.{*, given}
+ *
+ * val result = Excel.writeRecalculated(wb, "out.xlsx")
+ * if !result.isClean then result.errors.foreach(e => println(e.render))
+ * }}}
+ *
+ * Lives in the aggregate `xl` module — the only module that sees both the evaluator and the sync IO
+ * facade (xl-cats-effect cannot depend on xl-evaluator). Explicit overloads instead of default
+ * parameters: defaulted extension methods do not survive the prelude's wildcard export (see the
+ * WorkbookEvaluator note).
+ */
+object ExcelRecalc:
+
+  extension (excel: Excel.type)
+
+    /**
+     * Recalculate every formula (system clock), write the cached workbook to `path`, and return the
+     * [[com.tjclp.xl.formula.eval.RecalcResult]]. Writes even when formulas fail — inspect
+     * `result.errors` / `result.isClean`.
+     */
+    def writeRecalculated(workbook: Workbook, path: String): RecalcResult =
+      excel.writeRecalculated(workbook, path, Clock.system)
+
+    /**
+     * Recalculate with an explicit [[com.tjclp.xl.formula.Clock]] (deterministic TODAY/NOW), write
+     * the cached workbook, and return the result.
+     */
+    @annotation.targetName("writeRecalculatedWithClock")
+    def writeRecalculated(workbook: Workbook, path: String, clock: Clock): RecalcResult =
+      val result = workbook.recalculate(clock)
+      Excel.write(result.workbook, path)
+      result
+
+    /**
+     * Recalculate with an explicit clock and randomness source (GH-115: `Rng.seeded` makes
+     * RAND/RANDBETWEEN reproducible), write the cached workbook, and return the result.
+     */
+    @annotation.targetName("writeRecalculatedWithRng")
+    def writeRecalculated(workbook: Workbook, path: String, clock: Clock, rng: Rng): RecalcResult =
+      val result = workbook.recalculate(clock, rng)
+      Excel.write(result.workbook, path)
+      result
+
+    /**
+     * Convenience overload mirroring `Excel.write(result, path)`: unwraps an `XLResult[Workbook]`
+     * at the IO edge (throws [[com.tjclp.xl.error.XLException]] on `Left`), then recalculates and
+     * writes with the system clock.
+     */
+    @annotation.targetName("writeRecalculatedResult")
+    def writeRecalculated(result: XLResult[Workbook], path: String): RecalcResult =
+      excel.writeRecalculated(result, path, Clock.system)
+
+    /** `XLResult[Workbook]` overload with an explicit clock. */
+    @annotation.targetName("writeRecalculatedResultWithClock")
+    def writeRecalculated(result: XLResult[Workbook], path: String, clock: Clock): RecalcResult =
+      excel.writeRecalculated(result.fold(e => throw XLException(e), identity), path, clock)

--- a/xl/src/com/tjclp/xl/scripting.scala
+++ b/xl/src/com/tjclp/xl/scripting.scala
@@ -48,6 +48,11 @@ object scripting:
   export com.tjclp.xl.io.ExcelIO
   export com.tjclp.xl.io.RowData // streaming row type (readStream/writeStream)
 
+  // Recalculating write (GH-360): Excel.writeRecalculated — recalculate, write, return the
+  // RecalcResult. Defined in this aggregate module (the only one seeing both the evaluator and
+  // the sync facade) as extensions on Excel.type; the wildcard export puts them in scope here.
+  export com.tjclp.xl.io.ExcelRecalc.*
+
   // The one sanctioned unwrap: .unsafe / .getOrElse on XLResult
   export com.tjclp.xl.unsafe.*
 

--- a/xl/test/src/xlprelude/BaseImportProbe.scala
+++ b/xl/test/src/xlprelude/BaseImportProbe.scala
@@ -23,6 +23,9 @@ object BaseImportProbe:
   val constructed: ARef = ARef(column, theRow)
   val fromIdx: ARef = ARef.from0(2, 2)
   val parsed: Either[String, ARef] = ARef.parse("C3")
+  val colParsed: Either[String, Column] = Column.parse("D")
+  val colFromRef: Either[String, Column] = Column.parse("D1") // trailing row tolerated
+  val refTypeCol: Either[String, Column] = RefType.parse("Sales!C2:E9").map(_.col)
 
   // Extension methods chained directly on factory results (demo.sc regression)
   val chainedLetter: String = Column.from0(0).toLetter

--- a/xl/test/src/xlprelude/ScriptingPreludeTest.scala
+++ b/xl/test/src/xlprelude/ScriptingPreludeTest.scala
@@ -176,6 +176,89 @@ class ScriptingPreludeTest extends FunSuite:
       Some(3)
     )
 
+  test("writeRecalculated caches uncached formulas on disk and returns the RecalcResult (GH-360)"):
+    val sheet = Sheet("Calc3")
+      .put(ref"A1", 10)
+      .put(ref"A2", 20)
+      .put(ref"A3", fx"=SUM(A1:A2)")
+    val path = java.nio.file.Files.createTempDirectory("xl-prelude-wrecalc").resolve("clean.xlsx")
+    val result: RecalcResult = Excel.writeRecalculated(Workbook(sheet), path.toString)
+    assert(result.isClean)
+    assertEquals(
+      result.evaluated.values.headOption.flatMap(_.get(ref"A3")),
+      Some(CellValue.Number(BigDecimal(30)))
+    )
+    val cached = Excel
+      .read(path.toString)
+      .sheets
+      .headOption
+      .flatMap(_.cells.get(ref"A3"))
+      .map(_.value)
+    cached match
+      case Some(CellValue.Formula(_, Some(CellValue.Number(n)))) => assertEquals(n, BigDecimal(30))
+      case other => fail(s"expected a cached formula on disk, got $other")
+
+  test("writeRecalculated writes anyway on formula errors — errors are data (GH-360)"):
+    val sheet = Sheet("Err")
+      .put(ref"A1", 2)
+      .put(ref"A2", fx"=NOSUCHFN(A1)")
+      .put(ref"A3", fx"=A1*3")
+    val path = java.nio.file.Files.createTempDirectory("xl-prelude-wrecalc").resolve("partial.xlsx")
+    val result = Excel.writeRecalculated(Workbook(sheet), path.toString)
+    assert(!result.isClean)
+    assertEquals(result.errors.map(_.ref.toA1), Vector("A2"))
+    val cells = Excel.read(path.toString).sheets.headOption.map(_.cells).getOrElse(Map.empty)
+    cells.get(ref"A3").map(_.value) match
+      case Some(CellValue.Formula(_, Some(CellValue.Number(n)))) => assertEquals(n, BigDecimal(6))
+      case other => fail(s"expected A3 cached on disk, got $other")
+    cells.get(ref"A2").map(_.value) match
+      case Some(CellValue.Formula(_, None)) => () // failed cell stays uncached
+      case other => fail(s"expected A2 uncached on disk, got $other")
+
+  test("writeRecalculated accepts XLResult[Workbook], throwing only on Left (GH-360)"):
+    val wb = Workbook(Sheet("R").put(ref"A1", 4).put(ref"B1", fx"=A1*2"))
+    val dir = java.nio.file.Files.createTempDirectory("xl-prelude-wrecalc")
+    val okPath = dir.resolve("fromResult.xlsx")
+    val result = Excel.writeRecalculated(wb.update("R", _.put(ref"A2", 1)), okPath.toString)
+    assert(result.isClean)
+    assert(java.nio.file.Files.exists(okPath))
+    intercept[XLException]:
+      Excel.writeRecalculated(
+        wb.update("NoSuchSheet", identity),
+        dir.resolve("never.xlsx").toString
+      )
+
+  test("writeRecalculated threads the clock and rng overloads (GH-360)"):
+    val dir = java.nio.file.Files.createTempDirectory("xl-prelude-wrecalc")
+    val clock = Clock.fixedDate(java.time.LocalDate.of(2026, 7, 15))
+    val clocked = Excel.writeRecalculated(
+      Workbook(Sheet("Vol").put(ref"A1", fx"=TODAY()")),
+      dir.resolve("clock.xlsx").toString,
+      clock
+    )
+    assertEquals(
+      clocked.evaluated.values.headOption.flatMap(_.get(ref"A1")),
+      Some(CellValue.DateTime(java.time.LocalDate.of(2026, 7, 15).atStartOfDay()))
+    )
+    val seeded = Sheet("Rand").put(ref"A1", fx"=RANDBETWEEN(1,10)")
+    val r1 = Excel.writeRecalculated(
+      Workbook(seeded),
+      dir.resolve("rng1.xlsx").toString,
+      Clock.system,
+      Rng.seeded(42L)
+    )
+    val r2 = Excel.writeRecalculated(
+      Workbook(seeded),
+      dir.resolve("rng2.xlsx").toString,
+      Clock.system,
+      Rng.seeded(42L)
+    )
+    assert(r1.isClean && r2.isClean)
+    assertEquals(
+      r1.evaluated.values.headOption.flatMap(_.get(ref"A1")),
+      r2.evaluated.values.headOption.flatMap(_.get(ref"A1"))
+    )
+
   test("smart detection: FormattedParsers.detect and String.toFormatted via the prelude"):
     val detected = "$1,234.56".toFormatted
     assertEquals(detected.numFmt, NumFmt.Currency)

--- a/xl/test/src/xlprelude/ScriptingPreludeTest.scala
+++ b/xl/test/src/xlprelude/ScriptingPreludeTest.scala
@@ -58,15 +58,19 @@ class ScriptingPreludeTest extends FunSuite:
       Right(Some(BigDecimal("1000.50"))): Either[CodecError, Option[BigDecimal]]
     )
 
-  test("Patch DSL composes: :=, ++, styled, merge"):
+  test("Patch DSL composes: :=, ++, styled, merge, comment, conditionalFormat"):
     val patch =
       (ref"A1" := "Report") ++
         ref"A1".styled(CellStyle.default.bold) ++
         ref"A1:C1".merge ++
-        (ref"B2" := 19.99)
+        (ref"B2" := 19.99) ++
+        ref"B2".comment(Comment.plainText("unit price", Some("gen"))) ++
+        ref"B2:B9".conditionalFormat(CfRule.expression("B2>10", Dxf.fill(Color.Rgb(0xffffcc00))))
     val sheet = Sheet("Patched").put(patch)
     assertEquals(sheet.cells.size, 2)
     assertEquals(sheet.mergedRanges.size, 1)
+    assertEquals(sheet.getComment(ref"B2").map(_.text.toPlainText), Some("unit price"))
+    assertEquals(sheet.conditionalFormats.size, 1)
 
   test("range fill := and ARef navigation resolve through the prelude"):
     val sheet = Sheet("Fill").put(ref"A1:B2" := 0)

--- a/xl/test/src/xlprelude/ScriptingPreludeTest.scala
+++ b/xl/test/src/xlprelude/ScriptingPreludeTest.scala
@@ -84,6 +84,18 @@ class ScriptingPreludeTest extends FunSuite:
     val sheet = Sheet("Dyn").put(patch)
     assertEquals(sheet.cells.size, 1)
 
+  test("runtime column letters drive setColumnProperties (no macro literal, GH-361)"):
+    val widths = Vector("C" -> 14.0, "D" -> 22.0)
+    val sheet = widths.foldLeft(Sheet("Widths")) { case (s, (letter, w)) =>
+      val col = Column.parse(letter).getOrElse(fail(s"unparseable column: $letter"))
+      s.setColumnProperties(col, ColumnProperties(width = Some(w)))
+    }
+    assertEquals(sheet.columnProperties.size, 2)
+    assertEquals(sheet.getColumnProperties(Column.from0(3)).width, Some(22.0))
+    // Runtime-parsed RefType exposes the column handle directly
+    assertEquals(RefType.parse("E3").map(_.col.toLetter), Right("E"))
+    assertEquals(RefType.parse("Sales!C2:E9").map(_.col.toLetter), Right("C"))
+
   test("rich text extensions resolve"):
     val rich = "Status: ".bold + "ACTIVE".green
     val sheet = Sheet("Rich").put(ref"A1", rich)


### PR DESCRIPTION
## Summary

W4 of the replication-campaign roadmap (composing 0.13.0): six authoring-API additions, three worktree-isolated TDD clusters, each adversarially reviewed.

- **#375** — typed data-validation authoring (list dropdowns: inline values or range-ref formula1, allowBlank, OOXML-inverted showDropDown handled, multi-range sqref) + read-side parse into the model, structural-edit range shifting, unmodeled kinds preserved as `Preserved` (the conditional-formatting pattern); backend-parity pinned
- **#373 (part a)** — `Workbook.withCalcPr(CalcPr(...))`: scratch builds emit `<calcPr iterate iterateCount iterateDelta/>`; preserved calcPr overlaid in place (calcId/refMode survive); `markMetadataModified` wired so read→set→write can't fast-path the change away. Part (b) — bounded iterative evaluation — stays open for the evaluator wave
- **#379** — `Patch.SetComment` / `Patch.SetConditionalFormat` with DSL operators; CF auto-priority stamps through `Sheet.conditionalFormat`; composable section builders can now carry comments and CF rules
- **#380** — `Align.textRotation` (ST_TextRotation 0–180 + 255 stacked; `rotated(deg)` maps Excel-UI negatives); emitted on both backends, streamed via StylePatcher, and included in the hand-rolled `canonicalKey` so rotation-only styles stay distinct
- **#361** — `Column.parse("D")` + total `RefType.col` for runtime column loops (plain `def` on the aliased companion — no export-forwarder landmines)
- **#360** — `Excel.writeRecalculated(wb, path): RecalcResult` in the xl aggregator (the only module that sees both `Excel.write` and `recalculate`); writes even with formula errors (errors are data) and returns them for inspection

## Verification

Reviewers reverted individual source files and confirmed exactly the right tests fail (canonicalKey dedup, markMetadataModified surgical-write trap, dataValidations writer/reader wiring each independently load-bearing), ran acceptance shapes end-to-end (runtime column loop compiling against the prelude alone; rotated captions in real files; cycle workbooks still writing with uncached members), and re-ran all suites.

Integrated gates: `checkFormatAll __.sources` 25/25, `./mill __.test` 1028/1028 (4,200+ cases), roundtrip corpus 239/239, examples ✓, snippets ✓.

Skill-recipe updates for the new APIs ride the 0.13.0 release-prep (published-pin snippet gate).

Closes #375
Closes #379
Closes #380
Closes #361
Closes #360
Refs #373 (part a here; bounded iterative evaluation remains open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)