### PR TITLE
CalcPr full authoring: calcMode, fullCalcOnLoad, calcId (#400)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Full calcPr authoring** (#400): `CalcPr` models `calcMode`
+  (manual/auto/autoNoTable), `fullCalcOnLoad`, and `calcId` alongside the
+  iterate triple — a from-scratch workbook can author the TJC house
+  `<calcPr calcId="191029" calcMode="autoNoTable" iterate="1"/>` exactly,
+  retiring tjc-modeling's last post-write zip patch. Reader populates the
+  new fields; preserved-but-unmodeled attrs (`refMode`, `concurrentCalc`,
+  …) still ride through byte-faithfully, and a `None` field never strips a
+  preserved attribute. Freshly-authored calcPr attributes now emit in
+  deterministic ascending order on both writer backends.
+
 ### Changed
 
 - **Excel error VALUES are first-class evaluation results** (#344): `=1/0`

--- a/xl-core/src/com/tjclp/xl/api.scala
+++ b/xl-core/src/com/tjclp/xl/api.scala
@@ -72,7 +72,7 @@ object api:
   export patch.Patch
 
   // Workbook types
-  export workbooks.{Workbook, WorkbookMetadata, CalcPr}
+  export workbooks.{Workbook, WorkbookMetadata, CalcPr, CalcMode}
 
   // Context types (for surgical modification)
   export context.{SourceContext, SourceFingerprint}

--- a/xl-core/src/com/tjclp/xl/workbooks/CalcPr.scala
+++ b/xl-core/src/com/tjclp/xl/workbooks/CalcPr.scala
@@ -1,14 +1,35 @@
 package com.tjclp.xl.workbooks
 
 /**
- * Workbook calculation properties: the iterative-calculation subset of `<calcPr>` (GH-373).
+ * Workbook calculation mode — OOXML ST_CalcMode, the `calcMode` attribute of `<calcPr>` (GH-400).
  *
- * Professional financial models are routinely circular by design (interest on average debt
- * balances) and ship with iterative calculation enabled; a replica without it opens with circular
- * warnings the original never shows. The model uses friendly names — OOXML CT_CalcPr spells the
- * attributes `iterate` / `iterateCount` / `iterateDelta` and the codec maps between them. Unmodeled
- * calcPr attributes (calcId, fullCalcOnLoad, refMode, ...) are preserved on write and never surface
- * here.
+ * `AutoNoTable` (OOXML `autoNoTable`) recalculates everything EXCEPT data tables — the standard
+ * professional-model setting when sensitivity tables must hold their last computed values instead
+ * of recomputing on every edit. The codec maps cases to the OOXML tokens `manual` / `auto` /
+ * `autoNoTable`; unknown tokens parse to None (a read never fails on them).
+ */
+enum CalcMode derives CanEqual:
+  case Manual, Auto, AutoNoTable
+
+/**
+ * Workbook calculation properties: the modeled subset of `<calcPr>` (GH-373, GH-400).
+ *
+ * Two attribute families with distinct write semantics:
+ *
+ *   - The iterative-calculation triple (GH-373) — `iterativeCalculation` / `maxIterations` /
+ *     `maxChange` — is a coherent authored unit: OOXML spells the attributes `iterate` /
+ *     `iterateCount` / `iterateDelta` and an absent field means the Excel default (100 / 0.001), so
+ *     on write the model is the full truth for these three (a None field emits no attribute and
+ *     removes a stale preserved one). Professional financial models are routinely circular by
+ *     design (interest on average debt balances) and ship with iterative calculation enabled.
+ *   - The independent facts (GH-400) — `calcMode` / `fullCalcOnLoad` / `calcId` — where None means
+ *     "no opinion": nothing is emitted on a scratch build and a preserved attribute rides through
+ *     untouched on a source-backed write. Some(x) overlays x. This is what lets a from-scratch
+ *     build author the TJC house `<calcPr calcId="191029" calcMode="autoNoTable" iterate="1"/>`
+ *     without a post-write zip patch.
+ *
+ * Still-unmodeled calcPr attributes (refMode, concurrentCalc, calcOnSave, ...) are preserved on
+ * write and never surface here.
  *
  * @param iterativeCalculation
  *   True enables bounded iterative evaluation of circular references (`iterate="1"`)
@@ -16,9 +37,19 @@ package com.tjclp.xl.workbooks
  *   Iteration cap (`iterateCount`, Excel default 100 when absent)
  * @param maxChange
  *   Convergence threshold between iterations (`iterateDelta`, Excel default 0.001 when absent)
+ * @param calcMode
+ *   Calculation mode (`calcMode`): manual | auto | autoNoTable; None = not authored
+ * @param fullCalcOnLoad
+ *   Force a full recalculation when the file opens (`fullCalcOnLoad`); None = not authored
+ * @param calcId
+ *   Calculation engine build stamp (`calcId`, e.g. 191029); diff tooling already excludes it. None =
+ *   not authored (scratch builds need none — the LibreOffice precedent)
  */
 final case class CalcPr(
   iterativeCalculation: Boolean = false,
   maxIterations: Option[Int] = None,
-  maxChange: Option[BigDecimal] = None
+  maxChange: Option[BigDecimal] = None,
+  calcMode: Option[CalcMode] = None,
+  fullCalcOnLoad: Option[Boolean] = None,
+  calcId: Option[Int] = None
 )

--- a/xl-core/src/com/tjclp/xl/workbooks/Workbook.scala
+++ b/xl-core/src/com/tjclp/xl/workbooks/Workbook.scala
@@ -409,15 +409,17 @@ final case class Workbook(
     copy(metadata = newMetadata, sourceContext = sourceContext.map(_.markMetadataModified))
 
   /**
-   * Set the workbook's iterative-calculation properties (GH-373), serialized as `<calcPr>`
-   * attributes (`iterate` / `iterateCount` / `iterateDelta`). Unmodeled calcPr attributes of a
-   * source file (calcId, fullCalcOnLoad, refMode, ...) ride through unchanged. Marks metadata
-   * modified so a surgical write regenerates workbook.xml instead of copying the source verbatim
-   * (which would silently drop the change — the GH-294 setActiveSheet precedent).
+   * Set the workbook's calculation properties (GH-373, GH-400), serialized as `<calcPr>`
+   * attributes: the iterate triple (`iterate` / `iterateCount` / `iterateDelta`) plus `calcMode`,
+   * `fullCalcOnLoad` and `calcId`. A None fact field (calcMode / fullCalcOnLoad / calcId) leaves a
+   * source file's preserved attribute untouched; still-unmodeled attributes (refMode,
+   * concurrentCalc, ...) always ride through — see [[CalcPr]] for the per-family semantics. Marks
+   * metadata modified so a surgical write regenerates workbook.xml instead of copying the source
+   * verbatim (which would silently drop the change — the GH-294 setActiveSheet precedent).
    *
-   * Example (the circular-LBO shape: bounded iteration like Excel's UI defaults):
+   * Example (the TJC house shape: sticky data tables plus bounded iteration):
    * {{{
-   * wb.withCalcPr(CalcPr(iterativeCalculation = true, maxIterations = Some(100), maxChange = Some(BigDecimal("0.001"))))
+   * wb.withCalcPr(CalcPr(iterativeCalculation = true, calcMode = Some(CalcMode.AutoNoTable), calcId = Some(191029)))
    * }}}
    */
   def withCalcPr(calcPr: CalcPr): Workbook =
@@ -427,9 +429,10 @@ final case class Workbook(
     )
 
   /**
-   * Clear the modeled iterative-calculation settings (GH-373): the three iterate attributes are
-   * stripped from `<calcPr>` on write while unmodeled attributes (calcId, refMode, ...) survive.
-   * Marks metadata modified (see [[withCalcPr]]).
+   * Clear the modeled calculation settings (GH-373): the three iterate attributes are stripped from
+   * `<calcPr>` on write while every other attribute — the independent facts (calcMode,
+   * fullCalcOnLoad, calcId; a cleared model has no opinion on them, GH-400) and still-unmodeled
+   * attributes (refMode, ...) — survives. Marks metadata modified (see [[withCalcPr]]).
    */
   def removeCalcPr: Workbook =
     copy(

--- a/xl-core/src/com/tjclp/xl/workbooks/WorkbookMetadata.scala
+++ b/xl-core/src/com/tjclp/xl/workbooks/WorkbookMetadata.scala
@@ -15,10 +15,11 @@ import com.tjclp.xl.styles.color.ThemePalette
  *   Read from workbookPr and preserved on write; DateTime cells are serialized with the matching
  *   epoch (see `CellValue.dateTimeToExcelSerial(dt, date1904)`).
  * @param calcPr
- *   Iterative-calculation settings of `<calcPr>` (GH-373). None reflects a file whose calcPr
- *   carries no iterate attributes (or has no calcPr at all); unmodeled calcPr attributes (calcId,
- *   fullCalcOnLoad, refMode, ...) ride through on write either way. Author via
- *   `Workbook.withCalcPr` so surgical writes see the change.
+ *   Modeled `<calcPr>` settings (GH-373, GH-400): the iterate triple plus calcMode / fullCalcOnLoad
+ *   / calcId. None reflects a file whose calcPr carries none of the modeled attributes (or has no
+ *   calcPr at all); still-unmodeled attributes (refMode, concurrentCalc, ...) ride through on write
+ *   either way. Author via `Workbook.withCalcPr` so surgical writes see the change; see [[CalcPr]]
+ *   for the per-family write semantics.
  */
 final case class WorkbookMetadata(
   creator: Option[String] = None,

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/Workbook.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/Workbook.scala
@@ -11,7 +11,7 @@ private val defaultWorkbookScope =
   NamespaceBinding(null, nsSpreadsheetML, NamespaceBinding("r", nsRelationships, TopScope))
 import com.tjclp.xl.addressing.SheetName
 import com.tjclp.xl.api.Workbook
-import com.tjclp.xl.workbooks.{CalcPr, DefinedName}
+import com.tjclp.xl.workbooks.{CalcMode, CalcPr, DefinedName}
 
 /**
  * Sheet reference in workbook.xml
@@ -82,7 +82,7 @@ case class OoxmlWorkbook(
    */
   def date1904: Boolean = OoxmlWorkbook.parseDate1904(workbookPr)
 
-  /** The typed iterative-calculation settings of the raw `<calcPr>` element (GH-373). */
+  /** The typed modeled settings of the raw `<calcPr>` element (GH-373, GH-400). */
   def calcPrSettings: Option[CalcPr] = OoxmlWorkbook.parseCalcPr(calcPr)
 
   /**
@@ -293,8 +293,8 @@ object OoxmlWorkbook extends XmlReadable[OoxmlWorkbook]:
           // GH-294: fresh workbooks always ship bookViews/activeTab (Excel always writes bookViews)
           bookViews = buildBookViews(None, clampActiveTab(wb.activeSheetIndex, wb.sheets.size)),
           definedNames = buildDefinedNames(PrintNames.effective(wb)),
-          // GH-373: scratch builds emit authored iterative-calculation settings (no calcId needed,
-          // the LibreOffice precedent)
+          // GH-373/GH-400: scratch builds emit all authored calcPr settings — the iterate triple
+          // plus calcMode/fullCalcOnLoad/calcId (no calcId unless authored, the LO precedent)
           calcPr = reconcileCalcPr(None, wb.metadata.calcPr)
         )
 
@@ -323,51 +323,95 @@ object OoxmlWorkbook extends XmlReadable[OoxmlWorkbook]:
         case (None, true) => Some(elem("workbookPr", "date1904" -> "1")())
         case (None, false) => None
 
+  /** OOXML ST_CalcMode token for a [[CalcMode]] (GH-400). */
+  private def calcModeToken(mode: CalcMode): String = mode match
+    case CalcMode.Manual => "manual"
+    case CalcMode.Auto => "auto"
+    case CalcMode.AutoNoTable => "autoNoTable"
+
+  /** Total ST_CalcMode parse (GH-400): unknown tokens yield None — a read never fails on them. */
+  private def parseCalcModeToken(value: String): Option[CalcMode] = value match
+    case "manual" => Some(CalcMode.Manual)
+    case "auto" => Some(CalcMode.Auto)
+    case "autoNoTable" => Some(CalcMode.AutoNoTable)
+    case _ => None
+
+  /** Total xsd:boolean parse: canonical and lexical forms; anything else yields None. */
+  private def parseXsdBoolean(value: String): Option[Boolean] = value match
+    case "1" | "true" => Some(true)
+    case "0" | "false" => Some(false)
+    case _ => None
+
+  /** The CT_CalcPr attributes the model represents (GH-373 iterate triple + GH-400 facts). */
+  private val modeledCalcPrAttrs =
+    Seq("iterate", "iterateCount", "iterateDelta", "calcMode", "fullCalcOnLoad", "calcId")
+
   /**
-   * Parse the iterative-calculation attributes of a raw `<calcPr>` element (GH-373). OOXML
-   * CT_CalcPr spells them `iterate` / `iterateCount` / `iterateDelta`; the model uses friendly
-   * names. Some only when at least one of the three attributes is present — a calcPr carrying only
-   * unmodeled attributes (calcId, refMode, ...) parses to None and rides through on write. Lenient:
-   * malformed numeric values contribute no field (a read must never fail on them).
+   * Parse the modeled attributes of a raw `<calcPr>` element: the iterative-calculation triple
+   * (GH-373 — OOXML spells it `iterate` / `iterateCount` / `iterateDelta`, the model uses friendly
+   * names) plus `calcMode` / `fullCalcOnLoad` / `calcId` (GH-400). Some only when at least one
+   * modeled attribute NAME is present — a calcPr carrying only still-unmodeled attributes (refMode,
+   * concurrentCalc, ...) parses to None and rides through on write. Lenient: malformed values
+   * (unknown calcMode token, non-numeric calcId, ...) contribute no field — a read must never fail
+   * on them.
    */
   def parseCalcPr(calcPr: Option[Elem]): Option[CalcPr] =
     calcPr.flatMap { e =>
       val attrs = e.attributes.asAttrMap
-      val iterate = attrs.get("iterate")
-      val iterateCount = attrs.get("iterateCount")
-      val iterateDelta = attrs.get("iterateDelta")
-      Option.when(iterate.isDefined || iterateCount.isDefined || iterateDelta.isDefined)(
+      Option.when(modeledCalcPrAttrs.exists(attrs.contains))(
         CalcPr(
-          iterativeCalculation = iterate.exists(v => v == "1" || v == "true"),
-          maxIterations = iterateCount.flatMap(_.toIntOption),
-          maxChange = iterateDelta.flatMap(s => scala.util.Try(BigDecimal(s.trim)).toOption)
+          iterativeCalculation = attrs.get("iterate").flatMap(parseXsdBoolean).getOrElse(false),
+          maxIterations = attrs.get("iterateCount").flatMap(_.toIntOption),
+          maxChange =
+            attrs.get("iterateDelta").flatMap(s => scala.util.Try(BigDecimal(s.trim)).toOption),
+          calcMode = attrs.get("calcMode").flatMap(parseCalcModeToken),
+          fullCalcOnLoad = attrs.get("fullCalcOnLoad").flatMap(parseXsdBoolean),
+          calcId = attrs.get("calcId").flatMap(_.toIntOption)
         )
       )
     }
 
   /**
-   * Reconcile the `<calcPr>` iterative-calculation attributes with the model (model wins, GH-373 —
-   * the reconcileDate1904 pattern) while every unmodeled preserved attribute (calcId,
-   * fullCalcOnLoad, refMode, ...) rides through. Byte-identical when the model agrees with the
-   * preserved spelling; a fresh element is built when nothing is preserved (no calcId needed — the
-   * LibreOffice precedent). A model of None strips the three modeled attributes and keeps the rest.
+   * Reconcile the `<calcPr>` modeled attributes with the model (model wins, GH-373/GH-400 — the
+   * reconcileDate1904 pattern) while every still-unmodeled preserved attribute (refMode,
+   * concurrentCalc, ...) rides through. Byte-identical when the model agrees with the preserved
+   * spelling; a fresh element is built when nothing is preserved (no calcId needed unless authored
+   * — the LibreOffice precedent), with ascending-sorted attributes on both XML backends.
+   *
+   * Two write semantics by attribute family:
+   *   - Iterate triple (GH-373): the model is the full truth — a default/None field emits no
+   *     attribute and removes a stale preserved one (absent means the Excel defaults 100/0.001). A
+   *     model of None strips the triple too.
+   *   - Facts (GH-400: calcMode / fullCalcOnLoad / calcId): Some(x) overlays x in place; a None
+   *     field NEVER strips a preserved attribute — nothing is emitted on scratch and the preserved
+   *     spelling rides through on source-backed writes, exactly like still-unmodeled attributes.
    */
   def reconcileCalcPr(preservedPr: Option[Elem], model: Option[CalcPr]): Option[Elem] =
     if parseCalcPr(preservedPr) == model then preservedPr
     else
-      val modelAttrs: Seq[(String, String)] = model.toList.flatMap { cp =>
+      val iterateAttrs: Seq[(String, String)] = model.toList.flatMap { cp =>
         (if cp.iterativeCalculation then List("iterate" -> "1") else Nil) ++
           cp.maxIterations.map(n => "iterateCount" -> n.toString).toList ++
           cp.maxChange.map(d => "iterateDelta" -> d.toString).toList
       }
+      val factAttrs: Seq[(String, String)] = model.toList.flatMap { cp =>
+        cp.calcMode.map(m => "calcMode" -> calcModeToken(m)).toList ++
+          cp.fullCalcOnLoad.map(b => "fullCalcOnLoad" -> (if b then "1" else "0")).toList ++
+          cp.calcId.map(id => "calcId" -> id.toString).toList
+      }
+      val modelAttrs = (iterateAttrs ++ factAttrs).sortBy(_._1)
       preservedPr match
         case None =>
           // model must be Some here (the equal-guard covers None/None); an all-default CalcPr
-          // carries no attributes and emits nothing
-          if modelAttrs.isEmpty then None else Some(elem("calcPr", modelAttrs*)())
+          // carries no attributes and emits nothing. elemOrdered keeps the pre-sorted order on
+          // the scala-xml backend (elem's fold would reverse it); the SAX backend re-sorts
+          // ascending itself — so both backends emit identical, deterministic attribute order.
+          if modelAttrs.isEmpty then None else Some(elemOrdered("calcPr", modelAttrs*)())
         case Some(pr) =>
-          val stripped =
-            pr.attributes.remove("iterate").remove("iterateCount").remove("iterateDelta")
+          // strip the iterate triple always (model truth) and the fact keys the model re-sets
+          // (replace, never duplicate); a None fact key is NOT stripped and rides through
+          val stripped = (Seq("iterate", "iterateCount", "iterateDelta") ++ factAttrs.map(_._1))
+            .foldLeft(pr.attributes)(_.remove(_))
           val overlaid = modelAttrs.foldRight(stripped) { case ((k, v), acc) =>
             new UnprefixedAttribute(k, v, acc)
           }

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/XlsxReader.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/XlsxReader.scala
@@ -1316,7 +1316,8 @@ object XlsxReader:
    * @param date1904
    *   True when workbookPr declares the 1904 date system (GH-243)
    * @param calcPr
-   *   Iterative-calculation settings parsed from `<calcPr>` (GH-373)
+   *   Modeled `<calcPr>` settings — iterate triple plus calcMode/fullCalcOnLoad/calcId (GH-373,
+   *   GH-400)
    * @param activeSheetIndex
    *   Active tab parsed from bookViews, already clamped to the sheet count (GH-294)
    * @param docProps

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/CalcPrRoundTripSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/CalcPrRoundTripSpec.scala
@@ -9,23 +9,27 @@ import scala.xml.Elem
 
 import munit.FunSuite
 
-import com.tjclp.xl.api.{CalcPr, Workbook}
+import com.tjclp.xl.api.{CalcMode, CalcPr, Workbook}
 import com.tjclp.xl.codec.CellCodec.given
 import com.tjclp.xl.macros.ref
 
 /**
- * GH-373 (a): `WorkbookMetadata.calcPr` ⇄ `<calcPr>` iterative-calculation attributes.
+ * GH-373 (a) + GH-400: `WorkbookMetadata.calcPr` ⇄ `<calcPr>` modeled attributes.
  *
  * Contract (the GH-243 date1904 / GH-294 activeTab machinery):
- *   - The reader parses `iterate` / `iterateCount` / `iterateDelta` into the friendly-named
- *     [[CalcPr]] model; a calcPr with only unmodeled attributes (calcId, refMode, ...) parses to
- *     None and rides through on write.
+ *   - The reader parses the iterate triple (`iterate` / `iterateCount` / `iterateDelta`) plus
+ *     `calcMode` / `fullCalcOnLoad` / `calcId` (GH-400) into the friendly-named [[CalcPr]] model; a
+ *     calcPr with only still-unmodeled attributes (refMode, concurrentCalc, ...) parses to None and
+ *     rides through on write.
  *   - `Workbook.withCalcPr` marks metadata modified so a surgical write regenerates workbook.xml —
  *     without it the untouched fast path copies preserved bytes and silently drops the change.
- *   - Reconcile is model-wins for the three modeled attributes ONLY: unmodeled preserved attributes
- *     survive an overlay; the preserved element rides byte-stable when the model agrees.
- *   - Scratch builds emit `<calcPr>` with just the modeled attributes (no calcId — the LibreOffice
- *     precedent), in CT_Workbook schema position (after sheets/definedNames, before extLst).
+ *   - Reconcile: the iterate triple is model truth (a None field emits nothing and removes a stale
+ *     preserved attribute); the GH-400 facts overlay only when Some (a None fact NEVER strips a
+ *     preserved attribute). Still-unmodeled preserved attributes survive every overlay; the
+ *     preserved element rides byte-stable when the model agrees.
+ *   - Scratch builds emit `<calcPr>` with just the authored attributes (no calcId unless authored —
+ *     the LibreOffice precedent), in CT_Workbook schema position (after sheets/definedNames, before
+ *     extLst), with deterministically sorted attributes on both XML backends.
  */
 class CalcPrRoundTripSpec extends FunSuite:
 
@@ -136,7 +140,11 @@ class CalcPrRoundTripSpec extends FunSuite:
       Files.write(src, buildCalcPrWorkbook("""<calcPr calcId="191029"/>"""))
 
       val wb = XlsxReader.read(src).fold(e => fail(s"read failed: ${e.message}"), identity)
-      assertEquals(wb.metadata.calcPr, None, "calcId-only calcPr must parse to None")
+      assertEquals(
+        wb.metadata.calcPr,
+        Some(CalcPr(calcId = Some(191029))),
+        "calcId-only calcPr must surface calcId (GH-400)"
+      )
 
       // The ONLY change is calcPr — without markMetadataModified the untouched fast path
       // copies the source bytes verbatim and the authored setting silently vanishes.
@@ -146,7 +154,9 @@ class CalcPrRoundTripSpec extends FunSuite:
       val reread = XlsxReader.read(out).fold(e => fail(s"reread failed: ${e.message}"), identity)
       assertEquals(
         reread.metadata.calcPr,
-        Some(houseCalcPr),
+        // the authored model has no opinion on calcId (None) — the preserved 191029 rides through
+        // and the reader surfaces it (GH-400)
+        Some(houseCalcPr.copy(calcId = Some(191029))),
         "calcPr-only change was dropped on write"
       )
 
@@ -208,6 +218,84 @@ class CalcPrRoundTripSpec extends FunSuite:
     assertEquals(readBytes(bytes).metadata.calcPr, None)
   }
 
+  test("GH-400: scratch workbook writes the exact TJC house calcPr in schema position") {
+    // The issue's acceptance, byte-for-byte: authoring the house doctrine from scratch emits
+    // <calcPr calcId="191029" calcMode="autoNoTable" iterate="1"/> — sorted attributes, after
+    // sheets (CT_Workbook sequence), retiring tjc-modeling's last zip patch.
+    val wb = Workbook(com.tjclp.xl.api.Sheet("Model").put(ref"A1" -> 1))
+      .withCalcPr(
+        CalcPr(
+          iterativeCalculation = true,
+          calcMode = Some(CalcMode.AutoNoTable),
+          calcId = Some(191029)
+        )
+      )
+
+    val bytes = XlsxWriter.writeToBytes(wb).fold(e => fail(s"write failed: ${e.message}"), identity)
+    val workbookOut = zipEntryText(bytes, "xl/workbook.xml").getOrElse(fail("workbook.xml missing"))
+
+    assert(
+      workbookOut.contains("""<calcPr calcId="191029" calcMode="autoNoTable" iterate="1"/>"""),
+      s"exact house calcPr missing from raw workbook.xml: $workbookOut"
+    )
+    val sheetsEnd = workbookOut.indexOf("</sheets>")
+    val calcPrIdx = workbookOut.indexOf("<calcPr")
+    assert(sheetsEnd >= 0 && calcPrIdx > sheetsEnd, "calcPr must follow sheets (CT_Workbook)")
+
+    val reread = readBytes(bytes)
+    assertEquals(
+      reread.metadata.calcPr,
+      Some(
+        CalcPr(
+          iterativeCalculation = true,
+          calcMode = Some(CalcMode.AutoNoTable),
+          calcId = Some(191029)
+        )
+      ),
+      "read-back must surface the authored GH-400 fields"
+    )
+  }
+
+  test("GH-400: scratch calcPr lands between definedNames and nothing else (schema order)") {
+    val wb = Workbook(com.tjclp.xl.api.Sheet("Model").put(ref"A1" -> 1))
+      .withDefinedName("Rate", "0.08")
+      .withCalcPr(CalcPr(calcMode = Some(CalcMode.Manual)))
+
+    val bytes = XlsxWriter.writeToBytes(wb).fold(e => fail(s"write failed: ${e.message}"), identity)
+    val workbookOut = zipEntryText(bytes, "xl/workbook.xml").getOrElse(fail("workbook.xml missing"))
+
+    val dnEnd = workbookOut.indexOf("</definedNames>")
+    val calcPrIdx = workbookOut.indexOf("<calcPr")
+    assert(dnEnd >= 0, s"definedNames missing: $workbookOut")
+    assert(calcPrIdx > dnEnd, "calcPr must follow definedNames (CT_Workbook sequence)")
+    assert(workbookOut.contains("""<calcPr calcMode="manual"/>"""), workbookOut)
+  }
+
+  test("GH-400: all six modeled fields round-trip through a scratch write") {
+    val full = CalcPr(
+      iterativeCalculation = true,
+      maxIterations = Some(50),
+      maxChange = Some(BigDecimal("0.005")),
+      calcMode = Some(CalcMode.Auto),
+      fullCalcOnLoad = Some(true),
+      calcId = Some(999999)
+    )
+    val wb = Workbook(com.tjclp.xl.api.Sheet("Model").put(ref"A1" -> 1)).withCalcPr(full)
+    val bytes = XlsxWriter.writeToBytes(wb).fold(e => fail(s"write failed: ${e.message}"), identity)
+
+    val calcPr = calcPrElemOf(
+      zipEntryText(bytes, "xl/workbook.xml").getOrElse(fail("workbook.xml missing"))
+    ).getOrElse(fail("calcPr missing"))
+    assertEquals(calcPr \@ "calcMode", "auto")
+    assertEquals(calcPr \@ "fullCalcOnLoad", "1")
+    assertEquals(calcPr \@ "calcId", "999999")
+    assertEquals(calcPr \@ "iterate", "1")
+    assertEquals(calcPr \@ "iterateCount", "50")
+    assertEquals(calcPr \@ "iterateDelta", "0.005")
+
+    assertEquals(readBytes(bytes).metadata.calcPr, Some(full), "write→read must be the identity")
+  }
+
   // ---------------------------------------------------------------------------
   // Reader forms
   // ---------------------------------------------------------------------------
@@ -235,15 +323,71 @@ class CalcPrRoundTripSpec extends FunSuite:
         )
       )
     )
-    // unmodeled-only calcPr parses to None (and rides through on write elsewhere)
+    // GH-400: calcId/fullCalcOnLoad are modeled now — they surface instead of parsing to None
     assertEquals(
       readBytes(
         buildCalcPrWorkbook("""<calcPr calcId="191029" fullCalcOnLoad="1"/>""")
+      ).metadata.calcPr,
+      Some(CalcPr(fullCalcOnLoad = Some(true), calcId = Some(191029)))
+    )
+    // still-unmodeled-only calcPr parses to None (and rides through on write elsewhere)
+    assertEquals(
+      readBytes(
+        buildCalcPrWorkbook("""<calcPr refMode="A1" concurrentCalc="0"/>""")
       ).metadata.calcPr,
       None
     )
     // absent element
     assertEquals(readBytes(buildCalcPrWorkbook("")).metadata.calcPr, None)
+  }
+
+  test("GH-400: reader parses calcMode / fullCalcOnLoad / calcId (all spellings, total)") {
+    // the TJC house shape
+    assertEquals(
+      readBytes(
+        buildCalcPrWorkbook("""<calcPr calcId="191029" calcMode="autoNoTable" iterate="1"/>""")
+      ).metadata.calcPr,
+      Some(
+        CalcPr(
+          iterativeCalculation = true,
+          calcMode = Some(CalcMode.AutoNoTable),
+          calcId = Some(191029)
+        )
+      )
+    )
+    // every ST_CalcMode token
+    assertEquals(
+      readBytes(buildCalcPrWorkbook("""<calcPr calcMode="manual"/>""")).metadata.calcPr,
+      Some(CalcPr(calcMode = Some(CalcMode.Manual)))
+    )
+    assertEquals(
+      readBytes(buildCalcPrWorkbook("""<calcPr calcMode="auto"/>""")).metadata.calcPr,
+      Some(CalcPr(calcMode = Some(CalcMode.Auto)))
+    )
+    // xsd:boolean spellings of fullCalcOnLoad
+    assertEquals(
+      readBytes(buildCalcPrWorkbook("""<calcPr fullCalcOnLoad="true"/>""")).metadata.calcPr,
+      Some(CalcPr(fullCalcOnLoad = Some(true)))
+    )
+    assertEquals(
+      readBytes(buildCalcPrWorkbook("""<calcPr fullCalcOnLoad="0"/>""")).metadata.calcPr,
+      Some(CalcPr(fullCalcOnLoad = Some(false)))
+    )
+    // total parse: unknown/malformed values contribute no field, the read never fails —
+    // presence of a modeled attribute name still yields Some (the iterate="garbage" precedent)
+    assertEquals(
+      readBytes(
+        buildCalcPrWorkbook(
+          """<calcPr calcMode="bogus" fullCalcOnLoad="maybe" calcId="not-a-number"/>"""
+        )
+      ).metadata.calcPr,
+      Some(CalcPr())
+    )
+    // calcId beyond Int range (xsd:unsignedInt max) degrades to None, never throws
+    assertEquals(
+      readBytes(buildCalcPrWorkbook("""<calcPr calcId="4294967295"/>""")).metadata.calcPr,
+      Some(CalcPr())
+    )
   }
 
   // ---------------------------------------------------------------------------
@@ -261,7 +405,11 @@ class CalcPrRoundTripSpec extends FunSuite:
         )
       )
       val wb = XlsxReader.read(src).fold(e => fail(s"read failed: ${e.message}"), identity)
-      assertEquals(wb.metadata.calcPr, Some(CalcPr(true, Some(50), Some(BigDecimal("0.01")))))
+      assertEquals(
+        wb.metadata.calcPr,
+        // GH-400: calcId surfaces alongside the iterate triple
+        Some(CalcPr(true, Some(50), Some(BigDecimal("0.01")), calcId = Some(191029)))
+      )
 
       // trigger the metadata-modified (fromDomain) path with an unrelated authoring action
       val named = wb.withDefinedName("MyRange", "Model!$A$1")
@@ -282,19 +430,142 @@ class CalcPrRoundTripSpec extends FunSuite:
       Files.deleteIfExists(out)
   }
 
+  test("GH-400: flipping calcMode overlays while unmodeled attrs and extLst ride through") {
+    val src = Files.createTempFile("calcpr-flip-src", ".xlsx")
+    val out = Files.createTempFile("calcpr-flip-out", ".xlsx")
+    try
+      Files.write(
+        src,
+        buildCalcPrWorkbook(
+          """<calcPr calcId="171027" calcMode="manual" concurrentCalc="0" refMode="R1C1" iterate="1" iterateCount="50" iterateDelta="0.01"/>
+  <extLst><ext uri="{TEST-EXT}"/></extLst>"""
+        )
+      )
+      val wb = XlsxReader.read(src).fold(e => fail(s"read failed: ${e.message}"), identity)
+      val parsed = wb.metadata.calcPr.getOrElse(fail("calcPr must parse"))
+      assertEquals(parsed.calcMode, Some(CalcMode.Manual))
+      assertEquals(parsed.calcId, Some(171027))
+
+      // the modeled edit: flip calcMode only, everything else carried from the parsed model
+      val flipped = wb.withCalcPr(parsed.copy(calcMode = Some(CalcMode.AutoNoTable)))
+      XlsxWriter.write(flipped, out).fold(e => fail(s"write failed: ${e.message}"), identity)
+
+      val workbookOut = zipEntryText(Files.readAllBytes(out), "xl/workbook.xml")
+        .getOrElse(fail("workbook.xml missing"))
+      val calcPr = calcPrElemOf(workbookOut).getOrElse(fail("calcPr dropped"))
+      assertEquals(calcPr \@ "calcMode", "autoNoTable", "modeled edit must win")
+      assertEquals(calcPr \@ "calcId", "171027")
+      assertEquals(calcPr \@ "concurrentCalc", "0", "unmodeled concurrentCalc dropped")
+      assertEquals(calcPr \@ "refMode", "R1C1", "unmodeled refMode dropped")
+      assertEquals(calcPr \@ "iterate", "1")
+      assertEquals(calcPr \@ "iterateCount", "50")
+      assertEquals(calcPr \@ "iterateDelta", "0.01")
+      // the overlay must replace, never duplicate, a preserved modeled attribute
+      assertEquals(
+        "calcMode=".r.findAllIn(workbookOut).size,
+        1,
+        s"duplicate calcMode attribute: $workbookOut"
+      )
+      // CT_Workbook sequence: calcPr still before the preserved extLst
+      val calcPrIdx = workbookOut.indexOf("<calcPr")
+      val extIdx = workbookOut.indexOf("<extLst")
+      assert(extIdx >= 0, s"preserved extLst dropped: $workbookOut")
+      assert(calcPrIdx >= 0 && calcPrIdx < extIdx, "calcPr must precede extLst")
+    finally
+      Files.deleteIfExists(src)
+      Files.deleteIfExists(out)
+  }
+
+  test("GH-400: a calcMode-only edit on a read workbook survives the surgical write path") {
+    val src = Files.createTempFile("calcmode-only-src", ".xlsx")
+    val out = Files.createTempFile("calcmode-only-out", ".xlsx")
+    try
+      Files.write(
+        src,
+        buildCalcPrWorkbook("""<calcPr calcId="191029" calcMode="autoNoTable" iterate="1"/>""")
+      )
+      val wb = XlsxReader.read(src).fold(e => fail(s"read failed: ${e.message}"), identity)
+      val parsed = wb.metadata.calcPr.getOrElse(fail("calcPr must parse"))
+
+      // The ONLY change is calcMode — without the markMetadataModified trigger the untouched
+      // fast path would copy the source bytes verbatim and silently keep autoNoTable.
+      val edited = wb.withCalcPr(parsed.copy(calcMode = Some(CalcMode.Manual)))
+      XlsxWriter.write(edited, out).fold(e => fail(s"write failed: ${e.message}"), identity)
+
+      val reread = XlsxReader.read(out).fold(e => fail(s"reread failed: ${e.message}"), identity)
+      assertEquals(
+        reread.metadata.calcPr,
+        Some(
+          CalcPr(
+            iterativeCalculation = true,
+            calcMode = Some(CalcMode.Manual),
+            calcId = Some(191029)
+          )
+        ),
+        "calcMode-only edit was dropped by the surgical write"
+      )
+    finally
+      Files.deleteIfExists(src)
+      Files.deleteIfExists(out)
+  }
+
   // ---------------------------------------------------------------------------
   // reconcileCalcPr unit laws (model wins on the three modeled attrs only)
   // ---------------------------------------------------------------------------
 
   test("GH-373: reconcileCalcPr is the identity when the model agrees with the preserved bytes") {
     val pr =
-      parseElem("""<calcPr calcId="191029" iterate="1" iterateCount="50" iterateDelta="0.01"/>""")
+      parseElem(
+        """<calcPr calcId="191029" calcMode="autoNoTable" fullCalcOnLoad="1" iterate="1" iterateCount="50" iterateDelta="0.01" refMode="A1"/>"""
+      )
     val model = OoxmlWorkbook.parseCalcPr(Some(pr))
     assert(
       OoxmlWorkbook.reconcileCalcPr(Some(pr), model).exists(_ eq pr),
       "must return the preserved element untouched"
     )
     assertEquals(OoxmlWorkbook.reconcileCalcPr(None, None), None)
+  }
+
+  test("GH-400: a None fact field never strips a preserved attribute") {
+    // model authored without opinions on calcMode/fullCalcOnLoad/calcId — the preserved
+    // spellings must ride through untouched (only the iterate triple is model truth)
+    val pr = parseElem(
+      """<calcPr calcId="191029" calcMode="autoNoTable" fullCalcOnLoad="1" refMode="A1" iterate="1" iterateCount="100"/>"""
+    )
+    val model = Some(CalcPr(iterativeCalculation = true))
+    val result =
+      OoxmlWorkbook.reconcileCalcPr(Some(pr), model).getOrElse(fail("expected an element"))
+    assertEquals(result \@ "calcId", "191029", "None calcId stripped the preserved attr")
+    assertEquals(result \@ "calcMode", "autoNoTable", "None calcMode stripped the preserved attr")
+    assertEquals(result \@ "fullCalcOnLoad", "1", "None fullCalcOnLoad stripped the preserved attr")
+    assertEquals(result \@ "refMode", "A1")
+    assertEquals(result \@ "iterate", "1")
+    // the iterate triple IS model truth: absent fields remove stale preserved attributes
+    assertEquals(result.attribute("iterateCount"), None, "stale iterateCount must not survive")
+    assertEquals(result.attribute("iterateDelta"), None)
+  }
+
+  test("GH-400: Some fact fields overlay preserved attributes in place (no duplicates)") {
+    val pr = parseElem("""<calcPr calcId="150000" calcMode="auto" refMode="A1"/>""")
+    val model = Some(
+      CalcPr(calcMode = Some(CalcMode.Manual), fullCalcOnLoad = Some(true), calcId = Some(191029))
+    )
+    val result =
+      OoxmlWorkbook.reconcileCalcPr(Some(pr), model).getOrElse(fail("expected an element"))
+    assertEquals(result \@ "calcMode", "manual")
+    assertEquals(result \@ "fullCalcOnLoad", "1")
+    assertEquals(result \@ "calcId", "191029")
+    assertEquals(result \@ "refMode", "A1")
+    assertEquals(
+      "calcMode=".r.findAllIn(result.toString).size,
+      1,
+      s"duplicate calcMode: ${result.toString}"
+    )
+    assertEquals(
+      "calcId=".r.findAllIn(result.toString).size,
+      1,
+      s"duplicate calcId: ${result.toString}"
+    )
   }
 
   test("GH-373: reconcileCalcPr overlays the model in place (foreign attrs survive)") {
@@ -316,11 +587,17 @@ class CalcPrRoundTripSpec extends FunSuite:
     assertEquals(result \@ "iterateDelta", "0.05")
   }
 
-  test("GH-373: reconcileCalcPr with a cleared model strips only the modeled attrs") {
-    val pr = parseElem("""<calcPr calcId="191029" iterate="1" iterateCount="100" refMode="A1"/>""")
+  test("GH-373: reconcileCalcPr with a cleared model strips the iterate triple only") {
+    // a cleared model (removeCalcPr) has no opinion on the GH-400 facts — they survive, like
+    // every still-unmodeled attribute; only the iterate triple is removed
+    val pr = parseElem(
+      """<calcPr calcId="191029" calcMode="autoNoTable" fullCalcOnLoad="1" iterate="1" iterateCount="100" refMode="A1"/>"""
+    )
     val result =
       OoxmlWorkbook.reconcileCalcPr(Some(pr), None).getOrElse(fail("expected an element"))
     assertEquals(result \@ "calcId", "191029")
+    assertEquals(result \@ "calcMode", "autoNoTable")
+    assertEquals(result \@ "fullCalcOnLoad", "1")
     assertEquals(result \@ "refMode", "A1")
     assertEquals(result.attribute("iterate"), None)
     assertEquals(result.attribute("iterateCount"), None)
@@ -336,4 +613,23 @@ class CalcPrRoundTripSpec extends FunSuite:
     assertEquals(result \@ "iterateCount", "10")
     // and it parses back to the same model (round-trip)
     assertEquals(OoxmlWorkbook.parseCalcPr(Some(result)), model)
+  }
+
+  test("GH-400: every CalcMode token and both fullCalcOnLoad values round-trip via reconcile") {
+    List(
+      CalcMode.Manual -> "manual",
+      CalcMode.Auto -> "auto",
+      CalcMode.AutoNoTable -> "autoNoTable"
+    ).foreach { (mode, token) =>
+      val model = Some(CalcPr(calcMode = Some(mode)))
+      val result = OoxmlWorkbook.reconcileCalcPr(None, model).getOrElse(fail("expected an element"))
+      assertEquals(result \@ "calcMode", token)
+      assertEquals(OoxmlWorkbook.parseCalcPr(Some(result)), model, s"round-trip failed for $mode")
+    }
+    List(true -> "1", false -> "0").foreach { (b, token) =>
+      val model = Some(CalcPr(fullCalcOnLoad = Some(b)))
+      val result = OoxmlWorkbook.reconcileCalcPr(None, model).getOrElse(fail("expected an element"))
+      assertEquals(result \@ "fullCalcOnLoad", token)
+      assertEquals(OoxmlWorkbook.parseCalcPr(Some(result)), model, s"round-trip failed for $b")
+    }
   }


### PR DESCRIPTION
## Summary

Extends `CalcPr` beyond the iterate subset (#373) with `CalcMode` (manual/auto/autoNoTable), `fullCalcOnLoad`, and `calcId` — from-scratch builds now author the TJC house `<calcPr calcId="191029" calcMode="autoNoTable" iterate="1"/>` byte-exactly, retiring the last tjc-modeling post-write zip patch.

- Two-family reconcile semantics: the iterate triple stays model-truth (#373 semantics unchanged); the new fact fields overlay only when `Some` — a `None` never strips a preserved attribute (law-tested)
- Reader parses all six modeled attrs totally (unknown ST_CalcMode tokens, malformed booleans, out-of-Int-range calcId degrade to `None`, never throw); unmodeled attrs (`refMode`, `concurrentCalc`, …) still preserve byte-faithfully
- Scratch emission now uses deterministic ascending attribute order on both backends
- `IterativeCalc.fromCalcPr` unchanged

## Verification

TDD (11 red first), 18 tests in `CalcPrRoundTripSpec`. Adversarial review verified both issue acceptance criteria on real files via `unzip`/`xmllint`, ran the roundtrip corpus at `XL_ROUNDTRIP_MIN_SUCCESS=500` (no preservation regression from the attr-order change), cross-checked with openpyxl 3.1.5 (calcMode/calcId/iterate read back; caught openpyxl's own fullCalcOnLoad default masquerading as output), and probed break-it edges (Int-overflow calcId, case-variant tokens, unmodeled-only round-trip stability by identity).

Closes #400

🤖 Generated with [Claude Code](https://claude.com/claude-code)