### PR TITLE
Wave 16: CLI tooling — appearance/print-setup commands, cf add, putf format, JSON formula field, rasterizer diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Sheet appearance & print-setup CLI commands** (#358, completing the
+  issue): `sheet-view --gridlines on|off --zoom N [--tab-selected]`,
+  `tab-color <color>|--clear` (hex, named, `rgb()`, and new
+  `theme:<slot>[:<tint>]` syntax), `page-setup --orientation --scale
+  --fit-to-width/--fit-to-height/--fit-to-page`, and `header-footer`
+  (odd/even/first) — each with a batch-op twin. The full deliverable
+  finish (gridlines off, zoom 85, tab colors, landscape + fit, confidential
+  footer) is one batch file with zero XML patching.
+- **Conditional-formatting CLI** (#324): `xl cf add --range A1:A10 --rule
+  'cellIs:greaterThan:100' --bold --bg #FFC7CE` (+ `cf list` and a batch
+  `cf` op) — colon rule DSL covering cellIs/between/expression/colorScale/
+  dataBar/top10/text families with clean errors; priorities auto-stamp.
+- **Batch `putf` format field** (#356): `{"op":"putf","ref":"C1",
+  "value":"=A1*2","format":"#,##0.0"}` applies the numFmt with the formula
+  in all three variants (single, `values[]`, `from`-dragging), on both the
+  in-memory and streaming batch paths — no more second `style` pass.
+- **Rasterizer diagnostics** (#359): failed PNG/PDF exports now name the
+  probed backend chain, point at `xl rasterizers`, and say when you're on
+  the native binary (where Batik is unavailable by design) with one-liner
+  installs; `xl rasterizers` gains explicit native-image awareness.
+
+### Changed
+
+- **JSON formula cells carry a dedicated `formula` field** (#357):
+  `view --format json` now always emits `{ref, type:"formula", formula,
+  value, formatted}` — `value`/`formatted` hold the computed/cached value.
+  Previously, under `--formulas`, `value` held the formula *text* and the
+  computed value was absent; consumers keying on `value` there were reading
+  the misfeature this fixes. CSV/markdown behavior is unchanged.
+
 - **Defined-name resolution in formulas** (#384): `=IF(case=2,…)`,
   `=entry_mult*ltm_ebitda`, `=SUM(rev_range)` parse, evaluate, and
   round-trip byte-faithfully via a dedicated name AST node — workbook- and

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -849,7 +849,7 @@ Apply multiple operations atomically from JSON input.
 | Operation | Required Fields | Optional Fields | Description |
 |-----------|-----------------|-----------------|-------------|
 | `put` | `ref`, `value` | `format`, `values`, `detect` | Write value to cell |
-| `putf` | `ref`, `value` | `from`, `values` | Write formula(s) to cell(s) |
+| `putf` | `ref`, `value` | `from`, `values`, `format` | Write formula(s) to cell(s); `format` applies a number format to the formula cell(s) |
 | `style` | `range` | styling options | Apply cell styling |
 | `merge` | `range` | | Merge cells |
 | `unmerge` | `range` | | Unmerge cells |
@@ -949,6 +949,18 @@ Strings are automatically detected and formatted:
 
 // Explicit formulas for each cell (no dragging)
 {"op": "putf", "ref": "B2:B4", "values": ["=A2*2", "=A3*2", "=A4*2"]}
+```
+
+**Formula Number Formats** (`putf` with `format`, parity with `put`):
+
+The `format` field accepts the same named formats and custom codes as `put` and
+applies the number format to the formula cell(s) — no second `style` pass needed.
+Works with all three variants (single, dragging, explicit `values`):
+
+```json
+{"op": "putf", "ref": "C1", "value": "=A1*2", "format": "#,##0.0"}
+{"op": "putf", "ref": "B2:B10", "value": "=A2/A$1", "from": "B2", "format": "percent"}
+{"op": "putf", "ref": "D1:D2", "values": ["=SUM(A:A)", "=SUM(B:B)"], "format": "currency"}
 ```
 
 **Style Options**:

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -206,7 +206,7 @@ View a rectangular range — markdown table by default, or JSON/CSV/HTML/SVG/PNG
 | `--raster-output` | path | For raster | — | Output file (required for png/jpeg/webp/pdf) |
 | `--dpi` | int | No | 144 | Resolution for raster output |
 | `--quality` | int | No | 90 | JPEG quality 1-100 |
-| `--rasterizer` | string | No | batik | PNG/JPEG export uses Apache Batik by default (pure JVM, no external tools). Force another backend: cairosvg, rsvg-convert, resvg, imagemagick (explicit opt-in since 0.11.3) |
+| `--rasterizer` | string | No | batik | PNG/JPEG export uses Apache Batik by default (pure JVM, no external tools). Force another backend: cairosvg, rsvg-convert, resvg, imagemagick (explicit opt-in since 0.11.3). Native binaries need an external backend — see [`xl rasterizers`](#xl-rasterizers) |
 | `--gridlines` | flag | No | false | Show cell gridlines in SVG output |
 | `--print-scale` | flag | No | false | Apply print scaling (for PDF-like output) |
 
@@ -218,6 +218,29 @@ View a rectangular range — markdown table by default, or JSON/CSV/HTML/SVG/PNG
 | 2 | COGS        |         | $400,000   |         |
 | 4 | Gross Profit|         | =C1-C2     |         |
 ```
+
+---
+
+### `xl rasterizers`
+
+List SVG-to-raster backends with live availability on this machine (no `-f` needed). PNG/JPEG/WebP/PDF export probes backends in this order: `batik` → `cairosvg` → `rsvg-convert` → `resvg`; `imagemagick` is never probed automatically (fragile SVG delegate) and must be forced with `--rasterizer imagemagick`.
+
+**Platform matrix**:
+
+| Distribution | Rasterization |
+|--------------|---------------|
+| JAR (`java -jar`, `make install-jar`) | Works out of the box — Batik is bundled (pure JVM, needs AWT) |
+| Native binary (GitHub releases, `make install`) | Batik cannot work (no AWT under native-image, by design) — one external tool is required |
+
+**External tool installs** (any one is enough):
+
+```bash
+pip install cairosvg          # Python, most portable
+apt install librsvg2-bin      # rsvg-convert (Debian/Ubuntu); brew install librsvg (macOS)
+cargo install resvg           # or a prebuilt binary: github.com/linebender/resvg/releases
+```
+
+When no backend is available, raster exports fail with an error naming the probed chain and pointing back at `xl rasterizers`. `--format svg` always works (pure vector, no backend needed).
 
 ---
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -84,6 +84,7 @@ xl rasterizers                                     # List available PNG/PDF back
 | **Rows/columns** | `row`, `col`, `autofit`, `insert-rows`, `delete-rows`, `insert-cols`, `delete-cols` | Sizing, visibility, structural editing |
 | **Sheets & view** | `add-sheet`, `remove-sheet`, `rename-sheet`, `move-sheet`, `copy-sheet`, `sheets hide/show`, `freeze`, `unfreeze`, `name` | Workbook structure |
 | **Appearance & print** | `sheet-view`, `tab-color`, `page-setup`, `header-footer` | Deliverable finish: gridlines, zoom, tab colors, print setup, footers |
+| **Conditional formatting** | `cf add`, `cf list` | Highlight rules, color scales, data bars, top-N, text matches |
 
 ### Command Summary
 
@@ -123,6 +124,8 @@ xl rasterizers                                     # List available PNG/PDF back
 | `tab-color` | `<color>` \| `--clear` | Set/clear the sheet tab color (requires `-o`) |
 | `page-setup` | `[--orientation portrait\|landscape] [--scale n] [--fit-to-width n] [--fit-to-height n] [--fit-to-page on\|off]` | Set print page setup (requires `-o`) |
 | `header-footer` | `[--odd-header s] [--odd-footer s] [--even-\*] [--first-\*] [--different-odd-even] [--different-first]` | Set print header/footer text (requires `-o`) |
+| `cf add` | `--range <range> --rule <dsl> [format flags]` | Add a conditional-formatting rule (requires `-o`) |
+| `cf list` | | List conditional-formatting rules on the sheet (read-only) |
 | `chart add` | `--type <t> --data <range> --at <ref> [options]` | Add a chart built from sheet ranges (requires `-o`) |
 | `add-image` | `<image-file> --at <ref> [--size WxH]` | Embed an image (requires `-o`) |
 | `import` | `<csv-file> [start-ref] [options]` | Import CSV with type detection (requires `-o`) |
@@ -748,6 +751,49 @@ xl -f in.xlsx -s Model -o out.xlsx batch finish.json
 
 ---
 
+### `xl cf add --range <range> --rule <dsl>` / `xl cf list`
+
+Author conditional formatting (GH-324). `cf add` appends one rule to a range (requires `-o`);
+`cf list` shows the sheet's rules (read-only). Priorities are auto-assigned in add order
+(lower priority wins in Excel) — the CLI never hand-stamps them.
+
+**Rule DSL** (`--rule`):
+
+| Family | Syntax | Example |
+|--------|--------|---------|
+| Cell value | `cellIs:<op>:<value>` | `cellIs:greaterThan:100` (ops: `lessThan`/`lt`, `lessThanOrEqual`/`lte`, `equal`/`eq`, `notEqual`/`ne`, `greaterThanOrEqual`/`gte`, `greaterThan`/`gt`) |
+| Range | `between:<lo>:<hi>`, `notBetween:<lo>:<hi>` | `between:10:100` |
+| Formula | `expression:<formula>` | `expression:MOD(ROW(),2)=0` (formula may contain `:`) |
+| Color scale | `colorScale:<c1>:<c2>[:<c3>]` | `colorScale:red:white:green` (3-point mid at 50th percentile) |
+| Data bar | `dataBar:<color>` | `dataBar:#638EC6` |
+| Top/bottom N | `top10:<n>[:percent]`, `bottom10:<n>[:percent]` | `top10:5:percent` |
+| Text match | `text:<op>:<s>` | `text:contains:overdue` (ops: `contains`, `notContains`, `beginsWith`, `endsWith`; `<s>` may contain `:`) |
+
+**Format flags** (highlight rules — `cellIs`, `between`, `notBetween`, `expression`, `top10`,
+`bottom10`, `text` — require at least one; `colorScale`/`dataBar` carry inline colors and reject
+them): `--bold`, `--italic`, `--underline`, `--strike`, `--bg <color>`, `--fg <color>`.
+Flag colors accept the full color syntax including `theme:accent1[:tint]`; color tokens *inside*
+`colorScale:`/`dataBar:` rule strings accept named/`#hex`/`rgb(r,g,b)` only (the `:` separator
+conflicts with theme syntax).
+
+```bash
+# Red highlight for values over 100
+xl -f f.xlsx -s S1 -o o.xlsx cf add --range A1:A10 \
+   --rule 'cellIs:greaterThan:100' --bold --bg '#FFC7CE' --fg '#9C0006'
+
+# 3-point color scale, then inspect
+xl -f f.xlsx -s S1 -o o.xlsx cf add --range B2:B20 --rule 'colorScale:red:white:green'
+xl -f o.xlsx -s S1 cf list
+```
+
+**Batch op** `cf` mirrors the command:
+
+```json
+{"op": "cf", "range": "A1:A10", "rule": "cellIs:greaterThan:100", "bold": true, "bg": "#FFC7CE"}
+```
+
+---
+
 ### `xl chart add --type <t> --data <range> --at <ref> [options]`
 
 Add a typed chart built from sheet data ranges. Supported types: `column`, `bar` (horizontal),
@@ -936,6 +982,7 @@ Apply multiple operations atomically from JSON input.
 | `tab-color` | | `color`, `clear` | Set (`color`) or clear (`clear: true`) the sheet tab color |
 | `page-setup` | | `orientation`, `scale`, `fitToWidth`, `fitToHeight`, `fitToPage` | Set print page setup |
 | `header-footer` | | `oddHeader`, `oddFooter`, `evenHeader`, `evenFooter`, `firstHeader`, `firstFooter`, `differentOddEven`, `differentFirst` | Set print header/footer text |
+| `cf` | `range`, `rule` | `bold`, `italic`, `underline`, `strike`, `bg`, `fg` | Add a conditional-formatting rule (see `cf add`) |
 
 **Native JSON Types** (recommended):
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -83,6 +83,7 @@ xl rasterizers                                     # List available PNG/PDF back
 | **Mutate cells** | `put`, `putf`, `style`, `fill`, `clear`, `copy`, `sort`, `merge`, `unmerge`, `comment`, `remove-comment`, `batch`, `import` | Make changes (require `-o` or `-i`) |
 | **Rows/columns** | `row`, `col`, `autofit`, `insert-rows`, `delete-rows`, `insert-cols`, `delete-cols` | Sizing, visibility, structural editing |
 | **Sheets & view** | `add-sheet`, `remove-sheet`, `rename-sheet`, `move-sheet`, `copy-sheet`, `sheets hide/show`, `freeze`, `unfreeze`, `name` | Workbook structure |
+| **Appearance & print** | `sheet-view`, `tab-color`, `page-setup`, `header-footer` | Deliverable finish: gridlines, zoom, tab colors, print setup, footers |
 
 ### Command Summary
 
@@ -118,6 +119,10 @@ xl rasterizers                                     # List available PNG/PDF back
 | `remove-comment` | `<ref>` | Remove cell comment (requires `-o`) |
 | `freeze` | `<ref>` | Freeze panes at cell (requires `-o`) |
 | `unfreeze` | | Remove freeze panes (requires `-o`) |
+| `sheet-view` | `[--gridlines on\|off] [--zoom n] [--tab-selected on\|off]` | Set sheet view options (requires `-o`) |
+| `tab-color` | `<color>` \| `--clear` | Set/clear the sheet tab color (requires `-o`) |
+| `page-setup` | `[--orientation portrait\|landscape] [--scale n] [--fit-to-width n] [--fit-to-height n] [--fit-to-page on\|off]` | Set print page setup (requires `-o`) |
+| `header-footer` | `[--odd-header s] [--odd-footer s] [--even-\*] [--first-\*] [--different-odd-even] [--different-first]` | Set print header/footer text (requires `-o`) |
 | `chart add` | `--type <t> --data <range> --at <ref> [options]` | Add a chart built from sheet ranges (requires `-o`) |
 | `add-image` | `<image-file> --at <ref> [--size WxH]` | Embed an image (requires `-o`) |
 | `import` | `<csv-file> [start-ref] [options]` | Import CSV with type detection (requires `-o`) |
@@ -685,6 +690,64 @@ xl -f input.xlsx -s S1 -o output.xlsx unfreeze
 
 ---
 
+### Appearance & print setup: `sheet-view`, `tab-color`, `page-setup`, `header-footer`
+
+The "deliverable finish" commands (GH-358). Each merges into the sheet's current settings:
+unspecified options are preserved. All require `-o` (or `-i`).
+
+```bash
+# Gridlines off + 85% zoom
+xl -f in.xlsx -s Model -o out.xlsx sheet-view --gridlines off --zoom 85
+
+# Tab colors: named, #hex, rgb(r,g,b), or theme:<slot>[:<tint>]
+xl -f in.xlsx -s Model -o out.xlsx tab-color "#1F4E79"
+xl -f in.xlsx -s Model -o out.xlsx tab-color theme:accent2:0.25
+xl -f in.xlsx -s Model -o out.xlsx tab-color --clear     # clears a modeled color only
+
+# Landscape, fit to one page wide and tall
+xl -f in.xlsx -s Model -o out.xlsx page-setup --orientation landscape \
+   --fit-to-width 1 --fit-to-height 1
+
+# Confidential footer (&L/&C/&R sections; &P page, &N total, &D date, &F file, &A sheet)
+xl -f in.xlsx -s Model -o out.xlsx header-footer \
+   --odd-footer "&LProprietary & Confidential&RPage &P of &N"
+```
+
+**Options**:
+
+| Command | Options |
+|---------|---------|
+| `sheet-view` | `--gridlines on\|off`, `--zoom <10-400>`, `--tab-selected on\|off` |
+| `tab-color` | `<color>` or `--clear` |
+| `page-setup` | `--orientation portrait\|landscape`, `--scale <10-400>`, `--fit-to-width <n>`, `--fit-to-height <n>`, `--fit-to-page on\|off` |
+| `header-footer` | `--odd-header/--odd-footer`, `--even-header/--even-footer`, `--first-header/--first-footer`, `--different-odd-even`, `--different-first` |
+
+**Notes**:
+- Validation is up-front with clean errors (zoom/scale 10-400, orientation values, fit counts >= 1).
+- `tab-color --clear` removes the *modeled* color; a tab color already present in the source file's
+  XML is preserved on write (preserve-if-None semantics) and cannot be stripped by the CLI.
+- `page-setup --fit-to-page` is tri-state: omitted derives the sheetPr `fitToPage` flag from
+  `--fit-to-width`/`--fit-to-height` and preserves whatever the source carries; `on` forces the
+  flag; `off` actively strips a preserved flag.
+- Even-page text sets `different-odd-even` automatically, first-page text sets `different-first`
+  (Excel ignores the text while the corresponding flag is off).
+- Each command has a batch-op twin (`sheet-view`, `tab-color`, `page-setup`, `header-footer`) —
+  the full deliverable finish is one batch file:
+
+```bash
+cat > finish.json <<'EOF'
+[
+  {"op": "sheet-view", "gridlines": false, "zoom": 85},
+  {"op": "tab-color", "color": "#1F4E79"},
+  {"op": "page-setup", "orientation": "landscape", "fitToWidth": 1, "fitToHeight": 1},
+  {"op": "header-footer", "oddFooter": "&LProprietary & Confidential&RPage &P of &N"}
+]
+EOF
+xl -f in.xlsx -s Model -o out.xlsx batch finish.json
+```
+
+---
+
 ### `xl chart add --type <t> --data <range> --at <ref> [options]`
 
 Add a typed chart built from sheet data ranges. Supported types: `column`, `bar` (horizontal),
@@ -869,6 +932,10 @@ Apply multiple operations atomically from JSON input.
 | `freeze` | `ref` | | Freeze panes at cell |
 | `unfreeze` | | | Remove freeze panes |
 | `copy` | `source`, `target` | `valuesOnly` | Copy range with formula adjustment |
+| `sheet-view` | | `gridlines`, `zoom`, `tabSelected` | Set sheet view options (operates on `--sheet`) |
+| `tab-color` | | `color`, `clear` | Set (`color`) or clear (`clear: true`) the sheet tab color |
+| `page-setup` | | `orientation`, `scale`, `fitToWidth`, `fitToHeight`, `fitToPage` | Set print page setup |
+| `header-footer` | | `oddHeader`, `oddFooter`, `evenHeader`, `evenFooter`, `firstHeader`, `firstFooter`, `differentOddEven`, `differentFirst` | Set print header/footer text |
 
 **Native JSON Types** (recommended):
 

--- a/xl-cli/src/com/tjclp/xl/cli/ColorParser.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/ColorParser.scala
@@ -1,6 +1,6 @@
 package com.tjclp.xl.cli
 
-import com.tjclp.xl.styles.color.Color
+import com.tjclp.xl.styles.color.{Color, ThemeSlot}
 
 /**
  * Color parser for CLI input.
@@ -9,6 +9,7 @@ import com.tjclp.xl.styles.color.Color
  *   - Named colors: red, blue, yellow, green, white, black, etc.
  *   - Hex: #RGB, #RRGGBB, #AARRGGBB
  *   - RGB: rgb(r,g,b)
+ *   - Theme: theme:accent1 or theme:accent1:0.25 (slot + optional tint in [-1.0, 1.0])
  */
 object ColorParser:
 
@@ -41,8 +42,42 @@ object ColorParser:
     "lime" -> Color.fromRgb(0, 255, 0)
   )
 
+  /** Theme slot names for the `theme:<slot>[:<tint>]` syntax (GH-358). */
+  private val themeSlots: Map[String, ThemeSlot] = Map(
+    "dark1" -> ThemeSlot.Dark1,
+    "light1" -> ThemeSlot.Light1,
+    "dark2" -> ThemeSlot.Dark2,
+    "light2" -> ThemeSlot.Light2,
+    "accent1" -> ThemeSlot.Accent1,
+    "accent2" -> ThemeSlot.Accent2,
+    "accent3" -> ThemeSlot.Accent3,
+    "accent4" -> ThemeSlot.Accent4,
+    "accent5" -> ThemeSlot.Accent5,
+    "accent6" -> ThemeSlot.Accent6
+  )
+
   private val rgbPattern = """rgb\s*\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\)""".r
   private val shortHexPattern = """#([0-9A-Fa-f]{3})""".r
+
+  /** Parse `theme:<slot>[:<tint>]`, e.g. `theme:accent1` or `theme:accent2:0.25`. */
+  private def parseTheme(input: String): Either[String, Color] =
+    input.split(":", -1).toList match
+      case "theme" :: slotName :: rest if rest.length <= 1 =>
+        for
+          slot <- themeSlots
+            .get(slotName)
+            .toRight(
+              s"Unknown theme slot: $slotName. Use ${themeSlots.keys.toList.sorted.mkString(", ")}"
+            )
+          tint <- rest.headOption match
+            case None => Right(0.0)
+            case Some(t) =>
+              t.toDoubleOption
+                .toRight(s"Invalid theme tint: $t (expected a number in [-1.0, 1.0])")
+                .flatMap(Color.validTint)
+        yield Color.Theme(slot, tint)
+      case _ =>
+        Left(s"Invalid theme color: $input. Use theme:<slot>[:<tint>], e.g. theme:accent1:0.25")
 
   /**
    * Parse a color string.
@@ -58,6 +93,10 @@ object ColorParser:
       case Some(color) => Right(color)
       case None =>
         input match
+          // theme:<slot>[:<tint>] format (GH-358)
+          case theme if theme.startsWith("theme:") =>
+            parseTheme(theme)
+
           // rgb(r,g,b) format
           case rgbPattern(r, g, b) =>
             try
@@ -80,7 +119,8 @@ object ColorParser:
 
           case _ =>
             Left(
-              s"Unknown color: $s. Use named (red, blue, ...), hex (#RRGGBB), or rgb(r,g,b)"
+              s"Unknown color: $s. Use named (red, blue, ...), hex (#RRGGBB), rgb(r,g,b), " +
+                "or theme:<slot>[:<tint>] (e.g. theme:accent1:0.25)"
             )
 
   /** List available named colors */

--- a/xl-cli/src/com/tjclp/xl/cli/Command.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/Command.scala
@@ -154,6 +154,18 @@ enum CliCommand:
     differentOddEven: Boolean,
     differentFirst: Boolean
   )
+  // Conditional formatting (GH-324): add requires -o; list is read-only
+  case CfAdd(
+    range: String,
+    rule: String,
+    bold: Boolean,
+    italic: Boolean,
+    underline: Boolean,
+    strike: Boolean,
+    bg: Option[String],
+    fg: Option[String]
+  )
+  case CfList
   // Drawing layer (GH-221/GH-222, require -o)
   case ChartAdd(
     chartType: String, // column | bar | line | pie

--- a/xl-cli/src/com/tjclp/xl/cli/Command.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/Command.scala
@@ -134,6 +134,26 @@ enum CliCommand:
   // Freeze pane operations (require -o)
   case Freeze(ref: String) // Freeze panes at ref (rows above + columns left)
   case Unfreeze // Remove freeze panes
+  // Sheet appearance & print setup (GH-358, require -o)
+  case SheetViewOp(gridlines: Option[Boolean], zoom: Option[Int], tabSelected: Option[Boolean])
+  case TabColorOp(color: Option[String], clear: Boolean)
+  case PageSetupOp(
+    orientation: Option[String],
+    scale: Option[Int],
+    fitToWidth: Option[Int],
+    fitToHeight: Option[Int],
+    fitToPage: Option[Boolean] // tri-state: None derives/preserves (GH-284)
+  )
+  case HeaderFooterOp(
+    oddHeader: Option[String],
+    oddFooter: Option[String],
+    evenHeader: Option[String],
+    evenFooter: Option[String],
+    firstHeader: Option[String],
+    firstFooter: Option[String],
+    differentOddEven: Boolean,
+    differentFirst: Boolean
+  )
   // Drawing layer (GH-221/GH-222, require -o)
   case ChartAdd(
     chartType: String, // column | bar | line | pie

--- a/xl-cli/src/com/tjclp/xl/cli/Main.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/Main.scala
@@ -31,6 +31,7 @@ import com.tjclp.xl.cli.raster.{
   BatikRasterizer,
   CairoSvg,
   ImageMagick,
+  NativeImage,
   RasterizerChain,
   Resvg,
   RsvgConvert
@@ -1263,12 +1264,6 @@ USAGE:
    *
    * Returns (formatted output, true if at least one rasterizer works). Checks run in parallel for
    * better performance.
-   *
-   * Status terminology:
-   *   - available: Works correctly
-   *   - missing: Binary not in PATH
-   *   - broken: Found but non-functional (e.g., delegate missing)
-   *   - unavailable: Cannot be used in current environment (e.g., Batik on native-image)
    */
   private def formatRasterizerList(): IO[(String, Boolean)] =
     // Run all availability checks in parallel
@@ -1281,60 +1276,99 @@ USAGE:
       ImageMagick.diagnostics
     ).parMapN {
       (batikAvail, cairoAvail, rsvgAvail, resvgAvail, imageMagickAvail, imageMagickDiag) =>
-        val sb = new StringBuilder
-        sb.append("SVG Rasterizer Status\n")
-        sb.append("=" * 60 + "\n\n")
-        sb.append(f"${"Backend"}%-14s | ${"Status"}%-11s | ${"Notes"}\n")
-        sb.append("-" * 60 + "\n")
-
-        // Batik - the default backend; "unavailable" when AWT not present (native image)
-        val batikStatus = if batikAvail then "available" else "unavailable"
-        val batikNote = "Built-in default (requires AWT)"
-        sb.append(f"${"batik"}%-14s | ${batikStatus}%-11s | $batikNote\n")
-
-        // CairoSvg
-        val cairoStatus = if cairoAvail then "available" else "missing"
-        val cairoNote = if cairoAvail then "pip install cairosvg" else "Not in PATH"
-        sb.append(f"${"cairosvg"}%-14s | ${cairoStatus}%-11s | $cairoNote\n")
-
-        // rsvg-convert
-        val rsvgStatus = if rsvgAvail then "available" else "missing"
-        val rsvgNote = if rsvgAvail then "librsvg2-bin" else "Not in PATH"
-        sb.append(f"${"rsvg-convert"}%-14s | ${rsvgStatus}%-11s | $rsvgNote\n")
-
-        // resvg
-        val resvgStatus = if resvgAvail then "available" else "missing"
-        val resvgNote = if resvgAvail then "cargo install resvg" else "Not in PATH"
-        sb.append(f"${"resvg"}%-14s | ${resvgStatus}%-11s | $resvgNote\n")
-
-        // ImageMagick (with delegate check) - explicit opt-in only, never tried automatically
-        // "broken" = found but delegate missing, "missing" = not in PATH
-        val imStatus =
-          if imageMagickAvail then "available"
-          else if imageMagickDiag.contains("missing") then "broken"
-          else "missing"
-        val imNote =
-          val cleaned = imageMagickDiag.replaceAll("ImageMagick \\d+ \\((magick|convert)\\) ", "")
-          val withOptIn =
-            if imageMagickAvail then s"--rasterizer imagemagick only; $cleaned" else cleaned
-          if withOptIn.length > 40 then withOptIn.take(37) + "..." else withOptIn
-        sb.append(f"${"imagemagick"}%-14s | ${imStatus}%-11s | $imNote\n")
-
-        sb.append("\n")
-
-        val anyAvailable = batikAvail || cairoAvail || rsvgAvail || resvgAvail || imageMagickAvail
-        if anyAvailable then
-          sb.append("At least one rasterizer is available for PNG/JPEG/PDF export.\n")
-        else
-          sb.append("WARNING: No rasterizers available! PNG/JPEG/PDF export will fail.\n")
-          sb.append("\nInstall one of:\n")
-          sb.append("  pip install cairosvg           # Python, most portable\n")
-          sb.append("  apt install librsvg2-bin       # rsvg-convert, fast\n")
-          sb.append("  cargo install resvg            # Rust, best quality\n")
-          sb.append("  apt install imagemagick        # then pass --rasterizer imagemagick\n")
-
-        (sb.toString, anyAvailable)
+        renderRasterizerTable(
+          batikAvail = batikAvail,
+          cairoAvail = cairoAvail,
+          rsvgAvail = rsvgAvail,
+          resvgAvail = resvgAvail,
+          imageMagickAvail = imageMagickAvail,
+          imageMagickDiag = imageMagickDiag,
+          nativeImage = NativeImage.inNativeImage
+        )
     }
+
+  /**
+   * Pure formatting core of `xl rasterizers` - separated from the availability probes so every
+   * environment (JVM, native binary, nothing installed) is unit-testable.
+   *
+   * Returns (formatted output, true if at least one rasterizer works).
+   *
+   * Status terminology:
+   *   - available: Works correctly
+   *   - missing: Binary not in PATH
+   *   - broken: Found but non-functional (e.g., delegate missing)
+   *   - unavailable: Cannot be used in current environment (e.g., Batik on native-image)
+   */
+  private[cli] def renderRasterizerTable(
+    batikAvail: Boolean,
+    cairoAvail: Boolean,
+    rsvgAvail: Boolean,
+    resvgAvail: Boolean,
+    imageMagickAvail: Boolean,
+    imageMagickDiag: String,
+    nativeImage: Boolean
+  ): (String, Boolean) =
+    val sb = new StringBuilder
+    sb.append("SVG Rasterizer Status\n")
+    sb.append("=" * 60 + "\n\n")
+    sb.append(f"${"Backend"}%-14s | ${"Status"}%-11s | ${"Notes"}\n")
+    sb.append("-" * 60 + "\n")
+
+    // Batik - the default backend; "unavailable" when AWT not present (native image)
+    val batikStatus = if batikAvail then "available" else "unavailable"
+    val batikNote =
+      if batikAvail then "Built-in default (requires AWT)"
+      else if nativeImage then "Native binary: no AWT, by design"
+      else "Requires AWT (not present here)"
+    sb.append(f"${"batik"}%-14s | ${batikStatus}%-11s | $batikNote\n")
+
+    // CairoSvg
+    val cairoStatus = if cairoAvail then "available" else "missing"
+    val cairoNote = if cairoAvail then "pip install cairosvg" else "Not in PATH"
+    sb.append(f"${"cairosvg"}%-14s | ${cairoStatus}%-11s | $cairoNote\n")
+
+    // rsvg-convert
+    val rsvgStatus = if rsvgAvail then "available" else "missing"
+    val rsvgNote = if rsvgAvail then "librsvg2-bin" else "Not in PATH"
+    sb.append(f"${"rsvg-convert"}%-14s | ${rsvgStatus}%-11s | $rsvgNote\n")
+
+    // resvg
+    val resvgStatus = if resvgAvail then "available" else "missing"
+    val resvgNote = if resvgAvail then "cargo install resvg" else "Not in PATH"
+    sb.append(f"${"resvg"}%-14s | ${resvgStatus}%-11s | $resvgNote\n")
+
+    // ImageMagick (with delegate check) - explicit opt-in only, never tried automatically
+    // "broken" = found but delegate missing, "missing" = not in PATH
+    val imStatus =
+      if imageMagickAvail then "available"
+      else if imageMagickDiag.contains("missing") then "broken"
+      else "missing"
+    val imNote =
+      val cleaned = imageMagickDiag.replaceAll("ImageMagick \\d+ \\((magick|convert)\\) ", "")
+      val withOptIn =
+        if imageMagickAvail then s"--rasterizer imagemagick only; $cleaned" else cleaned
+      if withOptIn.length > 40 then withOptIn.take(37) + "..." else withOptIn
+    sb.append(f"${"imagemagick"}%-14s | ${imStatus}%-11s | $imNote\n")
+
+    sb.append("\n")
+
+    val anyAvailable = batikAvail || cairoAvail || rsvgAvail || resvgAvail || imageMagickAvail
+    if anyAvailable then
+      sb.append("At least one rasterizer is available for PNG/JPEG/PDF export.\n")
+    else
+      sb.append("WARNING: No rasterizers available! PNG/JPEG/PDF export will fail.\n")
+      if nativeImage then
+        sb.append("This is the native binary: the bundled Batik backend needs AWT and can\n")
+        sb.append("never work here - install one of the external tools below.\n")
+      sb.append("\nInstall one of:\n")
+      sb.append("  pip install cairosvg           # Python, most portable\n")
+      sb.append("  apt install librsvg2-bin       # rsvg-convert, fast\n")
+      sb.append(
+        "  cargo install resvg            # or prebuilt: github.com/linebender/resvg/releases\n"
+      )
+      sb.append("  apt install imagemagick        # then pass --rasterizer imagemagick\n")
+
+    (sb.toString, anyAvailable)
 
   private def formatFunctionList(): String =
     // Dynamically get all functions from the registry

--- a/xl-cli/src/com/tjclp/xl/cli/Main.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/Main.scala
@@ -913,7 +913,8 @@ USAGE:
 
 OPERATIONS:
   put       {"op": "put", "ref": "A1", "value": "Hello"}
-  putf      {"op": "putf", "ref": "A1", "value": "=SUM(B1:B10)"}  (also accepts "formula")
+  putf      {"op": "putf", "ref": "A1", "value": "=SUM(B1:B10)"}  (also accepts "formula";
+            optional "format" applies a number format to the formula cell(s))
   style     {"op": "style", "range": "A1:D1", "bold": true, "bg": "#FFFF00"}
   merge     {"op": "merge", "range": "A1:D1"}
   unmerge   {"op": "unmerge", "range": "A1:D1"}

--- a/xl-cli/src/com/tjclp/xl/cli/Main.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/Main.scala
@@ -100,7 +100,7 @@ object Main
     // Sheet-level write: --file, --sheet, and --output (required)
     // --stream uses SAX/StAX workbook writes for modifying commands.
     val sheetWriteSubcmds =
-      putCmd orElse putfCmd orElse styleCmd orElse rowCmd orElse colCmd orElse autoFitCmd orElse batchCmd orElse recalcCmd orElse importCmd orElse importMdCmd orElse addSheetCmd orElse removeSheetCmd orElse renameSheetCmd orElse moveSheetCmd orElse copySheetCmd orElse mergeCmd orElse unmergeCmd orElse commentCmd orElse removeCommentCmd orElse clearCmd orElse fillCmd orElse sortCmd orElse freezeCmd orElse unfreezeCmd orElse copyCmd orElse nameCmd orElse insertRowsCmd orElse deleteRowsCmd orElse insertColsCmd orElse deleteColsCmd orElse chartCmd orElse addImageCmd orElse sheetViewCmd orElse tabColorCmd orElse pageSetupCmd orElse headerFooterCmd
+      putCmd orElse putfCmd orElse styleCmd orElse rowCmd orElse colCmd orElse autoFitCmd orElse batchCmd orElse recalcCmd orElse importCmd orElse importMdCmd orElse addSheetCmd orElse removeSheetCmd orElse renameSheetCmd orElse moveSheetCmd orElse copySheetCmd orElse mergeCmd orElse unmergeCmd orElse commentCmd orElse removeCommentCmd orElse clearCmd orElse fillCmd orElse sortCmd orElse freezeCmd orElse unfreezeCmd orElse copyCmd orElse nameCmd orElse insertRowsCmd orElse deleteRowsCmd orElse insertColsCmd orElse deleteColsCmd orElse chartCmd orElse addImageCmd orElse sheetViewCmd orElse tabColorCmd orElse pageSetupCmd orElse headerFooterCmd orElse cfCmd
 
     val sheetWriteOpts =
       (
@@ -932,6 +932,11 @@ APPEARANCE & PRINT SETUP (GH-358):
                 "differentOddEven": true, "differentFirst": true}
                 (&L/&C/&R sections; &P page, &N total, &D date, &F file, &A sheet)
 
+CONDITIONAL FORMATTING (GH-324):
+  cf            {"op": "cf", "range": "A1:A10", "rule": "cellIs:greaterThan:100",
+                "bold": true, "bg": "#FFC7CE", "fg": "#9C0006"}
+                (rule DSL and flags as `xl cf add`; priorities auto-assigned in order)
+
 STYLE PROPERTIES:
   Font:      bold, italic, underline, fg, fontSize, fontName
   Fill:      bg (background color, e.g., "#FFFF00" or "yellow")
@@ -1243,6 +1248,51 @@ USAGE:
       val valuesOnlyOpt =
         Opts.flag("values-only", "Copy values only (no formula adjustment)").orFalse
       (copySrcArg, copyTgtArg, valuesOnlyOpt).mapN(CliCommand.Copy.apply)
+    }
+
+  // --- Conditional formatting command (GH-324) ---
+
+  private val cfCmd: Opts[CliCommand] =
+    Opts.subcommand("cf", "Conditional formatting: add, list") {
+      val addSub = Opts.subcommand(
+        "add",
+        """Add a conditional-formatting rule to a range (requires -o).
+
+RULE DSL (--rule):
+  cellIs:<op>:<value>       op: lessThan|lt, lessThanOrEqual|lte, equal|eq,
+                            notEqual|ne, greaterThanOrEqual|gte, greaterThan|gt
+  between:<lo>:<hi>         inclusive bounds (notBetween:<lo>:<hi> for the inverse)
+  expression:<formula>      custom formula, e.g. expression:MOD(ROW(),2)=0
+  colorScale:<c1>:<c2>[:<c3>]  2- or 3-point scale (mid at 50th percentile)
+  dataBar:<color>
+  top10:<n>[:percent]       bottom10:<n>[:percent] for bottom ranks
+  text:<op>:<s>             op: contains, notContains, beginsWith, endsWith
+
+FORMAT FLAGS (highlight rules; colorScale/dataBar carry inline colors instead):
+  --bold --italic --underline --strike --bg <color> --fg <color>
+
+Priorities are auto-assigned in add order (lower priority wins in Excel).
+
+EXAMPLES:
+  xl -f f.xlsx -s S1 -o o.xlsx cf add --range A1:A10 --rule 'cellIs:greaterThan:100' --bold --bg '#FFC7CE'
+  xl -f f.xlsx -s S1 -o o.xlsx cf add --range B2:B20 --rule 'colorScale:red:white:green'
+  xl -f f.xlsx -s S1 -o o.xlsx cf add --range C1:C50 --rule 'text:contains:overdue' --fg '#9C0006'"""
+      ) {
+        val cfRangeOpt =
+          Opts.option[String]("range", "Target range, e.g. A1:A10 (qualified refs accepted)")
+        val cfRuleOpt = Opts.option[String](
+          "rule",
+          "Rule DSL string, e.g. cellIs:greaterThan:100 (see cf add --help)"
+        )
+        val strikeOpt = Opts.flag("strike", "Strikethrough text").orFalse
+        (cfRangeOpt, cfRuleOpt, boldOpt, italicOpt, underlineOpt, strikeOpt, bgOpt, fgOpt)
+          .mapN(CliCommand.CfAdd.apply)
+      }
+      val listSub =
+        Opts.subcommand("list", "List conditional-formatting rules on the sheet (read-only)") {
+          Opts(CliCommand.CfList)
+        }
+      addSub orElse listSub
     }
 
   // --- Chart + image commands (GH-222) ---
@@ -2171,6 +2221,29 @@ USAGE:
           _
         )
       )
+
+    // Conditional formatting (GH-324)
+    case CliCommand.CfAdd(range, rule, bold, italic, underline, strike, bg, fg) =>
+      requireOutput(outputOpt, backendOpt, stream)(
+        WriteCommands.cfAdd(
+          wb,
+          sheetOpt,
+          range,
+          rule,
+          bold,
+          italic,
+          underline,
+          strike,
+          bg,
+          fg,
+          _,
+          _,
+          _
+        )
+      )
+
+    case CliCommand.CfList =>
+      WriteCommands.cfList(wb, sheetOpt)
 
     case CliCommand.Copy(source, target, valuesOnly) =>
       requireOutput(outputOpt, backendOpt, stream)(

--- a/xl-cli/src/com/tjclp/xl/cli/Main.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/Main.scala
@@ -100,7 +100,7 @@ object Main
     // Sheet-level write: --file, --sheet, and --output (required)
     // --stream uses SAX/StAX workbook writes for modifying commands.
     val sheetWriteSubcmds =
-      putCmd orElse putfCmd orElse styleCmd orElse rowCmd orElse colCmd orElse autoFitCmd orElse batchCmd orElse recalcCmd orElse importCmd orElse importMdCmd orElse addSheetCmd orElse removeSheetCmd orElse renameSheetCmd orElse moveSheetCmd orElse copySheetCmd orElse mergeCmd orElse unmergeCmd orElse commentCmd orElse removeCommentCmd orElse clearCmd orElse fillCmd orElse sortCmd orElse freezeCmd orElse unfreezeCmd orElse copyCmd orElse nameCmd orElse insertRowsCmd orElse deleteRowsCmd orElse insertColsCmd orElse deleteColsCmd orElse chartCmd orElse addImageCmd
+      putCmd orElse putfCmd orElse styleCmd orElse rowCmd orElse colCmd orElse autoFitCmd orElse batchCmd orElse recalcCmd orElse importCmd orElse importMdCmd orElse addSheetCmd orElse removeSheetCmd orElse renameSheetCmd orElse moveSheetCmd orElse copySheetCmd orElse mergeCmd orElse unmergeCmd orElse commentCmd orElse removeCommentCmd orElse clearCmd orElse fillCmd orElse sortCmd orElse freezeCmd orElse unfreezeCmd orElse copyCmd orElse nameCmd orElse insertRowsCmd orElse deleteRowsCmd orElse insertColsCmd orElse deleteColsCmd orElse chartCmd orElse addImageCmd orElse sheetViewCmd orElse tabColorCmd orElse pageSetupCmd orElse headerFooterCmd
 
     val sheetWriteOpts =
       (
@@ -921,6 +921,17 @@ OPERATIONS:
   colwidth  {"op": "colwidth", "col": "A", "width": 15.5}
   rowheight {"op": "rowheight", "row": 1, "height": 30}
 
+APPEARANCE & PRINT SETUP (GH-358):
+  sheet-view    {"op": "sheet-view", "gridlines": false, "zoom": 85, "tabSelected": true}
+  tab-color     {"op": "tab-color", "color": "#1F4E79"}  (or {"clear": true};
+                colors: named, #hex, rgb(r,g,b), theme:accent1[:tint])
+  page-setup    {"op": "page-setup", "orientation": "landscape", "scale": 90,
+                "fitToWidth": 1, "fitToHeight": 1, "fitToPage": true}
+  header-footer {"op": "header-footer", "oddFooter": "&LConfidential&RPage &P of &N",
+                "oddHeader": ..., "evenHeader/evenFooter": ..., "firstHeader/firstFooter": ...,
+                "differentOddEven": true, "differentFirst": true}
+                (&L/&C/&R sections; &P page, &N total, &D date, &F file, &A sheet)
+
 STYLE PROPERTIES:
   Font:      bold, italic, underline, fg, fontSize, fontName
   Fill:      bg (background color, e.g., "#FFFF00" or "yellow")
@@ -1131,6 +1142,96 @@ USAGE:
   private val unfreezeCmd: Opts[CliCommand] =
     Opts.subcommand("unfreeze", "Remove freeze panes") {
       Opts(CliCommand.Unfreeze)
+    }
+
+  // --- Sheet appearance & print setup commands (GH-358) ---
+
+  /** Parse an on|off (also true|false) option value. */
+  private def onOffOpt(name: String, help: String): Opts[Option[Boolean]] =
+    Opts
+      .option[String](name, help)
+      .mapValidated {
+        case "on" | "true" => cats.data.Validated.valid(true)
+        case "off" | "false" => cats.data.Validated.valid(false)
+        case other =>
+          cats.data.Validated.invalidNel(s"--$name expects on or off, got: $other")
+      }
+      .orNone
+
+  private val sheetViewCmd: Opts[CliCommand] =
+    Opts.subcommand(
+      "sheet-view",
+      "Set sheet view options: gridlines, zoom, tab selection (requires -o)"
+    ) {
+      val viewGridlines = onOffOpt("gridlines", "Show cell gridlines: on or off")
+      val viewZoom = Opts.option[Int]("zoom", "Zoom percentage (10-400)").orNone
+      val viewTabSelected = onOffOpt("tab-selected", "Select this sheet's tab: on or off")
+      (viewGridlines, viewZoom, viewTabSelected).mapN(CliCommand.SheetViewOp.apply)
+    }
+
+  private val tabColorCmd: Opts[CliCommand] =
+    Opts.subcommand(
+      "tab-color",
+      "Set the sheet tab color: named, #hex, rgb(r,g,b), or theme:accent1[:tint] (requires -o). " +
+        "--clear removes a modeled color (a color preserved from the source XML is not stripped)."
+    ) {
+      val colorArg = Opts.argument[String]("color").orNone
+      val clearFlag = Opts.flag("clear", "Clear the modeled tab color").orFalse
+      (colorArg, clearFlag).mapN(CliCommand.TabColorOp.apply)
+    }
+
+  private val pageSetupCmd: Opts[CliCommand] =
+    Opts.subcommand(
+      "page-setup",
+      "Set print page setup: orientation, scale, fit-to-page (requires -o)"
+    ) {
+      val orientationOpt =
+        Opts.option[String]("orientation", "Page orientation: portrait or landscape").orNone
+      val scaleOpt = Opts.option[Int]("scale", "Print scale percent (10-400)").orNone
+      val fitToWidthOpt = Opts.option[Int]("fit-to-width", "Fit printout to N pages wide").orNone
+      val fitToHeightOpt = Opts.option[Int]("fit-to-height", "Fit printout to N pages tall").orNone
+      val fitToPageOpt = onOffOpt(
+        "fit-to-page",
+        "Force the sheetPr fitToPage flag: on or off. Omit to derive from --fit-to-width/height " +
+          "and preserve whatever the source file carries (off actively strips a preserved flag)"
+      )
+      (orientationOpt, scaleOpt, fitToWidthOpt, fitToHeightOpt, fitToPageOpt)
+        .mapN(CliCommand.PageSetupOp.apply)
+    }
+
+  private val headerFooterCmd: Opts[CliCommand] =
+    Opts.subcommand(
+      "header-footer",
+      "Set print header/footer text with Excel codes: &L/&C/&R sections, &P page, &N total, " +
+        "&D date, &F file, &A sheet (requires -o)"
+    ) {
+      val oddHeaderOpt = Opts.option[String]("odd-header", "Header for odd/all pages").orNone
+      val oddFooterOpt = Opts.option[String]("odd-footer", "Footer for odd/all pages").orNone
+      val evenHeaderOpt =
+        Opts.option[String]("even-header", "Header for even pages (sets different-odd-even)").orNone
+      val evenFooterOpt =
+        Opts.option[String]("even-footer", "Footer for even pages (sets different-odd-even)").orNone
+      val firstHeaderOpt =
+        Opts
+          .option[String]("first-header", "Header for the first page (sets different-first)")
+          .orNone
+      val firstFooterOpt =
+        Opts
+          .option[String]("first-footer", "Footer for the first page (sets different-first)")
+          .orNone
+      val diffOddEvenFlag =
+        Opts.flag("different-odd-even", "Use even-page text on even pages").orFalse
+      val diffFirstFlag = Opts.flag("different-first", "Use first-page text on page 1").orFalse
+      (
+        oddHeaderOpt,
+        oddFooterOpt,
+        evenHeaderOpt,
+        evenFooterOpt,
+        firstHeaderOpt,
+        firstFooterOpt,
+        diffOddEvenFlag,
+        diffFirstFlag
+      ).mapN(CliCommand.HeaderFooterOp.apply)
     }
 
   // --- Copy command ---
@@ -2014,6 +2115,61 @@ USAGE:
     case CliCommand.Unfreeze =>
       requireOutput(outputOpt, backendOpt, stream)(
         WriteCommands.unfreeze(wb, sheetOpt, _, _, _)
+      )
+
+    // Sheet appearance & print setup (GH-358)
+    case CliCommand.SheetViewOp(gridlines, zoom, tabSelected) =>
+      requireOutput(outputOpt, backendOpt, stream)(
+        WriteCommands.sheetView(wb, sheetOpt, gridlines, zoom, tabSelected, _, _, _)
+      )
+
+    case CliCommand.TabColorOp(color, clear) =>
+      requireOutput(outputOpt, backendOpt, stream)(
+        WriteCommands.tabColor(wb, sheetOpt, color, clear, _, _, _)
+      )
+
+    case CliCommand.PageSetupOp(orientation, scale, fitToWidth, fitToHeight, fitToPage) =>
+      requireOutput(outputOpt, backendOpt, stream)(
+        WriteCommands.pageSetup(
+          wb,
+          sheetOpt,
+          orientation,
+          scale,
+          fitToWidth,
+          fitToHeight,
+          fitToPage,
+          _,
+          _,
+          _
+        )
+      )
+
+    case CliCommand.HeaderFooterOp(
+          oddHeader,
+          oddFooter,
+          evenHeader,
+          evenFooter,
+          firstHeader,
+          firstFooter,
+          differentOddEven,
+          differentFirst
+        ) =>
+      requireOutput(outputOpt, backendOpt, stream)(
+        WriteCommands.headerFooter(
+          wb,
+          sheetOpt,
+          oddHeader,
+          oddFooter,
+          evenHeader,
+          evenFooter,
+          firstHeader,
+          firstFooter,
+          differentOddEven,
+          differentFirst,
+          _,
+          _,
+          _
+        )
       )
 
     case CliCommand.Copy(source, target, valuesOnly) =>

--- a/xl-cli/src/com/tjclp/xl/cli/commands/StreamingWriteCommands.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/commands/StreamingWriteCommands.scala
@@ -752,7 +752,8 @@ object StreamingWriteCommands:
             _: BatchParser.BatchOp.Freeze | BatchParser.BatchOp.Unfreeze |
             _: BatchParser.BatchOp.CopyRange | _: BatchParser.BatchOp.Hyperlink |
             _: BatchParser.BatchOp.SetSheetView | _: BatchParser.BatchOp.SetTabColor |
-            _: BatchParser.BatchOp.SetPageSetup | _: BatchParser.BatchOp.SetHeaderFooter =>
+            _: BatchParser.BatchOp.SetPageSetup | _: BatchParser.BatchOp.SetHeaderFooter |
+            _: BatchParser.BatchOp.AddConditionalFormat =>
           throw new Exception(
             "This batch operation is not supported in streaming mode. " +
               "Remove --stream to use full workbook mode."

--- a/xl-cli/src/com/tjclp/xl/cli/commands/StreamingWriteCommands.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/commands/StreamingWriteCommands.scala
@@ -526,18 +526,30 @@ object StreamingWriteCommands:
                 StreamingTransform.CellPatch.SetValue(cellValue, preserveStyle = true)
           summaryLines += s"  PUT $refStr = $cellValue"
 
-        case BatchParser.BatchOp.PutFormula(refStr, formula) =>
+        case BatchParser.BatchOp.PutFormula(refStr, formula, formatOpt) =>
           val ref = ARef.parse(refStr) match
             case Right(r) => r
             case Left(e) => throw new Exception(s"Invalid ref '$refStr': $e")
           val formulaText = if formula.startsWith("=") then formula.drop(1) else formula
-          cellPatches(ref) = StreamingTransform.CellPatch.SetValue(
-            CellValue.Formula(formulaText, None),
-            preserveStyle = true
-          )
+          val formulaValue = CellValue.Formula(formulaText, None)
+          formatOpt match
+            case Some(numFmt) =>
+              // GH-356: apply numFmt to the formula cell (same styles.xml patching as put)
+              val cellStyle = CellStyle.default.withNumFmt(numFmt)
+              val (updatedStyles, styleId) =
+                StylePatcher.addStyle(currentStylesXml, cellStyle) match
+                  case Right(result) => result
+                  case Left(e) => throw new Exception(s"Failed to add style: ${e.message}")
+              currentStylesXml = updatedStyles
+              stylesModified = true
+              cellPatches(ref) =
+                StreamingTransform.CellPatch.SetStyleAndValue(styleId, formulaValue)
+            case None =>
+              cellPatches(ref) =
+                StreamingTransform.CellPatch.SetValue(formulaValue, preserveStyle = true)
           summaryLines += s"  PUTF $refStr = $formula"
 
-        case BatchParser.BatchOp.PutFormulaDragging(rangeStr, formula, fromRef) =>
+        case BatchParser.BatchOp.PutFormulaDragging(rangeStr, formula, fromRef, formatOpt) =>
           // Parse formula and apply with shifting (same as non-streaming batch mode)
           val fromARef = ARef.parse(fromRef) match
             case Right(r) => r
@@ -556,6 +568,18 @@ object StreamingWriteCommands:
                 s"Invalid formula '$fullFormula': ${ParseError.formatWithContext(e, fullFormula)}"
               )
 
+          // GH-356: register the format's style once, reuse across the dragged range
+          val styleIdOpt = formatOpt.map { numFmt =>
+            val cellStyle = CellStyle.default.withNumFmt(numFmt)
+            val (updatedStyles, styleId) =
+              StylePatcher.addStyle(currentStylesXml, cellStyle) match
+                case Right(result) => result
+                case Left(e) => throw new Exception(s"Failed to add style: ${e.message}")
+            currentStylesXml = updatedStyles
+            stylesModified = true
+            styleId
+          }
+
           // Apply formula with shifting
           val startCol = Column.index0(fromARef.col)
           val startRow = Row.index0(fromARef.row)
@@ -565,14 +589,16 @@ object StreamingWriteCommands:
             val rowDelta = Row.index0(targetRef.row) - startRow
             val shiftedExpr = FormulaShifter.shift(parsedExpr, colDelta, rowDelta)
             val shiftedFormula = FormulaPrinter.print(shiftedExpr, includeEquals = false)
-            cellPatches(targetRef) = StreamingTransform.CellPatch.SetValue(
-              CellValue.Formula(shiftedFormula, None),
-              preserveStyle = true
-            )
+            val formulaValue = CellValue.Formula(shiftedFormula, None)
+            cellPatches(targetRef) = styleIdOpt match
+              case Some(styleId) =>
+                StreamingTransform.CellPatch.SetStyleAndValue(styleId, formulaValue)
+              case None =>
+                StreamingTransform.CellPatch.SetValue(formulaValue, preserveStyle = true)
           }
           summaryLines += s"  PUTF $rangeStr = $formula (from $fromRef, ${range.cells.size} formulas)"
 
-        case BatchParser.BatchOp.PutFormulas(rangeStr, formulas) =>
+        case BatchParser.BatchOp.PutFormulas(rangeStr, formulas, formatOpt) =>
           val range = CellRange.parse(rangeStr) match
             case Right(r) => r
             case Left(e) => throw new Exception(s"Invalid range '$rangeStr': $e")
@@ -581,12 +607,25 @@ object StreamingWriteCommands:
             throw new Exception(
               s"Range $rangeStr has ${cells.length} cells but ${formulas.length} formulas provided"
             )
+          // GH-356: register the format's style once, reuse across the range
+          val styleIdOpt = formatOpt.map { numFmt =>
+            val cellStyle = CellStyle.default.withNumFmt(numFmt)
+            val (updatedStyles, styleId) =
+              StylePatcher.addStyle(currentStylesXml, cellStyle) match
+                case Right(result) => result
+                case Left(e) => throw new Exception(s"Failed to add style: ${e.message}")
+            currentStylesXml = updatedStyles
+            stylesModified = true
+            styleId
+          }
           cells.zip(formulas).foreach { case (ref, formula) =>
             val formulaText = if formula.startsWith("=") then formula.drop(1) else formula
-            cellPatches(ref) = StreamingTransform.CellPatch.SetValue(
-              CellValue.Formula(formulaText, None),
-              preserveStyle = true
-            )
+            val formulaValue = CellValue.Formula(formulaText, None)
+            cellPatches(ref) = styleIdOpt match
+              case Some(styleId) =>
+                StreamingTransform.CellPatch.SetStyleAndValue(styleId, formulaValue)
+              case None =>
+                StreamingTransform.CellPatch.SetValue(formulaValue, preserveStyle = true)
           }
           summaryLines += s"  PUTF $rangeStr = [${formulas.length} formulas]"
 

--- a/xl-cli/src/com/tjclp/xl/cli/commands/StreamingWriteCommands.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/commands/StreamingWriteCommands.scala
@@ -750,7 +750,9 @@ object StreamingWriteCommands:
             _: BatchParser.BatchOp.Clear | _: BatchParser.BatchOp.AutoFit |
             _: BatchParser.BatchOp.AddSheet | _: BatchParser.BatchOp.RenameSheet |
             _: BatchParser.BatchOp.Freeze | BatchParser.BatchOp.Unfreeze |
-            _: BatchParser.BatchOp.CopyRange | _: BatchParser.BatchOp.Hyperlink =>
+            _: BatchParser.BatchOp.CopyRange | _: BatchParser.BatchOp.Hyperlink |
+            _: BatchParser.BatchOp.SetSheetView | _: BatchParser.BatchOp.SetTabColor |
+            _: BatchParser.BatchOp.SetPageSetup | _: BatchParser.BatchOp.SetHeaderFooter =>
           throw new Exception(
             "This batch operation is not supported in streaming mode. " +
               "Remove --stream to use full workbook mode."

--- a/xl-cli/src/com/tjclp/xl/cli/commands/WriteCommands.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/commands/WriteCommands.scala
@@ -10,6 +10,7 @@ import com.tjclp.xl.cells.CellValue
 import com.tjclp.xl.cli.helpers.{
   AppearanceOps,
   BatchParser,
+  CfRuleParser,
   ColumnAutoFit,
   CopyOps,
   SheetResolver,
@@ -712,7 +713,7 @@ object WriteCommands:
           _: BatchParser.BatchOp.Freeze | BatchParser.BatchOp.Unfreeze |
           _: BatchParser.BatchOp.Hyperlink | _: BatchParser.BatchOp.SetSheetView |
           _: BatchParser.BatchOp.SetTabColor | _: BatchParser.BatchOp.SetPageSetup |
-          _: BatchParser.BatchOp.SetHeaderFooter =>
+          _: BatchParser.BatchOp.SetHeaderFooter | _: BatchParser.BatchOp.AddConditionalFormat =>
         false
 
   /**
@@ -1242,6 +1243,70 @@ object WriteCommands:
         "first-footer" -> firstFooter
       )
       s"Set header/footer on '${sheet.name.value}': $desc"
+    }
+
+  // ===== Conditional formatting (GH-324) =====
+
+  /**
+   * Add one conditional-formatting rule to a range. The rule string is the `cf add` colon DSL (see
+   * [[CfRuleParser]]); the dxf comes from the formatting flags. Priorities are stamped by
+   * `Sheet.conditionalFormat` (auto-priority, append order) — never by the CLI.
+   */
+  def cfAdd(
+    wb: Workbook,
+    sheetOpt: Option[Sheet],
+    rangeStr: String,
+    ruleStr: String,
+    bold: Boolean,
+    italic: Boolean,
+    underline: Boolean,
+    strike: Boolean,
+    bg: Option[String],
+    fg: Option[String],
+    outputPath: Path,
+    config: WriterConfig,
+    stream: Boolean = false
+  ): IO[String] =
+    for
+      resolved <- SheetResolver.resolveRef(wb, sheetOpt, rangeStr, "cf add")
+      (sheet, refOrRange) = resolved
+      range = refOrRange match
+        case Left(ref) => CellRange(ref, ref)
+        case Right(r) => r
+      dxf <- IO.fromEither(
+        CfRuleParser.buildDxf(bold, italic, underline, strike, bg, fg).left.map(new Exception(_))
+      )
+      rule <- IO.fromEither(CfRuleParser.parse(ruleStr, dxf).left.map(new Exception(_)))
+      updatedSheet = sheet.conditionalFormat(range, rule)
+      priority = updatedSheet.typedConditionalFormats.lastOption
+        .flatMap(_.rules.lastOption)
+        .flatMap(com.tjclp.xl.cf.CfRule.priorityOf)
+      _ <- writeWorkbook(wb.put(updatedSheet), outputPath, config, stream)
+    yield
+      val priorityNote = priority.fold("")(p => s" (priority $p)")
+      s"Added conditional format on '${sheet.name.value}': ${CfRuleParser.describe(rule)} " +
+        s"over ${range.toA1}$priorityNote\n${saveSuffix(outputPath, stream)}"
+
+  /** List conditional-formatting rules on the sheet (read-only — no output file needed). */
+  def cfList(wb: Workbook, sheetOpt: Option[Sheet]): IO[String] =
+    SheetResolver.requireSheet(wb, sheetOpt, "cf list").map { sheet =>
+      val blocks = sheet.conditionalFormats
+      if blocks.isEmpty then s"No conditional formatting on '${sheet.name.value}'"
+      else
+        blocks.zipWithIndex
+          .map {
+            case (com.tjclp.xl.cf.ConditionalFormat.Rules(ranges, rules, _), i) =>
+              val header = s"[$i] ${ranges.map(_.toA1).mkString(" ")}"
+              val ruleLines = rules.map { r =>
+                val priorityNote =
+                  com.tjclp.xl.cf.CfRule.priorityOf(r).fold("")(p => s" (priority $p)")
+                s"    ${CfRuleParser.describe(r)}$priorityNote"
+              }
+              (header +: ruleLines).mkString("\n")
+            case (com.tjclp.xl.cf.ConditionalFormat.Preserved(_), i) =>
+              s"[$i] (preserved block)"
+          }
+          .mkString("\n")
     }
 
   // ===== Structural editing: insert/delete rows & columns (GH-128, GH-129) =====

--- a/xl-cli/src/com/tjclp/xl/cli/commands/WriteCommands.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/commands/WriteCommands.scala
@@ -8,6 +8,7 @@ import com.tjclp.xl.{*, given}
 import com.tjclp.xl.addressing.{ARef, CellRange, Column, Row}
 import com.tjclp.xl.cells.CellValue
 import com.tjclp.xl.cli.helpers.{
+  AppearanceOps,
   BatchParser,
   ColumnAutoFit,
   CopyOps,
@@ -709,7 +710,9 @@ object WriteCommands:
           _: BatchParser.BatchOp.RowShow | _: BatchParser.BatchOp.AutoFit |
           _: BatchParser.BatchOp.AddSheet | _: BatchParser.BatchOp.RenameSheet |
           _: BatchParser.BatchOp.Freeze | BatchParser.BatchOp.Unfreeze |
-          _: BatchParser.BatchOp.Hyperlink =>
+          _: BatchParser.BatchOp.Hyperlink | _: BatchParser.BatchOp.SetSheetView |
+          _: BatchParser.BatchOp.SetTabColor | _: BatchParser.BatchOp.SetPageSetup |
+          _: BatchParser.BatchOp.SetHeaderFooter =>
         false
 
   /**
@@ -1103,6 +1106,143 @@ object WriteCommands:
       updatedWb = wb.put(updatedSheet)
       _ <- writeWorkbook(updatedWb, outputPath, config, stream)
     yield s"Removed freeze panes from sheet '${sheet.name.value}'\n${saveSuffix(outputPath, stream)}"
+
+  // ===== Sheet appearance & print setup (GH-358) =====
+
+  /** Shared shape of the four appearance handlers: requireSheet → pure applier → write. */
+  private def applyAppearance(
+    wb: Workbook,
+    sheetOpt: Option[Sheet],
+    context: String,
+    outputPath: Path,
+    config: WriterConfig,
+    stream: Boolean
+  )(f: Sheet => Either[String, Sheet])(message: Sheet => String): IO[String] =
+    for
+      sheet <- SheetResolver.requireSheet(wb, sheetOpt, context)
+      updatedSheet <- IO.fromEither(f(sheet).left.map(new Exception(_)))
+      _ <- writeWorkbook(wb.put(updatedSheet), outputPath, config, stream)
+    yield s"${message(sheet)}\n${saveSuffix(outputPath, stream)}"
+
+  /**
+   * Set sheet view options: gridline visibility, zoom scale (10-400), tab selection. Unspecified
+   * options preserve the sheet's current view settings.
+   */
+  def sheetView(
+    wb: Workbook,
+    sheetOpt: Option[Sheet],
+    gridlines: Option[Boolean],
+    zoom: Option[Int],
+    tabSelected: Option[Boolean],
+    outputPath: Path,
+    config: WriterConfig,
+    stream: Boolean = false
+  ): IO[String] =
+    applyAppearance(wb, sheetOpt, "sheet-view", outputPath, config, stream)(
+      AppearanceOps.applySheetView(_, gridlines, zoom, tabSelected)
+    ) { sheet =>
+      val desc = AppearanceOps.describe(
+        "gridlines" -> gridlines.map(g => if g then "on" else "off"),
+        "zoom" -> zoom.map(_.toString),
+        "tab-selected" -> tabSelected.map(t => if t then "on" else "off")
+      )
+      s"Set sheet view on '${sheet.name.value}': $desc"
+    }
+
+  /**
+   * Set or clear the sheet tab color (GH-358). `--clear` removes the modeled color only — a
+   * tabColor preserved from the source XML survives (preserve-if-None write semantics).
+   */
+  def tabColor(
+    wb: Workbook,
+    sheetOpt: Option[Sheet],
+    colorStr: Option[String],
+    clear: Boolean,
+    outputPath: Path,
+    config: WriterConfig,
+    stream: Boolean = false
+  ): IO[String] =
+    applyAppearance(wb, sheetOpt, "tab-color", outputPath, config, stream)(
+      AppearanceOps.applyTabColor(_, colorStr, clear)
+    ) { sheet =>
+      colorStr match
+        case Some(c) => s"Set tab color on '${sheet.name.value}': $c"
+        case None =>
+          s"Cleared tab color on '${sheet.name.value}' " +
+            "(a color preserved from the source file is not stripped)"
+    }
+
+  /**
+   * Set print page setup: orientation, scale, fit-to-width/height, and the tri-state fitToPage
+   * flag. Unspecified options preserve the sheet's current page setup.
+   */
+  def pageSetup(
+    wb: Workbook,
+    sheetOpt: Option[Sheet],
+    orientation: Option[String],
+    scale: Option[Int],
+    fitToWidth: Option[Int],
+    fitToHeight: Option[Int],
+    fitToPage: Option[Boolean],
+    outputPath: Path,
+    config: WriterConfig,
+    stream: Boolean = false
+  ): IO[String] =
+    applyAppearance(wb, sheetOpt, "page-setup", outputPath, config, stream)(
+      AppearanceOps.applyPageSetup(_, orientation, scale, fitToWidth, fitToHeight, fitToPage)
+    ) { sheet =>
+      val desc = AppearanceOps.describe(
+        "orientation" -> orientation,
+        "scale" -> scale.map(_.toString),
+        "fit-to-width" -> fitToWidth.map(_.toString),
+        "fit-to-height" -> fitToHeight.map(_.toString),
+        "fit-to-page" -> fitToPage.map(f => if f then "on" else "off")
+      )
+      s"Set page setup on '${sheet.name.value}': $desc"
+    }
+
+  /**
+   * Set print header/footer text (Excel codes: &L/&C/&R sections, &P page, &N total, &D date, &F
+   * file, &A sheet). Even/first text auto-sets the corresponding different-* flag.
+   */
+  def headerFooter(
+    wb: Workbook,
+    sheetOpt: Option[Sheet],
+    oddHeader: Option[String],
+    oddFooter: Option[String],
+    evenHeader: Option[String],
+    evenFooter: Option[String],
+    firstHeader: Option[String],
+    firstFooter: Option[String],
+    differentOddEven: Boolean,
+    differentFirst: Boolean,
+    outputPath: Path,
+    config: WriterConfig,
+    stream: Boolean = false
+  ): IO[String] =
+    applyAppearance(wb, sheetOpt, "header-footer", outputPath, config, stream)(
+      AppearanceOps.applyHeaderFooter(
+        _,
+        oddHeader,
+        oddFooter,
+        evenHeader,
+        evenFooter,
+        firstHeader,
+        firstFooter,
+        differentOddEven,
+        differentFirst
+      )
+    ) { sheet =>
+      val desc = AppearanceOps.describe(
+        "odd-header" -> oddHeader,
+        "odd-footer" -> oddFooter,
+        "even-header" -> evenHeader,
+        "even-footer" -> evenFooter,
+        "first-header" -> firstHeader,
+        "first-footer" -> firstFooter
+      )
+      s"Set header/footer on '${sheet.name.value}': $desc"
+    }
 
   // ===== Structural editing: insert/delete rows & columns (GH-128, GH-129) =====
   // Cell shift (xl-core) + formula rewriting across all sheets (StructuralEditor). #REF! on loss.

--- a/xl-cli/src/com/tjclp/xl/cli/helpers/AppearanceOps.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/helpers/AppearanceOps.scala
@@ -1,0 +1,148 @@
+package com.tjclp.xl.cli.helpers
+
+import com.tjclp.xl.{*, given}
+import com.tjclp.xl.cli.ColorParser
+import com.tjclp.xl.sheets.{HeaderFooter, PageSetup, SheetView}
+
+/**
+ * Pure sheet-appearance and print-setup appliers (GH-358), shared by the CLI command handlers
+ * (WriteCommands) and the batch ops (BatchParser) so the two paths cannot drift.
+ *
+ * Every applier merges into the sheet's CURRENT settings: unspecified fields are preserved
+ * (read-modify-write on the whole case class — the model has no granular withers). Validation
+ * happens here, returning Left with a clean message, so the model case classes' `require` guards
+ * are never tripped from the CLI.
+ */
+object AppearanceOps:
+
+  /** Merge view options (gridlines, zoom, tab selection) into the sheet's view settings. */
+  def applySheetView(
+    sheet: Sheet,
+    gridlines: Option[Boolean],
+    zoom: Option[Int],
+    tabSelected: Option[Boolean]
+  ): Either[String, Sheet] =
+    if gridlines.isEmpty && zoom.isEmpty && tabSelected.isEmpty then
+      Left("sheet-view requires at least one of: gridlines, zoom, tab-selected")
+    else
+      zoom.filter(z => z < 10 || z > 400) match
+        case Some(z) => Left(s"Zoom scale must be 10-400, got: $z")
+        case None =>
+          val current = sheet.viewSettings.getOrElse(SheetView.default)
+          Right(
+            sheet.withViewSettings(
+              current.copy(
+                showGridLines = gridlines.getOrElse(current.showGridLines),
+                zoomScale = zoom.orElse(current.zoomScale),
+                tabSelected = tabSelected.orElse(current.tabSelected)
+              )
+            )
+          )
+
+  /**
+   * Set or clear the sheet tab color. Clearing removes the MODELED color only: on write, a
+   * `tabColor` that arrived with the source file's XML is preserved when the model field is None
+   * (preserve-if-None semantics) — the CLI cannot strip a preserved color.
+   */
+  def applyTabColor(
+    sheet: Sheet,
+    colorStr: Option[String],
+    clear: Boolean
+  ): Either[String, Sheet] =
+    (colorStr, clear) match
+      case (Some(_), true) => Left("tab-color: <color> and --clear are mutually exclusive")
+      case (None, false) => Left("tab-color requires a <color> argument or --clear")
+      case (Some(s), false) => ColorParser.parse(s).map(sheet.withTabColor)
+      case (None, true) => Right(sheet.withoutTabColor)
+
+  /** Merge print options (orientation, scale, fit-to) into the sheet's page setup. */
+  def applyPageSetup(
+    sheet: Sheet,
+    orientation: Option[String],
+    scale: Option[Int],
+    fitToWidth: Option[Int],
+    fitToHeight: Option[Int],
+    fitToPage: Option[Boolean]
+  ): Either[String, Sheet] =
+    if orientation.isEmpty && scale.isEmpty && fitToWidth.isEmpty && fitToHeight.isEmpty &&
+      fitToPage.isEmpty
+    then
+      Left(
+        "page-setup requires at least one of: orientation, scale, fit-to-width, fit-to-height, fit-to-page"
+      )
+    else
+      for
+        _ <- orientation
+          .filterNot(o => o == "portrait" || o == "landscape")
+          .map(o => s"Orientation must be 'portrait' or 'landscape', got: $o")
+          .toLeft(())
+        _ <- scale
+          .filter(sc => sc < 10 || sc > 400)
+          .map(sc => s"Scale must be 10-400, got: $sc")
+          .toLeft(())
+        _ <- fitToWidth
+          .filter(_ < 1)
+          .map(n => s"fit-to-width must be >= 1, got: $n")
+          .toLeft(())
+        _ <- fitToHeight
+          .filter(_ < 1)
+          .map(n => s"fit-to-height must be >= 1, got: $n")
+          .toLeft(())
+      yield
+        val current = sheet.pageSetup.getOrElse(PageSetup.default)
+        sheet.withPageSetup(
+          current.copy(
+            scale = scale.getOrElse(current.scale),
+            orientation = orientation.orElse(current.orientation),
+            fitToWidth = fitToWidth.orElse(current.fitToWidth),
+            fitToHeight = fitToHeight.orElse(current.fitToHeight),
+            // Tri-state (GH-284): None derives from fitToWidth/fitToHeight and preserves
+            // any flag in the source file; Some(false) actively strips a preserved flag.
+            fitToPage = fitToPage.orElse(current.fitToPage)
+          )
+        )
+
+  /**
+   * Merge header/footer text into the sheet's page setup. Providing even-page text sets
+   * `differentOddEven`, and first-page text sets `differentFirst` (Excel ignores the text while the
+   * corresponding flag is off); the explicit flags force them on without text.
+   */
+  def applyHeaderFooter(
+    sheet: Sheet,
+    oddHeader: Option[String],
+    oddFooter: Option[String],
+    evenHeader: Option[String],
+    evenFooter: Option[String],
+    firstHeader: Option[String],
+    firstFooter: Option[String],
+    differentOddEven: Boolean,
+    differentFirst: Boolean
+  ): Either[String, Sheet] =
+    val anyText =
+      oddHeader.isDefined || oddFooter.isDefined || evenHeader.isDefined || evenFooter.isDefined ||
+        firstHeader.isDefined || firstFooter.isDefined
+    if !anyText && !differentOddEven && !differentFirst then
+      Left(
+        "header-footer requires at least one of: odd-header, odd-footer, even-header, " +
+          "even-footer, first-header, first-footer, different-odd-even, different-first"
+      )
+    else
+      val setup = sheet.pageSetup.getOrElse(PageSetup.default)
+      val hf = setup.headerFooter.getOrElse(HeaderFooter())
+      val updated = hf.copy(
+        oddHeader = oddHeader.orElse(hf.oddHeader),
+        oddFooter = oddFooter.orElse(hf.oddFooter),
+        evenHeader = evenHeader.orElse(hf.evenHeader),
+        evenFooter = evenFooter.orElse(hf.evenFooter),
+        firstHeader = firstHeader.orElse(hf.firstHeader),
+        firstFooter = firstFooter.orElse(hf.firstFooter),
+        differentOddEven =
+          hf.differentOddEven || differentOddEven || evenHeader.isDefined || evenFooter.isDefined,
+        differentFirst =
+          hf.differentFirst || differentFirst || firstHeader.isDefined || firstFooter.isDefined
+      )
+      Right(sheet.withPageSetup(setup.copy(headerFooter = Some(updated))))
+
+  /** Human-readable "key=value, ..." description of the provided (Some) options. */
+  def describe(pairs: (String, Option[String])*): String =
+    pairs.collect { case (k, Some(v)) => s"$k=$v" }.mkString(", ")

--- a/xl-cli/src/com/tjclp/xl/cli/helpers/BatchParser.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/helpers/BatchParser.scala
@@ -65,14 +65,19 @@ object BatchParser:
     /** Put a single value to a cell with optional format */
     case Put(ref: String, value: CellValue, format: Option[NumFmt])
 
-    /** Put a formula to a single cell */
-    case PutFormula(ref: String, formula: String)
+    /** Put a formula to a single cell with optional number format (GH-356) */
+    case PutFormula(ref: String, formula: String, format: Option[NumFmt] = None)
 
     /** Put a formula to a range with dragging (from anchor cell) */
-    case PutFormulaDragging(range: String, formula: String, from: String)
+    case PutFormulaDragging(
+      range: String,
+      formula: String,
+      from: String,
+      format: Option[NumFmt] = None
+    )
 
     /** Put explicit formulas to a range (no dragging) */
-    case PutFormulas(range: String, formulas: Vector[String])
+    case PutFormulas(range: String, formulas: Vector[String], format: Option[NumFmt] = None)
 
     /** Put explicit values to a range (row-major order) */
     case PutValues(range: String, values: Vector[ParsedValue])
@@ -106,23 +111,27 @@ object BatchParser:
    */
   final case class ParseResult(ops: Vector[BatchOp], warnings: Vector[String])
 
+  /** Render an optional format suffix like " (Currency)" / " (#,##0.0)". */
+  private def formatSuffix(fmt: Option[NumFmt]): String =
+    fmt
+      .map {
+        case NumFmt.Custom(code) => s" ($code)"
+        case f => s" ($f)"
+      }
+      .getOrElse("")
+
   /** Format a human-readable summary of batch operations. */
   def formatSummary(ops: Vector[BatchOp]): String =
     ops
       .map {
         case BatchOp.Put(ref, value, fmt) =>
-          val fmtStr = fmt
-            .map {
-              case NumFmt.Custom(code) => s" ($code)"
-              case f => s" ($f)"
-            }
-            .getOrElse("")
-          s"  PUT $ref = $value$fmtStr"
-        case BatchOp.PutFormula(ref, formula) => s"  PUTF $ref = $formula"
-        case BatchOp.PutFormulaDragging(range, formula, from) =>
-          s"  PUTF $range = $formula (from $from)"
-        case BatchOp.PutFormulas(range, formulas) =>
-          s"  PUTF $range = [${formulas.length} formulas]"
+          s"  PUT $ref = $value${formatSuffix(fmt)}"
+        case BatchOp.PutFormula(ref, formula, fmt) =>
+          s"  PUTF $ref = $formula${formatSuffix(fmt)}"
+        case BatchOp.PutFormulaDragging(range, formula, from, fmt) =>
+          s"  PUTF $range = $formula (from $from)${formatSuffix(fmt)}"
+        case BatchOp.PutFormulas(range, formulas, fmt) =>
+          s"  PUTF $range = [${formulas.length} formulas]${formatSuffix(fmt)}"
         case BatchOp.PutValues(range, values) =>
           s"  PUT $range = [${values.length} values]"
         case BatchOp.Style(range, _) => s"  STYLE $range"
@@ -260,6 +269,8 @@ object BatchParser:
           case "putf" =>
             collectUnknownPropsWarning(objMap, knownPutfProps, "putf", idx).foreach(warnings += _)
             val ref = requireString(objMap, "ref", idx)
+            // Optional number format applied to the formula cell(s) — parity with put (GH-356)
+            val format = objMap.get("format").flatMap(_.strOpt).flatMap(parseFormatName)
             // Check for explicit formulas array first
             objMap.get("values") match
               case Some(arr) if arr.arrOpt.isDefined =>
@@ -270,13 +281,13 @@ object BatchParser:
                     )
                   )
                 }
-                BatchOp.PutFormulas(ref, formulas)
+                BatchOp.PutFormulas(ref, formulas, format)
               case _ =>
                 val formula = requireStringValue(objMap, idx)
                 // Check for 'from' field for formula dragging
                 objMap.get("from").flatMap(_.strOpt) match
-                  case Some(fromRef) => BatchOp.PutFormulaDragging(ref, formula, fromRef)
-                  case None => BatchOp.PutFormula(ref, formula)
+                  case Some(fromRef) => BatchOp.PutFormulaDragging(ref, formula, fromRef, format)
+                  case None => BatchOp.PutFormula(ref, formula, format)
 
           case "style" =>
             collectUnknownPropsWarning(objMap, knownStyleProps, "style", idx).foreach(warnings += _)
@@ -404,7 +415,7 @@ object BatchParser:
   private val knownPutProps = Set("op", "ref", "value", "values", "format", "detect")
 
   /** Known properties for 'putf' operation */
-  private val knownPutfProps = Set("op", "ref", "value", "formula", "values", "from")
+  private val knownPutfProps = Set("op", "ref", "value", "formula", "values", "from", "format")
 
   /** Known properties for 'style' operation */
   private val knownStyleProps = Set(
@@ -769,14 +780,14 @@ object BatchParser:
           case BatchOp.Put(refStr, cellValue, format) =>
             applyPutTyped(currentWb, defaultSheetName, refStr, cellValue, format)
 
-          case BatchOp.PutFormula(refStr, formula) =>
-            applyPutFormula(currentWb, defaultSheetName, refStr, formula)
+          case BatchOp.PutFormula(refStr, formula, format) =>
+            applyPutFormula(currentWb, defaultSheetName, refStr, formula, format)
 
-          case BatchOp.PutFormulaDragging(rangeStr, formula, fromRef) =>
-            applyPutFormulaDragging(currentWb, defaultSheetName, rangeStr, formula, fromRef)
+          case BatchOp.PutFormulaDragging(rangeStr, formula, fromRef, format) =>
+            applyPutFormulaDragging(currentWb, defaultSheetName, rangeStr, formula, fromRef, format)
 
-          case BatchOp.PutFormulas(rangeStr, formulas) =>
-            applyPutFormulas(currentWb, defaultSheetName, rangeStr, formulas)
+          case BatchOp.PutFormulas(rangeStr, formulas, format) =>
+            applyPutFormulas(currentWb, defaultSheetName, rangeStr, formulas, format)
 
           case BatchOp.PutValues(rangeStr, values) =>
             applyPutValues(currentWb, defaultSheetName, rangeStr, values)
@@ -926,12 +937,27 @@ object BatchParser:
         // No format - just put the value
         updateSheet(wb, sheetName)(_.put(ref, cellValue))
 
+  /**
+   * Merge a number format into the cell's existing style (GH-356).
+   *
+   * Formula cells cannot reuse `Formatted` (that wraps VALUES); instead the numFmt is applied as a
+   * style write on top of whatever style the cell already has — the same semantics as the style
+   * batch op's numFormat property.
+   */
+  private def applyNumFmt(sheet: Sheet, ref: ARef, format: Option[NumFmt]): Sheet =
+    format match
+      case Some(numFmt) =>
+        val existing = sheet.getCellStyle(ref).getOrElse(CellStyle.default)
+        sheet.style(ref, existing.withNumFmt(numFmt))
+      case None => sheet
+
   /** Apply a single formula to a cell */
   private def applyPutFormula(
     wb: Workbook,
     defaultSheetName: Option[SheetName],
     refStr: String,
-    formulaStr: String
+    formulaStr: String,
+    format: Option[NumFmt]
   ): IO[Workbook] =
     val formula = if formulaStr.startsWith("=") then formulaStr.drop(1) else formulaStr
     val value = CellValue.Formula(formula, None)
@@ -940,12 +966,12 @@ object BatchParser:
       case RefType.Cell(ref) =>
         defaultSheetName match
           case Some(sheetName) =>
-            updateSheet(wb, sheetName)(_.put(ref -> value))
+            updateSheet(wb, sheetName)(s => applyNumFmt(s.put(ref -> value), ref, format))
           case None =>
             IO.raiseError(new Exception(s"batch requires --sheet for unqualified ref '$refStr'"))
 
       case RefType.QualifiedCell(sheetName, ref) =>
-        updateSheet(wb, sheetName)(_.put(ref -> value))
+        updateSheet(wb, sheetName)(s => applyNumFmt(s.put(ref -> value), ref, format))
 
       case RefType.Range(_) | RefType.QualifiedRange(_, _) =>
         IO.raiseError(
@@ -962,7 +988,8 @@ object BatchParser:
     defaultSheetName: Option[SheetName],
     rangeStr: String,
     formulaStr: String,
-    fromRef: String
+    fromRef: String,
+    format: Option[NumFmt]
   ): IO[Workbook] =
     val formula = if formulaStr.startsWith("=") then formulaStr.drop(1) else formulaStr
     val fullFormula = s"=$formula"
@@ -995,7 +1022,11 @@ object BatchParser:
           val shiftedFormula = FormulaPrinter.print(shiftedExpr, includeEquals = false)
           val cachedValue =
             SheetEvaluator.evaluateFormula(s)(s"=$shiftedFormula", workbook = Some(wb)).toOption
-          s.put(targetRef, CellValue.Formula(shiftedFormula, cachedValue))
+          applyNumFmt(
+            s.put(targetRef, CellValue.Formula(shiftedFormula, cachedValue)),
+            targetRef,
+            format
+          )
         }
       }
     yield result
@@ -1005,7 +1036,8 @@ object BatchParser:
     wb: Workbook,
     defaultSheetName: Option[SheetName],
     rangeStr: String,
-    formulas: Vector[String]
+    formulas: Vector[String],
+    format: Option[NumFmt]
   ): IO[Workbook] =
     for
       rangeRef <- parseRangeRef(rangeStr, defaultSheetName)
@@ -1028,7 +1060,7 @@ object BatchParser:
           val formula = if formulaStr.startsWith("=") then formulaStr.drop(1) else formulaStr
           val cachedValue =
             SheetEvaluator.evaluateFormula(s)(s"=$formula", workbook = Some(wb)).toOption
-          s.put(ref, CellValue.Formula(formula, cachedValue))
+          applyNumFmt(s.put(ref, CellValue.Formula(formula, cachedValue)), ref, format)
         }
       }
     yield result

--- a/xl-cli/src/com/tjclp/xl/cli/helpers/BatchParser.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/helpers/BatchParser.scala
@@ -100,6 +100,26 @@ object BatchParser:
     case Unfreeze
     case CopyRange(source: String, target: String, valuesOnly: Boolean)
     case Hyperlink(ref: String, target: Option[String]) // GH-235: target None clears
+    // Sheet appearance & print setup (GH-358)
+    case SetSheetView(gridlines: Option[Boolean], zoom: Option[Int], tabSelected: Option[Boolean])
+    case SetTabColor(color: Option[String], clear: Boolean)
+    case SetPageSetup(
+      orientation: Option[String],
+      scale: Option[Int],
+      fitToWidth: Option[Int],
+      fitToHeight: Option[Int],
+      fitToPage: Option[Boolean]
+    )
+    case SetHeaderFooter(
+      oddHeader: Option[String],
+      oddFooter: Option[String],
+      evenHeader: Option[String],
+      evenFooter: Option[String],
+      firstHeader: Option[String],
+      firstFooter: Option[String],
+      differentOddEven: Boolean,
+      differentFirst: Boolean
+    )
 
   /**
    * Result of batch parsing with optional warnings.
@@ -154,6 +174,25 @@ object BatchParser:
         case BatchOp.Unfreeze => "  UNFREEZE"
         case BatchOp.CopyRange(src, tgt, vo) =>
           s"  COPY $src -> $tgt${if vo then " (values-only)" else ""}"
+        case BatchOp.SetSheetView(gridlines, zoom, tabSelected) =>
+          val desc = AppearanceOps.describe(
+            "gridlines" -> gridlines.map(g => if g then "on" else "off"),
+            "zoom" -> zoom.map(_.toString),
+            "tabSelected" -> tabSelected.map(_.toString)
+          )
+          s"  SHEET-VIEW $desc"
+        case BatchOp.SetTabColor(color, clear) =>
+          s"  TAB-COLOR ${color.getOrElse(if clear then "(clear)" else "")}"
+        case BatchOp.SetPageSetup(orientation, scale, fitToWidth, fitToHeight, fitToPage) =>
+          val desc = AppearanceOps.describe(
+            "orientation" -> orientation,
+            "scale" -> scale.map(_.toString),
+            "fitToWidth" -> fitToWidth.map(_.toString),
+            "fitToHeight" -> fitToHeight.map(_.toString),
+            "fitToPage" -> fitToPage.map(_.toString)
+          )
+          s"  PAGE-SETUP $desc"
+        case _: BatchOp.SetHeaderFooter => "  HEADER-FOOTER"
       }
       .mkString("\n")
 
@@ -390,12 +429,55 @@ object BatchParser:
             val valuesOnly = objMap.get("valuesOnly").flatMap(_.boolOpt).getOrElse(false)
             BatchOp.CopyRange(source, target, valuesOnly)
 
+          case "sheet-view" =>
+            collectUnknownPropsWarning(objMap, knownSheetViewProps, "sheet-view", idx)
+              .foreach(warnings += _)
+            BatchOp.SetSheetView(
+              gridlines = objMap.get("gridlines").flatMap(_.boolOpt),
+              zoom = objMap.get("zoom").flatMap(_.numOpt).map(_.toInt),
+              tabSelected = objMap.get("tabSelected").flatMap(_.boolOpt)
+            )
+
+          case "tab-color" =>
+            collectUnknownPropsWarning(objMap, knownTabColorProps, "tab-color", idx)
+              .foreach(warnings += _)
+            BatchOp.SetTabColor(
+              color = objMap.get("color").flatMap(_.strOpt),
+              clear = objMap.get("clear").flatMap(_.boolOpt).getOrElse(false)
+            )
+
+          case "page-setup" =>
+            collectUnknownPropsWarning(objMap, knownPageSetupProps, "page-setup", idx)
+              .foreach(warnings += _)
+            BatchOp.SetPageSetup(
+              orientation = objMap.get("orientation").flatMap(_.strOpt),
+              scale = objMap.get("scale").flatMap(_.numOpt).map(_.toInt),
+              fitToWidth = objMap.get("fitToWidth").flatMap(_.numOpt).map(_.toInt),
+              fitToHeight = objMap.get("fitToHeight").flatMap(_.numOpt).map(_.toInt),
+              fitToPage = objMap.get("fitToPage").flatMap(_.boolOpt)
+            )
+
+          case "header-footer" =>
+            collectUnknownPropsWarning(objMap, knownHeaderFooterProps, "header-footer", idx)
+              .foreach(warnings += _)
+            BatchOp.SetHeaderFooter(
+              oddHeader = objMap.get("oddHeader").flatMap(_.strOpt),
+              oddFooter = objMap.get("oddFooter").flatMap(_.strOpt),
+              evenHeader = objMap.get("evenHeader").flatMap(_.strOpt),
+              evenFooter = objMap.get("evenFooter").flatMap(_.strOpt),
+              firstHeader = objMap.get("firstHeader").flatMap(_.strOpt),
+              firstFooter = objMap.get("firstFooter").flatMap(_.strOpt),
+              differentOddEven = objMap.get("differentOddEven").flatMap(_.boolOpt).getOrElse(false),
+              differentFirst = objMap.get("differentFirst").flatMap(_.boolOpt).getOrElse(false)
+            )
+
           case other =>
             throw new Exception(
               s"Object ${idx + 1}: Unknown operation '$other'. " +
                 "Valid: put, putf, style, merge, unmerge, colwidth, rowheight, " +
                 "comment, remove-comment, hyperlink, clear, col-hide, col-show, " +
-                "row-hide, row-show, autofit, add-sheet, rename-sheet, freeze, unfreeze, copy"
+                "row-hide, row-show, autofit, add-sheet, rename-sheet, freeze, unfreeze, copy, " +
+                "sheet-view, tab-color, page-setup, header-footer"
             )
       }
 
@@ -456,6 +538,29 @@ object BatchParser:
 
   /** Known properties for 'rename-sheet' operation */
   private val knownRenameSheetProps = Set("op", "from", "to")
+
+  /** Known properties for 'sheet-view' operation (GH-358) */
+  private val knownSheetViewProps = Set("op", "gridlines", "zoom", "tabSelected")
+
+  /** Known properties for 'tab-color' operation (GH-358) */
+  private val knownTabColorProps = Set("op", "color", "clear")
+
+  /** Known properties for 'page-setup' operation (GH-358) */
+  private val knownPageSetupProps =
+    Set("op", "orientation", "scale", "fitToWidth", "fitToHeight", "fitToPage")
+
+  /** Known properties for 'header-footer' operation (GH-358) */
+  private val knownHeaderFooterProps = Set(
+    "op",
+    "oddHeader",
+    "oddFooter",
+    "evenHeader",
+    "evenFooter",
+    "firstHeader",
+    "firstFooter",
+    "differentOddEven",
+    "differentFirst"
+  )
 
   /** Collect warning about unknown properties in a batch operation (if any) */
   private def collectUnknownPropsWarning(
@@ -892,6 +997,33 @@ object BatchParser:
 
           case BatchOp.CopyRange(sourceStr, targetStr, valuesOnly) =>
             applyCopyRange(currentWb, defaultSheetName, sourceStr, targetStr, valuesOnly)
+
+          case BatchOp.SetSheetView(gridlines, zoom, tabSelected) =>
+            updateSheetE(currentWb, defaultSheetName, "sheet-view")(
+              AppearanceOps.applySheetView(_, gridlines, zoom, tabSelected)
+            )
+
+          case BatchOp.SetTabColor(color, clear) =>
+            updateSheetE(currentWb, defaultSheetName, "tab-color")(
+              AppearanceOps.applyTabColor(_, color, clear)
+            )
+
+          case BatchOp.SetPageSetup(orientation, scale, fitToWidth, fitToHeight, fitToPage) =>
+            updateSheetE(currentWb, defaultSheetName, "page-setup")(
+              AppearanceOps.applyPageSetup(
+                _,
+                orientation,
+                scale,
+                fitToWidth,
+                fitToHeight,
+                fitToPage
+              )
+            )
+
+          case BatchOp.SetHeaderFooter(oh, of, eh, ef, fh, ff, diffOddEven, diffFirst) =>
+            updateSheetE(currentWb, defaultSheetName, "header-footer")(
+              AppearanceOps.applyHeaderFooter(_, oh, of, eh, ef, fh, ff, diffOddEven, diffFirst)
+            )
       }
     }
 
@@ -1565,3 +1697,26 @@ object BatchParser:
         )
       case Some(sheet) =>
         IO.pure(wb.put(f(sheet)))
+
+  /**
+   * Update the default sheet with a validated (Either-returning) transform; requires --sheet. Used
+   * by the appearance ops (GH-358) whose appliers pre-validate and report clean errors.
+   */
+  private def updateSheetE(
+    wb: Workbook,
+    defaultSheetName: Option[SheetName],
+    opName: String
+  )(f: Sheet => Either[String, Sheet]): IO[Workbook] =
+    defaultSheetName match
+      case None => IO.raiseError(new Exception(s"batch $opName requires --sheet"))
+      case Some(sheetName) =>
+        wb.sheets.find(_.name == sheetName) match
+          case None =>
+            IO.raiseError(
+              new Exception(
+                s"Sheet '${sheetName.value}' not found. " +
+                  s"Available: ${wb.sheetNames.map(_.value).mkString(", ")}"
+              )
+            )
+          case Some(sheet) =>
+            IO.fromEither(f(sheet).left.map(msg => new Exception(msg))).map(wb.put)

--- a/xl-cli/src/com/tjclp/xl/cli/helpers/BatchParser.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/helpers/BatchParser.scala
@@ -120,6 +120,17 @@ object BatchParser:
       differentOddEven: Boolean,
       differentFirst: Boolean
     )
+    // Conditional formatting (GH-324): rule is the cf add colon DSL, flags build the dxf
+    case AddConditionalFormat(
+      range: String,
+      rule: String,
+      bold: Boolean,
+      italic: Boolean,
+      underline: Boolean,
+      strike: Boolean,
+      bg: Option[String],
+      fg: Option[String]
+    )
 
   /**
    * Result of batch parsing with optional warnings.
@@ -193,6 +204,8 @@ object BatchParser:
           )
           s"  PAGE-SETUP $desc"
         case _: BatchOp.SetHeaderFooter => "  HEADER-FOOTER"
+        case BatchOp.AddConditionalFormat(range, rule, _, _, _, _, _, _) =>
+          s"  CF $range $rule"
       }
       .mkString("\n")
 
@@ -471,13 +484,26 @@ object BatchParser:
               differentFirst = objMap.get("differentFirst").flatMap(_.boolOpt).getOrElse(false)
             )
 
+          case "cf" =>
+            collectUnknownPropsWarning(objMap, knownCfProps, "cf", idx).foreach(warnings += _)
+            BatchOp.AddConditionalFormat(
+              range = requireString(objMap, "range", idx),
+              rule = requireString(objMap, "rule", idx),
+              bold = objMap.get("bold").flatMap(_.boolOpt).getOrElse(false),
+              italic = objMap.get("italic").flatMap(_.boolOpt).getOrElse(false),
+              underline = objMap.get("underline").flatMap(_.boolOpt).getOrElse(false),
+              strike = objMap.get("strike").flatMap(_.boolOpt).getOrElse(false),
+              bg = objMap.get("bg").flatMap(_.strOpt),
+              fg = objMap.get("fg").flatMap(_.strOpt)
+            )
+
           case other =>
             throw new Exception(
               s"Object ${idx + 1}: Unknown operation '$other'. " +
                 "Valid: put, putf, style, merge, unmerge, colwidth, rowheight, " +
                 "comment, remove-comment, hyperlink, clear, col-hide, col-show, " +
                 "row-hide, row-show, autofit, add-sheet, rename-sheet, freeze, unfreeze, copy, " +
-                "sheet-view, tab-color, page-setup, header-footer"
+                "sheet-view, tab-color, page-setup, header-footer, cf"
             )
       }
 
@@ -561,6 +587,10 @@ object BatchParser:
     "differentOddEven",
     "differentFirst"
   )
+
+  /** Known properties for 'cf' operation (GH-324) */
+  private val knownCfProps =
+    Set("op", "range", "rule", "bold", "italic", "underline", "strike", "bg", "fg")
 
   /** Collect warning about unknown properties in a batch operation (if any) */
   private def collectUnknownPropsWarning(
@@ -1023,6 +1053,29 @@ object BatchParser:
           case BatchOp.SetHeaderFooter(oh, of, eh, ef, fh, ff, diffOddEven, diffFirst) =>
             updateSheetE(currentWb, defaultSheetName, "header-footer")(
               AppearanceOps.applyHeaderFooter(_, oh, of, eh, ef, fh, ff, diffOddEven, diffFirst)
+            )
+
+          case BatchOp.AddConditionalFormat(
+                rangeStr,
+                rule,
+                bold,
+                italic,
+                underline,
+                strike,
+                bg,
+                fg
+              ) =>
+            applyConditionalFormat(
+              currentWb,
+              defaultSheetName,
+              rangeStr,
+              rule,
+              bold,
+              italic,
+              underline,
+              strike,
+              bg,
+              fg
             )
       }
     }
@@ -1652,6 +1705,32 @@ object BatchParser:
         CopyOps.validateDimensions(sourceRange, targetRange).left.map(new Exception(_))
       )
     yield CopyOps.copyRange(wb, sourceSheet, sourceRange, targetSheet, targetRange, valuesOnly)
+
+  /**
+   * Add one conditional-formatting rule to a range (GH-324). Rule DSL + dxf flags are parsed by
+   * [[CfRuleParser]]; priorities are auto-stamped by `Sheet.conditionalFormat` in add order.
+   */
+  private def applyConditionalFormat(
+    wb: Workbook,
+    defaultSheetName: Option[SheetName],
+    rangeStr: String,
+    ruleStr: String,
+    bold: Boolean,
+    italic: Boolean,
+    underline: Boolean,
+    strike: Boolean,
+    bg: Option[String],
+    fg: Option[String]
+  ): IO[Workbook] =
+    for
+      rangeRef <- parseRangeRef(rangeStr, defaultSheetName)
+      (sheetName, range) = rangeRef
+      dxf <- IO.fromEither(
+        CfRuleParser.buildDxf(bold, italic, underline, strike, bg, fg).left.map(new Exception(_))
+      )
+      rule <- IO.fromEither(CfRuleParser.parse(ruleStr, dxf).left.map(new Exception(_)))
+      result <- updateSheet(wb, sheetName)(_.conditionalFormat(range, rule))
+    yield result
 
   // ========== Utilities ==========
 

--- a/xl-cli/src/com/tjclp/xl/cli/helpers/CfRuleParser.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/helpers/CfRuleParser.scala
@@ -1,0 +1,258 @@
+package com.tjclp.xl.cli.helpers
+
+import com.tjclp.xl.cf.{CfOperator, CfPoint, CfRule, CfTextOp, Cfvo}
+import com.tjclp.xl.cli.ColorParser
+import com.tjclp.xl.styles.{Dxf, DxfFont}
+import com.tjclp.xl.styles.color.Color
+import com.tjclp.xl.styles.fill.Fill
+
+/**
+ * Parser for the `cf add` colon rule DSL (GH-324), mapping rule strings to the xl-core CfRule
+ * builders. All rules are built with [[CfRule.AutoPriority]] — priorities are stamped by
+ * `Sheet.conditionalFormat` at append, never by the CLI.
+ *
+ * Families:
+ *   - `cellIs:<op>:<value>` — op: lessThan/lt, lessThanOrEqual/lte, equal/eq, notEqual/ne,
+ *     greaterThanOrEqual/gte, greaterThan/gt
+ *   - `between:<lo>:<hi>` / `notBetween:<lo>:<hi>` — inclusive bounds
+ *   - `expression:<formula>` — the formula may itself contain ':' (ranges)
+ *   - `colorScale:<c1>:<c2>[:<c3>]` — 2- or 3-point scale (3-point mid at the 50th percentile)
+ *   - `dataBar:<color>`
+ *   - `top10:<n>[:percent]` / `bottom10:<n>[:percent]`
+ *   - `text:<op>:<s>` — op: contains, notContains, beginsWith, endsWith; `<s>` may contain ':'
+ *
+ * Color tokens inside colorScale/dataBar accept named, #hex, and rgb(r,g,b) colors; `theme:` colors
+ * are not representable there (the ':' separator conflicts) — dxf flag colors (`--bg`/`--fg`) have
+ * no such restriction.
+ */
+object CfRuleParser:
+
+  /** Rule families whose format comes from a dxf (highlight-style rules). */
+  private val dxfFamilies =
+    Set("cellis", "between", "notbetween", "expression", "top10", "bottom10", "text")
+
+  private val operators: Map[String, CfOperator] = Map(
+    "lessthan" -> CfOperator.LessThan,
+    "lt" -> CfOperator.LessThan,
+    "lessthanorequal" -> CfOperator.LessThanOrEqual,
+    "lte" -> CfOperator.LessThanOrEqual,
+    "equal" -> CfOperator.Equal,
+    "eq" -> CfOperator.Equal,
+    "notequal" -> CfOperator.NotEqual,
+    "ne" -> CfOperator.NotEqual,
+    "greaterthanorequal" -> CfOperator.GreaterThanOrEqual,
+    "gte" -> CfOperator.GreaterThanOrEqual,
+    "greaterthan" -> CfOperator.GreaterThan,
+    "gt" -> CfOperator.GreaterThan
+  )
+
+  private val textOps: Map[String, CfTextOp] = Map(
+    "contains" -> CfTextOp.Contains,
+    "notcontains" -> CfTextOp.NotContains,
+    "beginswith" -> CfTextOp.BeginsWith,
+    "startswith" -> CfTextOp.BeginsWith,
+    "endswith" -> CfTextOp.EndsWith
+  )
+
+  /**
+   * Build a Dxf from the cf command's formatting flags. Boolean flag presence means force-on
+   * (`Some(true)`) — DxfFont is tri-state and absent flags inherit from the base cell style. Colors
+   * accept the full ColorParser syntax (named, #hex, rgb, theme:slot[:tint]). Returns None when no
+   * flag is set.
+   */
+  def buildDxf(
+    bold: Boolean,
+    italic: Boolean,
+    underline: Boolean,
+    strike: Boolean,
+    bg: Option[String],
+    fg: Option[String]
+  ): Either[String, Option[Dxf]] =
+    for
+      bgColor <- parseColorOpt(bg)
+      fgColor <- parseColorOpt(fg)
+    yield
+      val font =
+        if bold || italic || underline || strike || fgColor.isDefined then
+          Some(
+            DxfFont(
+              bold = if bold then Some(true) else None,
+              italic = if italic then Some(true) else None,
+              strike = if strike then Some(true) else None,
+              underline = if underline then Some(true) else None,
+              color = fgColor
+            )
+          )
+        else None
+      val fill = bgColor.map(c => Fill.Solid(c))
+      if font.isEmpty && fill.isEmpty then None else Some(Dxf(font = font, fill = fill))
+
+  private def parseColorOpt(s: Option[String]): Either[String, Option[Color]] =
+    s match
+      case None => Right(None)
+      case Some(str) => ColorParser.parse(str).map(Some(_))
+
+  /**
+   * Parse a rule string into a typed CfRule. Highlight families require a dxf (at least one
+   * formatting flag); colorScale/dataBar carry inline colors and reject dxf flags.
+   */
+  def parse(rule: String, dxf: Option[Dxf]): Either[String, CfRule] =
+    val family = rule.takeWhile(_ != ':').toLowerCase
+    if dxfFamilies.contains(family) then
+      dxf match
+        case None =>
+          Left(
+            s"$family rules need a format: add at least one of --bold, --italic, --underline, " +
+              "--strike, --bg <color>, --fg <color>"
+          )
+        case Some(d) => parseFamily(rule, family, d)
+    else if family == "colorscale" || family == "databar" then
+      dxf match
+        case Some(_) =>
+          Left(
+            s"$family rules carry inline colors; formatting flags (--bold/--bg/--fg/...) " +
+              "have no effect — remove them"
+          )
+        case None => parseFamily(rule, family, Dxf())
+    else
+      Left(
+        s"Unknown rule family: '${rule.takeWhile(_ != ':')}'. Valid: cellIs, between, notBetween, " +
+          "expression, colorScale, dataBar, top10, bottom10, text"
+      )
+
+  @SuppressWarnings(Array("org.wartremover.warts.SeqApply"))
+  private def parseFamily(rule: String, family: String, dxf: Dxf): Either[String, CfRule] =
+    family match
+      case "cellis" =>
+        rule.split(":", 3).toList match
+          case _ :: opStr :: value :: Nil if value.nonEmpty =>
+            operators
+              .get(opStr.toLowerCase)
+              .toRight(
+                s"Unknown cellIs operator: '$opStr'. " +
+                  "Valid: lessThan, lessThanOrEqual, equal, notEqual, greaterThanOrEqual, " +
+                  "greaterThan (or lt, lte, eq, ne, gte, gt)"
+              )
+              .map(op => CfRule.cellIs(op, value, dxf))
+          case _ =>
+            Left("cellIs rule format: cellIs:<operator>:<value>, e.g. cellIs:greaterThan:100")
+
+      case "between" | "notbetween" =>
+        rule.split(":", 3).toList match
+          case _ :: lo :: hi :: Nil if lo.nonEmpty && hi.nonEmpty =>
+            if family == "between" then Right(CfRule.between(lo, hi, dxf))
+            else Right(CfRule.notBetween(lo, hi, dxf))
+          case _ =>
+            Left(s"$family rule format: $family:<lo>:<hi>, e.g. between:10:100")
+
+      case "expression" =>
+        rule.split(":", 2).toList match
+          case _ :: formula :: Nil if formula.nonEmpty =>
+            Right(CfRule.expression(formula, dxf))
+          case _ =>
+            Left("expression rule format: expression:<formula>, e.g. expression:MOD(ROW(),2)=0")
+
+      case "colorscale" =>
+        val tokens = rule.split(":").toList.drop(1)
+        if tokens.exists(_.equalsIgnoreCase("theme")) then
+          Left(
+            "theme colors are not supported inside colorScale/dataBar rule strings " +
+              "(the ':' separator conflicts); use named, #hex, or rgb(r,g,b) colors"
+          )
+        else
+          tokens match
+            case c1 :: c2 :: Nil =>
+              for
+                min <- ColorParser.parse(c1)
+                max <- ColorParser.parse(c2)
+              yield CfRule.colorScale2(CfPoint(Cfvo.Min, min), CfPoint(Cfvo.Max, max))
+            case c1 :: c2 :: c3 :: Nil =>
+              for
+                min <- ColorParser.parse(c1)
+                mid <- ColorParser.parse(c2)
+                max <- ColorParser.parse(c3)
+              yield CfRule.colorScale3(
+                CfPoint(Cfvo.Min, min),
+                CfPoint(Cfvo.Percentile(BigDecimal(50)), mid),
+                CfPoint(Cfvo.Max, max)
+              )
+            case _ =>
+              Left(
+                "colorScale rule format: colorScale:<c1>:<c2>[:<c3>], e.g. colorScale:red:white:green"
+              )
+
+      case "databar" =>
+        rule.split(":", 2).toList match
+          case _ :: colorStr :: Nil if colorStr.nonEmpty =>
+            if colorStr.toLowerCase.startsWith("theme") then
+              Left(
+                "theme colors are not supported inside colorScale/dataBar rule strings " +
+                  "(the ':' separator conflicts); use named, #hex, or rgb(r,g,b) colors"
+              )
+            else ColorParser.parse(colorStr).map(c => CfRule.dataBar(c))
+          case _ =>
+            Left("dataBar rule format: dataBar:<color>, e.g. dataBar:#638EC6")
+
+      case "top10" | "bottom10" =>
+        val bottom = family == "bottom10"
+        rule.split(":").toList.drop(1) match
+          case nStr :: rest if rest.isEmpty || rest == List("percent") =>
+            nStr.toIntOption.filter(_ >= 1) match
+              case Some(n) =>
+                Right(CfRule.top10(n, dxf, percent = rest.nonEmpty, bottom = bottom))
+              case None => Left(s"$family rank must be a positive integer, got: '$nStr'")
+          case _ =>
+            Left(s"$family rule format: $family:<n>[:percent], e.g. top10:5 or top10:10:percent")
+
+      case "text" =>
+        rule.split(":", 3).toList match
+          case _ :: opStr :: text :: Nil if text.nonEmpty =>
+            textOps
+              .get(opStr.toLowerCase)
+              .toRight(
+                s"Unknown text operator: '$opStr'. Valid: contains, notContains, beginsWith, endsWith"
+              )
+              .map {
+                case CfTextOp.Contains => CfRule.containsText(text, dxf)
+                case CfTextOp.NotContains => CfRule.notContainsText(text, dxf)
+                case CfTextOp.BeginsWith => CfRule.beginsWith(text, dxf)
+                case CfTextOp.EndsWith => CfRule.endsWith(text, dxf)
+              }
+          case _ =>
+            Left("text rule format: text:<operator>:<text>, e.g. text:contains:overdue")
+
+      case other =>
+        Left(s"Unknown rule family: '$other'") // unreachable — parse() gates families
+
+  /** Short human-readable description of a rule (for command output and `cf list`). */
+  def describe(rule: CfRule): String = rule match
+    case CfRule.CellIs(op, f1, f2, _, _, _) =>
+      f2 match
+        case Some(hi) =>
+          val name = if op == CfOperator.Between then "between" else "notBetween"
+          s"cellIs $name $f1 and $hi"
+        case None => s"cellIs ${opName(op)} $f1"
+    case CfRule.Expression(formula, _, _, _) => s"expression $formula"
+    case CfRule.ColorScale(_, mid, _, _) =>
+      s"colorScale (${if mid.isDefined then 3 else 2}-point)"
+    case CfRule.DataBar(_, _, _, _, _) => "dataBar"
+    case CfRule.Top10(rank, percent, bottom, _, _, _) =>
+      s"${if bottom then "bottom" else "top"} $rank${if percent then "%" else ""}"
+    case CfRule.Text(op, text, _, _, _) =>
+      val name = op match
+        case CfTextOp.Contains => "contains"
+        case CfTextOp.NotContains => "notContains"
+        case CfTextOp.BeginsWith => "beginsWith"
+        case CfTextOp.EndsWith => "endsWith"
+      s"text $name '$text'"
+    case CfRule.Preserved(_, _) => "(preserved rule)"
+
+  private def opName(op: CfOperator): String = op match
+    case CfOperator.LessThan => "lessThan"
+    case CfOperator.LessThanOrEqual => "lessThanOrEqual"
+    case CfOperator.Equal => "equal"
+    case CfOperator.NotEqual => "notEqual"
+    case CfOperator.GreaterThanOrEqual => "greaterThanOrEqual"
+    case CfOperator.GreaterThan => "greaterThan"
+    case CfOperator.Between => "between"
+    case CfOperator.NotBetween => "notBetween"

--- a/xl-cli/src/com/tjclp/xl/cli/output/JsonRenderer.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/output/JsonRenderer.scala
@@ -31,12 +31,16 @@ object JsonRenderer:
    *       "row": 1,
    *       "cells": [
    *         {"ref": "A1", "type": "text", "value": "Revenue", "formatted": "Revenue"},
-   *         {"ref": "B1", "type": "number", "value": 1000000, "formatted": "$1,000,000"}
+   *         {"ref": "B1", "type": "number", "value": 1000000, "formatted": "$1,000,000"},
+   *         {"ref": "C1", "type": "formula", "formula": "=B1*2", "value": 2000000, "formatted": "$2,000,000"}
    *       ]
    *     }
    *   ]
    * }
    * }}}
+   *
+   * Formula cells always carry the expression in a dedicated `formula` field (GH-357); `value` and
+   * `formatted` hold the computed (`evalFormulas`) or cached value — `null`/`""` when uncached.
    *
    * Output format (with headerRow):
    * {{{
@@ -50,6 +54,10 @@ object JsonRenderer:
    * }
    * }}}
    *
+   * @param showFormulas
+   *   Ignored for JSON output (GH-357): the formula expression is always present in the `formula`
+   *   field, so there is nothing to swap. Retained for signature compatibility with the other
+   *   renderers — `--formulas` only controls non-JSON display formats.
    * @param skipEmpty
    *   If true, omit cells where type is "empty" from output (reduces token usage for sparse ranges)
    * @param headerRow
@@ -74,14 +82,13 @@ object JsonRenderer:
         renderAsRecords(
           sheet,
           range,
-          showFormulas,
           skipEmpty,
           headerRowNum,
           evalFormulas,
           truncatedTotalRows
         )
       case None =>
-        renderAsRows(sheet, range, showFormulas, skipEmpty, evalFormulas, truncatedTotalRows)
+        renderAsRows(sheet, range, skipEmpty, evalFormulas, truncatedTotalRows)
 
   /**
    * Render range as array of records with header row values as keys.
@@ -89,7 +96,6 @@ object JsonRenderer:
   private def renderAsRecords(
     sheet: Sheet,
     range: CellRange,
-    showFormulas: Boolean,
     skipEmpty: Boolean,
     headerRowNum: Int,
     evalFormulas: Boolean,
@@ -136,7 +142,7 @@ object JsonRenderer:
             if skipEmpty && isEmpty then None
             else
               Some(
-                s"${escapeJsonString(headerName)}: ${renderCellValue(cell, sheet, showFormulas, evalFormulas)}"
+                s"${escapeJsonString(headerName)}: ${renderCellValue(cell, sheet, evalFormulas)}"
               )
           case None =>
             if skipEmpty then None
@@ -162,7 +168,6 @@ object JsonRenderer:
   private def renderAsRows(
     sheet: Sheet,
     range: CellRange,
-    showFormulas: Boolean,
     skipEmpty: Boolean,
     evalFormulas: Boolean,
     truncatedTotalRows: Option[Int]
@@ -192,7 +197,7 @@ object JsonRenderer:
             // Check if cell is effectively empty (including formulas returning empty)
             val isEmpty = RendererCommon.isCellEmpty(cell)
             if skipEmpty && isEmpty then None
-            else Some(renderCell(ref, cell, sheet, showFormulas, evalFormulas))
+            else Some(renderCell(ref, cell, sheet, evalFormulas))
           case None =>
             if skipEmpty then None
             else Some(renderEmptyCell(ref))
@@ -246,7 +251,6 @@ object JsonRenderer:
     ref: ARef,
     cell: Cell,
     sheet: Sheet,
-    showFormulas: Boolean,
     evalFormulas: Boolean
   ): String =
     val numFmt = cell.styleId
@@ -286,23 +290,52 @@ object JsonRenderer:
         ("empty", "null", "\"\"")
 
       case CellValue.Formula(expr, cached) =>
-        val displayExpr = if expr.startsWith("=") then expr else s"=$expr"
-        if showFormulas then
-          ("formula", escapeJsonString(displayExpr), escapeJsonString(displayExpr))
-        else if evalFormulas then
-          SheetEvaluator.evaluateFormula(sheet)(displayExpr) match
-            case Right(result) =>
-              val formatted = NumFmtFormatter.formatValue(result, numFmt)
-              ("formula", escapeJsonString(displayExpr), escapeJsonString(formatted))
-            case Left(err) =>
-              val errStr = RendererCommon.formatEvalError(err.message)
-              ("formula", escapeJsonString(displayExpr), escapeJsonString(errStr))
-        else
-          val cachedValue =
-            cached.map(cv => NumFmtFormatter.formatValue(cv, numFmt)).getOrElse(displayExpr)
-          ("formula", escapeJsonString(displayExpr), escapeJsonString(cachedValue))
+        val (raw, fmt) =
+          formulaValueJson(sheet, displayExpression(expr), cached, numFmt, evalFormulas)
+        ("formula", raw, fmt)
 
-    s"""{"ref": "${ref.toA1}", "type": "$typeStr", "value": $rawValue, "formatted": $formatted}"""
+    // GH-357: formula cells always carry the expression in a dedicated field; value/formatted
+    // hold the computed or cached value. --formulas only affects non-JSON display formats.
+    val formulaField = cell.value match
+      case CellValue.Formula(expr, _) =>
+        s""", "formula": ${escapeJsonString(displayExpression(expr))}"""
+      case _ => ""
+
+    s"""{"ref": "${ref.toA1}", "type": "$typeStr"$formulaField, "value": $rawValue, "formatted": $formatted}"""
+
+  /** Formula expression as displayed: always with a leading `=`. */
+  private def displayExpression(expr: String): String =
+    if expr.startsWith("=") then expr else s"=$expr"
+
+  /**
+   * Raw JSON value + formatted string for a formula cell (GH-357): evaluated when `evalFormulas`
+   * (error token on failure), else the cached value; `null`/`""` when uncached.
+   */
+  private def formulaValueJson(
+    sheet: Sheet,
+    displayExpr: String,
+    cached: Option[CellValue],
+    numFmt: NumFmt,
+    evalFormulas: Boolean
+  ): (String, String) =
+    if evalFormulas then
+      SheetEvaluator.evaluateFormula(sheet)(displayExpr) match
+        case Right(result) =>
+          (
+            renderCellValueFromCellValue(result, numFmt),
+            escapeJsonString(NumFmtFormatter.formatValue(result, numFmt))
+          )
+        case Left(err) =>
+          val errStr = escapeJsonString(RendererCommon.formatEvalError(err.message))
+          (errStr, errStr)
+    else
+      cached match
+        case Some(cv) =>
+          (
+            renderCellValueFromCellValue(cv, numFmt),
+            escapeJsonString(NumFmtFormatter.formatValue(cv, numFmt))
+          )
+        case None => ("null", "\"\"")
 
   private def renderEmptyCell(ref: ARef): String =
     s"""{"ref": "${ref.toA1}", "type": "empty", "value": null, "formatted": ""}"""
@@ -362,7 +395,6 @@ object JsonRenderer:
   private def renderCellValue(
     cell: Cell,
     sheet: Sheet,
-    showFormulas: Boolean,
     evalFormulas: Boolean
   ): String =
     val numFmt = cell.styleId
@@ -381,16 +413,9 @@ object JsonRenderer:
       case CellValue.Error(err) => escapeJsonString(err.toExcel)
       case CellValue.Empty => "null"
       case CellValue.Formula(expr, cached) =>
-        val displayExpr = if expr.startsWith("=") then expr else s"=$expr"
-        if showFormulas then escapeJsonString(displayExpr)
-        else if evalFormulas then
-          SheetEvaluator.evaluateFormula(sheet)(displayExpr) match
-            case Right(result) => renderCellValueFromCellValue(result, numFmt)
-            case Left(err) => escapeJsonString(RendererCommon.formatEvalError(err.message))
-        else
-          cached match
-            case Some(cv) => renderCellValueFromCellValue(cv, numFmt)
-            case None => escapeJsonString(displayExpr)
+        // GH-357: records mode is a scalar projection — always the computed/cached value,
+        // never the expression; null when uncached (matches empty cells).
+        formulaValueJson(sheet, displayExpression(expr), cached, numFmt, evalFormulas)._1
 
   private def renderCellValueFromCellValue(value: CellValue, numFmt: NumFmt): String =
     value match

--- a/xl-cli/src/com/tjclp/xl/cli/raster/Rasterizer.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/raster/Rasterizer.scala
@@ -69,6 +69,28 @@ enum RasterFormat:
     case Pdf => "pdf"
 
 /**
+ * GraalVM native-image runtime detection, used to explain why the bundled Batik backend (which
+ * needs AWT) can never work in the shipped native binary.
+ *
+ * Mirrors `org.graalvm.nativeimage.ImageInfo.inImageRuntimeCode()` without a compile-time GraalVM
+ * dependency: ImageInfo itself answers by reading the `org.graalvm.nativeimage.imagecode` system
+ * property, which Substrate VM sets to "runtime" inside every native binary. A reflective
+ * `Class.forName("org.graalvm.nativeimage.ImageInfo")` would be strictly less reliable here - the
+ * class is absent from JVM classpaths and may be unregistered for reflection inside the image - so
+ * the property is read directly. `java.vm.name` containing "Substrate VM" is kept as a fallback for
+ * older GraalVM releases.
+ */
+object NativeImage:
+
+  /** True when running inside a GraalVM native binary (never true on a regular JVM). */
+  lazy val inNativeImage: Boolean = detect(sys.props.get)
+
+  /** Detection core with injectable properties so both environments are unit-testable. */
+  private[cli] def detect(prop: String => Option[String]): Boolean =
+    prop("org.graalvm.nativeimage.imagecode").exists(_.equalsIgnoreCase("runtime")) ||
+      prop("java.vm.name").exists(_.contains("Substrate"))
+
+/**
  * Errors that can occur during rasterization.
  */
 sealed trait RasterError extends Exception:
@@ -77,14 +99,29 @@ sealed trait RasterError extends Exception:
 
 object RasterError:
   /** No rasterizer available on the system */
-  case class NoRasterizerAvailable(triedRasterizers: List[String]) extends RasterError:
+  case class NoRasterizerAvailable(
+    triedRasterizers: List[String],
+    runningNativeImage: Boolean = NativeImage.inNativeImage
+  ) extends RasterError:
     def message: String =
+      val platformNote =
+        if runningNativeImage then
+          "Running as a native binary: the bundled Batik backend needs AWT and is\n" +
+            "unavailable by design - install one of the external tools below."
+        else
+          "Note: the JAR distribution rasterizes out-of-the-box (bundled Batik); the\n" +
+            "native binary always needs one of the external tools below."
       s"""No SVG rasterizer available. Tried: ${triedRasterizers.mkString(", ")}
+         |
+         |$platformNote
+         |
+         |Run `xl rasterizers` to see backend status on this machine.
          |
          |Install one of:
          |  - cairosvg: pip install cairosvg
          |  - rsvg-convert: apt install librsvg2-bin (Debian/Ubuntu)
-         |  - resvg: cargo install resvg
+         |  - resvg: cargo install resvg, or a prebuilt binary from
+         |    https://github.com/linebender/resvg/releases
          |  - ImageMagick (not tried automatically): apt install imagemagick,
          |    then pass --rasterizer imagemagick
          |
@@ -92,7 +129,8 @@ object RasterError:
 
   /** Specific rasterizer requested but not available */
   case class RasterizerNotFound(name: String, installHint: String) extends RasterError:
-    def message: String = s"Rasterizer '$name' not found. $installHint"
+    def message: String =
+      s"Rasterizer '$name' not found. $installHint (run `xl rasterizers` for backend status)"
 
   /** Format not supported by this rasterizer */
   case class FormatNotSupported(rasterizer: String, format: RasterFormat) extends RasterError:
@@ -263,10 +301,14 @@ object RasterizerChain:
         }
 
   private def installHintFor(name: String): String = name match
-    case "batik" => "Batik is bundled but requires AWT (unavailable in this native image)"
+    case "batik" =>
+      if NativeImage.inNativeImage then
+        "Batik is bundled but needs AWT - unavailable in the native binary by design"
+      else "Batik is bundled but requires AWT, which is unavailable in this environment"
     case "cairosvg" => "Install: pip install cairosvg"
     case "rsvg-convert" => "Install: apt install librsvg2-bin (Debian/Ubuntu)"
-    case "resvg" => "Install: cargo install resvg"
+    case "resvg" =>
+      "Install: cargo install resvg, or a prebuilt binary from https://github.com/linebender/resvg/releases"
     case "imagemagick" => "Install: apt install imagemagick"
     case _ => s"Unknown rasterizer: $name"
 

--- a/xl-cli/test/src/com/tjclp/xl/cli/AppearanceCommandsSpec.scala
+++ b/xl-cli/test/src/com/tjclp/xl/cli/AppearanceCommandsSpec.scala
@@ -1,0 +1,547 @@
+package com.tjclp.xl.cli
+
+import munit.FunSuite
+
+import java.nio.file.{Files, Path}
+
+import cats.effect.{IO, unsafe}
+import com.tjclp.xl.{Workbook, Sheet}
+import com.tjclp.xl.cli.helpers.BatchParser
+import com.tjclp.xl.cli.commands.WriteCommands
+import com.tjclp.xl.io.ExcelIO
+import com.tjclp.xl.ooxml.writer.WriterConfig
+import com.tjclp.xl.styles.color.{Color, ThemeSlot}
+
+/**
+ * E2E tests for the sheet appearance & print setup commands (GH-358): sheet-view, tab-color,
+ * page-setup, header-footer — CLI handlers plus their batch ops, with write → re-read model
+ * assertions.
+ */
+@SuppressWarnings(
+  Array("org.wartremover.warts.OptionPartial", "org.wartremover.warts.IterableOps")
+)
+class AppearanceCommandsSpec extends FunSuite:
+
+  given unsafe.IORuntime = unsafe.IORuntime.global
+
+  val config: WriterConfig = WriterConfig.default
+
+  private def tempXlsx(): Path = Files.createTempFile("appearance-test", ".xlsx")
+
+  private def withTempOutput[A](f: Path => A): A =
+    val out = tempXlsx()
+    try f(out)
+    finally Files.deleteIfExists(out)
+
+  private def readBack(path: Path): Workbook =
+    ExcelIO.instance[IO].read(path).unsafeRunSync()
+
+  // ========== ColorParser theme syntax (GH-358) ==========
+
+  test("ColorParser: theme:accent1 parses to Theme color with zero tint") {
+    assertEquals(ColorParser.parse("theme:accent1"), Right(Color.Theme(ThemeSlot.Accent1, 0.0)))
+  }
+
+  test("ColorParser: theme:accent2:0.25 parses slot and tint") {
+    assertEquals(
+      ColorParser.parse("theme:accent2:0.25"),
+      Right(Color.Theme(ThemeSlot.Accent2, 0.25))
+    )
+  }
+
+  test("ColorParser: theme:dark1:-0.5 accepts negative tint") {
+    assertEquals(
+      ColorParser.parse("theme:dark1:-0.5"),
+      Right(Color.Theme(ThemeSlot.Dark1, -0.5))
+    )
+  }
+
+  test("ColorParser: unknown theme slot yields clean error") {
+    val result = ColorParser.parse("theme:accent9")
+    assert(result.isLeft, s"Expected error, got $result")
+    assert(result.swap.toOption.get.contains("accent9"), result.toString)
+  }
+
+  test("ColorParser: out-of-range tint yields clean error") {
+    val result = ColorParser.parse("theme:accent1:1.5")
+    assert(result.isLeft, s"Expected error, got $result")
+    assert(result.swap.toOption.get.contains("1.5"), result.toString)
+  }
+
+  // ========== sheet-view command ==========
+
+  test("sheet-view: gridlines off + zoom write and round-trip") {
+    withTempOutput { out =>
+      val wb = Workbook(Sheet("Test"))
+      val result = WriteCommands
+        .sheetView(
+          wb,
+          Some(wb.sheets.head),
+          gridlines = Some(false),
+          zoom = Some(85),
+          tabSelected = None,
+          out,
+          config
+        )
+        .unsafeRunSync()
+
+      assert(result.contains("Saved"), result)
+
+      val sheet = readBack(out).sheets.head
+      val view = sheet.viewSettings
+      assert(view.isDefined, "viewSettings should round-trip")
+      assertEquals(view.get.showGridLines, false)
+      assertEquals(view.get.zoomScale, Some(85))
+    }
+  }
+
+  test("sheet-view: zoom out of range yields clean error (no stack trace)") {
+    withTempOutput { out =>
+      val wb = Workbook(Sheet("Test"))
+      val result = WriteCommands
+        .sheetView(wb, Some(wb.sheets.head), None, Some(5), None, out, config)
+        .attempt
+        .unsafeRunSync()
+
+      assert(result.isLeft)
+      val msg = result.swap.toOption.get.getMessage
+      assert(msg.contains("10-400"), msg)
+      assert(msg.contains("5"), msg)
+    }
+  }
+
+  test("sheet-view: no options yields clean error") {
+    withTempOutput { out =>
+      val wb = Workbook(Sheet("Test"))
+      val result = WriteCommands
+        .sheetView(wb, Some(wb.sheets.head), None, None, None, out, config)
+        .attempt
+        .unsafeRunSync()
+
+      assert(result.isLeft)
+      assert(
+        result.swap.toOption.get.getMessage.contains("at least one"),
+        result.swap.toOption.get.getMessage
+      )
+    }
+  }
+
+  test("sheet-view: preserves unspecified fields from existing view settings") {
+    withTempOutput { out =>
+      val sheet = Sheet("Test").withViewSettings(
+        com.tjclp.xl.sheets.SheetView(showGridLines = false, zoomScale = Some(70))
+      )
+      val wb = Workbook(sheet)
+      WriteCommands
+        .sheetView(wb, Some(sheet), gridlines = None, zoom = Some(90), None, out, config)
+        .unsafeRunSync()
+
+      val view = readBack(out).sheets.head.viewSettings.get
+      assertEquals(view.showGridLines, false, "gridlines=off must survive a zoom-only edit")
+      assertEquals(view.zoomScale, Some(90))
+    }
+  }
+
+  // ========== tab-color command ==========
+
+  test("tab-color: hex color writes and round-trips") {
+    withTempOutput { out =>
+      val wb = Workbook(Sheet("Test"))
+      val result = WriteCommands
+        .tabColor(wb, Some(wb.sheets.head), Some("#1F4E79"), clear = false, out, config)
+        .unsafeRunSync()
+
+      assert(result.contains("Saved"), result)
+      val sheet = readBack(out).sheets.head
+      assertEquals(sheet.tabColor, Some(Color.Rgb(0xff1f4e79)))
+    }
+  }
+
+  test("tab-color: theme color round-trips through file") {
+    withTempOutput { out =>
+      val wb = Workbook(Sheet("Test"))
+      WriteCommands
+        .tabColor(wb, Some(wb.sheets.head), Some("theme:accent2:0.25"), clear = false, out, config)
+        .unsafeRunSync()
+
+      val sheet = readBack(out).sheets.head
+      assertEquals(sheet.tabColor, Some(Color.Theme(ThemeSlot.Accent2, 0.25)))
+    }
+  }
+
+  test("tab-color: --clear clears a modeled color") {
+    withTempOutput { out =>
+      val sheet = Sheet("Test").withTabColor(Color.Rgb(0xff1f4e79))
+      val wb = Workbook(sheet)
+      val result = WriteCommands
+        .tabColor(wb, Some(sheet), None, clear = true, out, config)
+        .unsafeRunSync()
+
+      assert(result.contains("Cleared"), result)
+      assertEquals(readBack(out).sheets.head.tabColor, None)
+    }
+  }
+
+  test("tab-color: color and --clear are mutually exclusive") {
+    withTempOutput { out =>
+      val wb = Workbook(Sheet("Test"))
+      val result = WriteCommands
+        .tabColor(wb, Some(wb.sheets.head), Some("red"), clear = true, out, config)
+        .attempt
+        .unsafeRunSync()
+
+      assert(result.isLeft)
+      assert(
+        result.swap.toOption.get.getMessage.contains("mutually exclusive"),
+        result.swap.toOption.get.getMessage
+      )
+    }
+  }
+
+  test("tab-color: neither color nor --clear yields clean error") {
+    withTempOutput { out =>
+      val wb = Workbook(Sheet("Test"))
+      val result = WriteCommands
+        .tabColor(wb, Some(wb.sheets.head), None, clear = false, out, config)
+        .attempt
+        .unsafeRunSync()
+
+      assert(result.isLeft)
+    }
+  }
+
+  test("tab-color: invalid color yields clean error") {
+    withTempOutput { out =>
+      val wb = Workbook(Sheet("Test"))
+      val result = WriteCommands
+        .tabColor(wb, Some(wb.sheets.head), Some("notacolor"), clear = false, out, config)
+        .attempt
+        .unsafeRunSync()
+
+      assert(result.isLeft)
+      assert(
+        result.swap.toOption.get.getMessage.contains("notacolor"),
+        result.swap.toOption.get.getMessage
+      )
+    }
+  }
+
+  // ========== page-setup command ==========
+
+  test("page-setup: landscape + fit 1x1 writes and round-trips") {
+    withTempOutput { out =>
+      val wb = Workbook(Sheet("Test"))
+      val result = WriteCommands
+        .pageSetup(
+          wb,
+          Some(wb.sheets.head),
+          orientation = Some("landscape"),
+          scale = None,
+          fitToWidth = Some(1),
+          fitToHeight = Some(1),
+          fitToPage = None,
+          out,
+          config
+        )
+        .unsafeRunSync()
+
+      assert(result.contains("Saved"), result)
+      val setup = readBack(out).sheets.head.pageSetup
+      assert(setup.isDefined, "pageSetup should round-trip")
+      assertEquals(setup.get.orientation, Some("landscape"))
+      assertEquals(setup.get.fitToWidth, Some(1))
+      assertEquals(setup.get.fitToHeight, Some(1))
+    }
+  }
+
+  test("page-setup: scale bounds pre-validated with clean error") {
+    withTempOutput { out =>
+      val wb = Workbook(Sheet("Test"))
+      val result = WriteCommands
+        .pageSetup(wb, Some(wb.sheets.head), None, Some(500), None, None, None, out, config)
+        .attempt
+        .unsafeRunSync()
+
+      assert(result.isLeft)
+      val msg = result.swap.toOption.get.getMessage
+      assert(msg.contains("10-400"), msg)
+    }
+  }
+
+  test("page-setup: invalid orientation yields clean error") {
+    withTempOutput { out =>
+      val wb = Workbook(Sheet("Test"))
+      val result = WriteCommands
+        .pageSetup(wb, Some(wb.sheets.head), Some("sideways"), None, None, None, None, out, config)
+        .attempt
+        .unsafeRunSync()
+
+      assert(result.isLeft)
+      val msg = result.swap.toOption.get.getMessage
+      assert(msg.contains("portrait"), msg)
+    }
+  }
+
+  test("page-setup: no options yields clean error") {
+    withTempOutput { out =>
+      val wb = Workbook(Sheet("Test"))
+      val result = WriteCommands
+        .pageSetup(wb, Some(wb.sheets.head), None, None, None, None, None, out, config)
+        .attempt
+        .unsafeRunSync()
+
+      assert(result.isLeft)
+    }
+  }
+
+  // ========== header-footer command ==========
+
+  test("header-footer: odd footer with codes writes and round-trips") {
+    withTempOutput { out =>
+      val wb = Workbook(Sheet("Test"))
+      val footer = "&LProprietary & Confidential&RPage &P of &N"
+      val result = WriteCommands
+        .headerFooter(
+          wb,
+          Some(wb.sheets.head),
+          oddHeader = None,
+          oddFooter = Some(footer),
+          evenHeader = None,
+          evenFooter = None,
+          firstHeader = None,
+          firstFooter = None,
+          differentOddEven = false,
+          differentFirst = false,
+          out,
+          config
+        )
+        .unsafeRunSync()
+
+      assert(result.contains("Saved"), result)
+      val hf = readBack(out).sheets.head.pageSetup.flatMap(_.headerFooter)
+      assert(hf.isDefined, "headerFooter should round-trip")
+      assertEquals(hf.get.oddFooter, Some(footer))
+    }
+  }
+
+  test("header-footer: even text auto-sets differentOddEven") {
+    withTempOutput { out =>
+      val wb = Workbook(Sheet("Test"))
+      WriteCommands
+        .headerFooter(
+          wb,
+          Some(wb.sheets.head),
+          None,
+          Some("&COdd"),
+          None,
+          Some("&CEven"),
+          None,
+          None,
+          differentOddEven = false,
+          differentFirst = false,
+          out,
+          config
+        )
+        .unsafeRunSync()
+
+      val hf = readBack(out).sheets.head.pageSetup.flatMap(_.headerFooter).get
+      assertEquals(hf.evenFooter, Some("&CEven"))
+      assert(hf.differentOddEven, "differentOddEven should be set when even text is provided")
+    }
+  }
+
+  test("header-footer: preserves existing page setup fields") {
+    withTempOutput { out =>
+      val sheet = Sheet("Test").withPageSetup(
+        com.tjclp.xl.sheets.PageSetup(orientation = Some("landscape"))
+      )
+      val wb = Workbook(sheet)
+      WriteCommands
+        .headerFooter(
+          wb,
+          Some(sheet),
+          None,
+          Some("&CFooter"),
+          None,
+          None,
+          None,
+          None,
+          differentOddEven = false,
+          differentFirst = false,
+          out,
+          config
+        )
+        .unsafeRunSync()
+
+      val setup = readBack(out).sheets.head.pageSetup.get
+      assertEquals(setup.orientation, Some("landscape"), "orientation must survive footer edit")
+      assertEquals(setup.headerFooter.flatMap(_.oddFooter), Some("&CFooter"))
+    }
+  }
+
+  test("header-footer: no options yields clean error") {
+    withTempOutput { out =>
+      val wb = Workbook(Sheet("Test"))
+      val result = WriteCommands
+        .headerFooter(
+          wb,
+          Some(wb.sheets.head),
+          None,
+          None,
+          None,
+          None,
+          None,
+          None,
+          differentOddEven = false,
+          differentFirst = false,
+          out,
+          config
+        )
+        .attempt
+        .unsafeRunSync()
+
+      assert(result.isLeft)
+    }
+  }
+
+  // ========== batch ops ==========
+
+  test("batch: sheet-view op parses without unknown-prop warnings") {
+    val json = """[{"op": "sheet-view", "gridlines": false, "zoom": 85}]"""
+    val result = BatchParser.parseBatchJson(json)
+    assert(result.isRight, s"Should parse: $result")
+    assertEquals(result.toOption.get.warnings, Vector.empty[String])
+  }
+
+  test("batch: tab-color, page-setup, header-footer ops parse") {
+    val json =
+      """[
+        {"op": "tab-color", "color": "#1F4E79"},
+        {"op": "page-setup", "orientation": "landscape", "fitToWidth": 1, "fitToHeight": 1},
+        {"op": "header-footer", "oddFooter": "&LConfidential&RPage &P"}
+      ]"""
+    val result = BatchParser.parseBatchJson(json)
+    assert(result.isRight, s"Should parse: $result")
+    assertEquals(result.toOption.get.ops.size, 3)
+    assertEquals(result.toOption.get.warnings, Vector.empty[String])
+  }
+
+  test("batch: sheet-view invalid zoom fails cleanly at apply time") {
+    val json = """[{"op": "sheet-view", "zoom": 5}]"""
+    val parsed = BatchParser.parseBatchJson(json)
+    assert(parsed.isRight, s"Should parse: $parsed")
+    val sheet = Sheet("Test")
+    val wb = Workbook(sheet)
+    val result = BatchParser
+      .applyBatchOperations(wb, Some(sheet), parsed.toOption.get.ops)
+      .attempt
+      .unsafeRunSync()
+    assert(result.isLeft)
+    assert(
+      result.swap.toOption.get.getMessage.contains("10-400"),
+      result.swap.toOption.get.getMessage
+    )
+  }
+
+  test("batch: deliverable finish combo applies via one batch file (GH-358 acceptance)") {
+    withTempOutput { out =>
+      val json =
+        """[
+          {"op": "sheet-view", "gridlines": false, "zoom": 85},
+          {"op": "tab-color", "color": "#1F4E79"},
+          {"op": "page-setup", "orientation": "landscape", "fitToWidth": 1, "fitToHeight": 1},
+          {"op": "header-footer", "oddFooter": "&LProprietary & Confidential&RPage &P of &N"}
+        ]"""
+      val jsonPath = Files.createTempFile("finish", ".json")
+      Files.writeString(jsonPath, json)
+      try
+        val wb = Workbook(Sheet("Model"))
+        val result = WriteCommands
+          .batch(wb, Some(wb.sheets.head), jsonPath.toString, out, config)
+          .unsafeRunSync()
+
+        assert(result.contains("Applied 4 operations"), result)
+
+        val sheet = readBack(out).sheets.head
+        val view = sheet.viewSettings.get
+        assertEquals(view.showGridLines, false)
+        assertEquals(view.zoomScale, Some(85))
+        assertEquals(sheet.tabColor, Some(Color.Rgb(0xff1f4e79)))
+        val setup = sheet.pageSetup.get
+        assertEquals(setup.orientation, Some("landscape"))
+        assertEquals(setup.fitToWidth, Some(1))
+        assertEquals(setup.fitToHeight, Some(1))
+        assertEquals(
+          setup.headerFooter.flatMap(_.oddFooter),
+          Some("&LProprietary & Confidential&RPage &P of &N")
+        )
+      finally Files.deleteIfExists(jsonPath)
+    }
+  }
+
+  test("batch: tab-color clear form clears a modeled color") {
+    withTempOutput { out =>
+      val sheet = Sheet("Test").withTabColor(Color.Rgb(0xffff0000))
+      val wb = Workbook(sheet)
+      val ops = BatchParser
+        .parseBatchJson("""[{"op": "tab-color", "clear": true}]""")
+        .toOption
+        .get
+        .ops
+      val updated = BatchParser.applyBatchOperations(wb, Some(sheet), ops).unsafeRunSync()
+      assertEquals(updated.sheets.head.tabColor, None)
+    }
+  }
+
+  test("deliverable finish: raw worksheet XML carries all four elements (GH-358)") {
+    withTempOutput { out =>
+      val json =
+        """[
+          {"op": "sheet-view", "gridlines": false, "zoom": 85},
+          {"op": "tab-color", "color": "theme:accent2:0.25"},
+          {"op": "page-setup", "orientation": "landscape", "fitToWidth": 1, "fitToHeight": 1},
+          {"op": "header-footer", "oddFooter": "&LConfidential&RPage &P"}
+        ]"""
+      val jsonPath = Files.createTempFile("finish-xml", ".json")
+      Files.writeString(jsonPath, json)
+      try
+        val wb = Workbook(Sheet("Model"))
+        WriteCommands
+          .batch(wb, Some(wb.sheets.head), jsonPath.toString, out, config)
+          .unsafeRunSync()
+
+        val zip = new java.util.zip.ZipFile(out.toFile)
+        val xml =
+          try
+            val entry = zip.getEntry("xl/worksheets/sheet1.xml")
+            new String(
+              zip.getInputStream(entry).readAllBytes(),
+              java.nio.charset.StandardCharsets.UTF_8
+            )
+          finally zip.close()
+
+        assert(xml.contains("showGridLines=\"0\""), xml)
+        assert(xml.contains("zoomScale=\"85\""), xml)
+        assert(xml.contains("<tabColor") && xml.contains("theme=\"5\""), xml)
+        assert(xml.contains("orientation=\"landscape\""), xml)
+        assert(xml.contains("fitToWidth=\"1\"") && xml.contains("fitToHeight=\"1\""), xml)
+        assert(xml.contains("fitToPage=\"1\""), "fitToPage should derive from fitTo* — " + xml)
+        assert(xml.contains("<oddFooter>&amp;LConfidential&amp;RPage &amp;P</oddFooter>"), xml)
+      finally Files.deleteIfExists(jsonPath)
+    }
+  }
+
+  test("batch: appearance ops require --sheet") {
+    val ops = BatchParser
+      .parseBatchJson("""[{"op": "sheet-view", "zoom": 85}]""")
+      .toOption
+      .get
+      .ops
+    val wb = Workbook(Sheet("Test"))
+    val result = BatchParser.applyBatchOperations(wb, None, ops).attempt.unsafeRunSync()
+    assert(result.isLeft)
+    assert(
+      result.swap.toOption.get.getMessage.contains("--sheet"),
+      result.swap.toOption.get.getMessage
+    )
+  }

--- a/xl-cli/test/src/com/tjclp/xl/cli/CfCommandSpec.scala
+++ b/xl-cli/test/src/com/tjclp/xl/cli/CfCommandSpec.scala
@@ -1,0 +1,383 @@
+package com.tjclp.xl.cli
+
+import munit.FunSuite
+
+import java.nio.file.{Files, Path}
+
+import cats.effect.{IO, unsafe}
+import com.tjclp.xl.{Workbook, Sheet}
+import com.tjclp.xl.cf.{CfOperator, CfRule, CfTextOp, Cfvo}
+import com.tjclp.xl.cli.commands.WriteCommands
+import com.tjclp.xl.cli.helpers.BatchParser
+import com.tjclp.xl.io.ExcelIO
+import com.tjclp.xl.ooxml.writer.WriterConfig
+import com.tjclp.xl.styles.color.Color
+import com.tjclp.xl.styles.fill.Fill
+
+/**
+ * E2E tests for the conditional-formatting authoring command (GH-324): `cf add`, `cf list`, and the
+ * batch op `cf` — each rule family write → read → typedConditionalFormats assertions, malformed
+ * rule strings, and auto-priority stamping.
+ */
+@SuppressWarnings(
+  Array("org.wartremover.warts.OptionPartial", "org.wartremover.warts.IterableOps")
+)
+class CfCommandSpec extends FunSuite:
+
+  given unsafe.IORuntime = unsafe.IORuntime.global
+
+  val config: WriterConfig = WriterConfig.default
+
+  private def withTempOutput[A](f: Path => A): A =
+    val out = Files.createTempFile("cf-test", ".xlsx")
+    try f(out)
+    finally Files.deleteIfExists(out)
+
+  private def readBackRules(path: Path): Vector[CfRule] =
+    ExcelIO
+      .instance[IO]
+      .read(path)
+      .unsafeRunSync()
+      .sheets
+      .head
+      .typedConditionalFormats
+      .flatMap(_.rules)
+
+  private def addRule(
+    out: Path,
+    rule: String,
+    bold: Boolean = false,
+    italic: Boolean = false,
+    underline: Boolean = false,
+    strike: Boolean = false,
+    bg: Option[String] = None,
+    fg: Option[String] = None,
+    wb: Workbook = Workbook(Sheet("Test"))
+  ): String =
+    WriteCommands
+      .cfAdd(
+        wb,
+        Some(wb.sheets.head),
+        "A1:A10",
+        rule,
+        bold,
+        italic,
+        underline,
+        strike,
+        bg,
+        fg,
+        out,
+        config
+      )
+      .unsafeRunSync()
+
+  private def addRuleError(
+    rule: String,
+    bold: Boolean = false,
+    bg: Option[String] = None
+  ): String =
+    withTempOutput { out =>
+      val wb = Workbook(Sheet("Test"))
+      WriteCommands
+        .cfAdd(
+          wb,
+          Some(wb.sheets.head),
+          "A1:A10",
+          rule,
+          bold,
+          false,
+          false,
+          false,
+          bg,
+          None,
+          out,
+          config
+        )
+        .attempt
+        .unsafeRunSync()
+        .swap
+        .toOption
+        .get
+        .getMessage
+    }
+
+  // ========== rule families E2E (write → read → typed assert) ==========
+
+  test("cf add: cellIs greaterThan with bold + bg round-trips with dxf") {
+    withTempOutput { out =>
+      val result = addRule(out, "cellIs:greaterThan:100", bold = true, bg = Some("#FFC7CE"))
+      assert(result.contains("Added conditional format"), result)
+      assert(result.contains("priority 1"), result)
+
+      readBackRules(out) match
+        case Vector(CfRule.CellIs(CfOperator.GreaterThan, "100", None, Some(dxf), priority, _)) =>
+          assertEquals(priority, 1)
+          assertEquals(dxf.fill, Some(Fill.Solid(Color.Rgb(0xffffc7ce))))
+          assertEquals(dxf.font.flatMap(_.bold), Some(true))
+        case other => fail(s"Expected one CellIs rule, got $other")
+    }
+  }
+
+  test("cf add: cellIs operator aliases (gt) map to the same operator") {
+    withTempOutput { out =>
+      addRule(out, "cellIs:gt:50", bold = true)
+      readBackRules(out) match
+        case Vector(CfRule.CellIs(CfOperator.GreaterThan, "50", None, _, _, _)) => ()
+        case other => fail(s"Expected GreaterThan from 'gt', got $other")
+    }
+  }
+
+  test("cf add: between round-trips both bounds") {
+    withTempOutput { out =>
+      addRule(out, "between:10:100", bg = Some("yellow"))
+      readBackRules(out) match
+        case Vector(CfRule.CellIs(CfOperator.Between, "10", Some("100"), Some(_), _, _)) => ()
+        case other => fail(s"Expected Between rule, got $other")
+    }
+  }
+
+  test("cf add: expression keeps colons inside the formula") {
+    withTempOutput { out =>
+      addRule(out, "expression:SUM(A1:A10)>100", fg = Some("#9C0006"))
+      readBackRules(out) match
+        case Vector(CfRule.Expression(formula, Some(dxf), _, _)) =>
+          assertEquals(formula, "SUM(A1:A10)>100")
+          assertEquals(dxf.font.flatMap(_.color), Some(Color.Rgb(0xff9c0006)))
+        case other => fail(s"Expected Expression rule, got $other")
+    }
+  }
+
+  test("cf add: 3-point colorScale round-trips colors with percentile mid") {
+    withTempOutput { out =>
+      addRule(out, "colorScale:red:white:green")
+      readBackRules(out) match
+        case Vector(CfRule.ColorScale(min, Some(mid), max, _)) =>
+          assertEquals(min.cfvo, Cfvo.Min)
+          assertEquals(min.color, Color.Rgb(0xffff0000))
+          assertEquals(mid.cfvo, Cfvo.Percentile(BigDecimal(50)))
+          assertEquals(mid.color, Color.Rgb(0xffffffff))
+          assertEquals(max.cfvo, Cfvo.Max)
+          assertEquals(max.color, Color.Rgb(0xff008000))
+        case other => fail(s"Expected 3-point ColorScale, got $other")
+    }
+  }
+
+  test("cf add: 2-point colorScale") {
+    withTempOutput { out =>
+      addRule(out, "colorScale:#FFFFFF:#4472C4")
+      readBackRules(out) match
+        case Vector(CfRule.ColorScale(_, None, _, _)) => ()
+        case other => fail(s"Expected 2-point ColorScale, got $other")
+    }
+  }
+
+  test("cf add: dataBar round-trips color") {
+    withTempOutput { out =>
+      addRule(out, "dataBar:#638EC6")
+      readBackRules(out) match
+        case Vector(CfRule.DataBar(Cfvo.Min, Cfvo.Max, color, _, _)) =>
+          assertEquals(color, Color.Rgb(0xff638ec6))
+        case other => fail(s"Expected DataBar, got $other")
+    }
+  }
+
+  test("cf add: top10 with percent and bottom10") {
+    withTempOutput { out =>
+      val wb = Workbook(Sheet("Test"))
+      WriteCommands
+        .cfAdd(
+          wb,
+          Some(wb.sheets.head),
+          "A1:A10",
+          "top10:5:percent",
+          true,
+          false,
+          false,
+          false,
+          None,
+          None,
+          out,
+          config
+        )
+        .unsafeRunSync()
+      val wb2 = ExcelIO.instance[IO].read(out).unsafeRunSync()
+      WriteCommands
+        .cfAdd(
+          wb2,
+          Some(wb2.sheets.head),
+          "B1:B10",
+          "bottom10:3",
+          true,
+          false,
+          false,
+          false,
+          None,
+          None,
+          out,
+          config
+        )
+        .unsafeRunSync()
+
+      readBackRules(out) match
+        case Vector(
+              CfRule.Top10(5, true, false, Some(_), p1, _),
+              CfRule.Top10(3, false, true, Some(_), p2, _)
+            ) =>
+          assertEquals(p1, 1)
+          assertEquals(p2, 2)
+        case other => fail(s"Expected top10 + bottom10 rules, got $other")
+    }
+  }
+
+  test("cf add: text contains keeps colons in the needle") {
+    withTempOutput { out =>
+      addRule(out, "text:contains:status: overdue", bold = true)
+      readBackRules(out) match
+        case Vector(CfRule.Text(CfTextOp.Contains, needle, Some(_), _, _)) =>
+          assertEquals(needle, "status: overdue")
+        case other => fail(s"Expected Text contains rule, got $other")
+    }
+  }
+
+  // ========== auto-priority ==========
+
+  test("cf add: two adds stamp priorities 1 then 2 (auto-priority)") {
+    withTempOutput { out =>
+      val wb = Workbook(Sheet("Test"))
+      addRule(out, "cellIs:greaterThan:100", bold = true, wb = wb)
+      val wb2 = ExcelIO.instance[IO].read(out).unsafeRunSync()
+      val result2 =
+        WriteCommands
+          .cfAdd(
+            wb2,
+            Some(wb2.sheets.head),
+            "A1:A10",
+            "cellIs:lessThan:0",
+            false,
+            false,
+            false,
+            false,
+            Some("#FFC7CE"),
+            None,
+            out,
+            config
+          )
+          .unsafeRunSync()
+      assert(result2.contains("priority 2"), result2)
+
+      val priorities = readBackRules(out).flatMap(CfRule.priorityOf)
+      assertEquals(priorities, Vector(1, 2))
+    }
+  }
+
+  // ========== malformed input → clean errors ==========
+
+  test("cf add: unknown rule family yields clean error listing families") {
+    val msg = addRuleError("blink:fast", bold = true)
+    assert(msg.contains("Unknown rule family"), msg)
+    assert(msg.contains("cellIs"), msg)
+  }
+
+  test("cf add: unknown cellIs operator yields clean error") {
+    val msg = addRuleError("cellIs:sortaBigger:100", bold = true)
+    assert(msg.contains("sortaBigger"), msg)
+    assert(msg.contains("greaterThan"), msg)
+  }
+
+  test("cf add: highlight rule without any format flag yields clean error") {
+    val msg = addRuleError("cellIs:greaterThan:100")
+    assert(msg.contains("--bold"), msg)
+  }
+
+  test("cf add: colorScale with format flags yields clean error") {
+    val msg = addRuleError("colorScale:red:green", bold = true)
+    assert(msg.contains("inline colors"), msg)
+  }
+
+  test("cf add: colorScale with bad color yields clean error") {
+    val msg = addRuleError("colorScale:red:notacolor")
+    assert(msg.contains("notacolor"), msg)
+  }
+
+  test("cf add: top10 with non-numeric rank yields clean error") {
+    val msg = addRuleError("top10:many", bold = true)
+    assert(msg.contains("positive integer"), msg)
+  }
+
+  test("cf add: malformed cellIs (missing value) yields usage error") {
+    val msg = addRuleError("cellIs:greaterThan", bold = true)
+    assert(msg.contains("cellIs:<operator>:<value>"), msg)
+  }
+
+  // ========== cf list ==========
+
+  test("cf list: renders typed rules with priorities") {
+    withTempOutput { out =>
+      addRule(out, "cellIs:greaterThan:100", bold = true)
+      val wb = ExcelIO.instance[IO].read(out).unsafeRunSync()
+      val listing = WriteCommands.cfList(wb, Some(wb.sheets.head)).unsafeRunSync()
+      assert(listing.contains("A1:A10"), listing)
+      assert(listing.contains("cellIs greaterThan 100"), listing)
+      assert(listing.contains("priority 1"), listing)
+    }
+  }
+
+  test("cf list: empty sheet reports no conditional formatting") {
+    val wb = Workbook(Sheet("Test"))
+    val listing = WriteCommands.cfList(wb, Some(wb.sheets.head)).unsafeRunSync()
+    assert(listing.contains("No conditional formatting"), listing)
+  }
+
+  // ========== batch op ==========
+
+  test("batch: cf op parses (GH-324)") {
+    val json =
+      """[{"op":"cf","range":"A1:A10","rule":"cellIs:greaterThan:100","bold":true,"bg":"#FFC7CE"}]"""
+    val result = BatchParser.parseBatchJson(json)
+    assert(result.isRight, s"Should parse: $result")
+    assertEquals(result.toOption.get.warnings, Vector.empty[String])
+  }
+
+  test("batch: cf op applies rule with dxf and auto-priority") {
+    withTempOutput { out =>
+      val json =
+        """[
+          {"op":"cf","range":"A1:A10","rule":"cellIs:greaterThan:100","bold":true,"bg":"#FFC7CE"},
+          {"op":"cf","range":"B1:B10","rule":"dataBar:#638EC6"}
+        ]"""
+      val jsonPath = Files.createTempFile("cf-batch", ".json")
+      Files.writeString(jsonPath, json)
+      try
+        val wb = Workbook(Sheet("Test"))
+        val result =
+          WriteCommands
+            .batch(wb, Some(wb.sheets.head), jsonPath.toString, out, config)
+            .unsafeRunSync()
+        assert(result.contains("Applied 2 operations"), result)
+
+        readBackRules(out) match
+          case Vector(
+                CfRule.CellIs(CfOperator.GreaterThan, "100", None, Some(dxf), 1, _),
+                CfRule.DataBar(_, _, _, _, 2)
+              ) =>
+            assertEquals(dxf.fill, Some(Fill.Solid(Color.Rgb(0xffffc7ce))))
+          case other => fail(s"Expected CellIs + DataBar with priorities 1,2, got $other")
+      finally Files.deleteIfExists(jsonPath)
+    }
+  }
+
+  test("batch: cf with malformed rule fails cleanly") {
+    val ops = BatchParser
+      .parseBatchJson("""[{"op":"cf","range":"A1:A10","rule":"nope:1","bold":true}]""")
+      .toOption
+      .get
+      .ops
+    val sheet = Sheet("Test")
+    val wb = Workbook(sheet)
+    val result = BatchParser.applyBatchOperations(wb, Some(sheet), ops).attempt.unsafeRunSync()
+    assert(result.isLeft)
+    assert(
+      result.swap.toOption.get.getMessage.contains("Unknown rule family"),
+      result.swap.toOption.get.getMessage
+    )
+  }

--- a/xl-cli/test/src/com/tjclp/xl/cli/MainSpec.scala
+++ b/xl-cli/test/src/com/tjclp/xl/cli/MainSpec.scala
@@ -904,7 +904,7 @@ class MainSpec extends CatsEffectSuite:
     assert(result.isRight, s"Should parse: $result")
     val op = result.toOption.get.ops.head
     op match
-      case BatchOp.PutFormulaDragging(range, formula, from) =>
+      case BatchOp.PutFormulaDragging(range, formula, from, None) =>
         assertEquals(range, "B2:B10")
         assertEquals(formula, "=SUM($A$1:A2)")
         assertEquals(from, "B2")
@@ -918,7 +918,7 @@ class MainSpec extends CatsEffectSuite:
     assert(result.isRight, s"Should parse: $result")
     val op = result.toOption.get.ops.head
     op match
-      case BatchOp.PutFormulas(range, formulas) =>
+      case BatchOp.PutFormulas(range, formulas, None) =>
         assertEquals(range, "B2:B4")
         assertEquals(formulas, Vector("=A2*2", "=A3*2", "=A4*2"))
       case other => fail(s"Expected PutFormulas, got $other")
@@ -931,7 +931,7 @@ class MainSpec extends CatsEffectSuite:
     assert(result.isRight, s"Should parse: $result")
     val op = result.toOption.get.ops.head
     op match
-      case BatchOp.PutFormula(ref, formula) =>
+      case BatchOp.PutFormula(ref, formula, None) =>
         assertEquals(ref, "D14")
         assertEquals(formula, "=SUM(D5:D12)")
       case other => fail(s"Expected PutFormula, got $other")
@@ -944,7 +944,7 @@ class MainSpec extends CatsEffectSuite:
     assert(result.isRight, s"Should parse: $result")
     val op = result.toOption.get.ops.head
     op match
-      case BatchOp.PutFormulaDragging(range, formula, from) =>
+      case BatchOp.PutFormulaDragging(range, formula, from, None) =>
         assertEquals(range, "B2:B10")
         assertEquals(formula, "=A2*2")
         assertEquals(from, "B2")
@@ -958,9 +958,138 @@ class MainSpec extends CatsEffectSuite:
     assert(result.isRight, s"Should parse: $result")
     val op = result.toOption.get.ops.head
     op match
-      case BatchOp.PutFormula(_, formula) =>
+      case BatchOp.PutFormula(_, formula, _) =>
         assertEquals(formula, "=B1")
       case other => fail(s"Expected PutFormula with 'value' winning, got $other")
+  }
+
+  test("parseBatchJson: putf accepts 'format' without unknown-prop warning (GH-356)") {
+    val json = """[{"op": "putf", "ref": "C1", "value": "=A1*2", "format": "#,##0.0"}]"""
+    val result = BatchParser.parseBatchJson(json)
+
+    assert(result.isRight, s"Should parse: $result")
+    assertEquals(
+      result.toOption.get.warnings,
+      Vector.empty[String],
+      "format is a known putf property and must not be warned about"
+    )
+  }
+
+  test("parseBatchJson: putf with custom format code creates PutFormula with NumFmt (GH-356)") {
+    val json = """[{"op": "putf", "ref": "C1", "value": "=A1*2", "format": "#,##0.0"}]"""
+    val result = BatchParser.parseBatchJson(json)
+
+    assert(result.isRight, s"Should parse: $result")
+    result.toOption.get.ops.head match
+      case BatchOp.PutFormula(ref, formula, Some(NumFmt.Custom(code))) =>
+        assertEquals(ref, "C1")
+        assertEquals(formula, "=A1*2")
+        assertEquals(code, "#,##0.0")
+      case other => fail(s"Expected PutFormula with Custom format, got $other")
+  }
+
+  test("parseBatchJson: putf named format applies to dragging variant (GH-356)") {
+    val json =
+      """[{"op": "putf", "ref": "B2:B10", "value": "=A2*2", "from": "B2", "format": "percent"}]"""
+    val result = BatchParser.parseBatchJson(json)
+
+    assert(result.isRight, s"Should parse: $result")
+    result.toOption.get.ops.head match
+      case BatchOp.PutFormulaDragging(range, formula, from, Some(NumFmt.Percent)) =>
+        assertEquals(range, "B2:B10")
+        assertEquals(formula, "=A2*2")
+        assertEquals(from, "B2")
+      case other => fail(s"Expected PutFormulaDragging with Percent format, got $other")
+  }
+
+  test("parseBatchJson: putf format applies to 'values' array variant (GH-356)") {
+    val json =
+      """[{"op": "putf", "ref": "B2:B4", "values": ["=A2*2", "=A3*2", "=A4*2"], "format": "currency"}]"""
+    val result = BatchParser.parseBatchJson(json)
+
+    assert(result.isRight, s"Should parse: $result")
+    result.toOption.get.ops.head match
+      case BatchOp.PutFormulas(range, formulas, Some(NumFmt.Currency)) =>
+        assertEquals(range, "B2:B4")
+        assertEquals(formulas.length, 3)
+      case other => fail(s"Expected PutFormulas with Currency format, got $other")
+  }
+
+  test("batch: putf with format writes formula and numFmt style (GH-356)") {
+    val sheet = Sheet("Test").put(ref"A1", CellValue.Number(BigDecimal(10)))
+    val wb = Workbook(Vector(sheet))
+
+    val ops = Vector(
+      BatchOp.PutFormula("C1", "=A1*2", Some(NumFmt.Custom("#,##0.0")))
+    )
+
+    BatchParser.applyBatchOperations(wb, Some(sheet), ops).map { updatedWb =>
+      val updatedSheet = updatedWb.sheets.head
+
+      updatedSheet.cells.get(ref"C1").map(_.value) match
+        case Some(CellValue.Formula(f, _)) => assertEquals(f, "A1*2")
+        case other => fail(s"Expected Formula at C1, got $other")
+
+      val style = updatedSheet.getCellStyle(ref"C1")
+      assert(style.isDefined, "numFmt style should be set on the formula cell")
+      assertEquals(style.get.numFmt, NumFmt.Custom("#,##0.0"))
+    }
+  }
+
+  test("batch: putf dragging with format applies numFmt to every cell (GH-356)") {
+    val sheet = Sheet("Test")
+      .put(ref"A1", CellValue.Number(BigDecimal(1)))
+      .put(ref"A2", CellValue.Number(BigDecimal(2)))
+    val wb = Workbook(Vector(sheet))
+
+    val ops = Vector(
+      BatchOp.PutFormulaDragging("B1:B2", "=A1*2", "B1", Some(NumFmt.Percent))
+    )
+
+    BatchParser.applyBatchOperations(wb, Some(sheet), ops).map { updatedWb =>
+      val updatedSheet = updatedWb.sheets.head
+      List(ref"B1", ref"B2").foreach { r =>
+        updatedSheet.cells.get(r).map(_.value) match
+          case Some(CellValue.Formula(_, _)) => ()
+          case other => fail(s"Expected Formula at ${r.toA1}, got $other")
+        val style = updatedSheet.getCellStyle(r)
+        assert(style.isDefined, s"numFmt style should be set at ${r.toA1}")
+        assertEquals(style.get.numFmt, NumFmt.Percent)
+      }
+    }
+  }
+
+  test("batch: putf explicit formulas with format applies numFmt to every cell (GH-356)") {
+    val sheet = Sheet("Test")
+    val wb = Workbook(Vector(sheet))
+
+    val ops = Vector(
+      BatchOp.PutFormulas("B1:B2", Vector("=1+1", "=2+2"), Some(NumFmt.Currency))
+    )
+
+    BatchParser.applyBatchOperations(wb, Some(sheet), ops).map { updatedWb =>
+      val updatedSheet = updatedWb.sheets.head
+      List(ref"B1", ref"B2").foreach { r =>
+        val style = updatedSheet.getCellStyle(r)
+        assert(style.isDefined, s"numFmt style should be set at ${r.toA1}")
+        assertEquals(style.get.numFmt, NumFmt.Currency)
+      }
+    }
+  }
+
+  test("batch: putf without format leaves existing cell style untouched (GH-356)") {
+    val ops = BatchParser
+      .parseBatchJson("""[{"op": "putf", "ref": "C1", "value": "=A1*2"}]""")
+      .toOption
+      .get
+      .ops
+    val sheet = Sheet("Test")
+    val wb = Workbook(Vector(sheet))
+
+    BatchParser.applyBatchOperations(wb, Some(sheet), ops).map { updatedWb =>
+      val updatedSheet = updatedWb.sheets.head
+      assertEquals(updatedSheet.getCellStyle(ref"C1"), None)
+    }
   }
 
   test("formatSummary: produces expected summary lines") {

--- a/xl-cli/test/src/com/tjclp/xl/cli/RasterizerListSpec.scala
+++ b/xl-cli/test/src/com/tjclp/xl/cli/RasterizerListSpec.scala
@@ -1,0 +1,113 @@
+package com.tjclp.xl.cli
+
+import munit.FunSuite
+
+/**
+ * Tests for the pure formatting core of `xl rasterizers` (GH-359).
+ *
+ * `Main.renderRasterizerTable` receives pre-computed availability, so these tests exercise every
+ * environment (JVM, native binary, nothing installed) without subprocesses or network.
+ */
+class RasterizerListSpec extends FunSuite:
+
+  private def render(
+    batik: Boolean = false,
+    cairo: Boolean = false,
+    rsvg: Boolean = false,
+    resvg: Boolean = false,
+    imageMagick: Boolean = false,
+    imageMagickDiag: String = "ImageMagick not found",
+    nativeImage: Boolean = false
+  ): (String, Boolean) =
+    Main.renderRasterizerTable(
+      batikAvail = batik,
+      cairoAvail = cairo,
+      rsvgAvail = rsvg,
+      resvgAvail = resvg,
+      imageMagickAvail = imageMagick,
+      imageMagickDiag = imageMagickDiag,
+      nativeImage = nativeImage
+    )
+
+  private def lineFor(output: String, backend: String): String =
+    output.linesIterator.find(_.startsWith(backend)).getOrElse("")
+
+  test("table lists backends in probe order, ImageMagick last (opt-in only)") {
+    val (out, _) = render(batik = true)
+    val positions =
+      List("batik", "cairosvg", "rsvg-convert", "resvg", "imagemagick").map(out.indexOf)
+    assert(positions.forall(_ >= 0), s"every backend must appear: $positions\n$out")
+    assertEquals(positions, positions.sorted, s"rows must follow the probe order:\n$out")
+  }
+
+  test("hasWorking is true when any backend is available") {
+    assert(render(batik = true)._2)
+    assert(render(cairo = true)._2)
+    assert(render(resvg = true)._2)
+    assert(
+      render(
+        imageMagick = true,
+        imageMagickDiag = "ImageMagick 7 (magick) available, SVG delegate: rsvg"
+      )._2
+    )
+  }
+
+  test("available Batik row shows the built-in default") {
+    val (out, _) = render(batik = true)
+    val row = lineFor(out, "batik")
+    assert(row.contains("available"), s"batik row: $row")
+    assert(row.contains("Built-in default"), s"batik row: $row")
+  }
+
+  test("Batik row explains the native binary when unavailable on native (GH-359)") {
+    val (out, _) = render(nativeImage = true)
+    val row = lineFor(out, "batik")
+    assert(row.contains("unavailable"), s"batik row: $row")
+    assert(row.toLowerCase.contains("native"), s"batik row must name the native binary: $row")
+  }
+
+  test("Batik row does not claim native binary when AWT is merely absent on a JVM") {
+    val (out, _) = render(nativeImage = false)
+    val row = lineFor(out, "batik")
+    assert(row.contains("unavailable"), s"batik row: $row")
+    assert(!row.toLowerCase.contains("native"), s"batik row must stay generic on the JVM: $row")
+  }
+
+  test("nothing installed: hasWorking=false, warning and install one-liners printed") {
+    val (out, hasWorking) = render()
+    assert(!hasWorking)
+    assert(out.contains("WARNING"), s"warning expected:\n$out")
+    assert(out.contains("pip install cairosvg"), "cairosvg one-liner")
+    assert(out.contains("apt install librsvg2-bin"), "rsvg-convert one-liner")
+    assert(out.contains("linebender/resvg/releases"), "resvg prebuilt release pointer")
+    assert(out.contains("--rasterizer imagemagick"), "ImageMagick opt-in reminder")
+  }
+
+  test("nothing installed on native binary: warning names Batik as by-design dead (GH-359)") {
+    val (out, hasWorking) = render(nativeImage = true)
+    assert(!hasWorking)
+    assert(out.contains("native binary"), s"native wording expected:\n$out")
+    assert(out.contains("never work"), s"by-design wording expected:\n$out")
+  }
+
+  test("something installed: success footer instead of warning") {
+    val (out, hasWorking) = render(batik = true)
+    assert(hasWorking)
+    assert(out.contains("At least one rasterizer is available"))
+    assert(!out.contains("WARNING"))
+  }
+
+  test("ImageMagick with missing SVG delegate reports broken, not missing") {
+    val (out, _) = render(
+      imageMagick = false,
+      imageMagickDiag = "ImageMagick 7 found but SVG delegate 'rsvg' is missing"
+    )
+    val row = lineFor(out, "imagemagick")
+    assert(row.contains("broken"), s"imagemagick row: $row")
+  }
+
+  test("ImageMagick not installed reports missing") {
+    val (out, _) = render()
+    val row = lineFor(out, "imagemagick")
+    assert(row.contains("missing"), s"imagemagick row: $row")
+  }

--- a/xl-cli/test/src/com/tjclp/xl/cli/StreamingWriteSpec.scala
+++ b/xl-cli/test/src/com/tjclp/xl/cli/StreamingWriteSpec.scala
@@ -865,3 +865,37 @@ class StreamingWriteSpec extends FunSuite:
       Files.deleteIfExists(outputPath)
       Files.deleteIfExists(jsonPath)
   }
+
+  test("streaming batch: putf with format writes formula and numFmt (GH-356)") {
+    val sourcePath = tempXlsx()
+    val outputPath = tempXlsx()
+    val jsonPath = tempJson("""[{"op":"putf","ref":"C1","value":"=A1*2","format":"#,##0.0"}]""")
+    try
+      val wb = Workbook(Sheet("Test").put(ARef.from0(0, 0), CellValue.Number(BigDecimal("10"))))
+      ExcelIO.instance[IO].write(wb, sourcePath).unsafeRunSync()
+
+      val result = StreamingWriteCommands
+        .batch(sourcePath, outputPath, Some("Test"), jsonPath.toString)
+        .unsafeRunSync()
+
+      assert(result.contains("Saved (streaming)"), result)
+
+      val imported = ExcelIO.instance[IO].read(outputPath).unsafeRunSync()
+      val sheet = imported.sheets.head
+      val c1 = sheet.cells.get(ARef.from0(2, 0))
+
+      c1.map(_.value) match
+        case Some(CellValue.Formula(f, _)) => assertEquals(f, "A1*2")
+        case other => fail(s"C1: expected Formula(A1*2), got $other")
+
+      val styleOpt = c1.flatMap(_.styleId).flatMap(sheet.styleRegistry.get)
+      assert(styleOpt.isDefined, "C1 should carry a style with the numFmt")
+      assertEquals(
+        styleOpt.map(_.numFmt),
+        Some(com.tjclp.xl.styles.numfmt.NumFmt.Custom("#,##0.0"))
+      )
+    finally
+      Files.deleteIfExists(sourcePath)
+      Files.deleteIfExists(outputPath)
+      Files.deleteIfExists(jsonPath)
+  }

--- a/xl-cli/test/src/com/tjclp/xl/cli/output/JsonRendererSpec.scala
+++ b/xl-cli/test/src/com/tjclp/xl/cli/output/JsonRendererSpec.scala
@@ -1,0 +1,274 @@
+package com.tjclp.xl.cli.output
+
+import cats.effect.IO
+import munit.CatsEffectSuite
+
+import com.tjclp.xl.{*, given}
+import com.tjclp.xl.addressing.CellRange
+import com.tjclp.xl.cells.CellValue
+import com.tjclp.xl.cli.ViewFormat
+import com.tjclp.xl.cli.commands.ReadCommands
+import com.tjclp.xl.macros.ref
+
+/**
+ * GH-357: JSON output carries a dedicated "formula" field for formula cells.
+ *
+ * Formula cells always render as {ref, type: "formula", formula, value, formatted}: `formula` holds
+ * the "=…" expression while value/formatted hold the computed (evalFormulas) or cached value —
+ * null/"" when uncached. --formulas no longer swaps the JSON payload (it only affects non-JSON
+ * display formats); non-formula cells keep the historical {ref, type, value, formatted} shape
+ * byte-for-byte.
+ */
+class JsonRendererSpec extends CatsEffectSuite:
+
+  private val sheet = Sheet("Data")
+    .put(ref"A1", CellValue.Number(BigDecimal(42)))
+    .put(ref"B1", CellValue.Text("Revenue"))
+    .put(ref"C1", CellValue.Formula("=A1*2", Some(CellValue.Number(BigDecimal(84)))))
+    .put(ref"D1", CellValue.Formula("=A1+1")) // uncached: no value until eval
+    .put(ref"E1", CellValue.Bool(true))
+
+  private val row1 = CellRange(ref"A1", ref"F1") // F1 unset → empty cell
+
+  private def countOccurrences(haystack: String, needle: String): Int =
+    haystack.split(java.util.regex.Pattern.quote(needle), -1).length - 1
+
+  // ========== rows path: formula cells ==========
+
+  test("rows: cached formula carries formula, cached value, and formatted value") {
+    val out = JsonRenderer.renderRange(sheet, row1)
+    assert(
+      out.contains(
+        """{"ref": "C1", "type": "formula", "formula": "=A1*2", "value": 84, "formatted": "84"}"""
+      ),
+      s"missing formula cell shape:\n$out"
+    )
+  }
+
+  test("rows: uncached formula renders null value and blank formatted") {
+    val out = JsonRenderer.renderRange(sheet, row1)
+    assert(
+      out.contains(
+        """{"ref": "D1", "type": "formula", "formula": "=A1+1", "value": null, "formatted": ""}"""
+      ),
+      s"missing uncached formula shape:\n$out"
+    )
+  }
+
+  test("rows: cache rewrite (--eval pre-pass style) is reflected in value") {
+    val rewritten =
+      sheet.put(ref"C1", CellValue.Formula("=A1*2", Some(CellValue.Number(BigDecimal(999)))))
+    val out = JsonRenderer.renderRange(rewritten, row1)
+    assert(
+      out.contains(
+        """{"ref": "C1", "type": "formula", "formula": "=A1*2", "value": 999, "formatted": "999"}"""
+      ),
+      s"cache rewrite not reflected:\n$out"
+    )
+  }
+
+  test("rows: text-typed cached value renders as a JSON string") {
+    val textCached =
+      Sheet("Data").put(ref"A1", CellValue.Formula("=B1", Some(CellValue.Text("Revenue"))))
+    val out = JsonRenderer.renderRange(textCached, CellRange(ref"A1", ref"A1"))
+    assert(
+      out.contains(
+        """{"ref": "A1", "type": "formula", "formula": "=B1", "value": "Revenue", "formatted": "Revenue"}"""
+      ),
+      s"typed cached value not rendered:\n$out"
+    )
+  }
+
+  test("rows: renderer-level evalFormulas computes values and keeps the formula field") {
+    val out = JsonRenderer.renderRange(sheet, row1, evalFormulas = true)
+    assert(
+      out.contains(
+        """{"ref": "D1", "type": "formula", "formula": "=A1+1", "value": 43, "formatted": "43"}"""
+      ),
+      s"evaluated uncached formula not rendered:\n$out"
+    )
+    assert(
+      out.contains(
+        """{"ref": "C1", "type": "formula", "formula": "=A1*2", "value": 84, "formatted": "84"}"""
+      ),
+      s"evaluated cached formula not rendered:\n$out"
+    )
+  }
+
+  test("rows: evalFormulas failure renders the error token as value and formatted") {
+    val errSheet = Sheet("Data").put(ref"A1", CellValue.Formula("=NOSUCHFN(1)"))
+    val out =
+      JsonRenderer.renderRange(errSheet, CellRange(ref"A1", ref"A1"), evalFormulas = true)
+    assert(out.contains(""""type": "formula""""), s"formula type lost on error:\n$out")
+    assert(out.contains(""""formula": "=NOSUCHFN(1)""""), s"formula field lost on error:\n$out")
+    assert(out.contains(""""value": "#"""), s"error token missing from value:\n$out")
+    assert(out.contains(""""formatted": "#"""), s"error token missing from formatted:\n$out")
+  }
+
+  test("rows: expression stored without leading = is normalized in the formula field") {
+    val bare =
+      Sheet("Data").put(ref"A1", CellValue.Formula("1+1", Some(CellValue.Number(BigDecimal(2)))))
+    val out = JsonRenderer.renderRange(bare, CellRange(ref"A1", ref"A1"))
+    assert(out.contains(""""formula": "=1+1""""), s"expression not normalized:\n$out")
+  }
+
+  test("rows: --formulas flag does not change JSON output") {
+    val withFlag = JsonRenderer.renderRange(sheet, row1, showFormulas = true)
+    val withoutFlag = JsonRenderer.renderRange(sheet, row1, showFormulas = false)
+    assertEquals(withFlag, withoutFlag, "JSON must be identical regardless of --formulas")
+  }
+
+  // ========== rows path: non-formula cells unchanged ==========
+
+  test("rows: non-formula cells keep the historical {ref, type, value, formatted} shape") {
+    val out = JsonRenderer.renderRange(sheet, row1)
+    assert(
+      out.contains("""{"ref": "A1", "type": "number", "value": 42, "formatted": "42"}"""),
+      s"number cell changed:\n$out"
+    )
+    assert(
+      out.contains(
+        """{"ref": "B1", "type": "text", "value": "Revenue", "formatted": "Revenue"}"""
+      ),
+      s"text cell changed:\n$out"
+    )
+    assert(
+      out.contains("""{"ref": "E1", "type": "boolean", "value": true, "formatted": "TRUE"}"""),
+      s"boolean cell changed:\n$out"
+    )
+    assert(
+      out.contains("""{"ref": "F1", "type": "empty", "value": null, "formatted": ""}"""),
+      s"empty cell changed:\n$out"
+    )
+    assertEquals(
+      countOccurrences(out, "\"formula\":"),
+      2,
+      s"only the two formula cells may carry a formula field:\n$out"
+    )
+  }
+
+  // ========== records path (--header-row) ==========
+
+  private val recordsSheet = Sheet("Data")
+    .put(ref"A1", CellValue.Text("Qty"))
+    .put(ref"B1", CellValue.Text("Double"))
+    .put(ref"C1", CellValue.Text("Plus"))
+    .put(ref"A2", CellValue.Number(BigDecimal(42)))
+    .put(ref"B2", CellValue.Formula("=A2*2", Some(CellValue.Number(BigDecimal(84)))))
+    .put(ref"C2", CellValue.Formula("=A2+1")) // uncached
+
+  private val recordsRange = CellRange(ref"A1", ref"C2")
+
+  test("records: formula cells project the cached value, null when uncached") {
+    val out = JsonRenderer.renderRange(recordsSheet, recordsRange, headerRow = Some(1))
+    assert(
+      out.contains("""{"Qty": 42, "Double": 84, "Plus": null}"""),
+      s"records must carry cached values, not expressions:\n$out"
+    )
+  }
+
+  test("records: evalFormulas computes values for uncached formulas") {
+    val out = JsonRenderer.renderRange(
+      recordsSheet,
+      recordsRange,
+      headerRow = Some(1),
+      evalFormulas = true
+    )
+    assert(
+      out.contains("""{"Qty": 42, "Double": 84, "Plus": 43}"""),
+      s"records must carry evaluated values:\n$out"
+    )
+  }
+
+  test("records: --formulas flag does not change JSON output") {
+    val withFlag =
+      JsonRenderer.renderRange(recordsSheet, recordsRange, showFormulas = true, headerRow = Some(1))
+    val withoutFlag =
+      JsonRenderer.renderRange(
+        recordsSheet,
+        recordsRange,
+        showFormulas = false,
+        headerRow = Some(1)
+      )
+    assertEquals(withFlag, withoutFlag, "records JSON must be identical regardless of --formulas")
+  }
+
+  // ========== end-to-end: view --format json / markdown ==========
+
+  private val wb = Workbook(Vector(sheet))
+
+  private def runView(
+    range: String,
+    format: ViewFormat,
+    showFormulas: Boolean = false,
+    evalFormulas: Boolean = false
+  ): IO[String] =
+    ReadCommands.view(
+      wb,
+      wb.sheets.headOption,
+      range,
+      showFormulas = showFormulas,
+      evalFormulas = evalFormulas,
+      strict = false,
+      limit = 0,
+      format = format,
+      printScale = false,
+      showGridlines = false,
+      showLabels = false,
+      dpi = 96,
+      quality = 90,
+      rasterOutput = None,
+      skipEmpty = false,
+      headerRow = None
+    )
+
+  test("view json: formula cells carry formula and cached value by default") {
+    runView("A1:F1", ViewFormat.Json).map { out =>
+      assert(
+        out.contains(
+          """{"ref": "C1", "type": "formula", "formula": "=A1*2", "value": 84, "formatted": "84"}"""
+        ),
+        s"view json missing formula cell shape:\n$out"
+      )
+    }
+  }
+
+  test("view json: --formulas yields byte-identical output") {
+    for
+      withFlag <- runView("A1:F1", ViewFormat.Json, showFormulas = true)
+      withoutFlag <- runView("A1:F1", ViewFormat.Json)
+    yield assertEquals(withFlag, withoutFlag, "view json must ignore --formulas")
+  }
+
+  test("view json: --eval surfaces computed values") {
+    // ReadCommands pre-evaluates via evaluateSheetFormulas, which replaces Formula cells
+    // with their computed plain values before the renderer runs — so under --eval the
+    // formula field is absent today (type reflects the computed value). Pinned here to
+    // document the boundary of the GH-357 renderer fix.
+    runView("A1:F1", ViewFormat.Json, evalFormulas = true).map { out =>
+      assert(
+        out.contains(""""value": 43"""),
+        s"--eval must surface the computed value of D1 (=A1+1):\n$out"
+      )
+      assert(
+        out.contains(""""value": 84"""),
+        s"--eval must surface the computed value of C1 (=A1*2):\n$out"
+      )
+    }
+  }
+
+  test("view markdown: --formulas still shows expressions (non-JSON formats unchanged)") {
+    for
+      withFlag <- runView("A1:D1", ViewFormat.Markdown, showFormulas = true)
+      withoutFlag <- runView("A1:D1", ViewFormat.Markdown)
+    yield
+      assert(
+        withFlag.contains("=A1*2"),
+        s"markdown --formulas must show the expression:\n$withFlag"
+      )
+      assert(
+        !withoutFlag.contains("=A1*2"),
+        s"markdown without --formulas must show the cached value:\n$withoutFlag"
+      )
+      assert(withoutFlag.contains("84"), s"markdown must show the cached value:\n$withoutFlag")
+  }

--- a/xl-cli/test/src/com/tjclp/xl/cli/raster/RasterizerChainSpec.scala
+++ b/xl-cli/test/src/com/tjclp/xl/cli/raster/RasterizerChainSpec.scala
@@ -116,10 +116,55 @@ class RasterizerChainSpec extends CatsEffectSuite:
     )
   }
 
+  test("NoRasterizerAvailable message points at xl rasterizers (GH-359)") {
+    val error =
+      RasterError.NoRasterizerAvailable(List("Batik", "cairosvg", "rsvg-convert", "resvg"))
+    assert(
+      error.message.contains("xl rasterizers"),
+      s"Should point at the xl rasterizers command: ${error.message}"
+    )
+  }
+
+  test("NoRasterizerAvailable message mentions resvg prebuilt releases (GH-359)") {
+    val error = RasterError.NoRasterizerAvailable(List("Batik"))
+    assert(
+      error.message.contains("releases"),
+      s"Should mention resvg prebuilt release binaries: ${error.message}"
+    )
+  }
+
+  test("NoRasterizerAvailable on the native binary says Batik is unavailable by design (GH-359)") {
+    val error = RasterError.NoRasterizerAvailable(
+      List("Batik", "cairosvg", "rsvg-convert", "resvg"),
+      runningNativeImage = true
+    )
+    assert(error.message.contains("native binary"), s"native wording: ${error.message}")
+    assert(error.message.contains("by design"), s"by-design wording: ${error.message}")
+    assert(error.message.contains("pip install cairosvg"), "install one-liner: cairosvg")
+    assert(error.message.contains("librsvg2-bin"), "install one-liner: rsvg-convert")
+  }
+
+  test("NoRasterizerAvailable on the JVM explains the JAR-vs-native matrix (GH-359)") {
+    val error = RasterError.NoRasterizerAvailable(List("Batik"), runningNativeImage = false)
+    assert(error.message.contains("JAR distribution"), s"jar wording: ${error.message}")
+    assert(
+      !error.message.contains("Running as a native binary"),
+      s"must not claim native on the JVM: ${error.message}"
+    )
+  }
+
   test("RasterizerNotFound message includes name and hint") {
     val error = RasterError.RasterizerNotFound("cairosvg", "Install: pip install cairosvg")
     assert(error.message.contains("cairosvg"), "Should mention rasterizer name")
     assert(error.message.contains("pip install"), "Should include install hint")
+  }
+
+  test("RasterizerNotFound message points at xl rasterizers (GH-359)") {
+    val error = RasterError.RasterizerNotFound("batik", "Batik requires AWT")
+    assert(
+      error.message.contains("xl rasterizers"),
+      s"Should point at the xl rasterizers command: ${error.message}"
+    )
   }
 
   test("FormatNotSupported message includes rasterizer and format") {
@@ -139,6 +184,30 @@ class RasterizerChainSpec extends CatsEffectSuite:
     val error = RasterError.FormatNotSupported("test", RasterFormat.Png)
     assertEquals(error.getMessage, error.message)
     assert(error.isInstanceOf[Exception])
+  }
+
+  // ========== Native-Image Detection Tests (GH-359) ==========
+
+  test("NativeImage.detect: true when Substrate sets imagecode=runtime") {
+    assert(NativeImage.detect(Map("org.graalvm.nativeimage.imagecode" -> "runtime").get))
+  }
+
+  test("NativeImage.detect: false at image build time (imagecode=buildtime)") {
+    // Build-time init runs on a hosting JVM where AWT may exist; only image runtime matters.
+    assert(!NativeImage.detect(Map("org.graalvm.nativeimage.imagecode" -> "buildtime").get))
+  }
+
+  test("NativeImage.detect: true when java.vm.name reports Substrate VM (fallback)") {
+    assert(NativeImage.detect(Map("java.vm.name" -> "Substrate VM").get))
+  }
+
+  test("NativeImage.detect: false on a standard JVM") {
+    assert(!NativeImage.detect(Map("java.vm.name" -> "OpenJDK 64-Bit Server VM").get))
+    assert(!NativeImage.detect(_ => None))
+  }
+
+  test("NativeImage.inNativeImage is false when tests run on the JVM") {
+    assert(!NativeImage.inNativeImage)
   }
 
   // ========== RasterizerChain Configuration Tests ==========


### PR DESCRIPTION
## Summary

W6 — the final 0.13.0 wave. Three worktree-isolated TDD clusters, each adversarially reviewed.

- **#358 (completes the issue)** — `sheet-view`, `tab-color` (with new `theme:<slot>[:<tint>]` color syntax), `page-setup` (incl. the GH-284 fitToPage tri-state), `header-footer` — plus batch-op twins. The issue's acceptance test is in verbatim: the full deliverable finish (gridlines off, zoom 85, tab color, landscape+fit, confidential footer) via ONE batch file, verified by model re-read and raw XML.
- **#324** — `xl cf add --range --rule 'cellIs:greaterThan:100'` + dxf flags, `cf list`, batch `cf` op; colon DSL for all common rule families; priorities auto-stamp through `Sheet.conditionalFormat`.
- **#356** — batch `putf` accepts `format` in all three variants on both in-memory and streaming paths (numFmt merged into the formula cell's style — `Formatted` wraps values, not formulas).
- **#357** — JSON formula cells always carry a dedicated `formula` field; `value`/`formatted` hold the computed/cached value. **Behavioral note**: under `--formulas`, JSON `value` previously held the formula text — that misfeature is the thing fixed; called out in the CHANGELOG. CSV/markdown unchanged.
- **#359** — `NoRasterizerAvailable` now names the probed chain, points at `xl rasterizers`, and detects native-image execution (Batik unavailable by design there); reviewer validated the acceptance criterion on a real GraalVM native build.

## Verification

Reviewers drove the real CLI end-to-end (raw XML assertions for every appearance command, cfRule/dxf inspection, streaming putf format round-trip), proved red-test refutation by restoring pre-fix sources (13/16 JSON tests fail with the old defect shape; 9 compile errors on the raster tests), and one built a GraalVM CE native image to confirm the native-binary diagnostics.

Integrated gates: `checkFormatAll __.sources` ✓, `./mill __.test` 1028/1028 (4,400+ cases), roundtrip corpus 239/239, examples ✓, snippets ✓.

Closes #356
Closes #357
Closes #324
Closes #359
Closes #358

🤖 Generated with [Claude Code](https://claude.com/claude-code)