### PR TITLE
Wave 15: evaluator — defined names, iterative recalc, coercion parity, MROUND

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Defined-name resolution in formulas** (#384): `=IF(case=2,…)`,
+  `=entry_mult*ltm_ebitda`, `=SUM(rev_range)` parse, evaluate, and
+  round-trip byte-faithfully via a dedicated name AST node — workbook- and
+  sheet-scoped names (sheet-scoped shadows global per OOXML), constants,
+  ranges, and name→name chains with a cycle guard; unresolvable names are
+  clean per-cell errors. Names contribute dependency edges, so
+  `recalculate()` orders name-gated formula families correctly — on one
+  real LBO gold this class was 926 of 1,571 recalc-probe rejections.
+- **Opt-in bounded iterative recalculation** (#373, completing part b):
+  `recalculate(IterativeCalc(maxIter, maxChange))` Jacobi-fixpoints
+  declared cycles (seeded at 0, per-Excel keep-last-values on maxIter,
+  dependents evaluate off converged values, clock pinned across
+  iterations, per-cell containment inside the loop); default
+  `recalculate()` still isolates cycles as errors.
+  `IterativeCalc.fromCalcPr` bridges the workbook's authored calcPr.
+  Circular LBO debt schedules now verify end-to-end.
+- **MROUND** (#386): the 108th registry function —
+  `multiple × ROUND(number/multiple)`, `MROUND(x, 0) = 0`, sign-mismatch
+  errors — the standard term-loan sizing idiom.
+
+### Fixed
+
+- **Coercion parity with Excel** (#385): raw serial `Number` cells coerce
+  in date positions (YEAR/MONTH/DAY/EOMONTH/EDATE/DATEDIF/NETWORKDAYS/
+  WORKDAY/YEARFRAC — professional workbooks store dates exclusively as
+  serials), and blank cells coerce to 0 in scalar numeric positions
+  (`=A1+1`, `=-A1`, `=A1%`) — while range aggregates still skip blanks and
+  error cells still propagate. Two real-model recalc-probe rejection
+  classes eliminated.
+
 - **Data-validation authoring** (#375): typed list dropdowns —
   `sheet.withDataValidation(range, DataValidation.list("\"Yes,No\""))` or a
   range-ref formula — with allowBlank/showDropdown (OOXML's inverted

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ xl/              → Aggregate module + scripting prelude (com.tjclp.xl.scriptin
 xl-core/         → Pure domain model (Cell, Sheet, Workbook, Patch, Style), macros, DSL
 xl-ooxml/        → Pure OOXML mapping (XlsxReader, XlsxWriter, SharedStrings, Styles)
 xl-cats-effect/  → IO interpreters and streaming (Excel[F], ExcelIO, SAX-based streaming)
-xl-evaluator/    → Formula parser/evaluator (TExpr GADT, 107 functions, dependency graphs)
+xl-evaluator/    → Formula parser/evaluator (TExpr GADT, 108 functions, dependency graphs)
 xl-cli/          → Stateless `xl` CLI (internal, native-image capable)
 xl-agent/        → AI agent benchmark runner (Anthropic API, skill comparison)
 xl-benchmarks/   → JMH performance benchmarks
@@ -364,7 +364,7 @@ sheet.evaluateFormula("=SUM(A1:A10)")      // XLResult[CellValue]
 sheet.evaluateWithDependencyCheck()         // Safe eval with cycle detection
 ```
 
-**107 Functions**: SUM, SUMIF, SUMIFS, SUMPRODUCT, COUNT, COUNTA, COUNTBLANK, COUNTIF, COUNTIFS, AVERAGE, AVERAGEIF, AVERAGEIFS, MAXIFS, MINIFS, MEDIAN, STDEV, STDEVP, VAR, VARP, LARGE, SMALL, RANK, PERCENTILE, QUARTILE, MIN, MAX, IF, IFS, IFERROR, SWITCH, CHOOSE, AND, OR, NOT, ISNUMBER, ISTEXT, ISBLANK, ISERR, ISERROR, CONCATENATE, LEFT, RIGHT, MID, LEN, UPPER, LOWER, TRIM, FIND, SUBSTITUTE, TEXT, VALUE, TODAY, NOW, DATE, YEAR, MONTH, DAY, EOMONTH, EDATE, DATEDIF, NETWORKDAYS, WORKDAY, YEARFRAC, ABS, ROUND, ROUNDUP, ROUNDDOWN, INT, MOD, POWER, SQRT, LOG, LN, EXP, FLOOR, CEILING, TRUNC, SIGN, PMT, FV, PV, RATE, NPER, NPV, IRR, XNPV, XIRR, VLOOKUP, HLOOKUP, XLOOKUP, INDEX, MATCH, OFFSET, INDIRECT, PI, ROW, COLUMN, ROWS, COLUMNS, ADDRESS, TRANSPOSE, SEQUENCE, SORT, UNIQUE, FILTER, RAND, RANDBETWEEN — plus LET (lexical bindings; a parser-level special form, not in the registry listing)
+**108 Functions**: SUM, SUMIF, SUMIFS, SUMPRODUCT, COUNT, COUNTA, COUNTBLANK, COUNTIF, COUNTIFS, AVERAGE, AVERAGEIF, AVERAGEIFS, MAXIFS, MINIFS, MEDIAN, STDEV, STDEVP, VAR, VARP, LARGE, SMALL, RANK, PERCENTILE, QUARTILE, MIN, MAX, IF, IFS, IFERROR, SWITCH, CHOOSE, AND, OR, NOT, ISNUMBER, ISTEXT, ISBLANK, ISERR, ISERROR, CONCATENATE, LEFT, RIGHT, MID, LEN, UPPER, LOWER, TRIM, FIND, SUBSTITUTE, TEXT, VALUE, TODAY, NOW, DATE, YEAR, MONTH, DAY, EOMONTH, EDATE, DATEDIF, NETWORKDAYS, WORKDAY, YEARFRAC, ABS, ROUND, ROUNDUP, ROUNDDOWN, INT, MOD, MROUND, POWER, SQRT, LOG, LN, EXP, FLOOR, CEILING, TRUNC, SIGN, PMT, FV, PV, RATE, NPER, NPV, IRR, XNPV, XIRR, VLOOKUP, HLOOKUP, XLOOKUP, INDEX, MATCH, OFFSET, INDIRECT, PI, ROW, COLUMN, ROWS, COLUMNS, ADDRESS, TRANSPOSE, SEQUENCE, SORT, UNIQUE, FILTER, RAND, RANDBETWEEN — plus LET (lexical bindings; a parser-level special form, not in the registry listing)
 
 ### Rich Text
 ```scala

--- a/xl-evaluator/src/com/tjclp/xl/exports.scala
+++ b/xl-evaluator/src/com/tjclp/xl/exports.scala
@@ -49,7 +49,7 @@ object formulaExports:
   export formula.eval.WorkbookEvaluator.*
 
   // Recalc result types (workbook-level total recalculation with per-cell errors)
-  export formula.eval.{CellEvalError, RecalcResult}
+  export formula.eval.{CellEvalError, IterativeCalc, RecalcResult}
 
   // DependentRecalculation extension methods (GH-163)
   // Note: Extension methods with default parameters must be imported directly,

--- a/xl-evaluator/src/com/tjclp/xl/formula/ast/TExpr.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/ast/TExpr.scala
@@ -360,14 +360,14 @@ enum TExpr[A] derives CanEqual:
    * `=SUM(rev_range)`. OOXML forbids defined names that collide with cell-ref shapes, so the
    * disambiguation is total: ARef-parseable identifiers (TAX1) stay PolyRef.
    *
-   * Resolution is deferred to evaluation (the parser has no workbook): the evaluator looks the
-   * name up in `WorkbookMetadata.definedNames` — sheet-scoped names SHADOW workbook-scoped ones
-   * per OOXML, lookup is case-insensitive — parses the refersTo text and evaluates it in the
-   * DEFINING sheet's context. Unresolvable names, unparseable refersTo text, and name→name
-   * cycles are clean per-cell errors. Existential-typed like PolyRef; the typed coercion
-   * boundary wraps it in [[Coerced]] so names work in typed argument positions. Prints as the
-   * bare identifier, verbatim. Never shifts on drag and contributes no local dependencies
-   * (workbook-level dependency extraction resolves it to its target cells).
+   * Resolution is deferred to evaluation (the parser has no workbook): the evaluator looks the name
+   * up in `WorkbookMetadata.definedNames` — sheet-scoped names SHADOW workbook-scoped ones per
+   * OOXML, lookup is case-insensitive — parses the refersTo text and evaluates it in the DEFINING
+   * sheet's context. Unresolvable names, unparseable refersTo text, and name→name cycles are clean
+   * per-cell errors. Existential-typed like PolyRef; the typed coercion boundary wraps it in
+   * [[Coerced]] so names work in typed argument positions. Prints as the bare identifier, verbatim.
+   * Never shifts on drag and contributes no local dependencies (workbook-level dependency
+   * extraction resolves it to its target cells).
    */
   case NameRef(name: String) extends TExpr[Nothing]
 

--- a/xl-evaluator/src/com/tjclp/xl/formula/ast/TExpr.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/ast/TExpr.scala
@@ -353,6 +353,25 @@ enum TExpr[A] derives CanEqual:
   case BindingRef(name: String) extends TExpr[Nothing]
 
   /**
+   * GH-384: reference to a workbook defined name (named range / named formula) by identifier.
+   *
+   * Emitted by the parser for a bare name-shaped identifier that is NOT a cell reference, NOT an
+   * in-scope LET binding, and NOT followed by `(` or `!` — `=case`, `=entry_mult*ltm_ebitda`,
+   * `=SUM(rev_range)`. OOXML forbids defined names that collide with cell-ref shapes, so the
+   * disambiguation is total: ARef-parseable identifiers (TAX1) stay PolyRef.
+   *
+   * Resolution is deferred to evaluation (the parser has no workbook): the evaluator looks the
+   * name up in `WorkbookMetadata.definedNames` — sheet-scoped names SHADOW workbook-scoped ones
+   * per OOXML, lookup is case-insensitive — parses the refersTo text and evaluates it in the
+   * DEFINING sheet's context. Unresolvable names, unparseable refersTo text, and name→name
+   * cycles are clean per-cell errors. Existential-typed like PolyRef; the typed coercion
+   * boundary wraps it in [[Coerced]] so names work in typed argument positions. Prints as the
+   * bare identifier, verbatim. Never shifts on drag and contributes no local dependencies
+   * (workbook-level dependency extraction resolves it to its target cells).
+   */
+  case NameRef(name: String) extends TExpr[Nothing]
+
+  /**
    * GH-193: An in-scope LET binding used in a statically-typed argument position.
    *
    * BindingRef is Any-typed like PolyRef, so the typed coercion boundary (asStringExpr, asIntExpr,

--- a/xl-evaluator/src/com/tjclp/xl/formula/ast/TExprCoercions.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/ast/TExprCoercions.scala
@@ -131,10 +131,13 @@ trait TExprCoercions:
    */
   @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
   def asNumericExpr(expr: TExpr[?]): TExpr[BigDecimal] = expr match
-    case PolyRef(at, anchor) => Ref(at, anchor, decodeNumeric)
+    // GH-385: scalar numeric positions treat a blank cell as 0 (=A1+1 with blank A1 is 1, like
+    // Excel); range FOLDS keep strict decodeNumeric (TExpr.Aggregate, cashflow collection) so
+    // MIN/MEDIAN skip blanks and NPV periods don't shift
+    case PolyRef(at, anchor) => Ref(at, anchor, decodeNumericScalar)
     // GH-374: push through the transparent unary-plus wrapper (see asStringExpr)
     case UnaryPlus(inner) => UnaryPlus(asNumericExpr(inner))
-    case SheetPolyRef(sheet, at, anchor) => SheetRef(sheet, at, anchor, decodeNumeric)
+    case SheetPolyRef(sheet, at, anchor) => SheetRef(sheet, at, anchor, decodeNumericScalar)
     // GH-193: LET bindings are Any-typed — coerce totally at evaluation time
     case BindingRef(name) => CoercedBindingRef[BigDecimal](name, BindingCoercion.Numeric)
     // GH-307: cross-typed literals coerce at evaluation time (=SQRT("16") → 4, TRUE → 1);

--- a/xl-evaluator/src/com/tjclp/xl/formula/ast/TExprCoercions.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/ast/TExprCoercions.scala
@@ -20,6 +20,9 @@ trait TExprCoercions:
    */
   private def isRuntimePolymorphic(expr: TExpr[?]): Boolean = expr match
     case _: TExpr.Call[?] | _: TExpr.Let[?] | _: TExpr.Aggregate | _: TExpr.Coerced[?] => true
+    // GH-384: a defined name's runtime value comes from the workbook's name table — coerce it
+    // at evaluation time like a call result (=EOMONTH(named_date, 0), =IF(case=2, ...))
+    case _: TExpr.NameRef => true
     case _: TExpr.Add | _: TExpr.Sub | _: TExpr.Mul | _: TExpr.Div | _: TExpr.Pow |
         _: TExpr.Percent =>
       true

--- a/xl-evaluator/src/com/tjclp/xl/formula/ast/TExprDecoders.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/ast/TExprDecoders.scala
@@ -6,7 +6,7 @@ import com.tjclp.xl.formula.functions.EvalContext
 
 import com.tjclp.xl.cells.{Cell, CellValue}
 import com.tjclp.xl.codec.CodecError
-import com.tjclp.xl.formula.eval.ArrayArithmetic
+import com.tjclp.xl.formula.eval.{ArrayArithmetic, ScalarCoercion}
 
 trait TExprDecoders:
   // Decoder functions for cell coercion
@@ -39,6 +39,23 @@ trait TExprDecoders:
             actual = other
           )
         )
+
+  /**
+   * GH-385: numeric decoding for SCALAR reference positions — Excel treats a direct reference to a
+   * blank cell as 0 in numeric contexts (=A1+1 with blank A1 is 1, =ABS(A1) is 0), matching
+   * ScalarCoercion.coerceNumeric's Empty -> 0 and ArrayArithmetic's Empty -> 0 broadcast rule.
+   *
+   * A separate decoder rather than an Empty case inside [[decodeNumeric]]: decodeNumeric is also
+   * the range-FOLD decoder for the TExpr.Aggregate path (Evaluator) and the XNPV/XIRR/NPV/IRR
+   * cashflow collector (FunctionSpecsFinancialCashflow), where Empty must stay a skip — MIN/MEDIAN
+   * over a sparse range ignore blanks, and a blank cashflow must not become a period-shifting 0.
+   * Error values still refuse via the delegate's catch-all (Empty and Error are distinct
+   * constructors, so blank-as-zero can never mask a carried error).
+   */
+  def decodeNumericScalar(cell: Cell): Either[CodecError, BigDecimal] =
+    cell.value match
+      case CellValue.Empty => scala.util.Right(BigDecimal(0))
+      case _ => decodeNumeric(cell)
 
   /**
    * Decode cell as LocalDate value (extracts date from DateTime).
@@ -169,16 +186,30 @@ trait TExprDecoders:
    *
    * Matches Excel semantics:
    *   - DateTime -> extract date component
-   *   - Number -> interpret as Excel serial number (not yet implemented)
-   *   - Text -> parse as ISO date (not yet implemented)
-   *   - Other -> error
+   *   - Number -> Excel serial number -> date (GH-385: professional workbooks store dates
+   *     exclusively as serials with date numFmts; guarded to 0..MaxExcelDateSerial like
+   *     ScalarCoercion.coerceDate, 1900 date system — the evaluator-wide assumption, see
+   *     docs/LIMITATIONS.md)
+   *   - Formula -> cached DateTime or cached serial Number, same conversions
+   *   - Text -> error (Excel does not coerce arbitrary text in date positions)
    */
   def decodeAsDate(cell: Cell): Either[CodecError, java.time.LocalDate] =
+    def serialToDate(serial: BigDecimal): Option[java.time.LocalDate] =
+      if serial >= 0 && serial <= ScalarCoercion.MaxExcelDateSerial then
+        Some(CellValue.excelSerialToDateTime(serial.toDouble).toLocalDate)
+      else None
+
     cell.value match
       case CellValue.DateTime(dt) => scala.util.Right(dt.toLocalDate)
+      // Out-of-range serials (negative or beyond 9999-12-31) fold to a clean error, mirroring
+      // ScalarCoercion.coerceDate's guard
+      case CellValue.Number(serial) =>
+        serialToDate(serial).toRight(CodecError.TypeMismatch("Date", cell.value))
+      case CellValue.Formula(_, Some(CellValue.DateTime(cached))) =>
+        scala.util.Right(cached.toLocalDate)
+      case CellValue.Formula(_, Some(CellValue.Number(cached))) =>
+        serialToDate(cached).toRight(CodecError.TypeMismatch("Date", cell.value))
       case other =>
-        // Future: could add Excel serial number -> date conversion for Number
-        // Future: could add ISO date string parsing for Text
         scala.util.Left(
           CodecError.TypeMismatch(
             expected = "Date",

--- a/xl-evaluator/src/com/tjclp/xl/formula/ast/TExprMathOps.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/ast/TExprMathOps.scala
@@ -104,6 +104,14 @@ trait TExprMathOps:
     Call(FunctionSpecs.ceiling, (number, significance))
 
   /**
+   * MROUND: round to the nearest multiple (half away from zero).
+   *
+   * Example: TExpr.mround(TExpr.Lit(10), TExpr.Lit(3))
+   */
+  def mround(number: TExpr[BigDecimal], multiple: TExpr[BigDecimal]): TExpr[BigDecimal] =
+    Call(FunctionSpecs.mround, (number, multiple))
+
+  /**
    * TRUNC: truncate to specified number of decimal places.
    *
    * Example: TExpr.trunc(TExpr.Lit(8.9), TExpr.Lit(0))

--- a/xl-evaluator/src/com/tjclp/xl/formula/eval/Evaluator.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/eval/Evaluator.scala
@@ -167,10 +167,10 @@ object Evaluator:
   /**
    * Look up a defined name visible from `currentSheet`.
    *
-   * OOXML/Excel scoping: a sheet-scoped entry (localSheetId is a POSITIONAL index into
-   * `wb.sheets`) SHADOWS a workbook-scoped entry of the same identifier; lookup is
-   * case-insensitive like Excel. (GH-384's issue text said "workbook-scoped first" — that
-   * contradicts OOXML §18.2.5/Excel behavior, so shadowing is implemented instead.)
+   * OOXML/Excel scoping: a sheet-scoped entry (localSheetId is a POSITIONAL index into `wb.sheets`)
+   * SHADOWS a workbook-scoped entry of the same identifier; lookup is case-insensitive like Excel.
+   * (GH-384's issue text said "workbook-scoped first" — that contradicts OOXML §18.2.5/Excel
+   * behavior, so shadowing is implemented instead.)
    */
   private[formula] def lookupDefinedName(
     wb: Workbook,
@@ -187,8 +187,8 @@ object Evaluator:
 
   /**
    * The sheet a defined name's refersTo evaluates against when the name is sheet-scoped; None for
-   * workbook-scoped names (callers fall back to the referencing formula's sheet — refersTo text
-   * is almost always fully qualified anyway).
+   * workbook-scoped names (callers fall back to the referencing formula's sheet — refersTo text is
+   * almost always fully qualified anyway).
    */
   private[formula] def definedNameScope(wb: Workbook, dn: DefinedName): Option[Sheet] =
     dn.localSheetId.flatMap(idx => wb.sheets.lift(idx))
@@ -333,8 +333,8 @@ object Evaluator:
  * @param resolvingNames
  *   GH-384: UPPERCASED defined names currently being resolved on this evaluation path — the
  *   name→name cycle guard. A refersTo chain that revisits a member (aa → bb → aa) is a clean
- *   per-cell error instead of unbounded recursion. Cell-mediated cycles (name → cell → name)
- *   are covered separately by the depth-guarded cross-sheet recursion.
+ *   per-cell error instead of unbounded recursion. Cell-mediated cycles (name → cell → name) are
+ *   covered separately by the depth-guarded cross-sheet recursion.
  */
 private class EvaluatorImpl(
   allowArrayResults: Boolean = false,
@@ -798,16 +798,16 @@ private class EvaluatorImpl(
    * Lookup (sheet-scoped SHADOWS workbook-scoped, case-insensitive — see
    * Evaluator.lookupDefinedName), then parse the refersTo text and evaluate it in the DEFINING
    * context: sheet-scoped names evaluate against their scope sheet, workbook-scoped names against
-   * the referencing formula's sheet (refersTo text is almost always fully qualified, so the
-   * ambient sheet rarely matters). Range-shaped targets materialize to an ArrayResult against the
-   * defining sheet — aggregate positions consume it directly (=SUM(rev_range)), operand positions
-   * broadcast, and scalar contexts collapse to the top-left value, exactly like a literal range.
+   * the referencing formula's sheet (refersTo text is almost always fully qualified, so the ambient
+   * sheet rarely matters). Range-shaped targets materialize to an ArrayResult against the defining
+   * sheet — aggregate positions consume it directly (=SUM(rev_range)), operand positions broadcast,
+   * and scalar contexts collapse to the top-left value, exactly like a literal range.
    *
    * Every failure mode is a clean Left: no workbook context (the SheetRef posture), unknown name,
    * unparseable refersTo, and name→name cycles (via `resolvingNames`). The environment for the
-   * refersTo body is fresh (no LET bindings leak into a name's definition), and the result
-   * unwraps CellValue wrappers to primitives exactly like LET binding values so names compose
-   * with arithmetic/comparison/text machinery.
+   * refersTo body is fresh (no LET bindings leak into a name's definition), and the result unwraps
+   * CellValue wrappers to primitives exactly like LET binding values so names compose with
+   * arithmetic/comparison/text machinery.
    */
   private def evalNameRef(
     name: String,

--- a/xl-evaluator/src/com/tjclp/xl/formula/eval/Evaluator.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/eval/Evaluator.scala
@@ -10,7 +10,7 @@ import com.tjclp.xl.formula.{Clock, Rng}
 import com.tjclp.xl.sheets.Sheet
 import com.tjclp.xl.addressing.ARef
 import com.tjclp.xl.cells.{Cell, CellValue}
-import com.tjclp.xl.workbooks.Workbook
+import com.tjclp.xl.workbooks.{DefinedName, Workbook}
 import com.tjclp.xl.SheetName
 import com.tjclp.xl.syntax.* // Extension methods for Sheet.get, CellRange.cells, ARef.toA1
 import scala.math.BigDecimal
@@ -162,6 +162,37 @@ object Evaluator:
       case loc @ TExpr.RangeLocation.External(_, _, _) =>
         Left(externalRefUnsupported(loc.toA1))
 
+  // ===== GH-384: defined-name resolution =====
+
+  /**
+   * Look up a defined name visible from `currentSheet`.
+   *
+   * OOXML/Excel scoping: a sheet-scoped entry (localSheetId is a POSITIONAL index into
+   * `wb.sheets`) SHADOWS a workbook-scoped entry of the same identifier; lookup is
+   * case-insensitive like Excel. (GH-384's issue text said "workbook-scoped first" — that
+   * contradicts OOXML §18.2.5/Excel behavior, so shadowing is implemented instead.)
+   */
+  private[formula] def lookupDefinedName(
+    wb: Workbook,
+    currentSheet: SheetName,
+    name: String
+  ): Option[DefinedName] =
+    val names = wb.metadata.definedNames
+    val sheetIdx = wb.sheets.indexWhere(_.name == currentSheet)
+    val sheetScoped =
+      if sheetIdx >= 0 then
+        names.find(dn => dn.name.equalsIgnoreCase(name) && dn.localSheetId.contains(sheetIdx))
+      else None
+    sheetScoped.orElse(names.find(dn => dn.name.equalsIgnoreCase(name) && dn.localSheetId.isEmpty))
+
+  /**
+   * The sheet a defined name's refersTo evaluates against when the name is sheet-scoped; None for
+   * workbook-scoped names (callers fall back to the referencing formula's sheet — refersTo text
+   * is almost always fully qualified anyway).
+   */
+  private[formula] def definedNameScope(wb: Workbook, dn: DefinedName): Option[Sheet] =
+    dn.localSheetId.flatMap(idx => wb.sheets.lift(idx))
+
   /** Maximum recursion depth for cross-sheet formula evaluation (GH-161 cycle protection). */
   private val MaxCrossSheetRecursionDepth = 100
 
@@ -299,11 +330,17 @@ object Evaluator:
  * @param rng
  *   GH-115: randomness capability for RAND/RANDBETWEEN, threaded like bindings so derived
  *   evaluators (array args, cross-sheet recursion, LET bodies) draw from the same source.
+ * @param resolvingNames
+ *   GH-384: UPPERCASED defined names currently being resolved on this evaluation path — the
+ *   name→name cycle guard. A refersTo chain that revisits a member (aa → bb → aa) is a clean
+ *   per-cell error instead of unbounded recursion. Cell-mediated cycles (name → cell → name)
+ *   are covered separately by the depth-guarded cross-sheet recursion.
  */
 private class EvaluatorImpl(
   allowArrayResults: Boolean = false,
   bindings: Map[String, Any] = Map.empty,
-  rng: Rng = Rng.system
+  rng: Rng = Rng.system,
+  resolvingNames: Set[String] = Set.empty
 ) extends Evaluator:
   /** Current recursion depth for cross-sheet formula evaluation. */
   protected def currentDepth: Int = 0
@@ -626,7 +663,8 @@ private class EvaluatorImpl(
             allowArrayResults = true,
             bindings,
             rng,
-            Some(callMemo)
+            Some(callMemo),
+            resolvingNames // GH-384: the name-cycle guard survives array-argument evaluation
           )
             .eval(expr, sheet, clock, workbook, currentCell)
 
@@ -683,6 +721,13 @@ private class EvaluatorImpl(
         evalLet(letBindings, body, sheet, clock, workbook, currentCell)
           .asInstanceOf[Either[EvalError, A]]
 
+      // ===== GH-384: defined-name references =====
+      // Resolved here (not at parse) because only the workbook knows the name table. Same
+      // Either-container cast rationale as BindingRef (TExpr[Nothing] refinement).
+      case TExpr.NameRef(name) =>
+        evalNameRef(name, sheet, clock, workbook, currentCell)
+          .asInstanceOf[Either[EvalError, A]]
+
   // ===== GH-193: LET evaluation =====
 
   /**
@@ -710,7 +755,14 @@ private class EvaluatorImpl(
             // Bare cell refs resolve to the cell's effective value (cached formula extracted,
             // Empty → 0) — same treatment as top-level refs and equality operands (GH-233).
             val resolved = TExpr.asResolvedValueExpr(valueExpr)
-            new EvaluatorWithDepth(currentDepth, allowArrayResults = true, env, rng, memoOpt)
+            new EvaluatorWithDepth(
+              currentDepth,
+              allowArrayResults = true,
+              env,
+              rng,
+              memoOpt,
+              resolvingNames
+            )
               .eval(resolved.asInstanceOf[TExpr[Any]], sheet, clock, workbook, currentCell)
               .map(value => env + (name -> unwrapBindingValue(value)))
               .left
@@ -734,9 +786,109 @@ private class EvaluatorImpl(
             .map(targetSheet => ArrayArithmetic.rangeToArray(range, targetSheet))
         case other =>
           val resolvedBody = TExpr.asResolvedValueExpr(other)
-          new EvaluatorWithDepth(currentDepth, allowArrayResults, env, rng, memoOpt)
+          new EvaluatorWithDepth(currentDepth, allowArrayResults, env, rng, memoOpt, resolvingNames)
             .eval(resolvedBody.asInstanceOf[TExpr[Any]], sheet, clock, workbook, currentCell)
     }
+
+  // ===== GH-384: defined-name resolution =====
+
+  /**
+   * Resolve a defined-name reference to its value.
+   *
+   * Lookup (sheet-scoped SHADOWS workbook-scoped, case-insensitive — see
+   * Evaluator.lookupDefinedName), then parse the refersTo text and evaluate it in the DEFINING
+   * context: sheet-scoped names evaluate against their scope sheet, workbook-scoped names against
+   * the referencing formula's sheet (refersTo text is almost always fully qualified, so the
+   * ambient sheet rarely matters). Range-shaped targets materialize to an ArrayResult against the
+   * defining sheet — aggregate positions consume it directly (=SUM(rev_range)), operand positions
+   * broadcast, and scalar contexts collapse to the top-left value, exactly like a literal range.
+   *
+   * Every failure mode is a clean Left: no workbook context (the SheetRef posture), unknown name,
+   * unparseable refersTo, and name→name cycles (via `resolvingNames`). The environment for the
+   * refersTo body is fresh (no LET bindings leak into a name's definition), and the result
+   * unwraps CellValue wrappers to primitives exactly like LET binding values so names compose
+   * with arithmetic/comparison/text machinery.
+   */
+  private def evalNameRef(
+    name: String,
+    sheet: Sheet,
+    clock: Clock,
+    workbook: Option[Workbook],
+    currentCell: Option[ARef]
+  ): Either[EvalError, Any] =
+    workbook match
+      case None =>
+        Left(
+          EvalError.EvalFailed(
+            s"Defined name '$name' requires workbook context, but none was provided.",
+            None
+          )
+        )
+      case Some(wb) =>
+        val key = name.toUpperCase
+        if resolvingNames.contains(key) then
+          Left(
+            EvalError.EvalFailed(
+              s"Defined name cycle detected while resolving '$name'.",
+              None
+            )
+          )
+        else
+          Evaluator.lookupDefinedName(wb, sheet.name, name) match
+            case None =>
+              Left(
+                EvalError.EvalFailed(
+                  s"Name '$name' is not defined in this workbook.",
+                  None
+                )
+              )
+            case Some(dn) =>
+              FormulaParser.parse(dn.formula) match
+                case Left(parseErr) =>
+                  Left(
+                    EvalError.EvalFailed(
+                      s"Defined name '$name' has an unparseable definition '${dn.formula}': " +
+                        s"${ParseError.toXLError(parseErr, dn.formula).message}",
+                      None
+                    )
+                  )
+                case Right(target) =>
+                  val definingSheet = Evaluator.definedNameScope(wb, dn).getOrElse(sheet)
+                  target match
+                    // Range-shaped names materialize like literal ranges in array positions:
+                    // consumers collapse (scalar), broadcast (operands), or aggregate (SUM)
+                    case TExpr.RangeRef(range) =>
+                      Right(ArrayArithmetic.rangeToArray(range, definingSheet))
+                    case TExpr.SheetRange(sheetName, range) =>
+                      Evaluator
+                        .resolveRangeLocation(
+                          TExpr.RangeLocation.CrossSheet(sheetName, range),
+                          definingSheet,
+                          workbook
+                        )
+                        .map(targetSheet => ArrayArithmetic.rangeToArray(range, targetSheet))
+                    case other =>
+                      // Bare refs resolve to the cell's effective value (cached formula
+                      // extracted, Empty → 0) like top-level refs; the derived evaluator
+                      // carries the cycle guard and a FRESH binding environment (LET
+                      // bindings never leak into a name's definition).
+                      val resolved = TExpr.asResolvedValueExpr(other)
+                      new EvaluatorWithDepth(
+                        currentDepth,
+                        allowArrayResults = true,
+                        Map.empty,
+                        rng,
+                        memoOpt,
+                        resolvingNames + key
+                      )
+                        .eval(
+                          resolved.asInstanceOf[TExpr[Any]],
+                          definingSheet,
+                          clock,
+                          workbook,
+                          currentCell
+                        )
+                        .map(unwrapBindingValue)
 
   /**
    * Total text coercion for '&' operands, mirroring the decodeAsString conventions (Number →
@@ -1045,7 +1197,8 @@ private class EvaluatorWithDepth(
   allowArrayResults: Boolean = false,
   bindings: Map[String, Any] = Map.empty,
   rng: Rng = Rng.system,
-  memo: Option[Evaluator.EvalMemo] = None
-) extends EvaluatorImpl(allowArrayResults, bindings, rng):
+  memo: Option[Evaluator.EvalMemo] = None,
+  resolvingNames: Set[String] = Set.empty
+) extends EvaluatorImpl(allowArrayResults, bindings, rng, resolvingNames):
   override protected def currentDepth: Int = depth
   override protected def memoOpt: Option[Evaluator.EvalMemo] = memo

--- a/xl-evaluator/src/com/tjclp/xl/formula/eval/FormulaFormatting.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/eval/FormulaFormatting.scala
@@ -177,6 +177,10 @@ object FormulaFormatting:
         case TExpr.BindingRef(_) => Vector.empty
         case TExpr.CoercedBindingRef(_, _) => Vector.empty
 
+        // GH-384: a defined-name reference's target cells live behind workbook metadata this
+        // sheet-level walk cannot see — no format to inherit (like cross-sheet refs)
+        case TExpr.NameRef(_) => Vector.empty
+
         // GH-306: runtime coercion wrapper — transparent for format inference
         case TExpr.Coerced(inner, _) => loop(inner)
 

--- a/xl-evaluator/src/com/tjclp/xl/formula/eval/Recalc.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/eval/Recalc.scala
@@ -3,7 +3,7 @@ package com.tjclp.xl.formula.eval
 import com.tjclp.xl.addressing.{ARef, SheetName}
 import com.tjclp.xl.cells.CellValue
 import com.tjclp.xl.error.XLError
-import com.tjclp.xl.workbooks.Workbook
+import com.tjclp.xl.workbooks.{CalcPr, Workbook}
 
 /**
  * A formula cell that failed to evaluate during `Workbook.recalculate`, with its location and
@@ -19,6 +19,42 @@ final case class CellEvalError(
    * sheet names quote (`'A1'!B2: ...`) so the location reads unambiguously.
    */
   def render: String = s"${SheetName.quoteForFormula(sheet.value)}!${ref.toA1}: ${error.message}"
+
+/**
+ * GH-373: opt-in bounded iterative calculation for circular workbooks.
+ *
+ * Professional models are routinely circular by design (interest on average debt balances) and ship
+ * with `<calcPr iterate="1">`. Passing an `IterativeCalc` to `recalculate` fixpoints cycle members
+ * with Jacobi iteration (every member reads PREVIOUS-iteration values, matching Excel): members
+ * seed to 0, iterate until every member's |Δ| < `maxChange` or `maxIter` rounds, and
+ * non-convergence keeps the last values with NO error — Excel's semantics, and the deliberate
+ * inversion of the default path's circular-reference errors.
+ *
+ * Deliberately NOT auto-derived from `wb.metadata.calcPr` — iteration is opt-in so the default
+ * `recalculate()` stays byte-identical. Bridge explicitly when honoring a file's settings:
+ * {{{
+ * wb.metadata.calcPr
+ *   .filter(_.iterativeCalculation)
+ *   .map(IterativeCalc.fromCalcPr)
+ *   .fold(wb.recalculate())(it => wb.recalculate(it))
+ * }}}
+ *
+ * @param maxIter
+ *   Iteration cap (Excel UI default 100; values < 1 are treated as 1)
+ * @param maxChange
+ *   Convergence threshold: iteration stops when every cycle member changes by LESS than this
+ *   between rounds (Excel UI default 0.001)
+ */
+final case class IterativeCalc(maxIter: Int, maxChange: BigDecimal) derives CanEqual
+
+object IterativeCalc:
+  /**
+   * Lift a workbook's modeled `<calcPr>` into iteration settings, applying Excel's defaults (100,
+   * 0.001) for absent attributes. Callers gate on `calcPr.iterativeCalculation` themselves — see
+   * the bridge example on [[IterativeCalc]].
+   */
+  def fromCalcPr(cp: CalcPr): IterativeCalc =
+    IterativeCalc(cp.maxIterations.getOrElse(100), cp.maxChange.getOrElse(BigDecimal("0.001")))
 
 /**
  * Result of a total, whole-workbook recalculation (`wb.recalculate()`).

--- a/xl-evaluator/src/com/tjclp/xl/formula/eval/ScalarCoercion.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/eval/ScalarCoercion.scala
@@ -34,8 +34,12 @@ import scala.math.BigDecimal
  */
 private[formula] object ScalarCoercion:
 
-  /** Largest Excel date serial (9999-12-31); guards excelSerialToDateTime against overflow. */
-  private val MaxExcelDateSerial = BigDecimal(2958465)
+  /**
+   * Largest Excel date serial (9999-12-31); guards excelSerialToDateTime against overflow. Shared
+   * with TExprDecoders.decodeAsDate (GH-385) so the direct-cell and Coerced date boundaries accept
+   * the same serial domain.
+   */
+  val MaxExcelDateSerial: BigDecimal = BigDecimal(2958465)
 
   /** Collapse an ArrayResult to its scalar value: top-left, Empty when empty (GH-302). */
   def collapseArray(ar: ArrayResult): CellValue =

--- a/xl-evaluator/src/com/tjclp/xl/formula/eval/WorkbookEvaluator.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/eval/WorkbookEvaluator.scala
@@ -157,7 +157,7 @@ object WorkbookEvaluator:
      * `recalculateDependents` treats dynamic cells as always dirty instead.
      */
     def recalculate(clock: Clock = Clock.system): RecalcResult =
-      recalculateImpl(wb, clock, None)
+      recalculateImpl(wb, clock, None, None)
 
     /**
      * Total whole-workbook recalculation with an explicit randomness source (GH-115).
@@ -167,11 +167,44 @@ object WorkbookEvaluator:
      */
     @annotation.targetName("recalculateWithRng")
     def recalculate(clock: Clock, rng: Rng): RecalcResult =
-      recalculateImpl(wb, clock, Some(rng))
+      recalculateImpl(wb, clock, Some(rng), None)
+
+    /**
+     * GH-373: recalculation with OPT-IN bounded iterative evaluation of circular references (system
+     * clock).
+     *
+     * Cycle members fixpoint via Jacobi iteration instead of erroring — see [[IterativeCalc]] for
+     * semantics (0-seeding, |Δ| < maxChange convergence, non-convergence keeps last values with no
+     * error) and for the explicit bridge from a file's `<calcPr>` settings
+     * (`wb.metadata.calcPr.filter(_.iterativeCalculation).map(IterativeCalc.fromCalcPr)`). Acyclic
+     * workbooks behave exactly like the default `recalculate()`.
+     *
+     * Note: explicit overloads instead of default parameters — extension methods with default
+     * arguments crash the compiler when merged through the formulaExports wildcard export (see the
+     * DependentRecalculation note in exports.scala).
+     */
+    @annotation.targetName("recalculateIterative")
+    def recalculate(iterative: IterativeCalc): RecalcResult =
+      recalculateImpl(wb, Clock.system, None, Some(iterative))
+
+    /** GH-373: iterative recalculation with an explicit clock. */
+    @annotation.targetName("recalculateIterativeWithClock")
+    def recalculate(clock: Clock, iterative: IterativeCalc): RecalcResult =
+      recalculateImpl(wb, clock, None, Some(iterative))
+
+    /** GH-373: iterative recalculation with an explicit clock and randomness source. */
+    @annotation.targetName("recalculateIterativeWithClockRng")
+    def recalculate(clock: Clock, rng: Rng, iterative: IterativeCalc): RecalcResult =
+      recalculateImpl(wb, clock, Some(rng), Some(iterative))
 
   // ========== recalculate internals ==========
 
-  private def recalculateImpl(wb: Workbook, clock: Clock, rngOpt: Option[Rng]): RecalcResult =
+  private def recalculateImpl(
+    wb: Workbook,
+    clock: Clock,
+    rngOpt: Option[Rng],
+    iterativeOpt: Option[IterativeCalc]
+  ): RecalcResult =
     val (deps, dependents) = DependencyGraph.fromWorkbookBounded(wb)
 
     def formulaText(q: QualifiedRef): String =
@@ -183,11 +216,19 @@ object WorkbookEvaluator:
     // alike are detected by Tarjan and removed up front (previously a cross-sheet cycle fell
     // through to the evaluator's recursion depth guard).
     val cyclicCore = DependencyGraph.qualifiedCyclicNodes(deps)
-    val blocked = DependencyGraph.qualifiedTransitiveDependents(dependents, cyclicCore)
+    // GH-373: iterative mode inverts the cycle posture — the core fixpoints (no circular
+    // errors) and its transitive dependents are NOT pre-marked blocked: they evaluate normally
+    // off the converged values, AFTER the iteration (see the pre/post partition below).
+    val iterating = iterativeOpt.isDefined && cyclicCore.nonEmpty
+    val coreDependents = DependencyGraph.qualifiedTransitiveDependents(dependents, cyclicCore)
+    val blocked = if iterating then Set.empty[QualifiedRef] else coreDependents
 
-    val cycleErrors = cyclicCore.toVector.map { q =>
-      CellEvalError(q.sheet, q.ref, XLError.FormulaError(formulaText(q), "Circular reference"))
-    }
+    val cycleErrors =
+      if iterating then Vector.empty[CellEvalError]
+      else
+        cyclicCore.toVector.map { q =>
+          CellEvalError(q.sheet, q.ref, XLError.FormulaError(formulaText(q), "Circular reference"))
+        }
     // qualifiedTransitiveDependents excludes its seed set, so `blocked` is disjoint from the core
     val blockedErrors = blocked.toVector.map { q =>
       CellEvalError(
@@ -197,6 +238,8 @@ object WorkbookEvaluator:
       )
     }
 
+    // The cyclic core always leaves the Kahn graph (it cannot be ordered); blocked dependents
+    // leave it only in the default (non-iterative) path.
     val removed = cyclicCore ++ blocked
     val prunedDeps = (deps -- removed).view.mapValues(_ -- removed).toMap
     val prunedDependents = (dependents -- removed).view.mapValues(_ -- removed).toMap
@@ -250,40 +293,71 @@ object WorkbookEvaluator:
         // values, so recursive re-derivation only arises on dynamic reads. The temp sheets live
         // in a Vector parallel to wb.sheets, updated incrementally, so per-cell cost is one
         // Workbook shell copy + one Vector update rather than re-mapping every sheet.
-        val (_, evaluated, evalErrors) = ordered.foldLeft(
-          (initialSheets, Map.empty[SheetName, Map[ARef, CellValue]], Vector.empty[CellEvalError])
-        ) { case ((sheets, acc, errs), q) =>
-          sheetIndex.get(q.sheet) match
-            case None => (sheets, acc, errs) // node names a sheet absent from the workbook
-            case Some(idx) =>
-              val tempSheet = sheets(idx)
-              val tempWb = wb.copy(sheets = sheets)
-              // GH-388 defense in depth: recalculate is documented total — a numeric blowup
-              // escaping a function implementation (e.g. BigDecimal scale overflow in a
-              // diverging Newton loop) must degrade to this cell's per-cell error, never
-              // unwind the whole recalculation.
-              val evaluatedCell =
-                try
-                  rngOpt match
-                    case Some(rng) => tempSheet.evaluateCell(q.ref, clock, rng, Some(tempWb))
-                    case None => tempSheet.evaluateCell(q.ref, clock, Some(tempWb))
-                catch
-                  case NonFatal(e) =>
-                    Left(
-                      XLError.FormulaError(
-                        formulaText(q),
-                        s"Evaluation threw ${e.getClass.getName}"
+        def evalPass(
+          order: List[QualifiedRef],
+          init: (Vector[Sheet], Map[SheetName, Map[ARef, CellValue]], Vector[CellEvalError])
+        ): (Vector[Sheet], Map[SheetName, Map[ARef, CellValue]], Vector[CellEvalError]) =
+          order.foldLeft(init) { case ((sheets, acc, errs), q) =>
+            sheetIndex.get(q.sheet) match
+              case None => (sheets, acc, errs) // node names a sheet absent from the workbook
+              case Some(idx) =>
+                val tempSheet = sheets(idx)
+                val tempWb = wb.copy(sheets = sheets)
+                // GH-388 defense in depth: recalculate is documented total — a numeric blowup
+                // escaping a function implementation (e.g. BigDecimal scale overflow in a
+                // diverging Newton loop) must degrade to this cell's per-cell error, never
+                // unwind the whole recalculation.
+                val evaluatedCell =
+                  try
+                    rngOpt match
+                      case Some(rng) => tempSheet.evaluateCell(q.ref, clock, rng, Some(tempWb))
+                      case None => tempSheet.evaluateCell(q.ref, clock, Some(tempWb))
+                  catch
+                    case NonFatal(e) =>
+                      Left(
+                        XLError.FormulaError(
+                          formulaText(q),
+                          s"Evaluation threw ${e.getClass.getName}"
+                        )
                       )
+                evaluatedCell match
+                  case Right(value) =>
+                    (
+                      sheets.updated(idx, tempSheet.put(q.ref, value)),
+                      acc.updated(q.sheet, acc.getOrElse(q.sheet, Map.empty) + (q.ref -> value)),
+                      errs
                     )
-              evaluatedCell match
-                case Right(value) =>
-                  (
-                    sheets.updated(idx, tempSheet.put(q.ref, value)),
-                    acc.updated(q.sheet, acc.getOrElse(q.sheet, Map.empty) + (q.ref -> value)),
-                    errs
-                  )
-                case Left(error) => (sheets, acc, errs :+ CellEvalError(q.sheet, q.ref, error))
-        }
+                  case Left(error) => (sheets, acc, errs :+ CellEvalError(q.sheet, q.ref, error))
+          }
+
+        // GH-373: iterative mode splits the order around the fixpoint — cells NOT downstream of
+        // the cyclic core evaluate first, then the core iterates to convergence, then the core's
+        // dependents evaluate off the converged values. `coreDependents` is dependent-closed, so
+        // the stable partition preserves topological validity within each part (the deferDynamic
+        // lemma). The default path is the identity split: everything in one pass, byte-identical
+        // to pre-GH-373 behavior.
+        val (preOrder, postOrder) =
+          if iterating then ordered.partition(q => !coreDependents.contains(q))
+          else (ordered, List.empty[QualifiedRef])
+
+        val preState = evalPass(
+          preOrder,
+          (initialSheets, Map.empty[SheetName, Map[ARef, CellValue]], Vector.empty[CellEvalError])
+        )
+        val iterated = iterativeOpt match
+          case Some(iterative) if cyclicCore.nonEmpty =>
+            iterateCycles(
+              wb,
+              cyclicCore,
+              iterative,
+              clock,
+              rngOpt,
+              sheetIndex,
+              formulaText,
+              preState
+            )
+          case _ => preState
+        val (_, evaluated, evalErrors) = evalPass(postOrder, iterated)
 
         // Cache computed values into formula cells on the original sheets; failed cells stay
         // uncached (Excel recalculates them on open). Track per sheet whether any recomputed
@@ -317,3 +391,105 @@ object WorkbookEvaluator:
           evaluated = wb.sheets.map(s => s.name -> evaluated.getOrElse(s.name, Map.empty)).toMap,
           errors = cycleErrors ++ blockedErrors ++ evalErrors
         )
+
+  /**
+   * GH-373: bounded Jacobi fixpoint over the cyclic core.
+   *
+   * Excel's iterative-calculation semantics: every member seeds to 0 (uninitialized cells), each
+   * round evaluates every member against the PREVIOUS round's values (Jacobi — implemented by
+   * overlaying each member's cell with `Formula(expr, Some(previousValue))`, so every reference to
+   * a member, including self-references, reads the cache while `evaluateCell` re-evaluates the
+   * formula text), and iteration stops when every member changes by less than `maxChange` or after
+   * `maxIter` rounds — non-convergence KEEPS the last values with no error.
+   *
+   * The clock is pinned ONCE before the loop (`Clock.fixed`) so TODAY()/NOW() cannot re-tick
+   * between rounds — one recalculation is one volatile generation, like Excel. Each member's
+   * evaluation sits under the same NonFatal guard as the main pass (GH-388): a member that throws
+   * holds its previous value for later rounds and, if still failing in the final round, degrades to
+   * a per-cell error with its cell left uncached (dependents then surface the failure exactly like
+   * any failed precedent).
+   */
+  private def iterateCycles(
+    wb: Workbook,
+    core: Set[QualifiedRef],
+    iterative: IterativeCalc,
+    clock: Clock,
+    rngOpt: Option[Rng],
+    sheetIndex: Map[SheetName, Int],
+    formulaText: QualifiedRef => String,
+    state: (Vector[Sheet], Map[SheetName, Map[ARef, CellValue]], Vector[CellEvalError])
+  ): (Vector[Sheet], Map[SheetName, Map[ARef, CellValue]], Vector[CellEvalError]) =
+    val (baseSheets, acc0, errs0) = state
+    // Deterministic member order: Jacobi values are order-independent (all reads see the
+    // previous round), but error vectors and sheet folds must be stable run to run.
+    val members: List[(QualifiedRef, Int, String)] =
+      core.toList
+        .flatMap(q => sheetIndex.get(q.sheet).map(idx => (q, idx, formulaText(q))))
+        .sortBy((q, _, _) => (q.sheet.value, q.ref.toA1))
+
+    val pinnedClock = Clock.fixed(clock.today(), clock.now())
+    val zero: CellValue = CellValue.Number(BigDecimal(0))
+    val seed: Map[QualifiedRef, CellValue] = members.map((q, _, _) => q -> zero).toMap
+    val maxRounds = math.max(1, iterative.maxIter)
+
+    // Convergence: numeric values compare by |Δ| < maxChange (strict, per Excel); non-numeric
+    // results converge only on exact equality.
+    def changeBelowThreshold(prev: CellValue, next: CellValue): Boolean =
+      (prev, next) match
+        case (CellValue.Number(a), CellValue.Number(b)) => (a - b).abs < iterative.maxChange
+        case (a, b) => a == b
+
+    @annotation.tailrec
+    def loop(
+      round: Int,
+      prev: Map[QualifiedRef, CellValue]
+    ): Map[QualifiedRef, Either[XLError, CellValue]] =
+      val overlaid = members.foldLeft(baseSheets) { case (sheets, (q, idx, expr)) =>
+        sheets.updated(idx, sheets(idx).put(q.ref, CellValue.Formula(expr, prev.get(q))))
+      }
+      val tempWb = wb.copy(sheets = overlaid)
+      val results: Map[QualifiedRef, Either[XLError, CellValue]] =
+        members.map { (q, idx, _) =>
+          val tempSheet = overlaid(idx)
+          val evaluatedCell =
+            try
+              rngOpt match
+                case Some(rng) => tempSheet.evaluateCell(q.ref, pinnedClock, rng, Some(tempWb))
+                case None => tempSheet.evaluateCell(q.ref, pinnedClock, Some(tempWb))
+            catch
+              case NonFatal(e) =>
+                Left(
+                  XLError.FormulaError(formulaText(q), s"Evaluation threw ${e.getClass.getName}")
+                )
+          q -> evaluatedCell
+        }.toMap
+      val converged = members.forall { (q, _, _) =>
+        results(q) match
+          case Right(next) => changeBelowThreshold(prev.getOrElse(q, zero), next)
+          case Left(_) => false
+      }
+      if converged || round >= maxRounds then results
+      else
+        // A throwing/failing member holds its previous value for the next round so the rest of
+        // the core keeps converging (GH-388 degradation, not unwinding).
+        val next = members.map { (q, _, _) =>
+          q -> results(q).getOrElse(prev.getOrElse(q, zero))
+        }.toMap
+        loop(round + 1, next)
+
+    val finalResults = loop(1, seed)
+    // Fold the fixpoint into the pass state: successful members write their value into the temp
+    // sheets (post-pass dependents read them) and the evaluated map (they cache at the end);
+    // failed members keep their original uncached formula cell, so dependents recursively
+    // evaluate and surface the underlying error — the same posture as a failed acyclic cell.
+    members.foldLeft((baseSheets, acc0, errs0)) { case ((sheets, acc, errs), (q, idx, _)) =>
+      finalResults.get(q) match
+        case Some(Right(value)) =>
+          (
+            sheets.updated(idx, sheets(idx).put(q.ref, value)),
+            acc.updated(q.sheet, acc.getOrElse(q.sheet, Map.empty) + (q.ref -> value)),
+            errs
+          )
+        case Some(Left(error)) => (sheets, acc, errs :+ CellEvalError(q.sheet, q.ref, error))
+        case None => (sheets, acc, errs) // unreachable: every member evaluates every round
+    }

--- a/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpecsMath.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpecsMath.scala
@@ -245,6 +245,34 @@ trait FunctionSpecsMath extends FunctionSpecsBase:
       yield result
     }
 
+  val mround: FunctionSpec[BigDecimal] { type Args = BinaryNumeric } =
+    FunctionSpec.simple[BigDecimal, BinaryNumeric](
+      "MROUND",
+      Arity.two,
+      flags = FunctionFlags(returnsNumeric = true)
+    ) { (args, ctx) =>
+      val (numberExpr, multipleExpr) = args
+      for
+        number <- ctx.evalExpr(numberExpr)
+        multiple <- ctx.evalExpr(multipleExpr)
+        result <-
+          // Excel: MROUND(x, 0) = 0 — unlike CEILING/FLOOR, a zero multiple is NOT an error
+          if multiple == 0 then Right(BigDecimal(0))
+          else if (number > 0 && multiple < 0) || (number < 0 && multiple > 0) then
+            Left(
+              EvalError.EvalFailed(
+                "MROUND: number and multiple must have same sign",
+                Some(s"MROUND($number, $multiple)")
+              )
+            )
+          else
+            // multiple * ROUND(number/multiple, 0); HALF_UP matches Excel's half-away-from-zero
+            // on the sign-equal domain (7.5/5 = 1.5 -> 2 -> 10; -7.5/-5 = 1.5 -> 2 -> -10)
+            val quotient = (number / multiple).setScale(0, BigDecimal.RoundingMode.HALF_UP)
+            Right(quotient * multiple)
+      yield result
+    }
+
   val trunc: FunctionSpec[BigDecimal] { type Args = BinaryNumericOpt } =
     FunctionSpec.simple[BigDecimal, BinaryNumericOpt](
       "TRUNC",

--- a/xl-evaluator/src/com/tjclp/xl/formula/graph/DependencyGraph.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/graph/DependencyGraph.scala
@@ -3,7 +3,9 @@ package com.tjclp.xl.formula.graph
 import com.tjclp.xl.formula.ast.TExpr
 import com.tjclp.xl.formula.functions.{FunctionSpecs, FunctionRegistry, ArgValue}
 import com.tjclp.xl.formula.parser.FormulaParser
-import com.tjclp.xl.formula.eval.EvalError
+import com.tjclp.xl.formula.eval.{EvalError, Evaluator}
+
+import com.tjclp.xl.workbooks.Workbook
 
 import com.tjclp.xl.addressing.{ARef, SheetName}
 import com.tjclp.xl.CellRange
@@ -182,6 +184,10 @@ object DependencyGraph:
         containsCellReferences(body)
       case TExpr.BindingRef(_) => false
       case TExpr.CoercedBindingRef(_, _) => false
+
+      // GH-384: a defined name resolves to cells (or a formula over cells) at evaluation time —
+      // it behaves like a reference for "does this formula read data?" checks
+      case TExpr.NameRef(_) => true
 
       // GH-306: runtime coercion wrapper — transparent for analysis
       case TExpr.Coerced(inner, _) => containsCellReferences(inner)
@@ -363,6 +369,10 @@ object DependencyGraph:
       case TExpr.BindingRef(_) => false
       case TExpr.CoercedBindingRef(_, _) => false
 
+      // GH-384: name resolution depends on the ambient sheet (sheet-scoped names SHADOW
+      // workbook-scoped ones), so a name-bearing formula needs a sheet context
+      case TExpr.NameRef(_) => true
+
       // GH-306: runtime coercion wrapper — transparent for analysis
       case TExpr.Coerced(inner, _) => containsUnqualifiedCellReferences(inner)
 
@@ -448,6 +458,9 @@ object DependencyGraph:
         }
       case TExpr.BindingRef(_) => Set.empty
       case TExpr.CoercedBindingRef(_, _) => Set.empty
+      // GH-384: name targets live behind workbook metadata this sheet-level walk cannot see —
+      // no intra-sheet edges (consistent with cross-sheet refs; the qualified extractor resolves)
+      case TExpr.NameRef(_) => Set.empty
 
       // GH-306: runtime coercion wrapper — transparent for analysis
       case TExpr.Coerced(inner, _) => extractDependencies(inner)
@@ -540,6 +553,9 @@ object DependencyGraph:
         }
       case TExpr.BindingRef(_) => Set.empty
       case TExpr.CoercedBindingRef(_, _) => Set.empty
+      // GH-384: name targets live behind workbook metadata this sheet-level walk cannot see —
+      // no intra-sheet edges (consistent with cross-sheet refs; the qualified extractor resolves)
+      case TExpr.NameRef(_) => Set.empty
 
       // GH-306: runtime coercion wrapper — transparent for analysis
       case TExpr.Coerced(inner, _) => extractDependenciesBounded(inner, bounds)
@@ -938,7 +954,8 @@ object DependencyGraph:
         cell.value match
           case CellValue.Formula(expression, _) =>
             val deps = FormulaParser.parse(expression) match
-              case scala.util.Right(expr) => extractQualifiedDependencies(expr, sheet.name)
+              case scala.util.Right(expr) =>
+                extractQualifiedDependencies(expr, sheet.name, workbook = Some(workbook))
               case scala.util.Left(_) => Set.empty[QualifiedRef]
             Some(QualifiedRef(sheet.name, cellRef) -> deps)
           case _ => None
@@ -974,7 +991,7 @@ object DependencyGraph:
           case CellValue.Formula(expression, _) =>
             val deps = FormulaParser.parse(expression) match
               case scala.util.Right(expr) =>
-                extractQualifiedDependencies(expr, sheet.name, cellsFor)
+                extractQualifiedDependencies(expr, sheet.name, cellsFor, Some(workbook))
               case scala.util.Left(_) => Set.empty[QualifiedRef]
             Some(QualifiedRef(sheet.name, cellRef) -> deps)
           case _ => None
@@ -1046,6 +1063,10 @@ object DependencyGraph:
    *   The sheet containing the formula (used for same-sheet ref qualification)
    * @param cellsFor
    *   Expands a range on a named sheet to qualified cells (possibly bounded)
+   * @param workbook
+   *   GH-384: name table for defined-name resolution (None disables name edges)
+   * @param visitingNames
+   *   GH-384: UPPERCASED names on the current resolution path — the name→name cycle guard
    * @return
    *   Set of qualified cell references used in the expression
    */
@@ -1053,7 +1074,9 @@ object DependencyGraph:
   private def extractQualifiedDependencies[A](
     expr: TExpr[A],
     currentSheet: SheetName,
-    cellsFor: (SheetName, CellRange) => Set[QualifiedRef] = unboundedQualifiedCells
+    cellsFor: (SheetName, CellRange) => Set[QualifiedRef] = unboundedQualifiedCells,
+    workbook: Option[Workbook] = None,
+    visitingNames: Set[String] = Set.empty
   ): Set[QualifiedRef] =
     def locCells(location: TExpr.RangeLocation): Set[QualifiedRef] =
       location match
@@ -1110,6 +1133,32 @@ object DependencyGraph:
           bindings.foldLeft(go(body)) { case (acc, (_, value)) => acc ++ go(value) }
         case TExpr.BindingRef(_) => Set.empty
         case TExpr.CoercedBindingRef(_, _) => Set.empty
+
+        // GH-384: resolve the defined name and recurse into its refersTo, qualifying its
+        // same-sheet refs to the DEFINING sheet — =IF(case=2, ...) contributes an edge to the
+        // cells 'case' targets, so Kahn orders a computed toggle before its name-gated
+        // dependents and Tarjan sees cycles routed through names. Name→name chains carry a
+        // visited guard; unresolvable/unparseable names contribute no edges (evaluation
+        // reports the per-cell error).
+        case TExpr.NameRef(name) =>
+          val key = name.toUpperCase
+          if visitingNames.contains(key) then Set.empty
+          else
+            (for
+              wb <- workbook
+              dn <- Evaluator.lookupDefinedName(wb, currentSheet, name)
+              target <- FormulaParser.parse(dn.formula).toOption
+            yield
+              val definingSheet =
+                Evaluator.definedNameScope(wb, dn).map(_.name).getOrElse(currentSheet)
+              extractQualifiedDependencies(
+                target,
+                definingSheet,
+                cellsFor,
+                workbook,
+                visitingNames + key
+              )
+            ).getOrElse(Set.empty)
 
         // GH-306: runtime coercion wrapper — transparent for analysis
         case TExpr.Coerced(inner, _) => go(inner)

--- a/xl-evaluator/src/com/tjclp/xl/formula/parser/FormulaParser.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/parser/FormulaParser.scala
@@ -1002,7 +1002,14 @@ object FormulaParser:
         // Cast needed due to opaque type erasure in pattern matching
         Right((TExpr.PolyRef(aref.asInstanceOf[ARef], anchor), state))
       case Left(err) =>
-        Left(ParseError.InvalidCellRef(refStr, startPos, err))
+        // GH-384: a name-shaped identifier that is not a cell reference is a defined-name
+        // reference (=case, =entry_mult), resolved against the workbook at evaluation time.
+        // Disambiguation is total: ARef.parse SUCCESS above means cell ref (TAX1 is a cell —
+        // OOXML forbids ref-shaped defined names); name-shaped failure means NameRef; anything
+        // else (e.g. '$' inside the token) keeps today's InvalidCellRef. Reuses the LET name
+        // shape (letter/underscore start, [A-Za-z0-9_]*, not TRUE/FALSE/AND/OR/NOT).
+        if isValidLetName(refStr) then Right((TExpr.NameRef(refStr), state))
+        else Left(ParseError.InvalidCellRef(refStr, startPos, err))
 
   /**
    * Parse quoted sheet name reference: 'Sheet Name'!A1 or 'Sheet-Name'!A1:B10

--- a/xl-evaluator/src/com/tjclp/xl/formula/printer/FormulaPrinter.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/printer/FormulaPrinter.scala
@@ -212,6 +212,10 @@ object FormulaPrinter:
 
       case TExpr.BindingRef(name) => name
 
+      // GH-384: a defined-name reference prints as the bare identifier, verbatim —
+      // =IF(case=2, 1, 0) round-trips byte-for-byte
+      case TExpr.NameRef(name) => name
+
       // A binding in a typed argument position prints as the bare name, exactly like BindingRef
       case TExpr.CoercedBindingRef(name, _) => name
 
@@ -447,6 +451,8 @@ object FormulaPrinter:
         s"Let($bindingsStr, ${printWithTypes(body)})"
       case TExpr.BindingRef(name) =>
         s"BindingRef($name)"
+      case TExpr.NameRef(name) =>
+        s"NameRef($name)"
       case TExpr.CoercedBindingRef(name, target) =>
         s"CoercedBindingRef($name, $target)"
       case TExpr.Coerced(inner, target) =>

--- a/xl-evaluator/src/com/tjclp/xl/formula/printer/FormulaShifter.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/printer/FormulaShifter.scala
@@ -175,6 +175,8 @@ object FormulaShifter:
           shiftInternal(body, colDelta, rowDelta)
         ).asInstanceOf[TExpr[A]]
       case bref: BindingRef => bref.asInstanceOf[TExpr[A]]
+      // GH-384: defined names are identifiers, not coordinates — they never shift on drag
+      case nref: NameRef => nref.asInstanceOf[TExpr[A]]
       case cbref: CoercedBindingRef[?] => cbref.asInstanceOf[TExpr[A]]
 
       // GH-306: runtime coercion wrapper — shift the wrapped expression, preserve the wrapper
@@ -450,6 +452,9 @@ object FormulaShifter:
           sb <- go(body)
         yield Let(bs.reverse, sb).asInstanceOf[TExpr[A]]
       case _: BindingRef => Some(expr)
+      // GH-384: defined names are identifiers — structural edits never move or void them
+      // (their refersTo text lives in workbook metadata, not in this formula)
+      case _: NameRef => Some(expr)
       case _: CoercedBindingRef[?] => Some(expr)
 
       // GH-306: runtime coercion wrapper — shift the wrapped expression, preserve the wrapper

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/FormulaParserSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/FormulaParserSpec.scala
@@ -1517,7 +1517,7 @@ class FormulaParserSpec extends ScalaCheckSuite:
     }
   }
 
-  test("Known functions include all 107 functions") {
+  test("Known functions include all 108 functions") {
     val functions = FunctionRegistry.allNames
     assert(functions.contains("SUM"))
     assert(functions.contains("MIN"))
@@ -1572,6 +1572,8 @@ class FormulaParserSpec extends ScalaCheckSuite:
     assert(functions.contains("EXP"))
     assert(functions.contains("FLOOR"))
     assert(functions.contains("CEILING"))
+    // GH-386: round to nearest multiple (LBO term-loan sizing idiom)
+    assert(functions.contains("MROUND"))
     assert(functions.contains("TRUNC"))
     assert(functions.contains("SIGN"))
     assert(functions.contains("INT"))
@@ -1634,7 +1636,7 @@ class FormulaParserSpec extends ScalaCheckSuite:
     assert(functions.contains("RANDBETWEEN"))
     // GH-274 dynamic references
     assert(functions.contains("INDIRECT"))
-    assertEquals(functions.length, 107)
+    assertEquals(functions.length, 108)
   }
 
   // ==================== INDIRECT Parsing Tests (GH-274) ====================

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/FormulaParserSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/FormulaParserSpec.scala
@@ -1062,8 +1062,15 @@ class FormulaParserSpec extends ScalaCheckSuite:
   }
 
   test("error: invalid cell reference") {
-    val result = FormulaParser.parse("=ZZZ9999999")
+    // GH-384: a bare out-of-grid token (ZZZ9999999) is a LEGAL Excel defined name — Excel's
+    // name rules only reject IN-grid collisions — so it now parses as NameRef and fails at
+    // evaluation instead (#NAME? posture). Anchored '$' forms are unambiguous cell-ref
+    // syntax and still fail at parse.
+    val result = FormulaParser.parse("=$ZZZ$9999999")
     assert(result.isLeft)
+    FormulaParser.parse("=ZZZ9999999") match
+      case Right(TExpr.NameRef(name)) => assertEquals(name, "ZZZ9999999")
+      case other => fail(s"Expected NameRef for out-of-grid token, got $other")
   }
 
   test("error: formula too long") {
@@ -1815,4 +1822,66 @@ class FormulaParserSpec extends ScalaCheckSuite:
       case Right(TExpr.Call(FunctionSpecs.yearfrac, (_, _, basis))) =>
         assert(basis != None)
       case _ => fail("Expected TExpr.Call(YEARFRAC) with basis")
+  }
+
+  // ==================== GH-384: defined-name references ====================
+  // A bare name-shaped identifier (=case, =entry_mult) parses to TExpr.NameRef and resolves
+  // against the workbook's defined names at evaluation time. Ref-shaped identifiers (TAX1)
+  // stay cell references — OOXML forbids ref-shaped defined names, so there is no ambiguity.
+
+  test("GH-384: bare name-shaped identifier parses to NameRef (=case)") {
+    FormulaParser.parse("=case") match
+      case Right(TExpr.NameRef(name)) => assertEquals(name, "case")
+      case other => fail(s"Expected NameRef(case), got $other")
+  }
+
+  test("GH-384: underscore and mixed-case names parse to NameRef preserving case") {
+    FormulaParser.parse("=Revolver_Toggle") match
+      case Right(TExpr.NameRef(name)) => assertEquals(name, "Revolver_Toggle")
+      case other => fail(s"Expected NameRef(Revolver_Toggle), got $other")
+    FormulaParser.parse("=_hidden1") match
+      case Right(TExpr.NameRef(name)) => assertEquals(name, "_hidden1")
+      case other => fail(s"Expected NameRef(_hidden1), got $other")
+  }
+
+  test("GH-384: ref-shaped identifier stays a cell reference (TAX1 is a cell, not a name)") {
+    FormulaParser.parse("=TAX1") match
+      case Right(TExpr.PolyRef(at, _)) => assertEquals(at.toA1, "TAX1")
+      case Right(TExpr.Ref(at, _, _)) => assertEquals(at.toA1, "TAX1")
+      case other => fail(s"Expected cell ref TAX1, got $other")
+  }
+
+  test("GH-384: names compose with operators (=entry_mult*ltm_ebitda)") {
+    FormulaParser.parse("=entry_mult*ltm_ebitda") match
+      case Right(TExpr.Mul(_, _)) => () // NameRefs live under numeric coercion wrappers
+      case other => fail(s"Expected Mul over names, got $other")
+  }
+
+  test("GH-384: names print back verbatim (round-trip)") {
+    assertPreserved("=case")
+    assertPreserved("=entry_mult*ltm_ebitda")
+    assertPreserved("=IF(case=2, 1, 0)")
+    assertPreserved("=SUM(rev_range)")
+  }
+
+  test("GH-384: parse-print-parse is identity for name-bearing formulas") {
+    for source <- List("=case", "=case*2", "=IF(case=2, 1, 0)", "=EOMONTH(named_date, 0)") do
+      val first = FormulaParser.parse(source)
+      assert(first.isRight, s"$source should parse: $first")
+      val reparsed = first.flatMap(e => FormulaParser.parse(FormulaPrinter.print(e)))
+      assertEquals(reparsed, first, s"parse-print-parse must be identity for $source")
+  }
+
+  test("GH-384: names do not shift on formula drag (=case*A1 dragged shifts A1 only)") {
+    FormulaParser.parse("=case*A1") match
+      case Right(expr) =>
+        val dragged = FormulaShifter.shift(expr, 0, 1)
+        assertEquals(FormulaPrinter.print(dragged), "=case*A2")
+      case Left(err) => fail(s"=case*A1 should parse: $err")
+  }
+
+  test("GH-384: tokens with '$' inside are not names — invalid cell ref preserved (=A$B)") {
+    FormulaParser.parse("=A$B") match
+      case Left(_) => ()
+      case Right(expr) => fail(s"'=A$$B' should not parse, got $expr")
   }

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/IterativeRecalcSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/IterativeRecalcSpec.scala
@@ -1,0 +1,186 @@
+package com.tjclp.xl.formula
+
+import com.tjclp.xl.{*, given}
+import com.tjclp.xl.addressing.{ARef, SheetName}
+import com.tjclp.xl.cells.CellValue
+import com.tjclp.xl.formula.eval.IterativeCalc
+import com.tjclp.xl.sheets.Sheet
+import com.tjclp.xl.workbooks.{CalcPr, Workbook}
+import munit.FunSuite
+
+/**
+ * GH-373b: opt-in bounded iterative recalculation for circular workbooks.
+ *
+ * `recalculate(IterativeCalc(maxIter, maxChange))` fixpoints cycle members with Jacobi iteration
+ * (every member reads PREVIOUS-iteration values) instead of erroring: members seed to 0 (Excel's
+ * uninitialized semantics), iterate until every |Δ| < maxChange or maxIter, and non-convergence
+ * KEEPS the last values with NO error (Excel semantics — the deliberate inversion vs the default
+ * path). Dependents of a cycle are NOT pre-marked blocked — they evaluate off the converged values.
+ * The default `recalculate()` is byte-identical to before (opt-in only; the CalcPr metadata is
+ * deliberately NOT auto-honored — bridge explicitly via
+ * `wb.metadata.calcPr.filter(_.iterativeCalculation).map(IterativeCalc.fromCalcPr)`).
+ */
+class IterativeRecalcSpec extends FunSuite:
+
+  private def num(i: Int): CellValue = CellValue.Number(BigDecimal(i))
+  private def formula(expr: String): CellValue = CellValue.Formula(expr, None)
+  private val a1 = ARef.from0(0, 0)
+  private val b1 = ARef.from0(1, 0)
+  private val c1 = ARef.from0(2, 0)
+  private val d1 = ARef.from0(3, 0)
+
+  private def cached(wb: Workbook, sheetName: String, ref: ARef): Option[CellValue] =
+    wb.sheets
+      .find(_.name.value == sheetName)
+      .flatMap(_.cells.get(ref))
+      .map(_.value)
+      .collect { case CellValue.Formula(_, Some(v)) => v }
+
+  private def cachedNum(wb: Workbook, sheetName: String, ref: ARef): Option[BigDecimal] =
+    cached(wb, sheetName, ref).collect { case CellValue.Number(n) => n }
+
+  /** The canonical convergent pair: fixpoint B1 = 100/0.95, A1 = B1/10. */
+  private def convergentPair: Workbook =
+    val sheet = Sheet(SheetName.unsafe("S"))
+      .put(a1, formula("=B1*0.1"))
+      .put(b1, formula("=100+A1/2"))
+    Workbook(sheet)
+
+  private val fixpointB = BigDecimal(100) / BigDecimal("0.95") // 105.26315789...
+  private val fixpointA = fixpointB / 10
+
+  test("GH-373: convergent cycle fixpoints to the analytic solution within tolerance") {
+    val result = convergentPair.recalculate(IterativeCalc(100, BigDecimal("0.001")))
+    assert(result.isClean, s"expected clean, got: ${result.errors.map(_.render)}")
+    val a = cachedNum(result.workbook, "S", a1).getOrElse(fail("A1 must cache"))
+    val b = cachedNum(result.workbook, "S", b1).getOrElse(fail("B1 must cache"))
+    assert((a - fixpointA).abs < BigDecimal("0.005"), s"A1=$a, expected ~$fixpointA")
+    assert((b - fixpointB).abs < BigDecimal("0.005"), s"B1=$b, expected ~$fixpointB")
+    // evaluated map includes both members
+    val evaluated = result.evaluated(SheetName.unsafe("S"))
+    assert(evaluated.contains(a1) && evaluated.contains(b1))
+  }
+
+  test("GH-373: non-convergent oscillator hits maxIter, keeps last values, NO circular error") {
+    // A1 = 1-B1, B1 = A1 oscillates with period 4 from the (0,0) seed; s10 = (1,1).
+    val sheet = Sheet(SheetName.unsafe("S"))
+      .put(a1, formula("=1-B1"))
+      .put(b1, formula("=A1"))
+    val result = Workbook(sheet).recalculate(IterativeCalc(10, BigDecimal("0.001")))
+    assert(
+      result.errors.isEmpty,
+      s"non-convergence must NOT error (Excel semantics), got: ${result.errors.map(_.render)}"
+    )
+    assertEquals(cachedNum(result.workbook, "S", a1), Some(BigDecimal(1)))
+    assertEquals(cachedNum(result.workbook, "S", b1), Some(BigDecimal(1)))
+  }
+
+  test("GH-373: loose vs tight maxChange trade precision (loose stops far from the fixpoint)") {
+    val loose = convergentPair.recalculate(IterativeCalc(100, BigDecimal(10)))
+    val tight = convergentPair.recalculate(IterativeCalc(100, BigDecimal("0.0001")))
+    val looseB = cachedNum(loose.workbook, "S", b1).getOrElse(fail("loose B1 must cache"))
+    val tightB = cachedNum(tight.workbook, "S", b1).getOrElse(fail("tight B1 must cache"))
+    assert((looseB - fixpointB).abs > BigDecimal("0.1"), s"loose stopped too precisely: $looseB")
+    assert((tightB - fixpointB).abs < BigDecimal("0.001"), s"tight not precise enough: $tightB")
+  }
+
+  test("GH-373: default recalculate() is unchanged — cycles error exactly as before") {
+    val result = convergentPair.recalculate()
+    assertEquals(cached(result.workbook, "S", a1), None)
+    assertEquals(cached(result.workbook, "S", b1), None)
+    assertEquals(result.errors.map(_.ref).toSet, Set(a1, b1))
+    assert(result.errors.forall(_.error.message.contains("Circular")))
+  }
+
+  test("GH-373: iterative recalc is total under numeric blowup (repeated squaring, no throw)") {
+    val sheet = Sheet(SheetName.unsafe("S"))
+      .put(a1, formula("=POWER(B1,2)+2"))
+      .put(b1, formula("=A1"))
+    // Doubling digit-count per round; must return a RecalcResult, never unwind (GH-388 posture).
+    val result = Workbook(sheet).recalculate(IterativeCalc(15, BigDecimal("0.001")))
+    assert(result.workbook.sheets.nonEmpty) // reached: no exception escaped
+  }
+
+  test("GH-373: acyclic remainder still computes in one pass alongside an iterated cycle") {
+    val sheet = Sheet(SheetName.unsafe("S"))
+      .put(a1, formula("=B1*0.1"))
+      .put(b1, formula("=100+A1/2"))
+      .put(c1, num(7))
+      .put(d1, formula("=C1*3")) // independent of the cycle
+    val result = Workbook(sheet).recalculate(IterativeCalc(100, BigDecimal("0.001")))
+    assert(result.isClean, s"expected clean, got: ${result.errors.map(_.render)}")
+    assertEquals(cachedNum(result.workbook, "S", d1), Some(BigDecimal(21)))
+  }
+
+  test("GH-373: dependents of the cycle get converged values (blocked-inversion pin)") {
+    val sheet = Sheet(SheetName.unsafe("S"))
+      .put(a1, formula("=B1*0.1"))
+      .put(b1, formula("=100+A1/2"))
+      .put(c1, formula("=B1*2")) // downstream of the cycle — blocked in the default path
+    val result = Workbook(sheet).recalculate(IterativeCalc(100, BigDecimal("0.001")))
+    assert(result.isClean, s"expected clean, got: ${result.errors.map(_.render)}")
+    val c = cachedNum(result.workbook, "S", c1).getOrElse(fail("C1 must cache"))
+    assert((c - fixpointB * 2).abs < BigDecimal("0.01"), s"C1=$c, expected ~${fixpointB * 2}")
+    // Contrast: the default path reports this exact cell as blocked
+    val blocked = Workbook(sheet).recalculate()
+    assert(blocked.errors.exists(e => e.ref == c1 && e.error.message.contains("Blocked")))
+  }
+
+  test("GH-373: cross-sheet cycle iterates too (workbook-level SCC)") {
+    val s1 = Sheet(SheetName.unsafe("S1")).put(a1, formula("=S2!A1*0.1"))
+    val s2 = Sheet(SheetName.unsafe("S2")).put(a1, formula("=100+S1!A1/2"))
+    val result = Workbook(s1, s2).recalculate(IterativeCalc(100, BigDecimal("0.001")))
+    assert(result.isClean, s"expected clean, got: ${result.errors.map(_.render)}")
+    val b = cachedNum(result.workbook, "S2", a1).getOrElse(fail("S2!A1 must cache"))
+    assert((b - fixpointB).abs < BigDecimal("0.005"), s"S2!A1=$b, expected ~$fixpointB")
+  }
+
+  test("GH-373: clock is pinned across iterations — NOW() must not re-tick per iteration") {
+    // A ticking clock advances one day per call. Unpinned, each Jacobi iteration would read a
+    // different NOW() and B1 (previous-iteration copy of A1) could never equal A1.
+    final class TickingClock extends Clock:
+      private var calls = 0
+      def today(): java.time.LocalDate =
+        calls += 1
+        java.time.LocalDate.of(2026, 1, 1).plusDays(calls.toLong)
+      def now(): java.time.LocalDateTime =
+        calls += 1
+        java.time.LocalDateTime.of(2026, 1, 1, 0, 0).plusDays(calls.toLong)
+    val sheet = Sheet(SheetName.unsafe("S"))
+      .put(a1, formula("=B1*0+NOW()"))
+      .put(b1, formula("=A1"))
+    val result =
+      Workbook(sheet).recalculate(new TickingClock, IterativeCalc(20, BigDecimal("0.001")))
+    assert(
+      result.isClean,
+      s"expected clean (pinned clock converges): ${result.errors.map(_.render)}"
+    )
+    assertEquals(
+      cachedNum(result.workbook, "S", a1),
+      cachedNum(result.workbook, "S", b1),
+      "A1 and B1 must agree — a re-ticking clock would leave them one iteration apart"
+    )
+  }
+
+  test("GH-373: IterativeCalc.fromCalcPr uses Excel defaults when attributes are absent") {
+    assertEquals(
+      IterativeCalc.fromCalcPr(CalcPr(iterativeCalculation = true)),
+      IterativeCalc(100, BigDecimal("0.001"))
+    )
+    assertEquals(
+      IterativeCalc.fromCalcPr(
+        CalcPr(iterativeCalculation = true, Some(50), Some(BigDecimal("0.01")))
+      ),
+      IterativeCalc(50, BigDecimal("0.01"))
+    )
+  }
+
+  test("GH-373: acyclic workbook under iterative settings behaves exactly like the default") {
+    val sheet = Sheet(SheetName.unsafe("S"))
+      .put(a1, num(10))
+      .put(b1, formula("=A1*2"))
+    val iterative = Workbook(sheet).recalculate(IterativeCalc(100, BigDecimal("0.001")))
+    val default = Workbook(sheet).recalculate()
+    assertEquals(iterative.workbook, default.workbook)
+    assertEquals(iterative.errors, default.errors)
+  }

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/LetFunctionSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/LetFunctionSpec.scala
@@ -241,8 +241,15 @@ class LetFunctionSpec extends ScalaCheckSuite:
     assertParseError("=LET(x, 1, y, 2)")
   }
 
-  test("unknown bare identifier in body is a parse error") {
-    assertParseError("=LET(x, 1, y)")
+  test("unknown bare identifier in body parses as a defined-name ref, then errors at eval") {
+    // GH-384 supersedes the old parse-error pin: Excel treats an unbound identifier in a LET
+    // body as a defined-name reference (#NAME? at evaluation when undefined), and so do we.
+    FormulaParser.parse("=LET(x, 1, y)") match
+      case Right(TExpr.Let(_, TExpr.NameRef(name))) => assertEquals(name, "y")
+      case other => fail(s"expected LET body to parse as NameRef(y), got $other")
+    sheet.evaluateFormula("=LET(x, 1, y)") match
+      case Left(err) => assert(err.message.contains("y"), s"got: ${err.message}")
+      case Right(v) => fail(s"unbound name must not evaluate, got $v")
   }
 
   // ===== Error propagation =====

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/MathFunctionsSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/MathFunctionsSpec.scala
@@ -291,6 +291,89 @@ class MathFunctionsSpec extends FunSuite:
     assertEquals(result, Right(BigDecimal(-6)))
   }
 
+  // ===== MROUND Tests (GH-386) =====
+
+  test("MROUND: mround(10, 3) = 9") {
+    val expr = TExpr.mround(TExpr.Lit(BigDecimal(10)), TExpr.Lit(BigDecimal(3)))
+    val result = evaluator.eval(expr, emptySheet)
+    assertEquals(result, Right(BigDecimal(9)))
+  }
+
+  test("MROUND: mround(1.3, 0.2) = 1.4 (decimal multiple)") {
+    val expr = TExpr.mround(TExpr.Lit(BigDecimal("1.3")), TExpr.Lit(BigDecimal("0.2")))
+    val result = evaluator.eval(expr, emptySheet)
+    assertEquals(result, Right(BigDecimal("1.4")))
+  }
+
+  test("MROUND: mround(7.5, 5) = 10 (half rounds away from zero)") {
+    val expr = TExpr.mround(TExpr.Lit(BigDecimal("7.5")), TExpr.Lit(BigDecimal(5)))
+    val result = evaluator.eval(expr, emptySheet)
+    assertEquals(result, Right(BigDecimal(10)))
+  }
+
+  test("MROUND: mround(-7.5, -5) = -10 (half away from zero, negative domain)") {
+    val expr = TExpr.mround(TExpr.Lit(BigDecimal("-7.5")), TExpr.Lit(BigDecimal(-5)))
+    val result = evaluator.eval(expr, emptySheet)
+    assertEquals(result, Right(BigDecimal(-10)))
+  }
+
+  test("MROUND: mround(-10, -3) = -9 (negative pair)") {
+    val expr = TExpr.mround(TExpr.Lit(BigDecimal(-10)), TExpr.Lit(BigDecimal(-3)))
+    val result = evaluator.eval(expr, emptySheet)
+    assertEquals(result, Right(BigDecimal(-9)))
+  }
+
+  test("MROUND: multiple 0 returns 0, not an error (divergence from CEILING/FLOOR)") {
+    val expr = TExpr.mround(TExpr.Lit(BigDecimal("2.5")), TExpr.Lit(BigDecimal(0)))
+    val result = evaluator.eval(expr, emptySheet)
+    assertEquals(result, Right(BigDecimal(0)))
+  }
+
+  test("MROUND: positive number with negative multiple returns error") {
+    val expr = TExpr.mround(TExpr.Lit(BigDecimal(10)), TExpr.Lit(BigDecimal(-3)))
+    val result = evaluator.eval(expr, emptySheet)
+    assert(result.isLeft, "MROUND(10, -3) should return error (mismatched signs)")
+  }
+
+  test("MROUND: negative number with positive multiple returns error") {
+    val expr = TExpr.mround(TExpr.Lit(BigDecimal(-10)), TExpr.Lit(BigDecimal(3)))
+    val result = evaluator.eval(expr, emptySheet)
+    assert(result.isLeft, "MROUND(-10, 3) should return error (mismatched signs)")
+  }
+
+  test("MROUND parser: parse and evaluate =MROUND(10, 3)") {
+    val result = emptySheet.evaluateFormula("=MROUND(10, 3)")
+    assertEquals(result, Right(CellValue.Number(BigDecimal(9))))
+  }
+
+  test("MROUND parser: decimal multiple =MROUND(1.3, 0.2) = 1.4") {
+    val result = emptySheet.evaluateFormula("=MROUND(1.3, 0.2)")
+    assertEquals(result, Right(CellValue.Number(BigDecimal("1.4"))))
+  }
+
+  test("MROUND parser: half rounds away from zero =MROUND(7.5, 5) = 10") {
+    // 7.5/5 = 1.5 -> HALF_UP -> 2 -> 10 (Excel rounds half away from zero)
+    val result = emptySheet.evaluateFormula("=MROUND(7.5, 5)")
+    assertEquals(result, Right(CellValue.Number(BigDecimal(10))))
+  }
+
+  test("MROUND parser: negative pair =MROUND(-10, -3) = -9") {
+    val result = emptySheet.evaluateFormula("=MROUND(-10, -3)")
+    assertEquals(result, Right(CellValue.Number(BigDecimal(-9))))
+  }
+
+  test("MROUND parser: multiple 0 returns 0 (unlike CEILING/FLOOR's error)") {
+    val result = emptySheet.evaluateFormula("=MROUND(10, 0)")
+    assertEquals(result, Right(CellValue.Number(BigDecimal(0))))
+  }
+
+  test("MROUND parser: mismatched signs return error") {
+    val result = emptySheet.evaluateFormula("=MROUND(-10, 3)")
+    assert(result.isLeft, "MROUND(-10, 3) should return error (mismatched signs)")
+    val result2 = emptySheet.evaluateFormula("=MROUND(10, -3)")
+    assert(result2.isLeft, "MROUND(10, -3) should return error (mismatched signs)")
+  }
+
   // ===== TRUNC Tests =====
 
   test("TRUNC: trunc(8.9) = 8") {

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/RandomFunctionsSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/RandomFunctionsSpec.scala
@@ -57,8 +57,8 @@ class RandomFunctionsSpec extends ScalaCheckSuite:
     val functions = FunctionRegistry.allNames
     assert(functions.contains("RAND"))
     assert(functions.contains("RANDBETWEEN"))
-    // total count asserted authoritatively in FormulaParserSpec ("all 107 functions")
-    assert(functions.length >= 107)
+    // total count asserted authoritatively in FormulaParserSpec ("all 108 functions")
+    assert(functions.length >= 108)
   }
 
   // ===== RAND =====

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/TypeCoercionSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/TypeCoercionSpec.scala
@@ -275,6 +275,137 @@ class TypeCoercionSpec extends FunSuite:
   }
 
   // ============================================================================
+  // GH-385: blank cells coerce to 0 in scalar numeric positions
+  // ============================================================================
+
+  test("GH-385: =A1+1 with explicitly Empty A1 is 1 (blank-as-zero)") {
+    val sheet = sheetWith(ref"A1" -> CellValue.Empty)
+    assertEquals(sheet.evaluateFormula("=A1+1"), Right(CellValue.Number(BigDecimal(1))))
+  }
+
+  test("GH-385: =A1+1 with absent A1 is 1 (blank-as-zero)") {
+    val sheet = sheetWith(ref"Z9" -> CellValue.Text("unrelated"))
+    assertEquals(sheet.evaluateFormula("=A1+1"), Right(CellValue.Number(BigDecimal(1))))
+  }
+
+  test("GH-385: blank cells are 0 across the scalar operators (*, %, unary -, ^)") {
+    val sheet = sheetWith(ref"Z9" -> CellValue.Text("unrelated"))
+    assertEquals(sheet.evaluateFormula("=A1*1"), Right(CellValue.Number(BigDecimal(0))))
+    assertEquals(sheet.evaluateFormula("=A1%"), Right(CellValue.Number(BigDecimal(0))))
+    assertEquals(sheet.evaluateFormula("=-A1"), Right(CellValue.Number(BigDecimal(0))))
+    assertEquals(sheet.evaluateFormula("=A1^2"), Right(CellValue.Number(BigDecimal(0))))
+  }
+
+  test("GH-385: blank ref as a scalar function argument is 0 (=ABS(A1))") {
+    val sheet = sheetWith(ref"Z9" -> CellValue.Text("unrelated"))
+    assertEquals(sheet.evaluateFormula("=ABS(A1)"), Right(CellValue.Number(BigDecimal(0))))
+  }
+
+  test("GH-385: SUM args mixing blank direct refs no longer reject (issue repro)") {
+    val sheet = sheetWith(ref"A1" -> CellValue.Number(BigDecimal(10)))
+    // A2 is blank: Excel evaluates SUM(A1, A2) = 10 rather than a strict-typing error
+    assertEquals(sheet.evaluateFormula("=SUM(A1, A2)"), Right(CellValue.Number(BigDecimal(10))))
+  }
+
+  test("GH-385: an error-valued cell still propagates through =A1+1 (not masked to 1)") {
+    val sheet = sheetWith(ref"A1" -> CellValue.Error(com.tjclp.xl.cells.CellError.Div0))
+    val result = sheet.evaluateFormula("=A1+1")
+    assert(result.isLeft, s"expected error propagation for #DIV/0! cell, got $result")
+  }
+
+  test("GH-385: text cell in numeric position is still a clean error (not 0)") {
+    val sheet = sheetWith(ref"A1" -> CellValue.Text("abc"))
+    val result = sheet.evaluateFormula("=A1+1")
+    assert(result.isLeft, s"expected error for text cell in numeric position, got $result")
+  }
+
+  test("GH-385: range aggregates still SKIP blanks while scalar refs coerce to 0") {
+    val sheet = sheetWith(
+      ref"A1" -> CellValue.Number(BigDecimal(10)),
+      // A2 deliberately blank
+      ref"A3" -> CellValue.Number(BigDecimal(20))
+    )
+    // Both must hold simultaneously: blank-skip in range folds, blank-as-zero at scalar refs
+    assertEquals(sheet.evaluateFormula("=SUM(A1:A3)"), Right(CellValue.Number(BigDecimal(30))))
+    assertEquals(sheet.evaluateFormula("=COUNT(A1:A3)"), Right(CellValue.Number(BigDecimal(2))))
+    assertEquals(sheet.evaluateFormula("=MIN(A1:A3)"), Right(CellValue.Number(BigDecimal(10))))
+    assertEquals(sheet.evaluateFormula("=AVERAGE(A1:A3)"), Right(CellValue.Number(BigDecimal(15))))
+    assertEquals(sheet.evaluateFormula("=A2+1"), Right(CellValue.Number(BigDecimal(1))))
+  }
+
+  // ============================================================================
+  // GH-385: date functions coerce raw Excel serial Numbers in date positions
+  // ============================================================================
+
+  private val serialDate = LocalDateTime.of(2024, 3, 15, 0, 0)
+  private val dateSerial = BigDecimal(CellValue.dateTimeToExcelSerial(serialDate))
+
+  test("GH-385: YEAR/MONTH/DAY accept a raw serial Number cell") {
+    val sheet = sheetWith(ref"A1" -> CellValue.Number(dateSerial))
+    assertEquals(sheet.evaluateFormula("=YEAR(A1)"), Right(CellValue.Number(BigDecimal(2024))))
+    assertEquals(sheet.evaluateFormula("=MONTH(A1)"), Right(CellValue.Number(BigDecimal(3))))
+    assertEquals(sheet.evaluateFormula("=DAY(A1)"), Right(CellValue.Number(BigDecimal(15))))
+  }
+
+  test("GH-385: EOMONTH accepts a raw serial Number cell (issue repro)") {
+    val sheet = sheetWith(ref"A1" -> CellValue.Number(dateSerial))
+    sheet.evaluateFormula("=EOMONTH(A1, 0)") match
+      case Right(CellValue.DateTime(dt)) =>
+        assertEquals(dt.toLocalDate, java.time.LocalDate.of(2024, 3, 31))
+      case other => fail(s"Expected DateTime, got $other")
+  }
+
+  test("GH-385: EDATE accepts a raw serial Number cell") {
+    val sheet = sheetWith(ref"A1" -> CellValue.Number(dateSerial))
+    sheet.evaluateFormula("=EDATE(A1, 1)") match
+      case Right(CellValue.DateTime(dt)) =>
+        assertEquals(dt.toLocalDate, java.time.LocalDate.of(2024, 4, 15))
+      case other => fail(s"Expected DateTime, got $other")
+  }
+
+  test("GH-385: YEARFRAC accepts raw serial Number cells") {
+    val start = BigDecimal(CellValue.dateTimeToExcelSerial(LocalDateTime.of(2024, 1, 1, 0, 0)))
+    val end = BigDecimal(CellValue.dateTimeToExcelSerial(LocalDateTime.of(2025, 1, 1, 0, 0)))
+    val sheet = sheetWith(
+      ref"A1" -> CellValue.Number(start),
+      ref"B1" -> CellValue.Number(end)
+    )
+    assertEquals(sheet.evaluateFormula("=YEARFRAC(A1, B1)"), Right(CellValue.Number(BigDecimal(1))))
+  }
+
+  test("GH-385: fractional serial (date + time) still lands on the right date") {
+    val sheet = sheetWith(ref"A1" -> CellValue.Number(dateSerial + BigDecimal("0.5")))
+    assertEquals(sheet.evaluateFormula("=YEAR(A1)"), Right(CellValue.Number(BigDecimal(2024))))
+    assertEquals(sheet.evaluateFormula("=DAY(A1)"), Right(CellValue.Number(BigDecimal(15))))
+  }
+
+  test("GH-385: formula cell with cached serial Number coerces in date position") {
+    val sheet = sheetWith(
+      ref"A1" -> CellValue.Formula("=B1*1", Some(CellValue.Number(dateSerial)))
+    )
+    assertEquals(sheet.evaluateFormula("=YEAR(A1)"), Right(CellValue.Number(BigDecimal(2024))))
+  }
+
+  test("GH-385: formula cell with cached DateTime coerces in date position") {
+    val sheet = sheetWith(
+      ref"A1" -> CellValue.Formula("=DATE(2024,3,15)", Some(CellValue.DateTime(serialDate)))
+    )
+    assertEquals(sheet.evaluateFormula("=YEAR(A1)"), Right(CellValue.Number(BigDecimal(2024))))
+  }
+
+  test("GH-385: negative serial in a date position is a clean error") {
+    val sheet = sheetWith(ref"A1" -> CellValue.Number(BigDecimal(-1)))
+    val result = sheet.evaluateFormula("=YEAR(A1)")
+    assert(result.isLeft, s"expected error for negative serial in date position, got $result")
+  }
+
+  test("GH-385: oversized serial (> 9999-12-31) in a date position is a clean error") {
+    val sheet = sheetWith(ref"A1" -> CellValue.Number(BigDecimal(2958466)))
+    val result = sheet.evaluateFormula("=YEAR(A1)")
+    assert(result.isLeft, s"expected error for oversized serial in date position, got $result")
+  }
+
+  // ============================================================================
   // GH-306: cross-type CALL-RESULT coercion in typed argument positions
   // (the wave-3 let-rand reviewer's probe list + totality sweep)
   // ============================================================================

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/WorkbookDefinedNameEvalSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/WorkbookDefinedNameEvalSpec.scala
@@ -1,0 +1,215 @@
+package com.tjclp.xl.formula
+
+import com.tjclp.xl.{*, given}
+import com.tjclp.xl.addressing.{ARef, SheetName}
+import com.tjclp.xl.cells.CellValue
+import com.tjclp.xl.formula.graph.DependencyGraph
+import com.tjclp.xl.formula.graph.DependencyGraph.QualifiedRef
+import com.tjclp.xl.sheets.Sheet
+import com.tjclp.xl.workbooks.{DefinedName, Workbook}
+import munit.FunSuite
+
+/**
+ * GH-384: defined-name references resolve inside formulas.
+ *
+ * Names are parsed as [[TExpr.NameRef]] and resolved at evaluation time against
+ * `WorkbookMetadata.definedNames`: a sheet-scoped name SHADOWS a workbook-scoped one of the same
+ * identifier (OOXML/Excel semantics), lookup is case-insensitive, and every failure mode (missing
+ * name, unparseable refersTo, name cycle, missing workbook context) is a clean per-cell error —
+ * never a throw.
+ */
+class WorkbookDefinedNameEvalSpec extends FunSuite:
+
+  private def num(i: Int): CellValue = CellValue.Number(BigDecimal(i))
+  private def formula(expr: String): CellValue = CellValue.Formula(expr, None)
+  private val a1 = ARef.from0(0, 0)
+  private val b2 = ARef.from0(1, 1)
+
+  private def model: Sheet =
+    Sheet(SheetName.unsafe("Model"))
+      .put(b2, num(2)) // Model!B2 = 2 (the 'case' toggle)
+      .put(ARef.from0(0, 0), num(10)) // Model!A1
+      .put(ARef.from0(0, 1), num(20)) // Model!A2
+      .put(ARef.from0(0, 2), num(30)) // Model!A3
+
+  private def withName(wb: Workbook, dn: DefinedName): Workbook =
+    wb.copy(metadata = wb.metadata.copy(definedNames = wb.metadata.definedNames :+ dn))
+
+  private def cached(wb: Workbook, sheetName: String, ref: ARef): Option[CellValue] =
+    wb.sheets
+      .find(_.name.value == sheetName)
+      .flatMap(_.cells.get(ref))
+      .map(_.value)
+      .collect { case CellValue.Formula(_, Some(v)) => v }
+
+  test("GH-384: single-cell name resolves to the target cell's value (=case)") {
+    val wb = Workbook(model).withDefinedName("case", "Model!$B$2")
+    assertEquals(wb.evaluateFormula("=case", "Model"), Right(num(2)))
+  }
+
+  test("GH-384: name lookup is case-insensitive (=CASE finds 'case')") {
+    val wb = Workbook(model).withDefinedName("case", "Model!$B$2")
+    assertEquals(wb.evaluateFormula("=CASE", "Model"), Right(num(2)))
+  }
+
+  test("GH-384: names compose in arithmetic (=entry_mult*ltm_ebitda)") {
+    val wb = Workbook(model)
+      .withDefinedName("entry_mult", "Model!$A$1") // 10
+      .withDefinedName("ltm_ebitda", "Model!$A$2") // 20
+    assertEquals(wb.evaluateFormula("=entry_mult*ltm_ebitda", "Model"), Right(num(200)))
+  }
+
+  test("GH-384: name in a comparison gates IF (=IF(case=2, ...)) — the LBO toggle shape") {
+    val wb = Workbook(model).withDefinedName("case", "Model!$B$2")
+    assertEquals(
+      wb.evaluateFormula("""=IF(case=2, "Downside", "Base")""", "Model"),
+      Right(CellValue.Text("Downside"))
+    )
+  }
+
+  test("GH-384: constant name (refersTo a literal) resolves (=tax_rate*100)") {
+    val wb = Workbook(model).withDefinedName("tax_rate", "0.25")
+    assertEquals(
+      wb.evaluateFormula("=tax_rate*100", "Model"),
+      Right(CellValue.Number(BigDecimal(25)))
+    )
+  }
+
+  test("GH-384: refersTo may carry a leading '=' (some producers write it)") {
+    val wb = Workbook(model).withDefinedName("tax_rate", "=0.25")
+    assertEquals(
+      wb.evaluateFormula("=tax_rate*4", "Model"),
+      Right(CellValue.Number(BigDecimal(1)))
+    )
+  }
+
+  test("GH-384: range name aggregates (=SUM(rev_range))") {
+    val wb = Workbook(model).withDefinedName("rev_range", "Model!$A$1:$A$3")
+    assertEquals(wb.evaluateFormula("=SUM(rev_range)", "Model"), Right(num(60)))
+  }
+
+  test("GH-384: name in a typed argument position coerces (=EOMONTH(named_date, 0))") {
+    val sheet = Sheet(SheetName.unsafe("Model"))
+      .put(a1, CellValue.DateTime(java.time.LocalDateTime.of(2026, 1, 15, 0, 0)))
+    val wb = Workbook(sheet).withDefinedName("named_date", "Model!$A$1")
+    wb.evaluateFormula("=EOMONTH(named_date, 0)", "Model") match
+      case Right(CellValue.DateTime(dt)) => assertEquals(dt.toLocalDate.getDayOfMonth, 31)
+      case other => fail(s"Expected end-of-month date, got $other")
+  }
+
+  test("GH-384: sheet-scoped name shadows workbook-scoped name of the same identifier") {
+    val other = Sheet(SheetName.unsafe("Other")).put(a1, num(99))
+    val wb0 = Workbook(model, other)
+    // Workbook-scoped: case -> Model!B2 (2). Sheet-scoped to Other (index 1): case -> Other!A1 (99).
+    val wb = withName(
+      withName(wb0, DefinedName("case", "Model!$B$2")),
+      DefinedName("case", "Other!$A$1", localSheetId = Some(1))
+    )
+    assertEquals(wb.evaluateFormula("=case", "Other"), Right(num(99)), "sheet scope must shadow")
+    assertEquals(wb.evaluateFormula("=case", "Model"), Right(num(2)), "global scope elsewhere")
+  }
+
+  test("GH-384: name-of-name chain resolves (alias -> case -> Model!B2)") {
+    val wb = Workbook(model)
+      .withDefinedName("case", "Model!$B$2")
+      .withDefinedName("alias", "case")
+    assertEquals(wb.evaluateFormula("=alias", "Model"), Right(num(2)))
+  }
+
+  test("GH-384: name cycle (A->B->A) is a clean error, never a throw or hang") {
+    val wb = Workbook(model)
+      .withDefinedName("aa", "bb")
+      .withDefinedName("bb", "aa")
+    wb.evaluateFormula("=aa", "Model") match
+      case Left(err) => assert(err.message.toLowerCase.contains("cycle"), s"got: ${err.message}")
+      case Right(v) => fail(s"name cycle must not evaluate, got $v")
+  }
+
+  test("GH-384: missing name is a clean per-cell error naming the identifier") {
+    val wb = Workbook(model)
+    wb.evaluateFormula("=no_such_name", "Model") match
+      case Left(err) => assert(err.message.contains("no_such_name"), s"got: ${err.message}")
+      case Right(v) => fail(s"missing name must not evaluate, got $v")
+  }
+
+  test("GH-384: unparseable refersTo is a clean per-cell error") {
+    val wb = withName(Workbook(model), DefinedName("broken", "###not-a-formula###"))
+    wb.evaluateFormula("=broken", "Model") match
+      case Left(err) => assert(err.message.contains("broken"), s"got: ${err.message}")
+      case Right(v) => fail(s"unparseable refersTo must not evaluate, got $v")
+  }
+
+  test("GH-384: single-sheet eval without workbook context is a clean error (SheetRef posture)") {
+    import com.tjclp.xl.formula.eval.SheetEvaluator.*
+    model.evaluateFormula("=case") match
+      case Left(err) =>
+        assert(err.message.contains("workbook"), s"got: ${err.message}")
+      case Right(v) => fail(s"expected clean error without workbook context, got $v")
+  }
+
+  test("GH-384: LET binding shadows a defined name of the same identifier") {
+    val wb = Workbook(model).withDefinedName("case", "Model!$B$2") // 2
+    assertEquals(
+      wb.evaluateFormula("=LET(case, 1, case+1)", "Model"),
+      Right(CellValue.Number(BigDecimal(2))) // binding (1) + 1, NOT defined name (2) + 1
+    )
+  }
+
+  test("GH-384: dependency graph carries an edge from the name user to the name's target") {
+    val other = Sheet(SheetName.unsafe("Other")).put(a1, formula("=IF(case=2, 10, 20)"))
+    val wb = Workbook(model.put(b2, formula("=1+1")), other).withDefinedName("case", "Model!$B$2")
+    val graph = DependencyGraph.fromWorkbook(wb)
+    val edges = graph.getOrElse(QualifiedRef(SheetName.unsafe("Other"), a1), Set.empty)
+    assert(
+      edges.contains(QualifiedRef(SheetName.unsafe("Model"), b2)),
+      s"expected Other!A1 -> Model!B2 edge via defined name, got $edges"
+    )
+  }
+
+  test("GH-384: recalculate() orders a computed toggle before its name-gated dependents") {
+    // Model!B2 is COMPUTED (=1+1); Other!A1 gates on the name 'case' -> Model!$B$2.
+    // Without the name edge, Kahn could order Other!A1 first and read a stale/uncached toggle.
+    val other = Sheet(SheetName.unsafe("Other")).put(a1, formula("=IF(case=2, 10, 20)"))
+    val wb = Workbook(model.put(b2, formula("=1+1")), other).withDefinedName("case", "Model!$B$2")
+    val result = wb.recalculate()
+    assert(result.isClean, s"expected clean recalc, got: ${result.errors.map(_.render)}")
+    assertEquals(cached(result.workbook, "Other", a1), Some(num(10)))
+  }
+
+  test("GH-384: cell cycle THROUGH a name is detected as circular by recalculate()") {
+    // Model!A9 = "=user" where user -> Model!$B$9, and Model!B9 = "=A9" — a cycle only visible
+    // when the graph resolves the name to its target.
+    val a9 = ARef.from0(0, 8)
+    val b9 = ARef.from0(1, 8)
+    val sheet = Sheet(SheetName.unsafe("Model"))
+      .put(a9, formula("=user*1"))
+      .put(b9, formula("=A9"))
+    val wb = Workbook(sheet).withDefinedName("user", "Model!$B$9")
+    val result = wb.recalculate()
+    assert(!result.isClean)
+    assert(
+      result.errors.exists(_.error.message.contains("Circular")),
+      s"expected a Circular reference error via the name edge, got: ${result.errors.map(_.render)}"
+    )
+  }
+
+  test("GH-384: recalculate() with defined-name formulas caches values (probe shape)") {
+    val other = Sheet(SheetName.unsafe("Calc"))
+      .put(a1, formula("=entry_mult*ltm_ebitda"))
+    val wb = Workbook(model, other)
+      .withDefinedName("entry_mult", "Model!$A$1")
+      .withDefinedName("ltm_ebitda", "Model!$A$2")
+    val result = wb.recalculate()
+    assert(result.isClean, s"expected clean, got: ${result.errors.map(_.render)}")
+    assertEquals(cached(result.workbook, "Calc", a1), Some(num(200)))
+  }
+
+  test("GH-384: name cycle inside recalculate() is a per-cell error, never a throw") {
+    val sheet = Sheet(SheetName.unsafe("Model")).put(a1, formula("=aa"))
+    val wb = Workbook(sheet)
+      .withDefinedName("aa", "bb")
+      .withDefinedName("bb", "aa")
+    val result = wb.recalculate() // must not throw or hang
+    assert(!result.isClean)
+    assertEquals(result.errors.map(_.ref), Vector(a1))
+  }


### PR DESCRIPTION
## Summary

W5 of the replication-campaign roadmap — the evaluator wave that unlocks milestones **M1** (house formulas `=+IF(case=2,…)` evaluate end-to-end) and **M2** (`recalculate()` verifies a real LBO including circular debt schedules).

- **#384** — defined-name resolution: bare identifiers parse to a dedicated `NameRef` node (cell-ref-shaped identifiers like `TAX1` stay cell refs, per OOXML's own collision rule) and resolve at eval through the workbook: sheet-scoped shadows global, constants/ranges/name-chains supported, cycle-guarded, clean per-cell errors when unresolvable. Names inject their targets' dependency edges into the recalc graph, so name-gated control flow orders correctly. This class was 926/1,571 recalc-probe rejections on one real LBO.
- **#373 (completes part b)** — opt-in bounded iterative recalculation: `recalculate(IterativeCalc(maxIter, maxChange))` runs a Jacobi fixpoint over declared cycles (seed 0, keep-last-values on maxIter per Excel, dependents evaluate off converged values, single pinned clock, per-cell NonFatal containment inside the loop). Default `recalculate()` behavior is byte-identical. `IterativeCalc.fromCalcPr` bridges wave-14's authored calcPr.
- **#385** — coercion parity: serial `Number` cells coerce in date positions (all nine date functions), blanks coerce to 0 in scalar numeric positions — via a dedicated scalar decoder so aggregate blank-skip and NPV/IRR cashflow collection are untouched (the implementer caught that the shared decoder has three consumers and rewired only the scalar boundary; the reviewer verified each consumer's semantics independently).
- **#386** — MROUND joins the registry (108 functions): `MROUND(x,0)=0` (unlike CEILING's zero-error), sign-mismatch errors, half-away-from-zero on both domains.

## Verification

Adversarial reviews with per-half revert refutation (parser/eval/graph halves of #384 proven independently load-bearing; pre-fix trees reproduce the issues' exact traced failures), analytic-fixpoint pinning (B1 = 100/0.95), cross-feature composition probes (a cycle visible only through a defined name is Tarjan-detected via the name edge and converges iteratively), and 13 edge probes including quoted-sheet refersTo and LET-shadowing precedence.

Integrated gates: `checkFormatAll __.sources` ✓, `./mill __.test` 1028/1028 (4,300+ cases), roundtrip corpus 239/239, examples ✓, snippets ✓.

Follow-up issues to be filed from disclosed gaps: names in strict range-typed argument positions (`=VLOOKUP(x, named_table, 2)`), variadic-aggregate direct-blank-arg Excel parity, remaining coercion edges (int positions, date-position blanks, sheet-qualified name refs, `.`/`\` name characters).

Closes #384
Closes #373
Closes #385
Closes #386

🤖 Generated with [Claude Code](https://claude.com/claude-code)