### PR TITLE
chore(release): Bump version to 0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0] "Fidelity" - 2026-07-17
+
 Field-hardening from the first production QA cycle (FinAgent LBO build):
 every open issue closed — the numFmt round-trip corruption, the
 post-round-trip XIRR poisoning, blank-arg parity, names in lookup

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ```scala 3 raw
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.14.0
+//> using dep com.tjclp::xl:0.15.0
 
 import com.tjclp.xl.{*, given}
 
@@ -55,13 +55,13 @@ import com.tjclp.xl.{*, given}
 
 ```scala 3 ignore
 // build.mill — single dependency for everything
-def ivyDeps = Agg(ivy"com.tjclp::xl:0.14.0")
+def ivyDeps = Agg(ivy"com.tjclp::xl:0.15.0")
 
 // Or individual modules for minimal footprint:
-// ivy"com.tjclp::xl-core:0.14.0"        — Pure domain model only
-// ivy"com.tjclp::xl-ooxml:0.14.0"       — Add OOXML read/write
-// ivy"com.tjclp::xl-cats-effect:0.14.0" — Add IO streaming
-// ivy"com.tjclp::xl-evaluator:0.14.0"   — Add formula evaluation
+// ivy"com.tjclp::xl-core:0.15.0"        — Pure domain model only
+// ivy"com.tjclp::xl-ooxml:0.15.0"       — Add OOXML read/write
+// ivy"com.tjclp::xl-cats-effect:0.15.0" — Add IO streaming
+// ivy"com.tjclp::xl-evaluator:0.15.0"   — Add formula evaluation
 ```
 
 ### Basic Usage

--- a/build.mill
+++ b/build.mill
@@ -14,7 +14,7 @@ val organization = "com.tjclp"
 /** Shared build configuration constants */
 object BuildConfig {
   /** Project version: CI sets PUBLISH_VERSION; local builds use this fallback */
-  val version: String = sys.env.getOrElse("PUBLISH_VERSION", "0.14.0")
+  val version: String = sys.env.getOrElse("PUBLISH_VERSION", "0.15.0")
 
   /** JVM options to silence Scala 3 LazyVals sun.misc.Unsafe deprecation warnings (JDK 21+) */
   val lazyValsJvmArgs: Seq[String] = Seq(

--- a/docs/QUICK-START.md
+++ b/docs/QUICK-START.md
@@ -12,19 +12,19 @@ import mill._, scalalib._
 
 object myproject extends ScalaModule {
   def scalaVersion = "3.8.3"
-  def ivyDeps = Agg(ivy"com.tjclp::xl:0.14.0")
+  def ivyDeps = Agg(ivy"com.tjclp::xl:0.15.0")
 }
 ```
 
 ### With sbt (build.sbt)
 ```scala
 scalaVersion := "3.8.3"
-libraryDependencies += "com.tjclp" %% "xl" % "0.14.0"
+libraryDependencies += "com.tjclp" %% "xl" % "0.15.0"
 ```
 
 ### With Scala CLI
 ```scala
-//> using dep com.tjclp::xl:0.14.0
+//> using dep com.tjclp::xl:0.15.0
 ```
 
 ### Individual Modules (Optional)
@@ -44,7 +44,7 @@ For scripts, skip the build setup entirely: a two-line `scala-cli` header and ON
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.14.0
+//> using dep com.tjclp::xl:0.15.0
 
 import com.tjclp.xl.scripting.{*, given}
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,12 +1,20 @@
 # XL Project Status
 
-**Last Updated**: 2026-07-16 (0.14.0)
+**Last Updated**: 2026-07-17 (0.15.0)
 
 ## Current State
 
 > **For detailed phase completion status and roadmap, see [plan/roadmap.md](plan/roadmap.md)**
 
 ### What Works (Production-Ready)
+
+**New in 0.15.0** (2026-07-17):
+- ✅ **numFmt round-trip fidelity** (#404) — `<numFmts>` declarations survive read→write verbatim (built-in-equal codes like `"0.00%"` no longer degrade to `General`); total `NumFmt.formatCode` inverse; whole-code `"General"` renders correctly (incl. `TEXT(n,"General")`)
+- ✅ **Range-date serial coercion** (#405) — XIRR/XNPV date ranges and NETWORKDAYS/WORKDAY holidays accept raw serial Numbers; post-round-trip recalc no longer poisons returns blocks
+- ✅ **Variadic blank-arg parity** (#395) + **decoder coercion edges** (#396) — direct blank refs ignored by COUNT/COUNTA/AVERAGE (`=AVERAGE(blank,blank)` → `#DIV/0!`); `decodeAsInt`/`decodeAsDate` mirror ScalarCoercion (Empty/Bool/cached-formula arms)
+- ✅ **Names + sheet-qualified refs in range-typed slots** (#394) — `=VLOOKUP(x, named_table, 2)`, ad-hoc `=XIRR(S!A1:B1,…)`, sheet-scoped names (`=Model!case`), `.`/`\` in names; new `RangeLocation.Name`/`TExpr.SheetNameRef`; latent cross-sheet wrong-sheet bug fixed for INDEX/MATCH/XLOOKUP/XIRR/NPV
+- ✅ **Chart series styling** (#407) — every series emits type-appropriate `<c:spPr>` (bar fills, line strokes, pie per-slice `dPt`) cycling `DefaultTheme.accents`; `Series.fill`, `chart add --series-colors`, `chart` batch op (27 ops), `<c:tx>` always emitted — LibreOffice renders chart output out of the box
+- ✅ **`xl lint`** (#397) — raw-zip validation of CT child order + r:id resolution (exit 0/1/2, `--format json`); preserved CT_Workbook children re-emit in schema position; hyperlink `#` normalization (#406)
 
 **New in 0.14.0** (2026-07-16):
 - ✅ **Excel error values as first-class results** (#344) — `=1/0` evaluates to `#DIV/0!` (IFERROR/ISERROR-catchable, cached as `t="e"` cells) instead of failing the formula; aggregates/logical folds/comparisons propagate per Excel policy (COUNT-family still skips); op-level `#NUM!`/`#DIV/0!`/`#N/A` codes; `#N/A` dimension padding; `"TRUE"`/`"FALSE"` text coerces in conditions; host failures stay loud — the boundary is law-tested (`RecalcResult.excelErrors` vs `errors`); design record `docs/design/error-propagation.md`

--- a/docs/reference/scripting.md
+++ b/docs/reference/scripting.md
@@ -33,7 +33,7 @@ release bump is a mechanical substitution):
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.14.0
+//> using dep com.tjclp::xl:0.15.0
 import com.tjclp.xl.scripting.{*, given}
 
 val sheet = Sheet("Demo").put(ref"A1", "Hello").put(ref"B1", 42)
@@ -51,7 +51,7 @@ read and write is pure values.
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.14.0
+//> using dep com.tjclp::xl:0.15.0
 import com.tjclp.xl.scripting.{*, given}
 
 val wb = Excel.read("input.xlsx")
@@ -167,7 +167,7 @@ throw — they are collected per cell.
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.14.0
+//> using dep com.tjclp::xl:0.15.0
 import com.tjclp.xl.scripting.{*, given}
 
 val title = CellStyle.default.bold.size(14.0).center
@@ -299,7 +299,7 @@ them explicitly:
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.14.0
+//> using dep com.tjclp::xl:0.15.0
 import com.tjclp.xl.scripting.{*, given}
 import com.tjclp.xl.sheets.{HeaderFooter, PageMargins, PageSetup, SheetView}
 
@@ -353,7 +353,7 @@ the whole workbook:
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.14.0
+//> using dep com.tjclp::xl:0.15.0
 import com.tjclp.xl.scripting.{*, given}
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global

--- a/examples/README.md
+++ b/examples/README.md
@@ -170,7 +170,7 @@ chmod +x examples/my_example.sc
 ./examples/my_example.sc
 ```
 
-The `project.scala` file centralizes dependencies (`com.tjclp::xl:0.14.0`) for all examples.
+The `project.scala` file centralizes dependencies (`com.tjclp::xl:0.15.0`) for all examples.
 
 ## Scripting Prelude & Skill
 

--- a/examples/project.scala
+++ b/examples/project.scala
@@ -2,4 +2,4 @@
 //> using repository ivy2Local
 
 // XL aggregate - includes all modules (core, ooxml, cats-effect, evaluator)
-//> using dep com.tjclp::xl:0.14.0
+//> using dep com.tjclp::xl:0.15.0

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "xl",
   "description": "LLM-friendly Excel tooling: the xl CLI for reading, writing, styling, and analyzing spreadsheets (xl-cli skill), plus type-safe Scala scripting against the xl library via scala-cli for bulk transformations, pipelines, and formula models (xl-scripting skill).",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "author": {
     "name": "TJC L.P.",
     "url": "https://github.com/TJC-LP"

--- a/plugin/skills/xl-scripting/SKILL.md
+++ b/plugin/skills/xl-scripting/SKILL.md
@@ -38,7 +38,7 @@ The canonical header for every script (this is the single source of truth — re
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.14.0
+//> using dep com.tjclp::xl:0.15.0
 
 import com.tjclp.xl.scripting.{*, given}
 
@@ -101,7 +101,7 @@ wb.update("Sales", f).unsafe                       // throws structured XLExcept
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.14.0
+//> using dep com.tjclp::xl:0.15.0
 import com.tjclp.xl.scripting.{*, given}
 
 val wb = Excel.read("input.xlsx")
@@ -240,7 +240,7 @@ Or lean on totality so there is nothing to unwrap: literal refs, `upsert`, range
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.14.0
+//> using dep com.tjclp::xl:0.15.0
 import com.tjclp.xl.scripting.{*, given}
 import java.nio.file.{Files, Paths}
 import scala.jdk.CollectionConverters.*
@@ -262,7 +262,7 @@ println(s"merged ${inputs.size} files, ${merged.sheets.size} sheets")
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.14.0
+//> using dep com.tjclp::xl:0.15.0
 import com.tjclp.xl.scripting.{*, given}
 
 val data = List(("North", 125000.50), ("South", 98000.25), ("West", 143500.00))
@@ -290,7 +290,7 @@ println(if result.isClean then "✓ report written" else result.errors.map(_.ren
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.14.0
+//> using dep com.tjclp::xl:0.15.0
 import com.tjclp.xl.scripting.{*, given}
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global

--- a/plugin/skills/xl-scripting/reference/API.md
+++ b/plugin/skills/xl-scripting/reference/API.md
@@ -175,6 +175,8 @@ sheet.addImage(image, ref"B2").unsafe                          // natural size (
 sheet.addImage(image, ref"B2:D8")                              // stretched over a range — total
 val chart = Chart.bar(series, title = Some("Revenue")).unsafe  // XLResult: validated; also Chart.line/pie
 sheet.addChart(chart, ref"F2:K16")                             // anchored over the range — total
+val branded = firstSeries.copy(fill = Some(Color.Rgb(0xFF307FE2))) // explicit series color (0.15.0, packed
+                                                               // ARGB); fill = None cycles theme accents (LO-visible)
 sheet.pictures; sheet.charts                                   // typed views (unmodeled drawings preserved)
 
 // Conditional formatting (0.12.1+) — typed rules with dxf differential formats

--- a/plugin/skills/xl-scripting/reference/RECIPES.md
+++ b/plugin/skills/xl-scripting/reference/RECIPES.md
@@ -10,7 +10,7 @@ Apply a 5% price increase to column C of every workbook in a directory, in place
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.14.0
+//> using dep com.tjclp::xl:0.15.0
 import com.tjclp.xl.scripting.{*, given}
 import java.nio.file.{Files, Paths}
 import scala.jdk.CollectionConverters.*
@@ -42,7 +42,7 @@ Read rows into case classes; collect per-cell validation failures into a new Iss
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.14.0
+//> using dep com.tjclp::xl:0.15.0
 import com.tjclp.xl.scripting.{*, given}
 
 final case class Order(id: Int, customer: String, amount: BigDecimal)
@@ -76,7 +76,7 @@ Three-year projection with growth formulas; fail the script if any formula error
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.14.0
+//> using dep com.tjclp::xl:0.15.0
 import com.tjclp.xl.scripting.{*, given}
 
 val header = CellStyle.default.bold.size(12.0).center
@@ -111,7 +111,7 @@ Stack the data rows of every input file under one header.
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.14.0
+//> using dep com.tjclp::xl:0.15.0
 import com.tjclp.xl.scripting.{*, given}
 import java.nio.file.{Files, Paths}
 import scala.jdk.CollectionConverters.*
@@ -147,7 +147,7 @@ println(s"combined ${files.size} files, ${combined.cells.size} cells")
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.14.0
+//> using dep com.tjclp::xl:0.15.0
 import com.tjclp.xl.scripting.{*, given}
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
@@ -176,7 +176,7 @@ println("✓ filtered (constant memory)")
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.14.0
+//> using dep com.tjclp::xl:0.15.0
 import com.tjclp.xl.scripting.{*, given}
 
 val before = Excel.read("before.xlsx")
@@ -204,7 +204,7 @@ else
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.14.0
+//> using dep com.tjclp::xl:0.15.0
 import com.tjclp.xl.scripting.{*, given}
 import java.nio.file.{Files, Paths}
 import scala.jdk.CollectionConverters.*
@@ -232,7 +232,7 @@ cell ships a cached value for `data_only` readers, pandas, and Excel-before-reca
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.14.0
+//> using dep com.tjclp::xl:0.15.0
 import com.tjclp.xl.scripting.{*, given}
 
 val reps = List(("Alice", 120000.0), ("Bob", 98000.0), ("Carol", 143500.0))
@@ -267,7 +267,7 @@ frozen header, a list-dropdown data validation, and a provenance comment — no 
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.14.0
+//> using dep com.tjclp::xl:0.15.0
 import com.tjclp.xl.scripting.{*, given}
 import com.tjclp.xl.sheets.SheetView // SheetView lives one import deeper than the prelude
 

--- a/xl-core/src/com/tjclp/xl/workbooks/WorkbookMetadata.scala
+++ b/xl-core/src/com/tjclp/xl/workbooks/WorkbookMetadata.scala
@@ -27,7 +27,7 @@ final case class WorkbookMetadata(
   modified: Option[java.time.LocalDateTime] = None,
   lastModifiedBy: Option[String] = None,
   application: Option[String] = Some("XL - Pure Scala 3.8 Excel Library"),
-  appVersion: Option[String] = Some("0.14.0"),
+  appVersion: Option[String] = Some("0.15.0"),
   theme: ThemePalette = ThemePalette.office,
   definedNames: Vector[DefinedName] = Vector.empty,
   sheetStates: Map[SheetName, Option[String]] = Map.empty,

--- a/xl/src/com/tjclp/xl/scripting.scala
+++ b/xl/src/com/tjclp/xl/scripting.scala
@@ -4,7 +4,7 @@ package com.tjclp.xl
  * Scripting prelude: everything a script needs in one import.
  *
  * {{{
- * //> using dep com.tjclp::xl:0.14.0
+ * //> using dep com.tjclp::xl:0.15.0
  * import com.tjclp.xl.scripting.{*, given}
  *
  * val wb = Excel.read("input.xlsx")


### PR DESCRIPTION
Version bump for 0.15.0 "Fidelity" (wave 18 — field-hardening sweep, #409): all pins swept 0.14.0 → 0.15.0 (build.mill fallback, WorkbookMetadata.appVersion, plugin.json, README/QUICK-START/scripting dep lines, examples, xl-scripting SKILL.md + RECIPES.md), CHANGELOG heading, STATUS 0.15.0 block, API.md Series.fill snippet.

Gates: compile 810/810, full suite 1028/1028 (one #414 wall-clock flake on the parallel run, green in isolation + full rerun), examples ✓, skill snippets ✓ (--local), scalafmt CI form ✓, SNAPSHOT grep empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)