### PR TITLE
chore(release): Bump version to 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0] "Candor" - 2026-07-16
+
+Errors tell the truth now: Excel error values are first-class evaluation
+results (the #344 typed-result refactor — the campaign's final deliberate
+divergences closed), and full calcPr authoring retires tjc-modeling's last
+zip patch. This completes the replication-campaign roadmap: W1–W7 shipped
+across 0.12.7, 0.13.0, and 0.14.0.
+
 ### Added
 
 - **Full calcPr authoring** (#400): `CalcPr` models `calcMode`

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ```scala 3 raw
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.13.0
+//> using dep com.tjclp::xl:0.14.0
 
 import com.tjclp.xl.{*, given}
 
@@ -55,13 +55,13 @@ import com.tjclp.xl.{*, given}
 
 ```scala 3 ignore
 // build.mill — single dependency for everything
-def ivyDeps = Agg(ivy"com.tjclp::xl:0.13.0")
+def ivyDeps = Agg(ivy"com.tjclp::xl:0.14.0")
 
 // Or individual modules for minimal footprint:
-// ivy"com.tjclp::xl-core:0.13.0"        — Pure domain model only
-// ivy"com.tjclp::xl-ooxml:0.13.0"       — Add OOXML read/write
-// ivy"com.tjclp::xl-cats-effect:0.13.0" — Add IO streaming
-// ivy"com.tjclp::xl-evaluator:0.13.0"   — Add formula evaluation
+// ivy"com.tjclp::xl-core:0.14.0"        — Pure domain model only
+// ivy"com.tjclp::xl-ooxml:0.14.0"       — Add OOXML read/write
+// ivy"com.tjclp::xl-cats-effect:0.14.0" — Add IO streaming
+// ivy"com.tjclp::xl-evaluator:0.14.0"   — Add formula evaluation
 ```
 
 ### Basic Usage

--- a/build.mill
+++ b/build.mill
@@ -14,7 +14,7 @@ val organization = "com.tjclp"
 /** Shared build configuration constants */
 object BuildConfig {
   /** Project version: CI sets PUBLISH_VERSION; local builds use this fallback */
-  val version: String = sys.env.getOrElse("PUBLISH_VERSION", "0.13.0")
+  val version: String = sys.env.getOrElse("PUBLISH_VERSION", "0.14.0")
 
   /** JVM options to silence Scala 3 LazyVals sun.misc.Unsafe deprecation warnings (JDK 21+) */
   val lazyValsJvmArgs: Seq[String] = Seq(

--- a/docs/QUICK-START.md
+++ b/docs/QUICK-START.md
@@ -12,19 +12,19 @@ import mill._, scalalib._
 
 object myproject extends ScalaModule {
   def scalaVersion = "3.8.3"
-  def ivyDeps = Agg(ivy"com.tjclp::xl:0.13.0")
+  def ivyDeps = Agg(ivy"com.tjclp::xl:0.14.0")
 }
 ```
 
 ### With sbt (build.sbt)
 ```scala
 scalaVersion := "3.8.3"
-libraryDependencies += "com.tjclp" %% "xl" % "0.13.0"
+libraryDependencies += "com.tjclp" %% "xl" % "0.14.0"
 ```
 
 ### With Scala CLI
 ```scala
-//> using dep com.tjclp::xl:0.13.0
+//> using dep com.tjclp::xl:0.14.0
 ```
 
 ### Individual Modules (Optional)
@@ -44,7 +44,7 @@ For scripts, skip the build setup entirely: a two-line `scala-cli` header and ON
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.13.0
+//> using dep com.tjclp::xl:0.14.0
 
 import com.tjclp.xl.scripting.{*, given}
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,12 +1,17 @@
 # XL Project Status
 
-**Last Updated**: 2026-07-16 (0.13.0)
+**Last Updated**: 2026-07-16 (0.14.0)
 
 ## Current State
 
 > **For detailed phase completion status and roadmap, see [plan/roadmap.md](plan/roadmap.md)**
 
 ### What Works (Production-Ready)
+
+**New in 0.14.0** (2026-07-16):
+- ✅ **Excel error values as first-class results** (#344) — `=1/0` evaluates to `#DIV/0!` (IFERROR/ISERROR-catchable, cached as `t="e"` cells) instead of failing the formula; aggregates/logical folds/comparisons propagate per Excel policy (COUNT-family still skips); op-level `#NUM!`/`#DIV/0!`/`#N/A` codes; `#N/A` dimension padding; `"TRUE"`/`"FALSE"` text coerces in conditions; host failures stay loud — the boundary is law-tested (`RecalcResult.excelErrors` vs `errors`); design record `docs/design/error-propagation.md`
+- ✅ **Full calcPr authoring** (#400) — `calcMode`/`fullCalcOnLoad`/`calcId` join the iterate triple; the TJC house `<calcPr>` authors byte-exactly; last tjc-modeling zip patch retired
+- ✅ **xl-agent robustness** (#344) — bounded `pause_turn` auto-resume with preserved container id, errored tasks counted in summaries, skill traces never overwritten by the engine fallback
 
 **New in 0.13.0** (2026-07-16):
 - ✅ **Defined-name resolution** (#384) — `=IF(case=2,…)`, `=entry_mult*ltm_ebitda` evaluate; sheet-scoped shadowing, name-chains with cycle guard, dependency-graph edges; was 926/1,571 probe rejections on a real LBO

--- a/docs/plan/roadmap.md
+++ b/docs/plan/roadmap.md
@@ -12,7 +12,7 @@
 
 **Current Status**: Production-ready with **108 formula functions** (incl. dynamic arrays SEQUENCE/SORT/UNIQUE/FILTER and OFFSET), **structural editing** (insert/delete rows & columns with formula rewriting), the **scripting prelude** (`com.tjclp.xl.scripting`), whole-workbook `recalculate`, named-range & hyperlink authoring, **typed charts + embedded pictures** (0.12.0), **conditional formatting** (0.12.1), SAX streaming (36% faster than POI), Excel tables, and full OOXML round-trip. 4,085 tests passing.
 
-**Current Version**: **0.13.0 "Fixpoint"** (released 2026-07-16)
+**Current Version**: **0.14.0 "Candor"** (released 2026-07-16)
 
 ---
 
@@ -60,6 +60,10 @@ Phased: (a) verbatim chart/drawing preservation proven by the wave-2 fixture cor
 ### v0.12.1 "Clean Sweep" — wave 7 (Released 2026-06-11)
 
 Every remaining open issue closed in one wave. **Conditional formatting** ([#136](https://github.com/TJC-LP/xl/issues/136)) is the headline — typed cellIs/expression/colorScale/dataBar/top10/text rules + `dxf` differential formats, `sheet.conditionalFormat` authoring with auto-priority, structural-edit range shifting, unmodeled families preserved byte-faithfully — alongside twelve fidelity/writer fixes: openpyxl comment subdirectory dialect (#292), RichText SST keying (#303), exact surgical SST counts (#304), `[Content_Types]` preservation (#314), identity-keyed source mappings (#315), activeTab (#294), fitToPage tri-state (#284), `Cell.comment` deprecated→`Sheet.comments` (#295). Codec `put` paths 2.4x faster (#297).
+
+### v0.14.0 "Candor" — wave 17 + #400 (Released 2026-07-16)
+
+The replication campaign's finale (PRs #401, #402): the **typed-result refactor** ([#344](https://github.com/TJC-LP/xl/issues/344), design-panel-directed) makes Excel error values first-class evaluation results — `=1/0` → `#DIV/0!` as a catchable, cacheable value; aggregate/logical/comparison propagation per Excel per-function policy; op-level `#NUM!` classification; `#N/A` dimension padding; TRUE/FALSE text conditions; host failures stay loud behind a law-tested boundary — plus xl-agent robustness (pause_turn auto-resume, errored-task accounting, trace-overwrite guard) and **full calcPr authoring** ([#400](https://github.com/TJC-LP/xl/issues/400): calcMode/fullCalcOnLoad/calcId — the last tjc-modeling zip patch retired). Campaign complete: every issue in waves W1–W7 closed across 0.12.7 → 0.13.0 → 0.14.0. Open follow-ups: [#394](https://github.com/TJC-LP/xl/issues/394)–[#397](https://github.com/TJC-LP/xl/issues/397).
 
 ### v0.13.0 "Fixpoint" — waves 13–16 (Released 2026-07-16)
 

--- a/docs/reference/scripting.md
+++ b/docs/reference/scripting.md
@@ -33,7 +33,7 @@ release bump is a mechanical substitution):
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.13.0
+//> using dep com.tjclp::xl:0.14.0
 import com.tjclp.xl.scripting.{*, given}
 
 val sheet = Sheet("Demo").put(ref"A1", "Hello").put(ref"B1", 42)
@@ -51,7 +51,7 @@ read and write is pure values.
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.13.0
+//> using dep com.tjclp::xl:0.14.0
 import com.tjclp.xl.scripting.{*, given}
 
 val wb = Excel.read("input.xlsx")
@@ -167,7 +167,7 @@ throw — they are collected per cell.
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.13.0
+//> using dep com.tjclp::xl:0.14.0
 import com.tjclp.xl.scripting.{*, given}
 
 val title = CellStyle.default.bold.size(14.0).center
@@ -217,8 +217,9 @@ For Excel-style format inheritance on formula entry, use the opt-in
 |--------|---------|
 | `workbook` | The workbook with every successful formula cached (`Formula(expr, Some(value))`) |
 | `evaluated` | `Map[SheetName, Map[ARef, CellValue]]` — computed values for inspection |
-| `errors` | `Vector[CellEvalError]` — per-cell failures (parse/eval errors, cycle participants, cells blocked by a cycle) |
-| `isClean` | `true` when `errors.isEmpty` |
+| `errors` | `Vector[CellEvalError]` — per-cell **host failures** (parse errors, missing sheets, cycle participants, cells blocked by a cycle). Since 0.14.0, Excel **error values** (`#DIV/0!`, `#N/A`, …) are *results*, not failures — they cache like any value and do not appear here |
+| `excelErrors` | (0.14.0) `Vector[(SheetName, ARef, CellError)]` — cells whose cached result is an Excel error value, sorted; inspect when you want to surface `#DIV/0!`s without treating them as host failures |
+| `isClean` | `true` when `errors.isEmpty` — a workbook full of cached `#DIV/0!`s is "clean" (the recalculation succeeded; the errors are data) |
 | `toEither` | `Right(workbook)` when clean, `Left(errors)` otherwise — for fail-hard pipelines |
 
 Reference cycles are **isolated**: the participants and their downstream dependents are reported
@@ -298,7 +299,7 @@ them explicitly:
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.13.0
+//> using dep com.tjclp::xl:0.14.0
 import com.tjclp.xl.scripting.{*, given}
 import com.tjclp.xl.sheets.{HeaderFooter, PageMargins, PageSetup, SheetView}
 
@@ -352,7 +353,7 @@ the whole workbook:
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.13.0
+//> using dep com.tjclp::xl:0.14.0
 import com.tjclp.xl.scripting.{*, given}
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global

--- a/examples/README.md
+++ b/examples/README.md
@@ -170,7 +170,7 @@ chmod +x examples/my_example.sc
 ./examples/my_example.sc
 ```
 
-The `project.scala` file centralizes dependencies (`com.tjclp::xl:0.13.0`) for all examples.
+The `project.scala` file centralizes dependencies (`com.tjclp::xl:0.14.0`) for all examples.
 
 ## Scripting Prelude & Skill
 

--- a/examples/project.scala
+++ b/examples/project.scala
@@ -2,4 +2,4 @@
 //> using repository ivy2Local
 
 // XL aggregate - includes all modules (core, ooxml, cats-effect, evaluator)
-//> using dep com.tjclp::xl:0.13.0
+//> using dep com.tjclp::xl:0.14.0

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "xl",
   "description": "LLM-friendly Excel tooling: the xl CLI for reading, writing, styling, and analyzing spreadsheets (xl-cli skill), plus type-safe Scala scripting against the xl library via scala-cli for bulk transformations, pipelines, and formula models (xl-scripting skill).",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "author": {
     "name": "TJC L.P.",
     "url": "https://github.com/TJC-LP"

--- a/plugin/skills/xl-scripting/SKILL.md
+++ b/plugin/skills/xl-scripting/SKILL.md
@@ -38,7 +38,7 @@ The canonical header for every script (this is the single source of truth — re
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.13.0
+//> using dep com.tjclp::xl:0.14.0
 
 import com.tjclp.xl.scripting.{*, given}
 
@@ -101,7 +101,7 @@ wb.update("Sales", f).unsafe                       // throws structured XLExcept
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.13.0
+//> using dep com.tjclp::xl:0.14.0
 import com.tjclp.xl.scripting.{*, given}
 
 val wb = Excel.read("input.xlsx")
@@ -207,7 +207,7 @@ if !result.isClean then
 Excel.write(result.workbook, "model.xlsx")       // computed values cached for Excel/viewers
 ```
 
-`recalculate` evaluates every formula across all sheets in dependency order, resolves cross-sheet references automatically, isolates reference cycles (the rest of the workbook still computes), and reports failures per cell in `result.errors`. `result.toEither` gives `Left(errors)` for fail-hard pipelines. For one-off questions: `wb.evaluateFormula("=SUM(Data!A:A)", "Summary")`. When the very next step is a write, `Excel.writeRecalculated(wb, path)` (0.13.0) fuses recalculate + write and returns the same `RecalcResult` — see the gotcha below.
+`recalculate` evaluates every formula across all sheets in dependency order, resolves cross-sheet references automatically, isolates reference cycles (the rest of the workbook still computes), and reports failures per cell in `result.errors`. `result.toEither` gives `Left(errors)` for fail-hard pipelines. **Excel error values are results, not failures** (0.14.0): `=1/0` evaluates to `#DIV/0!` — catchable with `IFERROR`, cached into the written file exactly like Excel would, and listed via `result.excelErrors` rather than `result.errors` (which now carries only host failures: parse errors, missing sheets, cycles). For one-off questions: `wb.evaluateFormula("=SUM(Data!A:A)", "Summary")`. When the very next step is a write, `Excel.writeRecalculated(wb, path)` (0.13.0) fuses recalculate + write and returns the same `RecalcResult` — see the gotcha below.
 
 **Defined names resolve** (0.13.0): `fx"=IF(case=2,rev,cost)"`, `fx"=entry_mult*ltm_ebitda"`, `fx"=SUM(rev_range)"` evaluate against workbook- and sheet-scoped defined names (sheet-scoped shadows global), contribute dependency edges so recalc orders name-gated families correctly, and round-trip byte-faithfully; an unresolvable name is a clean per-cell error.
 
@@ -240,7 +240,7 @@ Or lean on totality so there is nothing to unwrap: literal refs, `upsert`, range
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.13.0
+//> using dep com.tjclp::xl:0.14.0
 import com.tjclp.xl.scripting.{*, given}
 import java.nio.file.{Files, Paths}
 import scala.jdk.CollectionConverters.*
@@ -262,7 +262,7 @@ println(s"merged ${inputs.size} files, ${merged.sheets.size} sheets")
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.13.0
+//> using dep com.tjclp::xl:0.14.0
 import com.tjclp.xl.scripting.{*, given}
 
 val data = List(("North", 125000.50), ("South", 98000.25), ("West", 143500.00))
@@ -290,7 +290,7 @@ println(if result.isClean then "✓ report written" else result.errors.map(_.ren
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.13.0
+//> using dep com.tjclp::xl:0.14.0
 import com.tjclp.xl.scripting.{*, given}
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global

--- a/plugin/skills/xl-scripting/reference/API.md
+++ b/plugin/skills/xl-scripting/reference/API.md
@@ -19,7 +19,7 @@ Everything below is in scope after `import com.tjclp.xl.scripting.{*, given}`.
 | `SheetView` | display settings: `(showGridLines, zoomScale, tabSelected)` — see Sheet View & Print Setup |
 | `PageSetup` | print settings: scale, orientation, fit, header/footer, margins, print area, repeat rows |
 | `DataValidation` | `.Rules(ranges, kind, allowBlank, showDropdown)` \| `.Preserved` — list dropdowns via `DataValidation.list`/`listOf` |
-| `CalcPr` | workbook `<calcPr>`: `(iterativeCalculation, maxIterations, maxChange)` — iterative-calc authoring |
+| `CalcPr` | workbook `<calcPr>`: `(iterativeCalculation, maxIterations, maxChange, calcMode, fullCalcOnLoad, calcId)` — iterative-calc + calculation-mode authoring; `CalcMode.Manual/Auto/AutoNoTable` (0.14.0) |
 | `IterativeCalc` | `(maxIter, maxChange)` — opt-in bounded circular recalc; `fromCalcPr` bridges a file's `CalcPr` |
 | `NumFmt` | `General`, `Currency`, `Percent`, `Date`, `DateTime`, `Decimal`, custom |
 | `Formatted` | `(value: CellValue, numFmt: NumFmt)` — value + display format pair |

--- a/plugin/skills/xl-scripting/reference/RECIPES.md
+++ b/plugin/skills/xl-scripting/reference/RECIPES.md
@@ -10,7 +10,7 @@ Apply a 5% price increase to column C of every workbook in a directory, in place
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.13.0
+//> using dep com.tjclp::xl:0.14.0
 import com.tjclp.xl.scripting.{*, given}
 import java.nio.file.{Files, Paths}
 import scala.jdk.CollectionConverters.*
@@ -42,7 +42,7 @@ Read rows into case classes; collect per-cell validation failures into a new Iss
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.13.0
+//> using dep com.tjclp::xl:0.14.0
 import com.tjclp.xl.scripting.{*, given}
 
 final case class Order(id: Int, customer: String, amount: BigDecimal)
@@ -76,7 +76,7 @@ Three-year projection with growth formulas; fail the script if any formula error
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.13.0
+//> using dep com.tjclp::xl:0.14.0
 import com.tjclp.xl.scripting.{*, given}
 
 val header = CellStyle.default.bold.size(12.0).center
@@ -111,7 +111,7 @@ Stack the data rows of every input file under one header.
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.13.0
+//> using dep com.tjclp::xl:0.14.0
 import com.tjclp.xl.scripting.{*, given}
 import java.nio.file.{Files, Paths}
 import scala.jdk.CollectionConverters.*
@@ -147,7 +147,7 @@ println(s"combined ${files.size} files, ${combined.cells.size} cells")
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.13.0
+//> using dep com.tjclp::xl:0.14.0
 import com.tjclp.xl.scripting.{*, given}
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
@@ -176,7 +176,7 @@ println("✓ filtered (constant memory)")
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.13.0
+//> using dep com.tjclp::xl:0.14.0
 import com.tjclp.xl.scripting.{*, given}
 
 val before = Excel.read("before.xlsx")
@@ -204,7 +204,7 @@ else
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.13.0
+//> using dep com.tjclp::xl:0.14.0
 import com.tjclp.xl.scripting.{*, given}
 import java.nio.file.{Files, Paths}
 import scala.jdk.CollectionConverters.*
@@ -232,7 +232,7 @@ cell ships a cached value for `data_only` readers, pandas, and Excel-before-reca
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.13.0
+//> using dep com.tjclp::xl:0.14.0
 import com.tjclp.xl.scripting.{*, given}
 
 val reps = List(("Alice", 120000.0), ("Bob", 98000.0), ("Carol", 143500.0))
@@ -267,7 +267,7 @@ frozen header, a list-dropdown data validation, and a provenance comment — no 
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.13.0
+//> using dep com.tjclp::xl:0.14.0
 import com.tjclp.xl.scripting.{*, given}
 import com.tjclp.xl.sheets.SheetView // SheetView lives one import deeper than the prelude
 

--- a/xl-core/src/com/tjclp/xl/workbooks/WorkbookMetadata.scala
+++ b/xl-core/src/com/tjclp/xl/workbooks/WorkbookMetadata.scala
@@ -27,7 +27,7 @@ final case class WorkbookMetadata(
   modified: Option[java.time.LocalDateTime] = None,
   lastModifiedBy: Option[String] = None,
   application: Option[String] = Some("XL - Pure Scala 3.8 Excel Library"),
-  appVersion: Option[String] = Some("0.13.0"),
+  appVersion: Option[String] = Some("0.14.0"),
   theme: ThemePalette = ThemePalette.office,
   definedNames: Vector[DefinedName] = Vector.empty,
   sheetStates: Map[SheetName, Option[String]] = Map.empty,

--- a/xl/src/com/tjclp/xl/scripting.scala
+++ b/xl/src/com/tjclp/xl/scripting.scala
@@ -4,7 +4,7 @@ package com.tjclp.xl
  * Scripting prelude: everything a script needs in one import.
  *
  * {{{
- * //> using dep com.tjclp::xl:0.13.0
+ * //> using dep com.tjclp::xl:0.14.0
  * import com.tjclp.xl.scripting.{*, given}
  *
  * val wb = Excel.read("input.xlsx")


### PR DESCRIPTION
Release prep for **0.14.0 "Candor"** — the replication-campaign finale (#344 typed-result refactor via PR #401, #400 full calcPr authoring via PR #402).

- Version pins `0.13.0` → `0.14.0` across build, metadata, plugin, docs, examples, skill snippets
- CHANGELOG: `[0.14.0] "Candor"` heading (release-notes source for the tag)
- STATUS.md + roadmap.md campaign-finale bookkeeping (W1–W7 complete across three releases)
- Skill/reference docs: the new error-value contract (`RecalcResult.excelErrors` vs host-failure `errors`; `=1/0` → catchable `#DIV/0!`), CalcPr's new fields (`CalcMode.Manual/Auto/AutoNoTable`, `fullCalcOnLoad`, `calcId`)

Gates: compile ✓, full test 1028/1028, examples ✓, skill snippets ✓ (--local), `checkFormatAll` ✓, no SNAPSHOT refs.

After merge: annotated tag `v0.14.0` on the squash commit triggers binaries + Maven Central + GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)