### PR TITLE
fix(cli): structural commands recalculate before writing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,12 @@ reads, and `xl lint` catches what Excel refuses.
   a structural edit can change referenced aggregates (a delete that
   shrinks a `SUM` range) and position-sensitive results (`ROW()`), so a
   preserved cache could ship silently-wrong values. A formula whose
-  reference is fully deleted degrades to `#REF!`. Re-bake display values
-  with `xl recalc` / `recalculate()` after structural edits.
+  reference is fully deleted degrades to `#REF!`. The four structural CLI
+  commands then end with one global recalculate before writing (the #352
+  batch contract: failing cells stay uncached, the file is written
+  regardless) — so `insert-rows` output carries fresh-correct `<v>`, never
+  stale or absent ones. Library API callers use `recalculate()` /
+  `writeRecalculated` for the same effect.
 - **Range shifts clamp at the sheet edge** (#428): a full-height range
   (CF sqref `A1:XFD1048576`, DV, merges) shifted past row 1,048,576 /
   column XFD on insertion — `A144:XFD1048578`-class output that **Excel

--- a/xl-cli/src/com/tjclp/xl/cli/commands/WriteCommands.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/commands/WriteCommands.scala
@@ -1328,6 +1328,9 @@ object WriteCommands:
 
   // ===== Structural editing: insert/delete rows & columns (GH-128, GH-129) =====
   // Cell shift (xl-core) + formula rewriting across all sheets (StructuralEditor). #REF! on loss.
+  // A structural edit invalidates every shifted formula's cache (stale aggregates/ROW() would be
+  // silently wrong), so each command ends with one global recalculate() before writing — the
+  // GH-352 batch contract: failing cells stay uncached, the workbook is written regardless.
 
   private def requirePositive(n: Int, label: String): IO[Unit] =
     if n >= 1 then IO.unit
@@ -1369,9 +1372,9 @@ object WriteCommands:
       sheet <- SheetResolver.requireSheet(wb, sheetOpt, "insert-rows")
       _ <- requirePositive(at, "row number")
       _ <- requirePositive(count, "count")
-      updatedWb = StructuralEditor.insertRows(wb, sheet.name, at - 1, count)
-      _ <- writeWorkbook(updatedWb, outputPath, config, stream)
-    yield s"Inserted $count row(s) before row $at on '${sheet.name.value}'\n${saveSuffix(outputPath, stream)}"
+      recalced = StructuralEditor.insertRows(wb, sheet.name, at - 1, count).recalculate()
+      _ <- writeWorkbook(recalced.workbook, outputPath, config, stream)
+    yield s"Inserted $count row(s) before row $at on '${sheet.name.value}'\n${formatRecalcSummary(recalced)}\n${saveSuffix(outputPath, stream)}"
 
   def deleteRows(
     wb: Workbook,
@@ -1386,9 +1389,9 @@ object WriteCommands:
       sheet <- SheetResolver.requireSheet(wb, sheetOpt, "delete-rows")
       _ <- requirePositive(at, "row number")
       _ <- requirePositive(count, "count")
-      updatedWb = StructuralEditor.deleteRows(wb, sheet.name, at - 1, count)
-      _ <- writeWorkbook(updatedWb, outputPath, config, stream)
-    yield s"Deleted $count row(s) from row $at on '${sheet.name.value}'\n${saveSuffix(outputPath, stream)}"
+      recalced = StructuralEditor.deleteRows(wb, sheet.name, at - 1, count).recalculate()
+      _ <- writeWorkbook(recalced.workbook, outputPath, config, stream)
+    yield s"Deleted $count row(s) from row $at on '${sheet.name.value}'\n${formatRecalcSummary(recalced)}\n${saveSuffix(outputPath, stream)}"
 
   def insertColumns(
     wb: Workbook,
@@ -1404,9 +1407,9 @@ object WriteCommands:
       spec <- colSpec(col, count)
       (at0, n) = spec
       _ <- requirePositive(n, "count")
-      updatedWb = StructuralEditor.insertColumns(wb, sheet.name, at0, n)
-      _ <- writeWorkbook(updatedWb, outputPath, config, stream)
-    yield s"Inserted $n column(s) at column ${col.trim.toUpperCase} on '${sheet.name.value}'\n${saveSuffix(outputPath, stream)}"
+      recalced = StructuralEditor.insertColumns(wb, sheet.name, at0, n).recalculate()
+      _ <- writeWorkbook(recalced.workbook, outputPath, config, stream)
+    yield s"Inserted $n column(s) at column ${col.trim.toUpperCase} on '${sheet.name.value}'\n${formatRecalcSummary(recalced)}\n${saveSuffix(outputPath, stream)}"
 
   def deleteColumns(
     wb: Workbook,
@@ -1422,9 +1425,9 @@ object WriteCommands:
       spec <- colSpec(col, count)
       (at0, n) = spec
       _ <- requirePositive(n, "count")
-      updatedWb = StructuralEditor.deleteColumns(wb, sheet.name, at0, n)
-      _ <- writeWorkbook(updatedWb, outputPath, config, stream)
-    yield s"Deleted $n column(s) from column ${col.trim.toUpperCase} on '${sheet.name.value}'\n${saveSuffix(outputPath, stream)}"
+      recalced = StructuralEditor.deleteColumns(wb, sheet.name, at0, n).recalculate()
+      _ <- writeWorkbook(recalced.workbook, outputPath, config, stream)
+    yield s"Deleted $n column(s) from column ${col.trim.toUpperCase} on '${sheet.name.value}'\n${formatRecalcSummary(recalced)}\n${saveSuffix(outputPath, stream)}"
 
   /**
    * Copy a range of cells to another location with optional formula adjustment.

--- a/xl-cli/test/src/com/tjclp/xl/cli/StructuralCommandSpec.scala
+++ b/xl-cli/test/src/com/tjclp/xl/cli/StructuralCommandSpec.scala
@@ -47,19 +47,21 @@ class StructuralCommandSpec extends CatsEffectSuite:
       result <- excel.read(out)
     yield
       val s = result.sheets.head
-      // GH-427: the rewrite emits the model's equals-free canonical form
-      assertEquals(s(ref"B1").value, CellValue.Formula("A1+A4", None)) // A3 -> A4
+      // GH-427: equals-free canonical form; the command's recalc re-bakes the cache (10+30).
+      assertEquals(s(ref"B1").value, CellValue.Formula("A1+A4", Some(CellValue.Number(40))))
       assertEquals(s(ref"A4").value, CellValue.Number(30)) // cell shifted down
       assertEquals(s(ref"A1").value, CellValue.Number(10)) // unchanged
   }
 
-  test("insert-rows invalidates cached <v> and emits a single equals-free <f>") {
-    val cached = Some(CellValue.Number(BigDecimal(4)))
+  test("insert-rows recomputes cached <v> and emits a single equals-free <f>") {
+    // Deliberately WRONG cache (999): only the command's recalc can produce 4, so the file
+    // assertion below distinguishes fresh-correct from stale-preserved.
+    val stale = Some(CellValue.Number(BigDecimal(999)))
     val wb = Workbook(
       Vector(
         Sheet("S")
           .put(ref"A1", CellValue.Number(2))
-          .put(ref"B1", CellValue.Formula("A1*2", cached))
+          .put(ref"B1", CellValue.Formula("A1*2", stale))
       )
     )
     val in = tmp("in427")
@@ -77,12 +79,43 @@ class StructuralCommandSpec extends CatsEffectSuite:
         finally zip.close()
       }
     yield
-      // Model: formula text stays equals-free and the structural edit invalidates its cache.
-      assertEquals(result.sheets.head(ref"B1").value, CellValue.Formula("A1*2", None))
-      // File: <f> carries no '=' and the stale cached <v> is omitted.
+      // Model: equals-free text; the structural edit invalidated the stale cache and the
+      // command's global recalc re-baked the true value.
+      assertEquals(
+        result.sheets.head(ref"B1").value,
+        CellValue.Formula("A1*2", Some(CellValue.Number(4)))
+      )
+      // File: <f> carries no '=' and <v> is the recomputed value, never the stale one.
       assert(raw.contains("<f>A1*2</f>"), s"expected equals-free <f> in: $raw")
       assert(!raw.contains("<f>="), s"leading '=' must not land inside <f>: $raw")
-      assert(!raw.contains("<v>4</v>"), s"stale cached <v> must be omitted: $raw")
+      assert(raw.contains("<v>4</v>"), s"recomputed <v> must be present: $raw")
+      assert(!raw.contains("<v>999</v>"), s"stale <v> must not survive: $raw")
+  }
+
+  test("delete-rows re-bakes a shrinking SUM to its new true value") {
+    val wb = Workbook(
+      Vector(
+        Sheet("S")
+          .put(ref"A1", CellValue.Number(1))
+          .put(ref"A2", CellValue.Number(2))
+          .put(ref"A3", CellValue.Number(3))
+          .put(ref"C1", CellValue.Formula("SUM(A1:A3)", Some(CellValue.Number(6))))
+      )
+    )
+    val in = tmp("inShrink")
+    val out = tmp("outShrink")
+    for
+      _ <- excel.write(wb, in)
+      read <- excel.read(in)
+      _ <- WriteCommands.deleteRows(read, read.sheets.headOption, 2, 1, out, config)
+      result <- excel.read(out)
+    yield
+      // A2 deleted: SUM(A1:A2) now spans A1=1 and A2=3 (was A3). The old cache (6) would be
+      // silently wrong; the command's recalc writes the true 4.
+      assertEquals(
+        result.sheets.head(ref"C1").value,
+        CellValue.Formula("SUM(A1:A2)", Some(CellValue.Number(4)))
+      )
   }
 
   test("delete-rows: a reference into the deleted row becomes #REF!") {
@@ -120,7 +153,9 @@ class StructuralCommandSpec extends CatsEffectSuite:
       result <- excel.read(out)
     yield assertEquals(
       result.sheets.head(ref"A2").value,
-      CellValue.Formula("D1", None) // C1 -> D1 (GH-427: equals-free canonical form)
+      // C1 -> D1 (GH-427: equals-free canonical form); the command's recalc caches the
+      // empty-reference result (0, Excel-consistent).
+      CellValue.Formula("D1", Some(CellValue.Number(0)))
     )
   }
 


### PR DESCRIPTION
Follow-through from the #436 review discussion: 8c021a9's cache-invalidation policy is correct (stale shrink-aggregates/ROW() must never ship), but it left `insert-rows`/`delete-rows`/`insert-cols`/`delete-cols` output with **no cached `<v>` workbook-wide** — blank in openpyxl `data_only`/pandas/`xl view` until a manual recalc, the original field complaint from the Delrin audit.

This wires the #352 batch contract into the four structural commands: one global `recalculate()` before write — fresh-correct caches, failing cells stay uncached, the file is written regardless, errors surface in the command summary.

**Pins** (StructuralCommandSpec): a deliberately-wrong stale cache (`999` → recomputed `4`) and a shrinking-SUM delete (`SUM(A1:A3)` cached `6` → `SUM(A1:A2)` re-baked to the true `4`) — distinguishing fresh-correct from both stale-preserved and absent. Empirical: `insert-rows` on the audit fixture now ships `<f>A4*2</f><v>4</v>`, the array record with `<v>60</v>`, equals-free throughout.

Gates: xl-cli 343/343, full suite 1028/1028, scalafmt CI form clean.

Refs #427

🤖 Generated with [Claude Code](https://claude.com/claude-code)