### PR TITLE
Wave 20: CLI & fidelity correctness — numFmt parity, batch/arg ergonomics, sheet lifecycle, comment/sheetFormatPr round-trip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,65 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+CLI & fidelity correctness wave (wave 20): display parity between every
+numFmt path, batch/CLI ergonomics, sheet-lifecycle bookkeeping, and the
+remaining comment/sheet-default round-trip gaps.
+
+### Fixed
+
+- **Streaming styles emit canonical builtin numFmt ids** (#408):
+  `StylePatcher.findOrAddNumFmt` hand-rolled its own table with three
+  wrong mappings — Decimal wrote id 4 (thousands separators appeared),
+  Percent wrote 10 (`12%` gained decimals), Currency wrote 44 (accounting
+  semantics leaked in). Every non-Custom arm now delegates to the
+  canonical `NumFmt.builtInId` (Decimal→2, Percent→9, Currency→7), so the
+  streaming path — including `--stream put` detected formats from #431 —
+  renders identically to the in-memory writer.
+- **Built-in display arms unified onto FormatCodeParser** (#410):
+  `NumFmtFormatter`'s enum arms hand-rolled rendering that diverged from
+  the same format code through `FormatCodeParser` — `PercentDecimal`
+  showed `15.6%` where Excel shows `15.60%`. Built-in arms now render via
+  `FormatCodeParser(NumFmt.formatCode(fmt))`, property-tested identical
+  to the file-declared path for every built-in variant.
+- **Batch `put` values[] honors the op-level `format`** (#416):
+  `{"op":"put","ref":"A1:A2","values":[1,2],"format":"0.00%"}` silently
+  wrote General cells (the field was accepted-and-ignored). The op-level
+  format now threads into every element with exact single-put semantics —
+  native numbers carry it, strings parse according to it (including the
+  #438 explicit-date rejection), booleans/nulls stay bare — on both the
+  in-memory and streaming batch paths.
+- **Sheet-scoped defined names survive sheet order mutations** (#434):
+  `removeAt`/`insertAt`/`reorder` never remapped
+  `DefinedName.localSheetId`, so sheet-local names (and verbatim-preserved
+  print names) attached to the wrong sheet after any add/remove/reorder.
+  All three now remap scopes (names scoped to a removed sheet are
+  dropped, matching Excel).
+- **remove-sheet prunes its orphaned chart/drawing parts** (#417):
+  deleting a sheet carrying charts left `xl/charts/*`, `xl/drawings/*`,
+  their `.rels` and `[Content_Types]` overrides as dead weight. Parts
+  reachable only via the removed sheet's relationship closure are pruned;
+  anything referenced by a surviving part (shared images) survives.
+- **Comment round-trip fidelity** (#433): a file-authored comment whose
+  first run already spells the author prefix no longer gains a second
+  synthesized prefix, and run colors (`<color indexed=…>`) survive —
+  raw rPr payloads now ride through rewrite byte-faithfully.
+- **Usage errors name their flags** (#422): every write verb without
+  `-o` now says `<verb> requires -o <out.xlsx> (or -i to modify in
+  place)` instead of `Error: Internal: output required`, and `xl lint
+  <file>` accepts the positional file form.
+
+### Added
+
+- **`<sheetFormatPr>` write path** (#426): `Sheet.defaultRowHeight` /
+  `defaultColumnWidth` now emit on both writer backends (and populate on
+  read), so from-scratch books can set sheet-default grid metrics (house
+  grids want 12.75); unmodeled attrs of a preserved `sheetFormatPr` ride
+  through dirty writes.
+- **`Sheet.named(name): XLResult[Sheet]`** (#420): the documented
+  dynamic-name factory beside the literal-specializing transparent-inline
+  `Sheet.apply`, ending the literal-vs-dynamic return-type surprise in
+  scripts; scripting docs and skills now explain the split.
+
 ## [0.16.0] "Bedrock" - 2026-07-29
 
 Structural-integrity wave (wave 19) plus two follow-through fixes: the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ excel.read(path).flatMap(wb => excel.write(wb, outPath))
 
 ```bash
 ./mill __.compile          # Compile all
-./mill __.test             # Run all tests (4,836)
+./mill __.test             # Run all tests (4,908)
 ./mill xl-core.test        # Test specific module
 ./mill __.reformat         # Format (Scalafmt 3.10.1)
 ./mill __.checkFormat      # CI check
@@ -396,12 +396,12 @@ Styles deduplicated by `CellStyle.canonicalKey`. Build style index before emitti
 
 **Framework**: MUnit + ScalaCheck | **Generators**: `xl-core/test/src/com/tjclp/xl/Generators.scala`
 
-**4,836 tests** by module: xl-evaluator (1855), xl-core (1191), xl-ooxml (923), xl-cli (585), xl-cats-effect (135), xl-agent (122), xl prelude probes (25). See `docs/reference/testing-guide.md` for suite structure and patterns.
+**4,908 tests** by module: xl-evaluator (1855), xl-core (1217), xl-ooxml (947), xl-cli (601), xl-cats-effect (141), xl-agent (122), xl prelude probes (25). See `docs/reference/testing-guide.md` for suite structure and patterns.
 
 ## Documentation
 
 - **Roadmap**: `docs/plan/roadmap.md` (single source of truth for work scheduling)
-- **Status**: `docs/STATUS.md` (current capabilities, 4,836 tests)
+- **Status**: `docs/STATUS.md` (current capabilities, 4,908 tests)
 - **Design**: `docs/design/*.md` (architecture, purity charter, domain model)
 - **Reference**: `docs/reference/*.md` (examples, scaffolds, performance guide)
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -163,7 +163,7 @@
 
 ### Test Coverage
 
-**4,836 tests** (verified via `./mill __.test`, 2026-07-29):
+**4,908 tests** (verified via `./mill __.test`, 2026-07-29):
 
 | Module | Tests | Covers |
 |--------|-------|--------|

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -141,7 +141,7 @@ xl rasterizers                                     # List available PNG/PDF back
 | `delete-cols` | `<at-col> [count]` | Delete columns; `#REF!` on lost references (requires `-o`) |
 | `batch` | `<file\|-> [--dry-run]` | Apply multiple operations from JSON (requires `-o`; `--dry-run` validates without a file) |
 | `diff` | `-g <file2> [--format markdown\|json]` | Compare two workbooks; exit 0 identical, 1 differs, 2 error |
-| `lint` | `[--format text\|json]` | Validate package structure (child order, r:id resolution); exit 0 clean, 1 findings, 2 error |
+| `lint` | `[<file>] [--format text\|json]` | Validate package structure (child order, r:id resolution, over-max refs); positional file or `-f`; exit 0 clean, 1 findings, 2 error |
 
 ---
 
@@ -1202,7 +1202,7 @@ xl -f old.xlsx diff -g new.xlsx && echo "unchanged"  # Exit-code driven
 
 ---
 
-### `xl lint [--format text|json]`
+### `xl lint [<file>] [--format text|json]`
 
 Validate the raw package structure against the Excel-repair classes — the defects Excel
 repairs loudly (repair dialog, content stripped) but every lenient reader, xl's own
@@ -1210,7 +1210,8 @@ repairs loudly (repair dialog, content stripped) but every lenient reader, xl's 
 model, so nothing gets normalized before it's checked.
 
 ```bash
-xl -f deliverable.xlsx lint                      # Human-readable findings
+xl lint deliverable.xlsx                         # Positional file form
+xl -f deliverable.xlsx lint                      # Flag form (equivalent)
 xl -f deliverable.xlsx lint --format json        # Stable schema for pipelines
 xl -f deliverable.xlsx lint && echo "safe to send"
 ```

--- a/docs/reference/scripting.md
+++ b/docs/reference/scripting.md
@@ -112,6 +112,35 @@ val formE = fx"=B$row*C$row" // Either[XLError, CellValue]
 val cell2 = fx"=B$row*2".unsafe // explicit boundary when fail-fast is fine
 ```
 
+The **same split applies to `Sheet(name)`** — and it is easier to trip over because there is no
+`$` at the call site to warn you. A string **literal** validates at compile time and returns
+`Sheet`; a name held in a `val` makes the very same call return `XLResult[Sheet]`, so a chained
+`.put(...)` suddenly type-errors:
+
+```scala
+val lit = Sheet("Acquisitions").put(ref"A1", 1) // : Sheet
+val nm: String = config.sheetName
+val dyn = Sheet(nm)                             // : XLResult[Sheet] — the return type changed!
+```
+
+For names computed at runtime, use **`Sheet.named`** (since 0.17.0) — the documented dynamic-name
+factory. Validation is identical (Excel's rules: non-empty, ≤31 chars, no `: \ / ? * [ ]`); the
+difference is that `XLResult` is spelled in the signature, so the `.map`/`.unsafe` step reads as
+intended instead of surprising the chain:
+
+```scala
+//> using scala 3.8.3
+//> using dep com.tjclp::xl:0.16.0
+import com.tjclp.xl.scripting.{*, given}
+
+val region = Seq("North", "East").mkString(" ")                     // runtime name
+val sheet = Sheet.named(region).map(_.put(ref"A1", "ready")).unsafe // XLResult, spelled out
+Excel.write(Workbook(sheet), "/tmp/named.xlsx")
+```
+
+On ≤0.16.0 (no `named`), make the union explicit at the call site with an ascription:
+`val s: XLResult[Sheet] = Sheet(nm)`.
+
 Prefer **total navigation** over interpolated refs in loops — no `Either` at all:
 
 ```scala

--- a/plugin/skills/xl-scripting/SKILL.md
+++ b/plugin/skills/xl-scripting/SKILL.md
@@ -66,6 +66,9 @@ wb("Sales")                                        // XLResult[Sheet] (literal n
 wb.upsert("Summary", _.put(ref"A1", "Total"))      // total: update-or-create, returns Workbook
 wb.update("Sales", f)                              // XLResult[Workbook] (errors if absent)
 
+// Sheet creation: Sheet("lit") is compile-checked and returns Sheet; for RUNTIME names
+Sheet.named(dynamicName)                           // XLResult[Sheet] — the dynamic-name factory (0.17.0)
+
 // Cell writes (literal refs are compile-time validated and infallible)
 sheet.put(ref"A1", "Title")                        // Sheet
 sheet.put("A1", "Title")                           // literal string: Sheet; runtime string: XLResult[Sheet]
@@ -134,6 +137,18 @@ val formE = fx"=B$row*C$row"              // Either[XLError, CellValue]
 // sequence with for-comprehensions, or unwrap explicitly:
 val patch = (ref"A$row").map(_ := "x").getOrElse(Patch.empty)
 val cell2 = fx"=B$row*2".unsafe           // explicit boundary
+```
+
+**The same split applies to `Sheet(name)`** — with no `$` at the call site to warn you. A string
+literal validates at compile time and returns `Sheet`; a name held in a `val` makes the very same
+call return `XLResult[Sheet]`, so a chained `.put(...)` type-errors. For runtime names use
+`Sheet.named` (since 0.17.0), which spells the `XLResult` in its signature:
+
+```scala
+val lit = Sheet("Acquisitions").put(ref"A1", 1)  // : Sheet (literal, compile-time validated)
+val nm: String = config.sheetName
+val dyn = Sheet(nm)                              // : XLResult[Sheet] — return type changed silently
+val ok = Sheet.named(nm).map(_.put(ref"A1", 1))  // XLResult[Sheet], spelled out — map/unsafe as intended
 ```
 
 **Prefer total navigation over interpolated refs in loops** — no Either at all:
@@ -322,6 +337,7 @@ Switch to streaming above ~100k rows; `Excel.read` loads the whole workbook. Str
 - **`Excel.write` does NOT recalculate** — freshly built `fx"…"` cells are written with no cached values, so Excel-before-recalc, openpyxl `data_only`, pandas, and previewers all show blanks. Since 0.13.0 the one-call fix is **`Excel.writeRecalculated(wb, path)`** ([#360](https://github.com/TJC-LP/xl/issues/360)): it recalculates, writes the cached workbook (even when some formulas fail — errors are data), and returns the `RecalcResult` (inspect `result.errors` / `result.isClean`). For fail-hard pipelines that must abort *before* anything lands on disk, keep the explicit `val result = wb.recalculate(); …; Excel.write(result.workbook, path)` pattern. On ≤0.12.x, `writeRecalculated` is unavailable — recalculate then write `result.workbook` (a single pass suffices on 0.12.5+).
 - **Percent postfix works since 0.13.0** ([#355](https://github.com/TJC-LP/xl/issues/355)): `fx"=A1*10%"`, `fx"=10%"`, `fx"=(1+5%)^2"` parse, evaluate (`10%` → exact `0.1`), broadcast over ranges, and print back byte-identically (never rewritten to `/100`). On ≤0.12.x the parser rejects `%` — write `/100` there. External-workbook refs (`[2]Book!A1`) parse and pin their Excel-written caches **since 0.12.6** ([#353](https://github.com/TJC-LP/xl/issues/353)): `recalculate()` preserves those cells verbatim and dependents compute from the caches (uncached external cells yield a per-cell error); on ≤0.12.5 they fail to parse entirely — compute from cached values there.
 - **Runtime column handles for `setColumnProperties`** ([#361](https://github.com/TJC-LP/xl/issues/361), since 0.13.0): fold over letters computed at runtime with `Column.parse("D")` (`Either[String, Column]`; trailing row digits tolerated, so `"D1"` works) — e.g. `Column.parse(letter).map(c => sheet.setColumnProperties(c, ColumnProperties(width = Some(w))))`. A runtime `RefType` also exposes `.col` (`RefType.parse(s).map(_.col)`). On ≤0.12.x only the compile-time `ref"D1".col` existed — set widths with literal refs per column there.
+- **`Sheet(name)` with a runtime name returns `XLResult[Sheet]`, not `Sheet`** ([#420](https://github.com/TJC-LP/xl/issues/420)): the factory is `transparent inline` — a string literal validates at compile time and returns `Sheet`, while a name held in a `val` makes the very same call return `XLResult[Sheet]`, so a chained `.put(...)` type-errors with nothing at the call site to warn you. For dynamic names use **`Sheet.named(name)`** (since 0.17.0) — identical validation, `XLResult` spelled in the signature: `Sheet.named(nm).map(_.put(ref"A1", 1))`. On ≤0.16.0, make the union explicit with an ascription: `val s: XLResult[Sheet] = Sheet(nm)`.
 
 ## Reference
 

--- a/plugin/skills/xl-scripting/reference/API.md
+++ b/plugin/skills/xl-scripting/reference/API.md
@@ -67,7 +67,8 @@ RefType.parse("Sales!C2:E9").map(_.col)  // Right(C) — runtime ref's (starting
 
 | Method | Returns | Notes |
 |--------|---------|-------|
-| `Sheet("Name")` | `Sheet` | literal validated at compile time |
+| `Sheet("Name")` | `Sheet` (literal) / `XLResult[Sheet]` (runtime string) | literal validated at compile time; the specialization is invisible at the call site — prefer `Sheet.named` for runtime names ([#420](https://github.com/TJC-LP/xl/issues/420)) |
+| `Sheet.named(name)` | `XLResult[Sheet]` | THE dynamic-name factory (0.17.0): same validation as `Sheet(name)`, result type spelled in the signature — `Sheet.named(nm).map(_.put(ref"A1", 1))` |
 | `sheet.put(ref"A1", value)` | `Sheet` | value: String, Int, Long, Double, BigDecimal, Boolean, LocalDate, LocalDateTime, RichText, CellValue, Formatted |
 | `sheet.put(ref"A1", value, style)` | `Sheet` | put with inline style |
 | `sheet.put("A1", value)` | `Sheet` (literal) / `XLResult[Sheet]` (runtime string) | |

--- a/xl-cats-effect/src/com/tjclp/xl/io/streaming/StylePatcher.scala
+++ b/xl-cats-effect/src/com/tjclp/xl/io/streaming/StylePatcher.scala
@@ -306,20 +306,6 @@ object StylePatcher:
     numFmt: NumFmt
   ): (Option[Elem], Int) =
     numFmt match
-      case NumFmt.General => (numFmts, 0)
-      case NumFmt.Text => (numFmts, 49)
-      case NumFmt.Decimal => (numFmts, 4)
-      case NumFmt.Percent => (numFmts, 10)
-      case NumFmt.Currency => (numFmts, 44)
-      case NumFmt.Date => (numFmts, 14)
-      case NumFmt.DateTime => (numFmts, 22)
-      case NumFmt.Time => (numFmts, 21)
-      case NumFmt.Integer => (numFmts, 1)
-      case NumFmt.ThousandsSeparator => (numFmts, 3)
-      case NumFmt.ThousandsDecimal => (numFmts, 4)
-      case NumFmt.PercentDecimal => (numFmts, 10)
-      case NumFmt.Scientific => (numFmts, 11)
-      case NumFmt.Fraction => (numFmts, 12)
       case NumFmt.Custom(code) =>
         val existing = numFmts.map(n => (n \ "numFmt").toSeq).getOrElse(Seq.empty)
 
@@ -360,6 +346,12 @@ object StylePatcher:
                 )
 
             (Some(updated), nextId)
+
+      case builtin =>
+        // One source of truth (GH-408): the canonical NumFmt.builtInId table — the same one
+        // the in-memory StyleSerializer writes — so both write paths emit identical ids.
+        // builtInId is total for every non-Custom variant; the fallback is unreachable.
+        (numFmts, NumFmt.builtInId(builtin).getOrElse(0))
 
   private def createCellXf(
     fontId: Int,
@@ -570,22 +562,12 @@ object StylePatcher:
       .getOrElse(Border.none)
 
   private def extractNumFmt(root: Elem, numFmtId: Int): NumFmt =
-    numFmtId match
-      case 0 => NumFmt.General
-      case 49 => NumFmt.Text
-      case 4 => NumFmt.Decimal
-      case 10 => NumFmt.Percent
-      case 44 => NumFmt.Currency
-      case 14 => NumFmt.Date
-      case 22 => NumFmt.DateTime
-      case 21 => NumFmt.Time
-      case id =>
-        // Look up custom format
-        val numFmts = (root \ "numFmts" \ "numFmt")
-        numFmts
-          .find(nf => (nf \ "@numFmtId").text.toIntOption.contains(id))
-          .map(nf => NumFmt.Custom((nf \ "@formatCode").text))
-          .getOrElse(NumFmt.General)
+    // DOM StyleParser parity (GH-408): declared <numFmt> entries win with their code kept
+    // VERBATIM as Custom (GH-404), then the canonical builtin table, then General.
+    val declared = (root \ "numFmts" \ "numFmt")
+      .find(nf => (nf \ "@numFmtId").text.toIntOption.contains(numFmtId))
+      .map(nf => NumFmt.Custom((nf \ "@formatCode").text))
+    declared.orElse(NumFmt.fromId(numFmtId)).getOrElse(NumFmt.General)
 
   private def extractAlignment(xf: Node): Align =
     val alignment = (xf \ "alignment")

--- a/xl-cats-effect/test/src/com/tjclp/xl/io/streaming/StylePatcherSpec.scala
+++ b/xl-cats-effect/test/src/com/tjclp/xl/io/streaming/StylePatcherSpec.scala
@@ -1,0 +1,127 @@
+package com.tjclp.xl.io.streaming
+
+import munit.FunSuite
+import com.tjclp.xl.ooxml.XmlSecurity
+import com.tjclp.xl.styles.CellStyle
+import com.tjclp.xl.styles.numfmt.NumFmt
+
+/**
+ * StylePatcher numFmt-id parity with the canonical NumFmt table (GH-408).
+ *
+ * The streaming style path (addStyle) and the in-memory writer (StyleSerializer via
+ * NumFmt.builtInId) must emit the same numFmtId for the same NumFmt value, and getStyle must
+ * resolve ids the way the DOM StyleParser does (declared entries win verbatim, then
+ * NumFmt.fromId). A hand-rolled id table here made Decimal/Percent/Currency render differently
+ * between the two write paths.
+ */
+class StylePatcherSpec extends FunSuite:
+
+  private val minimalStylesXml: String =
+    """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+      |<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+      |<fonts count="1"><font><sz val="11"/><name val="Calibri"/></font></fonts>
+      |<fills count="2"><fill><patternFill patternType="none"/></fill><fill><patternFill patternType="gray125"/></fill></fills>
+      |<borders count="1"><border><left/><right/><top/><bottom/><diagonal/></border></borders>
+      |<cellStyleXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0"/></cellStyleXfs>
+      |<cellXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0"/></cellXfs>
+      |</styleSheet>""".stripMargin.replaceAll("\n", "")
+
+  /** Every built-in NumFmt variant with its canonical OOXML id (ECMA-376 Part 1, §18.8.30). */
+  private val builtInIds: List[(NumFmt, Int)] = List(
+    NumFmt.General -> 0,
+    NumFmt.Integer -> 1,
+    NumFmt.Decimal -> 2,
+    NumFmt.ThousandsSeparator -> 3,
+    NumFmt.ThousandsDecimal -> 4,
+    NumFmt.Currency -> 7,
+    NumFmt.Percent -> 9,
+    NumFmt.PercentDecimal -> 10,
+    NumFmt.Scientific -> 11,
+    NumFmt.Fraction -> 12,
+    NumFmt.Date -> 14,
+    NumFmt.Time -> 21,
+    NumFmt.DateTime -> 22,
+    NumFmt.Text -> 49
+  )
+
+  /** Patch a style with the given numFmt into styles.xml, returning (updated xml, new xf id). */
+  private def patch(stylesXml: String, fmt: NumFmt): (String, Int) =
+    StylePatcher.addStyle(stylesXml, CellStyle.default.withNumFmt(fmt)) match
+      case Right(result) => result
+      case Left(e) => fail(s"addStyle failed for $fmt: ${e.message}")
+
+  /** The numFmtId attribute of cellXfs/xf at the given index. */
+  private def numFmtIdOf(stylesXml: String, xfId: Int): Int =
+    XmlSecurity.parseSafe(stylesXml, "styles.xml") match
+      case Right(root) =>
+        (root \ "cellXfs" \ "xf").lift(xfId) match
+          case Some(xf) =>
+            (xf \ "@numFmtId").text.toIntOption.getOrElse(fail(s"xf $xfId has no numFmtId"))
+          case None => fail(s"no cellXfs/xf at index $xfId")
+      case Left(e) => fail(s"parse failed: ${e.message}")
+
+  test("addStyle: every builtin numFmt lands its canonical ECMA-376 id (GH-408)") {
+    builtInIds.foreach { case (fmt, expectedId) =>
+      val (updated, xfId) = patch(minimalStylesXml, fmt)
+      assertEquals(numFmtIdOf(updated, xfId), expectedId, s"wrong numFmtId for $fmt")
+    }
+  }
+
+  test("addStyle: emitted ids delegate to NumFmt.builtInId (one source of truth, GH-408)") {
+    builtInIds.map(_._1).foreach { fmt =>
+      val (updated, xfId) = patch(minimalStylesXml, fmt)
+      assertEquals(
+        Some(numFmtIdOf(updated, xfId)),
+        NumFmt.builtInId(fmt),
+        s"StylePatcher diverged from NumFmt.builtInId for $fmt"
+      )
+    }
+  }
+
+  test("addStyle then getStyle round-trips every builtin numFmt (GH-408)") {
+    builtInIds.map(_._1).foreach { fmt =>
+      val (updated, xfId) = patch(minimalStylesXml, fmt)
+      StylePatcher.getStyle(updated, xfId) match
+        case Right(Some(style)) => assertEquals(style.numFmt, fmt, s"round-trip lost $fmt")
+        case Right(None) => fail(s"style $xfId not found after addStyle($fmt)")
+        case Left(e) => fail(s"getStyle failed for $fmt: ${e.message}")
+    }
+  }
+
+  test("addStyle then getStyle round-trips a custom format code (GH-408)") {
+    val custom = NumFmt.Custom("0.000")
+    val (updated, xfId) = patch(minimalStylesXml, custom)
+    assertEquals(numFmtIdOf(updated, xfId), NumFmt.FirstCustomId, "custom ids start at 164")
+    StylePatcher.getStyle(updated, xfId) match
+      case Right(Some(style)) => assertEquals(style.numFmt, custom)
+      case other => fail(s"expected round-tripped custom style, got $other")
+  }
+
+  test("addStyle: identical custom codes reuse one declared numFmt id (GH-408)") {
+    val custom = NumFmt.Custom("0.000")
+    val (afterFirst, _) = patch(minimalStylesXml, custom)
+    val (afterSecond, secondXfId) = patch(afterFirst, custom)
+    assertEquals(numFmtIdOf(afterSecond, secondXfId), NumFmt.FirstCustomId)
+    XmlSecurity.parseSafe(afterSecond, "styles.xml") match
+      case Right(root) =>
+        assertEquals((root \ "numFmts" \ "numFmt").size, 1, "same code must not re-declare")
+      case Left(e) => fail(s"parse failed: ${e.message}")
+  }
+
+  test("getStyle: declared numFmt entries win over the builtin table (DOM parity, GH-408)") {
+    // The DOM StyleParser resolves numFmts.get(id).orElse(NumFmt.fromId(id)): a declared
+    // <numFmt> keeps its code VERBATIM (GH-404) even when its id shadows a builtin slot.
+    val declared =
+      """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        |<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+        |<numFmts count="1"><numFmt numFmtId="10" formatCode="0.0%"/></numFmts>
+        |<fonts count="1"><font><sz val="11"/><name val="Calibri"/></font></fonts>
+        |<fills count="2"><fill><patternFill patternType="none"/></fill><fill><patternFill patternType="gray125"/></fill></fills>
+        |<borders count="1"><border><left/><right/><top/><bottom/><diagonal/></border></borders>
+        |<cellStyleXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0"/></cellStyleXfs>
+        |<cellXfs count="1"><xf numFmtId="10" fontId="0" fillId="0" borderId="0" xfId="0" applyNumberFormat="1"/></cellXfs>
+        |</styleSheet>""".stripMargin.replaceAll("\n", "")
+    StylePatcher.getStyle(declared, 0) match
+      case Right(Some(style)) => assertEquals(style.numFmt, NumFmt.Custom("0.0%"))
+      case other => fail(s"expected declared code to win, got $other")
+  }

--- a/xl-cats-effect/test/src/com/tjclp/xl/io/streaming/StylePatcherSpec.scala
+++ b/xl-cats-effect/test/src/com/tjclp/xl/io/streaming/StylePatcherSpec.scala
@@ -10,9 +10,9 @@ import com.tjclp.xl.styles.numfmt.NumFmt
  *
  * The streaming style path (addStyle) and the in-memory writer (StyleSerializer via
  * NumFmt.builtInId) must emit the same numFmtId for the same NumFmt value, and getStyle must
- * resolve ids the way the DOM StyleParser does (declared entries win verbatim, then
- * NumFmt.fromId). A hand-rolled id table here made Decimal/Percent/Currency render differently
- * between the two write paths.
+ * resolve ids the way the DOM StyleParser does (declared entries win verbatim, then NumFmt.fromId).
+ * A hand-rolled id table here made Decimal/Percent/Currency render differently between the two
+ * write paths.
  */
 class StylePatcherSpec extends FunSuite:
 

--- a/xl-cli/src/com/tjclp/xl/cli/Main.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/Main.scala
@@ -133,10 +133,14 @@ object Main
           IO.println(Format.errorSimple(s"Unexpected diff command: $other")).as(ExitCode.Error)
     }
 
-    // Lint: raw-zip structural validation (GH-397, no output file); custom exit codes
-    val lintOpts = (fileOpt, lintCmd).mapN { (file, cmd) =>
+    // Lint: raw-zip structural validation (GH-397, no output file); custom exit codes.
+    // The file arrives via -f or positionally (GH-422); exactly one form must be used.
+    val lintOpts = (fileOpt.orNone, lintCmd).mapN { case (flagFile, (cmd, positional)) =>
       cmd match
-        case CliCommand.Lint(format) => runLint(file, format)
+        case CliCommand.Lint(format) =>
+          resolveLintFile(flagFile, positional) match
+            case Right(file) => runLint(file, format)
+            case Left(msg) => IO.println(Format.errorSimple(msg)).as(ExitCode(2))
         case other =>
           IO.println(Format.errorSimple(s"Unexpected lint command: $other")).as(ExitCode.Error)
     }
@@ -577,8 +581,9 @@ lenient reader accepts silently:
     part missing from the package
 
 USAGE:
-  xl -f report.xlsx lint
-  xl -f report.xlsx lint --format json       # Stable machine-readable schema
+  xl lint report.xlsx
+  xl -f report.xlsx lint                     # Equivalent flag form
+  xl lint report.xlsx --format json          # Stable machine-readable schema
 
 FINDING CATEGORIES:
   child-order | unresolved-rel-id | wrong-rel-type | missing-part
@@ -591,8 +596,8 @@ EXIT CODES:
 Docs: xl lint is read-only; it never repairs or rewrites the file.
 
 EXAMPLES:
-  xl -f deliverable.xlsx lint && echo "safe to send"
-  xl -f deliverable.xlsx lint --format json | jq '.findings'"""
+  xl lint deliverable.xlsx && echo "safe to send"
+  xl lint deliverable.xlsx --format json | jq '.findings'"""
 
   private val lintFormatOpt: Opts[LintFormat] =
     Opts
@@ -606,9 +611,15 @@ EXAMPLES:
             cats.data.Validated.invalidNel(s"Unknown format: $other. Use text or json")
       }
 
-  val lintCmd: Opts[CliCommand] =
+  /**
+   * Lint reads exactly one file and writes nothing, so it also accepts the file as a positional
+   * argument — `xl lint report.xlsx` — alongside the global `-f` form (GH-422).
+   */
+  val lintCmd: Opts[(CliCommand, Option[Path])] =
     Opts.subcommand("lint", lintHelp) {
-      lintFormatOpt.map(CliCommand.Lint.apply)
+      (lintFormatOpt, Opts.argument[Path]("file").orNone).mapN((format, positional) =>
+        (CliCommand.Lint(format), positional)
+      )
     }
 
   // --- Info commands (no --file required) ---
@@ -1693,6 +1704,22 @@ EXAMPLES:
     }
 
   /**
+   * Resolve lint's input file from the `-f` flag and the positional form — exactly one must be
+   * given (GH-422). Errors use lint's exit-code 2 convention at the call site.
+   */
+  private[cli] def resolveLintFile(
+    flagFile: Option[Path],
+    positional: Option[Path]
+  ): Either[String, Path] =
+    (flagFile, positional) match
+      case (Some(file), None) => Right(file)
+      case (None, Some(file)) => Right(file)
+      case (Some(f), Some(p)) =>
+        Left(s"lint takes exactly one file — got both -f '$f' and positional '$p'")
+      case (None, None) =>
+        Left("lint requires a file: xl lint <file> (or xl -f <file> lint)")
+
+  /**
    * Run the lint command with its exit-code convention: 0 = clean, 1 = findings, 2 = error
    * (unreadable file, missing/malformed core part). Opens the zip directly — NOT ExcelIO.read —
    * because a full parse would repair/normalize the very structure lint inspects (GH-397).
@@ -1997,7 +2024,7 @@ EXAMPLES:
         )
       )
 
-  private def executeCommand(
+  private[cli] def executeCommand(
     wb: Workbook,
     sheetOpt: Option[Sheet],
     outputOpt: Option[Path],
@@ -2010,11 +2037,11 @@ EXAMPLES:
       action match
         case SheetsAction.List(_) => WorkbookCommands.sheets(wb)
         case SheetsAction.Hide(name, veryHide) =>
-          requireOutput(outputOpt, backendOpt, stream)(
+          requireOutput("sheets hide", outputOpt, backendOpt, stream)(
             SheetCommands.hideSheet(wb, name, veryHide, _, _, _)
           )
         case SheetsAction.Show(name) =>
-          requireOutput(outputOpt, backendOpt, stream)(
+          requireOutput("sheets show", outputOpt, backendOpt, stream)(
             SheetCommands.showSheet(wb, name, _, _, _)
           )
 
@@ -2082,12 +2109,12 @@ EXAMPLES:
 
     // Write commands (require output)
     case CliCommand.Put(refStr, values, csvSplit, detect) =>
-      requireOutput(outputOpt, backendOpt, stream)(
+      requireOutput("put", outputOpt, backendOpt, stream)(
         WriteCommands.put(wb, sheetOpt, refStr, values, _, _, _, csvSplit, detect)
       )
 
     case CliCommand.PutFormula(refStr, formulas) =>
-      requireOutput(outputOpt, backendOpt, stream)(
+      requireOutput("putf", outputOpt, backendOpt, stream)(
         WriteCommands.putFormula(wb, sheetOpt, refStr, formulas, _, _, _)
       )
 
@@ -2112,7 +2139,7 @@ EXAMPLES:
           borderColor,
           replace
         ) =>
-      requireOutput(outputOpt, backendOpt, stream) { (outputPath, config, streamWrite) =>
+      requireOutput("style", outputOpt, backendOpt, stream) { (outputPath, config, streamWrite) =>
         WriteCommands.style(
           wb,
           sheetOpt,
@@ -2142,12 +2169,12 @@ EXAMPLES:
       }
 
     case CliCommand.RowOp(rowNum, height, hide, show) =>
-      requireOutput(outputOpt, backendOpt, stream)(
+      requireOutput("row", outputOpt, backendOpt, stream)(
         WriteCommands.row(wb, sheetOpt, rowNum, height, hide, show, _, _, _)
       )
 
     case CliCommand.ColOp(colStr, width, hide, show, autoFit) =>
-      requireOutput(outputOpt, backendOpt, stream)(
+      requireOutput("col", outputOpt, backendOpt, stream)(
         WriteCommands.col(wb, sheetOpt, colStr, width, hide, show, autoFit, _, _, _)
       )
 
@@ -2155,146 +2182,152 @@ EXAMPLES:
       batchDryRun(source)
 
     case CliCommand.Batch(source, _) =>
-      requireOutput(outputOpt, backendOpt, stream)(
+      requireOutput("batch", outputOpt, backendOpt, stream)(
         WriteCommands.batch(wb, sheetOpt, source, _, _, _)
       )
 
     case CliCommand.Recalc =>
-      requireOutput(outputOpt, backendOpt, stream)(
+      requireOutput("recalc", outputOpt, backendOpt, stream)(
         WriteCommands.recalc(wb, _, _, _)
       )
 
     case CliCommand.Import(csvPath, startRefOpt, delim, skipHeader, enc, newSheetOpt, noInfer) =>
-      requireOutput(outputOpt, backendOpt, stream) { (outputPath, writerConfig, streamWrite) =>
-        ImportCommands.importCsv(
-          wb,
-          sheetOpt,
-          csvPath,
-          startRefOpt,
-          delim,
-          skipHeader,
-          enc,
-          newSheetOpt,
-          noInfer,
-          outputPath,
-          writerConfig,
-          streamWrite
-        )
+      requireOutput("import", outputOpt, backendOpt, stream) {
+        (outputPath, writerConfig, streamWrite) =>
+          ImportCommands.importCsv(
+            wb,
+            sheetOpt,
+            csvPath,
+            startRefOpt,
+            delim,
+            skipHeader,
+            enc,
+            newSheetOpt,
+            noInfer,
+            outputPath,
+            writerConfig,
+            streamWrite
+          )
       }
 
     case CliCommand.ImportMarkdown(mdPath, startRefOpt, skipHeader, newSheetOpt, noInfer) =>
-      requireOutput(outputOpt, backendOpt, stream) { (outputPath, writerConfig, streamWrite) =>
-        ImportCommands.importMarkdown(
-          wb,
-          sheetOpt,
-          mdPath,
-          startRefOpt,
-          skipHeader,
-          newSheetOpt,
-          noInfer,
-          outputPath,
-          writerConfig,
-          streamWrite
-        )
+      requireOutput("import-md", outputOpt, backendOpt, stream) {
+        (outputPath, writerConfig, streamWrite) =>
+          ImportCommands.importMarkdown(
+            wb,
+            sheetOpt,
+            mdPath,
+            startRefOpt,
+            skipHeader,
+            newSheetOpt,
+            noInfer,
+            outputPath,
+            writerConfig,
+            streamWrite
+          )
       }
 
     // Sheet management commands
     case CliCommand.AddSheet(name, afterOpt, beforeOpt) =>
-      requireOutput(outputOpt, backendOpt, stream)(
+      requireOutput("add-sheet", outputOpt, backendOpt, stream)(
         SheetCommands.addSheet(wb, name, afterOpt, beforeOpt, _, _, _)
       )
 
     case CliCommand.RemoveSheet(name) =>
-      requireOutput(outputOpt, backendOpt, stream)(SheetCommands.removeSheet(wb, name, _, _, _))
+      requireOutput("remove-sheet", outputOpt, backendOpt, stream)(
+        SheetCommands.removeSheet(wb, name, _, _, _)
+      )
 
     case CliCommand.RenameSheet(oldName, newName) =>
-      requireOutput(outputOpt, backendOpt, stream)(
+      requireOutput("rename-sheet", outputOpt, backendOpt, stream)(
         SheetCommands.renameSheet(wb, oldName, newName, _, _, _)
       )
 
     case CliCommand.Name(action) =>
       action match
         case NameAction.Add(nm, refersTo) =>
-          requireOutput(outputOpt, backendOpt, stream)(
+          requireOutput("name add", outputOpt, backendOpt, stream)(
             SheetCommands.nameAdd(wb, nm, refersTo, _, _, _)
           )
         case NameAction.Remove(nm) =>
-          requireOutput(outputOpt, backendOpt, stream)(SheetCommands.nameRemove(wb, nm, _, _, _))
+          requireOutput("name rm", outputOpt, backendOpt, stream)(
+            SheetCommands.nameRemove(wb, nm, _, _, _)
+          )
 
     case CliCommand.MoveSheet(name, toIndexOpt, afterOpt, beforeOpt) =>
-      requireOutput(outputOpt, backendOpt, stream)(
+      requireOutput("move-sheet", outputOpt, backendOpt, stream)(
         SheetCommands.moveSheet(wb, name, toIndexOpt, afterOpt, beforeOpt, _, _, _)
       )
 
     case CliCommand.CopySheet(sourceName, targetName) =>
-      requireOutput(outputOpt, backendOpt, stream)(
+      requireOutput("copy-sheet", outputOpt, backendOpt, stream)(
         SheetCommands.copySheet(wb, sourceName, targetName, _, _, _)
       )
 
     // Cell commands
     case CliCommand.Merge(rangeStr) =>
-      requireOutput(outputOpt, backendOpt, stream)(
+      requireOutput("merge", outputOpt, backendOpt, stream)(
         CellCommands.merge(wb, sheetOpt, rangeStr, _, _, _)
       )
 
     case CliCommand.Unmerge(rangeStr) =>
-      requireOutput(outputOpt, backendOpt, stream)(
+      requireOutput("unmerge", outputOpt, backendOpt, stream)(
         CellCommands.unmerge(wb, sheetOpt, rangeStr, _, _, _)
       )
 
     case CliCommand.AddComment(refStr, text, author) =>
-      requireOutput(outputOpt, backendOpt, stream)(
+      requireOutput("comment", outputOpt, backendOpt, stream)(
         CommentCommands.addComment(wb, sheetOpt, refStr, text, author, _, _, _)
       )
 
     case CliCommand.RemoveComment(refStr) =>
-      requireOutput(outputOpt, backendOpt, stream)(
+      requireOutput("remove-comment", outputOpt, backendOpt, stream)(
         CommentCommands.removeComment(wb, sheetOpt, refStr, _, _, _)
       )
 
     case CliCommand.Clear(rangeStr, all, styles, comments) =>
-      requireOutput(outputOpt, backendOpt, stream)(
+      requireOutput("clear", outputOpt, backendOpt, stream)(
         CellCommands.clear(wb, sheetOpt, rangeStr, all, styles, comments, _, _, _)
       )
 
     case CliCommand.Fill(source, target, direction) =>
-      requireOutput(outputOpt, backendOpt, stream)(
+      requireOutput("fill", outputOpt, backendOpt, stream)(
         WriteCommands.fill(wb, sheetOpt, source, target, direction, _, _, _)
       )
 
     case CliCommand.AutoFit(columnsOpt) =>
-      requireOutput(outputOpt, backendOpt, stream)(
+      requireOutput("autofit", outputOpt, backendOpt, stream)(
         WriteCommands.autoFit(wb, sheetOpt, columnsOpt, _, _, _)
       )
 
     case CliCommand.Sort(rangeStr, sortKeys, hasHeader) =>
-      requireOutput(outputOpt, backendOpt, stream)(
+      requireOutput("sort", outputOpt, backendOpt, stream)(
         WriteCommands.sort(wb, sheetOpt, rangeStr, sortKeys, hasHeader, _, _, _)
       )
 
     case CliCommand.Freeze(refStr) =>
-      requireOutput(outputOpt, backendOpt, stream)(
+      requireOutput("freeze", outputOpt, backendOpt, stream)(
         WriteCommands.freeze(wb, sheetOpt, refStr, _, _, _)
       )
 
     case CliCommand.Unfreeze =>
-      requireOutput(outputOpt, backendOpt, stream)(
+      requireOutput("unfreeze", outputOpt, backendOpt, stream)(
         WriteCommands.unfreeze(wb, sheetOpt, _, _, _)
       )
 
     // Sheet appearance & print setup (GH-358)
     case CliCommand.SheetViewOp(gridlines, zoom, tabSelected) =>
-      requireOutput(outputOpt, backendOpt, stream)(
+      requireOutput("sheet-view", outputOpt, backendOpt, stream)(
         WriteCommands.sheetView(wb, sheetOpt, gridlines, zoom, tabSelected, _, _, _)
       )
 
     case CliCommand.TabColorOp(color, clear) =>
-      requireOutput(outputOpt, backendOpt, stream)(
+      requireOutput("tab-color", outputOpt, backendOpt, stream)(
         WriteCommands.tabColor(wb, sheetOpt, color, clear, _, _, _)
       )
 
     case CliCommand.PageSetupOp(orientation, scale, fitToWidth, fitToHeight, fitToPage) =>
-      requireOutput(outputOpt, backendOpt, stream)(
+      requireOutput("page-setup", outputOpt, backendOpt, stream)(
         WriteCommands.pageSetup(
           wb,
           sheetOpt,
@@ -2319,7 +2352,7 @@ EXAMPLES:
           differentOddEven,
           differentFirst
         ) =>
-      requireOutput(outputOpt, backendOpt, stream)(
+      requireOutput("header-footer", outputOpt, backendOpt, stream)(
         WriteCommands.headerFooter(
           wb,
           sheetOpt,
@@ -2339,7 +2372,7 @@ EXAMPLES:
 
     // Conditional formatting (GH-324)
     case CliCommand.CfAdd(range, rule, bold, italic, underline, strike, bg, fg) =>
-      requireOutput(outputOpt, backendOpt, stream)(
+      requireOutput("cf add", outputOpt, backendOpt, stream)(
         WriteCommands.cfAdd(
           wb,
           sheetOpt,
@@ -2361,7 +2394,7 @@ EXAMPLES:
       WriteCommands.cfList(wb, sheetOpt)
 
     case CliCommand.Copy(source, target, valuesOnly) =>
-      requireOutput(outputOpt, backendOpt, stream)(
+      requireOutput("copy", outputOpt, backendOpt, stream)(
         WriteCommands.copyRange(wb, sheetOpt, source, target, valuesOnly, _, _, _)
       )
 
@@ -2376,7 +2409,7 @@ EXAMPLES:
           legend,
           at
         ) =>
-      requireOutput(outputOpt, backendOpt, stream)(
+      requireOutput("chart add", outputOpt, backendOpt, stream)(
         ChartCommands.chartAdd(
           wb,
           sheetOpt,
@@ -2396,27 +2429,27 @@ EXAMPLES:
       )
 
     case CliCommand.AddImage(imagePath, at, size) =>
-      requireOutput(outputOpt, backendOpt, stream)(
+      requireOutput("add-image", outputOpt, backendOpt, stream)(
         ChartCommands.addImage(wb, sheetOpt, imagePath, at, size, _, _, _)
       )
 
     case CliCommand.InsertRows(at, count) =>
-      requireOutput(outputOpt, backendOpt, stream)(
+      requireOutput("insert-rows", outputOpt, backendOpt, stream)(
         WriteCommands.insertRows(wb, sheetOpt, at, count, _, _, _)
       )
 
     case CliCommand.DeleteRows(at, count) =>
-      requireOutput(outputOpt, backendOpt, stream)(
+      requireOutput("delete-rows", outputOpt, backendOpt, stream)(
         WriteCommands.deleteRows(wb, sheetOpt, at, count, _, _, _)
       )
 
     case CliCommand.InsertColumns(col, count) =>
-      requireOutput(outputOpt, backendOpt, stream)(
+      requireOutput("insert-cols", outputOpt, backendOpt, stream)(
         WriteCommands.insertColumns(wb, sheetOpt, col, count, _, _, _)
       )
 
     case CliCommand.DeleteColumns(col, count) =>
-      requireOutput(outputOpt, backendOpt, stream)(
+      requireOutput("delete-cols", outputOpt, backendOpt, stream)(
         WriteCommands.deleteColumns(wb, sheetOpt, col, count, _, _, _)
       )
 
@@ -2432,15 +2465,20 @@ EXAMPLES:
   // Helpers
   // ==========================================================================
 
-  private def requireOutput(
+  /** Usage message for write commands invoked without -o/-i — names the flag (GH-422). */
+  private def missingOutputError(commandName: String): String =
+    s"$commandName requires -o <out.xlsx> (or -i to modify in place)"
+
+  private[cli] def requireOutput(
+    commandName: String,
     outputOpt: Option[Path],
     backendOpt: Option[XmlBackend],
     stream: Boolean = false
   )(f: (Path, WriterConfig, Boolean) => IO[String]): IO[String] =
     val config = backendOpt.fold(WriterConfig.default)(b => WriterConfig(backend = b))
-    outputOpt.fold(IO.raiseError[String](new Exception("Internal: output required")))(path =>
-      f(path, config, stream)
-    )
+    outputOpt.fold(
+      IO.raiseError[String](new Exception(missingOutputError(commandName)))
+    )(path => f(path, config, stream))
 
   /**
    * Dispatch `run` with effective output path from --output / --in-place flags.
@@ -2494,7 +2532,7 @@ EXAMPLES:
     outputOpt match
       case Some(path) => f(path)
       case None =>
-        IO.raiseError(new Exception(s"$commandName requires -o/--output"))
+        IO.raiseError(new Exception(missingOutputError(commandName)))
 
   /** Build WriterConfig from CLI backend option */
   private def buildWriterConfig(backendOpt: Option[XmlBackend]): WriterConfig =

--- a/xl-cli/src/com/tjclp/xl/cli/helpers/BatchParser.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/helpers/BatchParser.scala
@@ -327,8 +327,11 @@ object BatchParser:
             // Check for explicit values array first (like putf's "values" support)
             objMap.get("values") match
               case Some(arr) if arr.arrOpt.isDefined =>
+                // GH-416: the op-level format threads into every element exactly as the
+                // single-value arm applies it (numbers/strings get it; bool/null stay bare)
+                val format = objMap.get("format").flatMap(_.strOpt).flatMap(parseFormatName)
                 val values = arr.arr.toVector.zipWithIndex.map { case (v, i) =>
-                  parseJsonValue(v, idx, i, detect)
+                  parseJsonValue(v, idx, i, detect, format)
                 }
                 BatchOp.PutValues(ref, values)
               case _ =>
@@ -841,17 +844,20 @@ object BatchParser:
    * Parse a single JSON value element (from a "values" array).
    *
    * Handles native JSON types and smart string detection, mirroring parseTypedValue but operating
-   * on a bare ujson.Value instead of an ObjMap with a "value" key.
+   * on a bare ujson.Value instead of an ObjMap with a "value" key. The op-level explicit format
+   * follows single-put semantics (GH-416): numbers carry it directly, strings are parsed according
+   * to it, booleans and nulls never take a format.
    */
   private def parseJsonValue(
     json: ujson.Value,
     objIdx: Int,
     elemIdx: Int,
-    detect: Boolean
+    detect: Boolean,
+    explicitFormat: Option[NumFmt]
   ): ParsedValue =
     json.numOpt match
       case Some(num) =>
-        ParsedValue(CellValue.Number(BigDecimal(num)), None)
+        ParsedValue(CellValue.Number(BigDecimal(num)), explicitFormat)
       case None =>
         json.boolOpt match
           case Some(b) => ParsedValue(CellValue.Bool(b), None)
@@ -860,7 +866,7 @@ object BatchParser:
             else
               json.strOpt match
                 case Some(s) =>
-                  parseStringValue(s, None, objIdx, detect)
+                  parseStringValue(s, explicitFormat, objIdx, detect)
                 case None =>
                   throw new Exception(
                     s"Object ${objIdx + 1}: 'values[$elemIdx]' must be string, number, boolean, or null"

--- a/xl-cli/test/src/com/tjclp/xl/cli/LintCommandSpec.scala
+++ b/xl-cli/test/src/com/tjclp/xl/cli/LintCommandSpec.scala
@@ -162,3 +162,64 @@ class LintCommandSpec extends CatsEffectSuite:
     assertEquals(parsed("clean").bool, true)
     assertEquals(parsed("findings").arr.size, 0)
   }
+
+  // ========== Arg shape: positional file form (GH-422) ==========
+
+  private def xlCommand = com.monovore.decline.Command("xl", "test")(Main.main)
+
+  private def parsedIO(args: Seq[String]): IO[IO[ExitCode]] =
+    IO.fromEither(
+      xlCommand.parse(args, Map.empty).left.map(help => new Exception(help.toString))
+    )
+
+  test("lint: positional file form parses (GH-422)") {
+    val result = xlCommand.parse(Seq("lint", "book.xlsx"), Map.empty)
+    assert(result.isRight, s"xl lint <file> must parse, got: $result")
+  }
+
+  test("lint: positional file form works end-to-end, exit 0 on clean file (GH-422)") {
+    for
+      path <- cleanXlsx()
+      io <- parsedIO(Seq("lint", path.toString))
+      code <- io
+      _ <- IO(Files.deleteIfExists(path))
+    yield assertEquals(code, ExitCode.Success)
+  }
+
+  test("lint: -f flag form still works end-to-end (GH-422)") {
+    for
+      path <- cleanXlsx()
+      io <- parsedIO(Seq("-f", path.toString, "lint"))
+      code <- io
+      _ <- IO(Files.deleteIfExists(path))
+    yield assertEquals(code, ExitCode.Success)
+  }
+
+  test("lint: giving the file both ways is rejected with exit 2 (GH-422)") {
+    for
+      io <- parsedIO(Seq("-f", "a.xlsx", "lint", "b.xlsx"))
+      code <- io
+    yield assertEquals(code, ExitCode(2))
+  }
+
+  test("lint: no file at all exits 2 with a hint instead of decline noise (GH-422)") {
+    for
+      io <- parsedIO(Seq("lint"))
+      code <- io
+    yield assertEquals(code, ExitCode(2))
+  }
+
+  test("resolveLintFile: exactly-one-file resolution and hint messages (GH-422)") {
+    val a = Paths.get("a.xlsx")
+    val b = Paths.get("b.xlsx")
+    assertEquals(Main.resolveLintFile(Some(a), None), Right(a))
+    assertEquals(Main.resolveLintFile(None, Some(b)), Right(b))
+    Main.resolveLintFile(Some(a), Some(b)) match
+      case Left(msg) => assert(msg.contains("exactly one file"), msg)
+      case Right(p) => fail(s"Expected rejection when the file is given twice, got $p")
+    Main.resolveLintFile(None, None) match
+      case Left(msg) =>
+        assert(msg.contains("lint requires a file"), msg)
+        assert(msg.contains("-f"), msg)
+      case Right(p) => fail(s"Expected rejection when no file is given, got $p")
+  }

--- a/xl-cli/test/src/com/tjclp/xl/cli/MainSpec.scala
+++ b/xl-cli/test/src/com/tjclp/xl/cli/MainSpec.scala
@@ -1130,10 +1130,13 @@ class MainSpec extends CatsEffectSuite:
     result.toOption.get.ops.head match
       case BatchOp.PutValues(range, values) =>
         assertEquals(range, "A1:A2")
-        assertEquals(values.map(_.cellValue), Vector[CellValue](
-          CellValue.Number(BigDecimal("1.0")),
-          CellValue.Number(BigDecimal("2.0"))
-        ))
+        assertEquals(
+          values.map(_.cellValue),
+          Vector[CellValue](
+            CellValue.Number(BigDecimal("1.0")),
+            CellValue.Number(BigDecimal("2.0"))
+          )
+        )
         assertEquals(
           values.map(_.format),
           Vector[Option[NumFmt]](Some(NumFmt.Custom("0.00%")), Some(NumFmt.Custom("0.00%"))),
@@ -1298,6 +1301,44 @@ class MainSpec extends CatsEffectSuite:
       case BatchOp.Put(ref, CellValue.Number(n), Some(NumFmt.Currency)) =>
         assertEquals(n, BigDecimal("99.00"))
       case other => fail(s"Expected Put with Currency detection, got $other")
+  }
+
+  // ========== Write commands without -o: usage error, not "Internal:" (GH-422) ==========
+
+  test("recalc without -o reports a usage error naming the flag (GH-422)") {
+    val wb = Workbook(Vector(Sheet("T")))
+    Main.executeCommand(wb, None, None, None, false, CliCommand.Recalc).attempt.map {
+      case Left(err) =>
+        assert(
+          err.getMessage.contains("recalc requires -o"),
+          s"message must name the command and flag, got: ${err.getMessage}"
+        )
+        assert(
+          !err.getMessage.contains("Internal"),
+          s"usage error must not masquerade as internal, got: ${err.getMessage}"
+        )
+      case Right(out) => fail(s"Expected missing-output error, got: $out")
+    }
+  }
+
+  test("unfreeze without -o names the command in the usage error (GH-422)") {
+    val wb = Workbook(Vector(Sheet("T")))
+    Main.executeCommand(wb, None, None, None, false, CliCommand.Unfreeze).attempt.map {
+      case Left(err) =>
+        assert(
+          err.getMessage.contains("unfreeze requires -o"),
+          s"every write verb should name itself, got: ${err.getMessage}"
+        )
+      case Right(out) => fail(s"Expected missing-output error, got: $out")
+    }
+  }
+
+  test("requireOutput: with -o supplied invokes the write (GH-422)") {
+    Main
+      .requireOutput("recalc", Some(java.nio.file.Paths.get("out.xlsx")), None)((path, _, _) =>
+        IO.pure(s"wrote $path")
+      )
+      .map(out => assertEquals(out, "wrote out.xlsx"))
   }
 
   test("StyleBuilder.parseNumFmt: custom format codes accepted") {

--- a/xl-cli/test/src/com/tjclp/xl/cli/MainSpec.scala
+++ b/xl-cli/test/src/com/tjclp/xl/cli/MainSpec.scala
@@ -1119,6 +1119,102 @@ class MainSpec extends CatsEffectSuite:
     }
   }
 
+  // ========== Batch put values[] op-level format (GH-416) ==========
+
+  test("parseBatchJson: put values[] threads op-level format into every element (GH-416)") {
+    // Exact repro from GH-416: this used to write General cells, silently dropping the format
+    val json = """[{"op":"put","ref":"A1:A2","values":[1.0,2.0],"format":"0.00%"}]"""
+    val result = BatchParser.parseBatchJson(json)
+
+    assert(result.isRight, s"Should parse: $result")
+    result.toOption.get.ops.head match
+      case BatchOp.PutValues(range, values) =>
+        assertEquals(range, "A1:A2")
+        assertEquals(values.map(_.cellValue), Vector[CellValue](
+          CellValue.Number(BigDecimal("1.0")),
+          CellValue.Number(BigDecimal("2.0"))
+        ))
+        assertEquals(
+          values.map(_.format),
+          Vector[Option[NumFmt]](Some(NumFmt.Custom("0.00%")), Some(NumFmt.Custom("0.00%"))),
+          "op-level format must apply to every value the op writes"
+        )
+      case other => fail(s"Expected PutValues, got $other")
+  }
+
+  test("batch: put values[] with op-level format writes numFmt on every cell (GH-416)") {
+    val sheet = Sheet("Test")
+    val wb = Workbook(Vector(sheet))
+    val ops = BatchParser
+      .parseBatchJson("""[{"op":"put","ref":"A1:A2","values":[1.0,2.0],"format":"0.00%"}]""")
+      .toOption
+      .get
+      .ops
+
+    BatchParser.applyBatchOperations(wb, Some(sheet), ops).map { updatedWb =>
+      val updatedSheet = updatedWb.sheets.head
+      assertEquals(
+        updatedSheet.cells.get(ref"A1").map(_.value),
+        Some[CellValue](CellValue.Number(BigDecimal("1.0")))
+      )
+      assertEquals(
+        updatedSheet.cells.get(ref"A2").map(_.value),
+        Some[CellValue](CellValue.Number(BigDecimal("2.0")))
+      )
+      List(ref"A1", ref"A2").foreach { r =>
+        val style = updatedSheet.getCellStyle(r)
+        assert(style.isDefined, s"numFmt style should be set at ${r.toA1}")
+        assertEquals(style.get.numFmt, NumFmt.Custom("0.00%"))
+      }
+    }
+  }
+
+  test("parseBatchJson: put values[] op-level format leaves bool/null elements bare (GH-416)") {
+    // Single-put parity: explicit format applies to numbers/strings, never to booleans/null
+    val json = """[{"op":"put","ref":"A1:A3","values":[1.5,true,null],"format":"currency"}]"""
+    val result = BatchParser.parseBatchJson(json)
+
+    assert(result.isRight, s"Should parse: $result")
+    result.toOption.get.ops.head match
+      case BatchOp.PutValues(_, values) =>
+        assertEquals(values.map(_.format).toList, List(Some(NumFmt.Currency), None, None))
+      case other => fail(s"Expected PutValues, got $other")
+  }
+
+  test("parseBatchJson: put values[] element parses exactly like the single-value arm (GH-416)") {
+    val singleJson = """[{"op":"put","ref":"A1","value":"$99.00","format":"currency"}]"""
+    val arrayJson = """[{"op":"put","ref":"A1:A1","values":["$99.00"],"format":"currency"}]"""
+
+    val single = BatchParser.parseBatchJson(singleJson).toOption.get.ops.head match
+      case BatchOp.Put(_, cv, fmt) => (cv, fmt)
+      case other => fail(s"Expected Put, got $other")
+    val fromArray = BatchParser.parseBatchJson(arrayJson).toOption.get.ops.head match
+      case BatchOp.PutValues(_, values) => (values.head.cellValue, values.head.format)
+      case other => fail(s"Expected PutValues, got $other")
+
+    assertEquals(fromArray, single, "values[] elements must follow single-put format semantics")
+  }
+
+  test("parseBatchJson: put values[] explicit date format rejects unparseable strings (GH-416)") {
+    val json = """[{"op":"put","ref":"A1","values":["not-a-date"],"format":"date"}]"""
+    val result = BatchParser.parseBatchJson(json)
+
+    assert(result.isLeft, s"Explicit date format should reject unparseable input: $result")
+    val error = result.swap.toOption.getOrElse(fail("Expected parse error"))
+    assert(error.getMessage.contains("invalid for explicit format"))
+  }
+
+  test("parseBatchJson: put values[] without op-level format keeps smart detection") {
+    val json = """[{"op":"put","ref":"A1:A2","values":["$99.00","59.4%"]}]"""
+    val result = BatchParser.parseBatchJson(json)
+
+    assert(result.isRight, s"Should parse: $result")
+    result.toOption.get.ops.head match
+      case BatchOp.PutValues(_, values) =>
+        assertEquals(values.map(_.format).toList, List(Some(NumFmt.Currency), Some(NumFmt.Percent)))
+      case other => fail(s"Expected PutValues, got $other")
+  }
+
   test("formatSummary: produces expected summary lines") {
     val ops = Vector(
       BatchOp.PutFormula("A1", "=SUM(B1:B10)"),

--- a/xl-cli/test/src/com/tjclp/xl/cli/StreamingWriteSpec.scala
+++ b/xl-cli/test/src/com/tjclp/xl/cli/StreamingWriteSpec.scala
@@ -118,6 +118,34 @@ class StreamingWriteSpec extends FunSuite:
         case None => fail("Missing xl/styles.xml")
     finally zipFile.close()
 
+  private def zipEntryXml(path: Path, entryName: String): scala.xml.Elem =
+    val zipFile = new ZipFile(path.toFile)
+    try
+      Option(zipFile.getEntry(entryName)) match
+        case Some(entry) =>
+          val input = zipFile.getInputStream(entry)
+          val xml =
+            try new String(input.readAllBytes(), StandardCharsets.UTF_8)
+            finally input.close()
+          XmlSecurity.parseSafe(xml, entryName) match
+            case Right(root) => root
+            case Left(error) => fail(s"Failed to parse $entryName: ${error.message}")
+        case None => fail(s"Missing $entryName")
+    finally zipFile.close()
+
+  /** The numFmtId of the style the given cell references (sheet1.xml s= index into cellXfs). */
+  private def numFmtIdOfCell(path: Path, cellRef: String): Int =
+    val sheetXml = zipEntryXml(path, "xl/worksheets/sheet1.xml")
+    val styleIdx = (sheetXml \\ "c")
+      .find(c => (c \ "@r").text == cellRef)
+      .map(c => (c \ "@s").text.toIntOption.getOrElse(0))
+      .getOrElse(fail(s"cell $cellRef not found in sheet1.xml"))
+    val stylesXml = zipEntryXml(path, "xl/styles.xml")
+    (stylesXml \ "cellXfs" \ "xf")
+      .lift(styleIdx)
+      .map(xf => (xf \ "@numFmtId").text.toIntOption.getOrElse(0))
+      .getOrElse(fail(s"cellXfs has no xf at index $styleIdx"))
+
   // ========== Hybrid Streaming: put command ==========
 
   test("streaming put: basic value preserved") {
@@ -162,6 +190,31 @@ class StreamingWriteSpec extends FunSuite:
       val style = sheet.getCellStyle(ARef.from0(0, 0))
       assertEquals(style.map(_.numFmt), Some(NumFmt.Date))
       assertEquals(style.map(_.font.bold), Some(true))
+    finally
+      Files.deleteIfExists(sourcePath)
+      Files.deleteIfExists(outputPath)
+  }
+
+  test("streaming put: percent detection lands builtin numFmtId 9 (GH-408)") {
+    val sourcePath = tempXlsx()
+    val outputPath = tempXlsx()
+    try
+      ExcelIO.instance[IO].write(Workbook(Sheet("Test")), sourcePath).unsafeRunSync()
+
+      StreamingWriteCommands
+        .put(sourcePath, outputPath, Some("Test"), "A1", List("45.5%"))
+        .unsafeRunSync()
+
+      // The streamed positional put writes detected formats through StylePatcher (PR #438);
+      // NumFmt.Percent must land the canonical builtin id 9 ("0%"), not 10 ("0.00%").
+      assertEquals(numFmtIdOfCell(outputPath, "A1"), 9)
+
+      val sheet = ExcelIO.instance[IO].read(outputPath).unsafeRunSync().sheets.head
+      assertEquals(
+        sheet.cells.get(ARef.from0(0, 0)).map(_.value),
+        Some(CellValue.Number(BigDecimal("0.455")))
+      )
+      assertEquals(sheet.getCellStyle(ARef.from0(0, 0)).map(_.numFmt), Some(NumFmt.Percent))
     finally
       Files.deleteIfExists(sourcePath)
       Files.deleteIfExists(outputPath)

--- a/xl-core/src/com/tjclp/xl/display/FormatCodeParser.scala
+++ b/xl-core/src/com/tjclp/xl/display/FormatCodeParser.scala
@@ -143,6 +143,12 @@ object FormatCodeParser:
     /** At sign: @ = text placeholder */
     case TextPlaceholder
 
+    /**
+     * Scientific exponent: `E`/`e` + sign convention + digit-placeholder run (GH-410). `E+` always
+     * writes the exponent sign, `E-` only when the exponent is negative.
+     */
+    case Exponent(letter: Char, sign: Char, digits: String)
+
   // ========== Parser ==========
 
   /**
@@ -392,6 +398,16 @@ object FormatCodeParser:
           tokens += FormatToken.AmPm("A/P")
           i += 3
 
+        case 'E' | 'e'
+            if i + 2 < pattern.length && (pattern(i + 1) == '+' || pattern(i + 1) == '-') &&
+              isDigitPlaceholder(pattern(i + 2)) =>
+          // Scientific exponent (GH-410): E/e, a sign convention, then digit placeholders.
+          // A bare E without sign+placeholder stays a literal (date-era codes, plain text).
+          var j = i + 2
+          while j < pattern.length && isDigitPlaceholder(pattern(j)) do j += 1
+          tokens += FormatToken.Exponent(c, pattern(i + 1), pattern.substring(i + 2, j))
+          i = j
+
         case '/' =>
           // Fraction when digit placeholders directly flank the slash (GH-243): pop the
           // numerator run and consume the denominator (placeholder run or fixed integer).
@@ -444,6 +460,10 @@ object FormatCodeParser:
   /** Characters that may appear in a fraction numerator/denominator run. */
   private def isFractionChar(c: Char): Boolean =
     c == '#' || c == '?' || (c >= '0' && c <= '9')
+
+  /** Digit placeholder characters: 0 (forced), # (optional), ? (space-padded). */
+  private def isDigitPlaceholder(c: Char): Boolean =
+    c == '0' || c == '#' || c == '?'
 
   // ========== Formatter ==========
 
@@ -552,7 +572,15 @@ object FormatCodeParser:
     }
     pattern.tokens.lift(fracIdx) match
       case Some(f: FormatToken.Fraction) => applyFractionPattern(value, pattern.tokens, fracIdx, f)
-      case _ => applyNumericPattern(value, pattern)
+      case _ =>
+        val expIdx = pattern.tokens.indexWhere {
+          case _: FormatToken.Exponent => true
+          case _ => false
+        }
+        pattern.tokens.lift(expIdx) match
+          case Some(e: FormatToken.Exponent) =>
+            applyScientificPattern(value, pattern, expIdx, e)
+          case _ => applyNumericPattern(value, pattern)
 
   private def applyNumericPattern(value: BigDecimal, pattern: FormatPattern): String =
     // Handle percent: multiply by 100
@@ -642,6 +670,104 @@ object FormatCodeParser:
           // Date/time tokens not applicable
           ()
 
+    result.toString
+
+  /**
+   * Render a scientific-notation pattern (GH-410).
+   *
+   * Excel semantics (ECMA-376 §18.8.30 ids 11 `0.00E+00` and 48 `##0.0E+0`, cross-checked against
+   * the Excel-corpus-tested SheetJS/SSF):
+   *   - the exponent snaps to the largest multiple of the mantissa's integer-placeholder count not
+   *     exceeding floor(log10 |x|) — one placeholder is normalized scientific (mantissa in [1,
+   *     10)), three is engineering notation
+   *   - `E+` always writes the exponent sign; `E-` writes it only when the exponent is negative
+   *   - exponent digits pad to the placeholder run and never truncate
+   *   - a mantissa that rounds up to 10^placeholders renormalizes (9.999 → 1.00E+01)
+   *
+   * The sign of the value is handled by [[applyFormat]] (default leading minus).
+   */
+  private def applyScientificPattern(
+    value: BigDecimal,
+    pattern: FormatPattern,
+    expIdx: Int,
+    exp: FormatToken.Exponent
+  ): String =
+    val tokens = pattern.tokens
+    val adjusted = (if pattern.hasPercent then value * 100 else value).abs
+
+    def digitCount(ts: Vector[FormatToken]): Int = ts.count {
+      case FormatToken.Digit(_) => true
+      case _ => false
+    }
+    val mantissaTokens = tokens.take(expIdx)
+    val decimalIdx = mantissaTokens.indexWhere {
+      case FormatToken.Decimal => true
+      case _ => false
+    }
+    val intTokens = if decimalIdx >= 0 then mantissaTokens.take(decimalIdx) else mantissaTokens
+    val intPlaceholders = math.max(digitCount(intTokens), 1)
+    val decimalDigits =
+      if decimalIdx >= 0 then digitCount(mantissaTokens.drop(decimalIdx + 1)) else 0
+    val minIntDigits = intTokens.count {
+      case FormatToken.Digit('0') => true
+      case _ => false
+    }
+
+    val (mantissa, exponent) =
+      if adjusted.signum == 0 then
+        (BigDecimal(0).setScale(decimalDigits, BigDecimal.RoundingMode.HALF_UP), 0)
+      else
+        // floor(log10 |x|), exact from the decimal representation (no Double detour)
+        val e10 = adjusted.precision - adjusted.scale - 1
+        val e = Math.floorDiv(e10, intPlaceholders) * intPlaceholders
+        val rounded = BigDecimal(adjusted.underlying.movePointLeft(e))
+          .setScale(decimalDigits, BigDecimal.RoundingMode.HALF_UP)
+        val limit = BigDecimal(10).pow(intPlaceholders)
+        if rounded >= limit then
+          (
+            BigDecimal(rounded.underlying.movePointLeft(intPlaceholders))
+              .setScale(decimalDigits, BigDecimal.RoundingMode.HALF_UP),
+            e + intPlaceholders
+          )
+        else (rounded, e)
+
+    // mantissa is non-negative with scale == decimalDigits, so toPlainString is "int[.dec]"
+    val plain = mantissa.underlying.toPlainString
+    val dotIdx = plain.indexOf('.')
+    val rawInt = if dotIdx >= 0 then plain.substring(0, dotIdx) else plain
+    val decStr = if dotIdx >= 0 then plain.substring(dotIdx + 1) else ""
+    val paddedInt =
+      if rawInt.length < minIntDigits then "0" * (minIntDigits - rawInt.length) + rawInt
+      else rawInt
+    val mantissaStr = if decimalIdx >= 0 then s"$paddedInt.$decStr" else paddedInt
+
+    val absExp = math.abs(exponent).toString
+    val paddedExp =
+      if absExp.length < exp.digits.length then "0" * (exp.digits.length - absExp.length) + absExp
+      else absExp
+    val expSign =
+      if exponent < 0 then "-"
+      else if exp.sign == '+' then "+"
+      else ""
+
+    val result = new StringBuilder
+    var numberEmitted = false
+    tokens.foreach {
+      case _: FormatToken.Exponent =>
+        result ++= s"${exp.letter}$expSign$paddedExp"
+      case FormatToken.Digit(_) | FormatToken.Decimal | FormatToken.Thousands =>
+        if !numberEmitted then
+          result ++= mantissaStr
+          numberEmitted = true
+      case FormatToken.Percent =>
+        result += '%'
+      case FormatToken.Literal(text) =>
+        result ++= text
+      case FormatToken.Spacer(_) =>
+        result += ' '
+      case _ =>
+        ()
+    }
     result.toString
 
   /**
@@ -871,8 +997,14 @@ object FormatCodeParser:
   def applyDateFormat(dt: LocalDateTime, section: FormatSection): String =
     val tokens = section.pattern.tokens
     val minutePositions = findMinutePositions(tokens)
+    // ECMA-376 §18.8.31: the hour uses the 12-hour clock only when the code contains an
+    // AM/PM marker; otherwise it is the 24-hour clock (GH-410).
+    val twelveHour = tokens.exists {
+      case FormatToken.AmPm(_) => true
+      case _ => false
+    }
     tokens.zipWithIndex.map { case (token, idx) =>
-      renderDateToken(dt, token, minutePositions.contains(idx))
+      renderDateToken(dt, token, minutePositions.contains(idx), twelveHour)
     }.mkString
 
   /**
@@ -917,8 +1049,15 @@ object FormatCodeParser:
    *   The format token
    * @param isMinute
    *   Whether 'm'/'mm' should render as minute (vs month)
+   * @param twelveHour
+   *   Whether 'h'/'hh' use the 12-hour clock (the section has an AM/PM marker, GH-410)
    */
-  private def renderDateToken(dt: LocalDateTime, token: FormatToken, isMinute: Boolean): String =
+  private def renderDateToken(
+    dt: LocalDateTime,
+    token: FormatToken,
+    isMinute: Boolean,
+    twelveHour: Boolean
+  ): String =
     token match
       // Year
       case FormatToken.DatePart("y") =>
@@ -953,13 +1092,17 @@ object FormatCodeParser:
       case FormatToken.DatePart("dddd") =>
         dt.getDayOfWeek.getDisplayName(TextStyle.FULL, Locale.US)
 
-      // Hour (12-hour format assumed when AM/PM present)
+      // Hour: 12-hour clock only when the section carries AM/PM (ECMA-376 §18.8.31)
       case FormatToken.DatePart("h") =>
-        val hour = dt.getHour % 12
-        (if hour == 0 then 12 else hour).toString
+        if twelveHour then
+          val hour = dt.getHour % 12
+          (if hour == 0 then 12 else hour).toString
+        else dt.getHour.toString
       case FormatToken.DatePart("hh") =>
-        val hour = dt.getHour % 12
-        f"${if hour == 0 then 12 else hour}%02d"
+        if twelveHour then
+          val hour = dt.getHour % 12
+          f"${if hour == 0 then 12 else hour}%02d"
+        else f"${dt.getHour}%02d"
 
       // Second
       case FormatToken.DatePart("s") =>

--- a/xl-core/src/com/tjclp/xl/display/NumFmtFormatter.scala
+++ b/xl-core/src/com/tjclp/xl/display/NumFmtFormatter.scala
@@ -3,9 +3,7 @@ package com.tjclp.xl.display
 import com.tjclp.xl.cells.CellValue
 import com.tjclp.xl.styles.numfmt.NumFmt
 
-import java.text.DecimalFormat
 import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
 
 /**
  * Formats cell values according to Excel number format codes.
@@ -17,9 +15,30 @@ import java.time.format.DateTimeFormatter
  */
 object NumFmtFormatter:
 
-  /** Parsed pattern for the built-in NumFmt.Fraction (format id 12, "# ?/?"). */
-  private val builtInFractionFormat: Either[String, FormatCodeParser.FormatCode] =
-    FormatCodeParser.parse("# ?/?")
+  /**
+   * Parsed format codes for every built-in (non-Custom, non-General) NumFmt variant.
+   *
+   * The built-in enum arms render through FormatCodeParser on [[NumFmt.formatCode]], so a
+   * programmatic NumFmt.PercentDecimal and a file-declared "0.00%" are provably the same display
+   * (GH-410). Every code in the canonical table parses, making the map total over the variants
+   * listed; the lookup fallbacks below are defensive only.
+   */
+  private val builtInFormats: Map[NumFmt, FormatCodeParser.FormatCode] =
+    List(
+      NumFmt.Integer,
+      NumFmt.Decimal,
+      NumFmt.ThousandsSeparator,
+      NumFmt.ThousandsDecimal,
+      NumFmt.Currency,
+      NumFmt.Percent,
+      NumFmt.PercentDecimal,
+      NumFmt.Scientific,
+      NumFmt.Fraction,
+      NumFmt.Date,
+      NumFmt.DateTime,
+      NumFmt.Time,
+      NumFmt.Text
+    ).flatMap(fmt => FormatCodeParser.parse(NumFmt.formatCode(fmt)).toOption.map(fmt -> _)).toMap
 
   /**
    * Format a cell value according to its number format.
@@ -57,57 +76,6 @@ object NumFmtFormatter:
     numFmt match
       case NumFmt.General => formatGeneral(n)
 
-      case NumFmt.Integer =>
-        n.setScale(0, BigDecimal.RoundingMode.HALF_UP).toString
-
-      case NumFmt.Decimal =>
-        f"${n.toDouble}%.2f"
-
-      case NumFmt.ThousandsSeparator =>
-        decimalFormat("#,##0").format(n.underlying)
-
-      case NumFmt.ThousandsDecimal =>
-        decimalFormat("#,##0.00").format(n.underlying)
-
-      case NumFmt.Currency =>
-        decimalFormat("$#,##0.00").format(n.underlying)
-
-      case NumFmt.Percent =>
-        // Excel stores 0.15 for 15%, multiply by 100 for display
-        val pct = (n * 100).setScale(0, BigDecimal.RoundingMode.HALF_UP)
-        s"$pct%"
-
-      case NumFmt.PercentDecimal =>
-        val pct = (n * 100).setScale(1, BigDecimal.RoundingMode.HALF_UP)
-        s"$pct%"
-
-      case NumFmt.Scientific =>
-        f"${n.toDouble}%.2E"
-
-      case NumFmt.Date =>
-        // Interpret number as Excel date serial (days since 1900-01-01)
-        formatExcelDateSerial(n, "M/d/yy")
-
-      case NumFmt.DateTime =>
-        formatExcelDateSerial(n, "M/d/yy h:mm")
-
-      case NumFmt.Time =>
-        // Interpret fractional part as time of day
-        val hours = ((n % 1) * 24).toInt
-        val minutes = (((n % 1) * 24 * 60) % 60).toInt
-        val seconds = (((n % 1) * 24 * 60 * 60) % 60).toInt
-        f"$hours%d:$minutes%02d:$seconds%02d"
-
-      case NumFmt.Fraction =>
-        // Built-in fraction format id 12: "# ?/?" (up to one denominator digit, GH-243)
-        builtInFractionFormat match
-          case Right(fmt) => FormatCodeParser.applyFormat(n, fmt)._1
-          case Left(_) => formatGeneral(n)
-
-      case NumFmt.Text =>
-        // Text format displays numbers as text
-        n.toString
-
       case NumFmt.Custom(code) if isGeneralCode(code) =>
         // The literal code "General" (ECMA-376 §18.8.30, case-insensitive) means General
         // rendering, not the literal characters. Reached since GH-404: file-declared
@@ -119,19 +87,15 @@ object NumFmtFormatter:
           case Right(fmt) => formatCustom(n, serialToDateTime(n), fmt)
           case Left(_) => formatGeneral(n) // Fallback for unparseable formats
 
+      case builtin =>
+        // Built-in arms render through FormatCodeParser on their canonical format code, so
+        // the programmatic enum and a file-declared equal code display identically (GH-410).
+        builtInFormats.get(builtin) match
+          case Some(fmt) => formatCustom(n, serialToDateTime(n), fmt)
+          case None => formatGeneral(n) // unreachable: the map covers every such variant
+
   /** ECMA-376 §18.8.30: the whole-code "General" keyword, matched case-insensitively. */
   private def isGeneralCode(code: String): Boolean = code.equalsIgnoreCase("General")
-
-  /**
-   * DecimalFormat with Excel's display rounding: half away from zero (HALF_UP), not Java's default
-   * HALF_EVEN — keeps the enum arms in parity with FormatCodeParser rendering of the same codes
-   * (GH-404: 1234.5 under "#,##0" is "1,235" in Excel). Formatting the BigDecimal itself (not
-   * .toDouble) rounds in decimal, avoiding binary-representation drift on half-way values.
-   */
-  private def decimalFormat(pattern: String): DecimalFormat =
-    val formatter = DecimalFormat(pattern)
-    formatter.setRoundingMode(java.math.RoundingMode.HALF_UP)
-    formatter
 
   /**
    * Format in General style (Excel's default number format).
@@ -176,14 +140,13 @@ object NumFmtFormatter:
    */
   def formatDateTime(dt: LocalDateTime, numFmt: NumFmt): String =
     numFmt match
-      case NumFmt.Date =>
-        dt.toLocalDate.format(DateTimeFormatter.ofPattern("M/d/yy"))
-
-      case NumFmt.DateTime =>
-        dt.format(DateTimeFormatter.ofPattern("M/d/yy H:mm")) // 24-hour format
-
-      case NumFmt.Time =>
-        dt.toLocalTime.format(DateTimeFormatter.ofPattern("H:mm:ss")) // 24-hour format
+      case NumFmt.Date | NumFmt.DateTime | NumFmt.Time =>
+        // The calendar variants render straight off the LocalDateTime through their parsed
+        // canonical codes (GH-410) — no serial round-trip, which truncates seconds. Bare 'h'
+        // is the 24-hour clock (no AM/PM in these codes, ECMA-376 §18.8.31).
+        builtInFormats.get(numFmt) match
+          case Some(fmt) => FormatCodeParser.applyDateFormat(dt, fmt)
+          case None => dt.toString // unreachable: the map covers the three variants
 
       case NumFmt.Custom(code) if isGeneralCode(code) =>
         // "General" keyword code: dates ARE numbers in Excel, so render the serial (GH-283)
@@ -265,19 +228,6 @@ object NumFmtFormatter:
       val seconds = (((timeFraction * 24 * 60 * 60) % 60)).toInt
       date.atTime(hours, minutes, seconds)
     else date.atStartOfDay()
-
-  /**
-   * Format Excel date serial number (days since 1900-01-01).
-   *
-   * @param serial
-   *   Excel date serial number
-   * @param pattern
-   *   DateTimeFormatter pattern
-   * @return
-   *   Formatted date string
-   */
-  private def formatExcelDateSerial(serial: BigDecimal, pattern: String): String =
-    excelSerialToDateTime(serial).format(DateTimeFormatter.ofPattern(pattern))
 
   /**
    * Format error values in Excel style.

--- a/xl-core/src/com/tjclp/xl/sheets/Sheet.scala
+++ b/xl-core/src/com/tjclp/xl/sheets/Sheet.scala
@@ -1184,10 +1184,33 @@ object Sheet:
    * Examples:
    *   - `Sheet("Sales")` → `Sheet` (compile-time validated)
    *   - `Sheet(userInput)` → `XLResult[Sheet]` (runtime validated)
+   *
+   * The literal-vs-dynamic specialization is invisible at the call site — nothing in `Sheet(nm)`
+   * hints that the return type changed. For names computed at runtime, prefer [[named]], which
+   * spells the `XLResult` in its signature (GH-420).
    */
   @annotation.targetName("applyStringLiteral")
   transparent inline def apply(inline name: String): Sheet | XLResult[Sheet] =
     ${ com.tjclp.xl.macros.SheetLiteral.sheetImpl('name) }
+
+  /**
+   * Create an empty sheet from a name computed at runtime — the documented dynamic-name factory
+   * (GH-420).
+   *
+   * Semantically identical to the dynamic branch of the union-typed `apply` (same [[SheetName]]
+   * validation, same [[com.tjclp.xl.error.XLError.InvalidSheetName]] error), but non-inline with
+   * the `XLResult` spelled in the signature, so the `.map`/`.unsafe` step is expected rather than a
+   * surprise:
+   *
+   * {{{
+   * val nm: String = config.sheetName
+   * val sheet: XLResult[Sheet] = Sheet.named(nm).map(_.put(ref"A1", 1))
+   * }}}
+   */
+  def named(name: String): XLResult[Sheet] =
+    SheetName(name) match
+      case Right(validName) => Right(Sheet(validName))
+      case Left(err) => Left(XLError.InvalidSheetName(name, err))
 
   /** Create empty sheet with validated name */
   @annotation.targetName("applySheetName")

--- a/xl-core/src/com/tjclp/xl/workbooks/Workbook.scala
+++ b/xl-core/src/com/tjclp/xl/workbooks/Workbook.scala
@@ -154,8 +154,20 @@ final case class Workbook(
       // GH-315: the deleted NAME drops out of the identity-keyed source mappings, so a later
       // sheet reusing the name carries no stale source identity.
       val updatedContext = sourceContext.map(_.markSheetDeleted(index, sheets(index).name))
+      // GH-434: localSheetId is positional — names above the removal shift down, names scoped
+      // to the removed sheet leave the workbook with it (Excel's delete-sheet semantics).
+      val remapped = remapDefinedNameScopes(i =>
+        if i == index then None
+        else if i > index then Some(i - 1)
+        else Some(i)
+      )
       Right(
-        copy(sheets = newSheets, activeSheetIndex = newActiveIndex, sourceContext = updatedContext)
+        copy(
+          sheets = newSheets,
+          metadata = remapped,
+          activeSheetIndex = newActiveIndex,
+          sourceContext = updatedContext
+        )
       )
     else Left(XLError.OutOfBounds(s"sheet[$index]", s"Valid range: 0 to ${sheets.size - 1}"))
 
@@ -286,8 +298,18 @@ final case class Workbook(
       // Sheet reordering only modifies workbook.xml (order metadata), not individual sheet files.
       // Therefore we mark reordered but don't mark individual sheets as modified.
       val updatedContext = sourceContext.map(_.markReordered)
+      // GH-434: localSheetId is positional — apply the old-index -> new-index permutation.
+      val permutation = sheets.zipWithIndex.map { case (sheet, oldIdx) =>
+        oldIdx -> newOrder.indexWhere(_ == sheet.name)
+      }.toMap
+      val remapped = remapDefinedNameScopes(i => Some(permutation.getOrElse(i, i)))
       Right(
-        copy(sheets = reordered, activeSheetIndex = newActiveIndex, sourceContext = updatedContext)
+        copy(
+          sheets = reordered,
+          metadata = remapped,
+          activeSheetIndex = newActiveIndex,
+          sourceContext = updatedContext
+        )
       )
 
   /** Insert sheet at specific index (explicit positioning - rarely needed) */
@@ -298,7 +320,31 @@ final case class Workbook(
     else
       val (before, after) = sheets.splitAt(index)
       val updatedContext = sourceContext.map(_.markMetadataModified)
-      Right(copy(sheets = before ++ (sheet +: after), sourceContext = updatedContext))
+      // GH-434: localSheetId is positional — names at or above the insertion point shift up.
+      val remapped = remapDefinedNameScopes(i => if i >= index then Some(i + 1) else Some(i))
+      Right(
+        copy(
+          sheets = before ++ (sheet +: after),
+          metadata = remapped,
+          sourceContext = updatedContext
+        )
+      )
+
+  /**
+   * Remap sheet-scoped defined-name indices after a sheet-order mutation (GH-434). `localSheetId`
+   * stores a raw positional index, so every insert/remove/reorder must translate it or the name
+   * silently attaches to whatever sheet now occupies the old position. `remap` returns the new
+   * index for an old one, or None to drop the name (its sheet was removed). Workbook-scoped names
+   * (no localSheetId) always ride through untouched.
+   */
+  private def remapDefinedNameScopes(remap: Int => Option[Int]): WorkbookMetadata =
+    if metadata.definedNames.forall(_.localSheetId.isEmpty) then metadata
+    else
+      metadata.copy(definedNames = metadata.definedNames.flatMap { dn =>
+        dn.localSheetId match
+          case None => Some(dn)
+          case Some(idx) => remap(idx).map(newIdx => dn.copy(localSheetId = Some(newIdx)))
+      })
 
   // ========== Deprecated Methods (Removed in v0.3.0) ==========
 

--- a/xl-core/test/src/com/tjclp/xl/display/DisplaySpec.scala
+++ b/xl-core/test/src/com/tjclp/xl/display/DisplaySpec.scala
@@ -10,13 +10,77 @@ import com.tjclp.xl.styles.CellStyle
 import com.tjclp.xl.styles.numfmt.NumFmt
 import com.tjclp.xl.unsafe.* // For .unsafe extension
 
-import munit.FunSuite
+import munit.ScalaCheckSuite
+import org.scalacheck.Gen
+import org.scalacheck.Prop.forAll
 
 import java.time.LocalDateTime
 
-class DisplaySpec extends FunSuite:
+class DisplaySpec extends ScalaCheckSuite:
 
   // ========== NumFmtFormatter Tests ==========
+
+  /** Every built-in (non-Custom) NumFmt variant. */
+  private val builtInVariants: List[NumFmt] = List(
+    NumFmt.General,
+    NumFmt.Integer,
+    NumFmt.Decimal,
+    NumFmt.ThousandsSeparator,
+    NumFmt.ThousandsDecimal,
+    NumFmt.Currency,
+    NumFmt.Percent,
+    NumFmt.PercentDecimal,
+    NumFmt.Scientific,
+    NumFmt.Fraction,
+    NumFmt.Date,
+    NumFmt.DateTime,
+    NumFmt.Time,
+    NumFmt.Text
+  )
+
+  private val genNumeric: Gen[BigDecimal] = Gen
+    .oneOf(
+      Gen.chooseNum(-1e6, 1e6), // covers negative serials and general magnitudes
+      Gen.chooseNum(-1.0, 1.0), // percent/fraction territory
+      Gen.chooseNum(0.0, 60000.0) // Excel date-serial range for the calendar variants
+    )
+    .map(d => BigDecimal(java.lang.Double.toString(d)))
+
+  private val genDateTime: Gen[LocalDateTime] = for
+    day <- Gen.chooseNum(0, 59999)
+    hour <- Gen.chooseNum(0, 23)
+    minute <- Gen.chooseNum(0, 59)
+    second <- Gen.chooseNum(0, 59)
+  yield LocalDateTime.of(1900, 1, 1, hour, minute, second).plusDays(day.toLong)
+
+  property("built-in enum arms render numbers exactly like their format codes (GH-410)") {
+    // The enum arm and a file-declared Custom carrying NumFmt.formatCode(fmt) are the same
+    // format per ECMA-376; both must render through FormatCodeParser identically.
+    forAll(genNumeric) { (n: BigDecimal) =>
+      builtInVariants.foreach { fmt =>
+        assertEquals(
+          NumFmtFormatter.formatValue(CellValue.Number(n), fmt),
+          NumFmtFormatter.formatValue(CellValue.Number(n), NumFmt.Custom(NumFmt.formatCode(fmt))),
+          s"enum arm diverged from its own format code for $fmt on $n"
+        )
+      }
+      true
+    }
+  }
+
+  property("built-in enum arms render DateTime values exactly like their format codes (GH-410)") {
+    forAll(genDateTime) { (dt: LocalDateTime) =>
+      builtInVariants.foreach { fmt =>
+        assertEquals(
+          NumFmtFormatter.formatValue(CellValue.DateTime(dt), fmt),
+          NumFmtFormatter
+            .formatValue(CellValue.DateTime(dt), NumFmt.Custom(NumFmt.formatCode(fmt))),
+          s"enum arm diverged from its own format code for $fmt on $dt"
+        )
+      }
+      true
+    }
+  }
 
   test("formatValue - Currency format") {
     val value = CellValue.Number(BigDecimal("1234.56"))
@@ -31,18 +95,67 @@ class DisplaySpec extends FunSuite:
   }
 
   test("formatValue - PercentDecimal format") {
+    // Re-pinned by GH-410: PercentDecimal is "0.00%" (ECMA-376 id 10) — two forced decimal
+    // placeholders, so Excel renders 15.60%, not the old enum arm's single-decimal 15.6%.
     val value = CellValue.Number(BigDecimal("0.156"))
     val result = NumFmtFormatter.formatValue(value, NumFmt.PercentDecimal)
-    assertEquals(result, "15.6%")
+    assertEquals(result, "15.60%")
   }
 
-  test("formatValue - Custom 0.00% renders two decimals (GH-404 delta pin)") {
-    // Since GH-404 the reader keeps file-declared codes verbatim, so a declared "0.00%" renders
-    // through FormatCodeParser as Excel does ("15.60%") — not the PercentDecimal enum arm above
-    // ("15.6%"). Deliberate behavioral delta: the Custom rendering is the Excel-correct one.
+  test("formatValue - Custom 0.00% renders identically to PercentDecimal (GH-410)") {
+    // GH-404 kept file-declared codes verbatim, which made a declared "0.00%" render correctly
+    // ("15.60%") while the PercentDecimal enum arm hand-rolled "15.6%". GH-410 closed that
+    // delta: the enum arms now render through FormatCodeParser on NumFmt.formatCode.
     val value = CellValue.Number(BigDecimal("0.156"))
     val result = NumFmtFormatter.formatValue(value, NumFmt.Custom("0.00%"))
     assertEquals(result, "15.60%")
+    assertEquals(result, NumFmtFormatter.formatValue(value, NumFmt.PercentDecimal))
+  }
+
+  test("formatValue - Scientific format matches its 0.00E+00 code (GH-410)") {
+    // ECMA-376 id 11 is "0.00E+00": one mantissa integer digit, two decimals, signed
+    // two-digit exponent.
+    def sci(s: String): String =
+      NumFmtFormatter.formatValue(CellValue.Number(BigDecimal(s)), NumFmt.Scientific)
+    assertEquals(sci("1234.5"), "1.23E+03")
+    assertEquals(sci("0"), "0.00E+00")
+    assertEquals(sci("0.0001234"), "1.23E-04")
+    assertEquals(sci("-1234.5"), "-1.23E+03")
+  }
+
+  test("formatValue - Decimal rounds HALF_UP on the exact decimal value (GH-410)") {
+    // "0.00" of exactly 2.675 is 2.68 in decimal HALF_UP; the old arm detoured through
+    // Double where 2.675 is stored as 2.67499..., yielding 2.67.
+    val result = NumFmtFormatter.formatValue(CellValue.Number(BigDecimal("2.675")), NumFmt.Decimal)
+    assertEquals(result, "2.68")
+  }
+
+  test("formatValue - DateTime serial renders 24-hour like its m/d/yy h:mm code (GH-410)") {
+    // ECMA-376 §18.8.31: 'h' is the 12-hour clock only when the code contains AM/PM;
+    // "m/d/yy h:mm" (id 22) has none, so 14:30 renders as 14:30. The old arm used the
+    // Java pattern 'h' (clock-hour 1-12) and showed 2:30.
+    val serial = BigDecimal("45982.6041666666666667") // 2025-11-21 14:30
+    val result = NumFmtFormatter.formatValue(CellValue.Number(serial), NumFmt.DateTime)
+    assertEquals(result, "11/21/25 14:30")
+  }
+
+  test("formatValue - Time serial renders 24-hour (GH-410)") {
+    val result = NumFmtFormatter.formatValue(CellValue.Number(BigDecimal("0.75")), NumFmt.Time)
+    assertEquals(result, "18:00:00")
+  }
+
+  test("formatValue - Date format fills ###### for out-of-range serials (GH-410)") {
+    // Excel renders negative (pre-1900) serials under date formats as ######; the old arm
+    // fabricated an 1899 calendar date.
+    val result = NumFmtFormatter.formatValue(CellValue.Number(BigDecimal(-5)), NumFmt.Date)
+    assertEquals(result, "######")
+  }
+
+  test("formatValue - Text format renders numbers like General (GH-410)") {
+    // "@" (id 49) has no numeric section: Excel shows the number in General format. The old
+    // arm leaked BigDecimal.toString ("1E+3").
+    val result = NumFmtFormatter.formatValue(CellValue.Number(BigDecimal("1E+3")), NumFmt.Text)
+    assertEquals(result, "1000")
   }
 
   test("formatValue - Custom thousands/currency codes match the enum arms (GH-404 parity)") {

--- a/xl-core/test/src/com/tjclp/xl/display/FormatCodeParserSpec.scala
+++ b/xl-core/test/src/com/tjclp/xl/display/FormatCodeParserSpec.scala
@@ -617,11 +617,75 @@ class FormatCodeParserSpec extends FunSuite:
     val dateCode = FormatCodeParser.parse("m/d/yyyy").toOption.get
     val dt = java.time.LocalDateTime.of(2025, 3, 15, 14, 30, 45)
 
+    // Re-pinned by GH-410 per ECMA-376 §18.8.31: 'h' uses the 12-hour clock only when the
+    // code contains AM/PM; "h:mm:ss" has none, so 14:30:45 renders as 14:30:45 (was 2:30:45).
     val timeResult = FormatCodeParser.applyDateFormat(dt, timeCode)
-    assertEquals(timeResult, "2:30:45") // mm = 30 (minute)
+    assertEquals(timeResult, "14:30:45") // mm = 30 (minute)
 
     val dateResult = FormatCodeParser.applyDateFormat(dt, dateCode)
     assertEquals(dateResult, "3/15/2025") // m = 3 (month)
+  }
+
+  test("applyDateFormat: bare h is the 24-hour clock, AM/PM switches to 12-hour (GH-410)") {
+    // ECMA-376 §18.8.31: "If the format contains an AM or PM code, the hour is based on
+    // the 12-hour clock; otherwise, it is based on the 24-hour clock."
+    val bare = FormatCodeParser.parse("h:mm").toOption.get
+    val meridiem = FormatCodeParser.parse("h:mm AM/PM").toOption.get
+    val padded = FormatCodeParser.parse("hh:mm").toOption.get
+    val afternoon = java.time.LocalDateTime.of(2025, 1, 1, 16, 5, 0)
+    val morning = java.time.LocalDateTime.of(2025, 1, 1, 9, 5, 0)
+    val midnight = java.time.LocalDateTime.of(2025, 1, 1, 0, 5, 0)
+
+    assertEquals(FormatCodeParser.applyDateFormat(afternoon, bare), "16:05")
+    assertEquals(FormatCodeParser.applyDateFormat(morning, bare), "9:05")
+    assertEquals(FormatCodeParser.applyDateFormat(midnight, bare), "0:05")
+    assertEquals(FormatCodeParser.applyDateFormat(afternoon, padded), "16:05")
+    assertEquals(FormatCodeParser.applyDateFormat(midnight, padded), "00:05")
+    assertEquals(FormatCodeParser.applyDateFormat(afternoon, meridiem), "4:05 PM")
+    assertEquals(FormatCodeParser.applyDateFormat(midnight, meridiem), "12:05 AM")
+  }
+
+  // ========== Scientific Notation (GH-410) ==========
+
+  private def formatWith(code: String, value: BigDecimal): String =
+    FormatCodeParser.parse(code) match
+      case Right(fmt) => FormatCodeParser.applyFormat(value, fmt)._1
+      case Left(e) => fail(s"parse('$code') failed: $e")
+
+  test("applyFormat: scientific 0.00E+00 basics (GH-410)") {
+    assertEquals(formatWith("0.00E+00", BigDecimal("1234.5")), "1.23E+03")
+    assertEquals(formatWith("0.00E+00", BigDecimal("123456.789")), "1.23E+05")
+    assertEquals(formatWith("0.00E+00", BigDecimal("0")), "0.00E+00")
+    assertEquals(formatWith("0.00E+00", BigDecimal("1")), "1.00E+00")
+    assertEquals(formatWith("0.00E+00", BigDecimal("0.0001234")), "1.23E-04")
+    assertEquals(formatWith("0.00E+00", BigDecimal("-1234.5")), "-1.23E+03")
+  }
+
+  test("applyFormat: scientific mantissa rounding renormalizes (GH-410)") {
+    // 9.999 rounds to 10.00 at two decimals, which overflows one integer digit: Excel
+    // renormalizes to 1.00E+01.
+    assertEquals(formatWith("0.00E+00", BigDecimal("9.999")), "1.00E+01")
+  }
+
+  test("applyFormat: engineering ##0.0E+0 snaps exponent to placeholder multiples (GH-410)") {
+    // Three integer placeholders make the exponent a multiple of 3 (id 48's code).
+    assertEquals(formatWith("##0.0E+0", BigDecimal("123456")), "123.5E+3")
+    assertEquals(formatWith("##0.0E+0", BigDecimal("1234.5")), "1.2E+3")
+    assertEquals(formatWith("##0.0E+0", BigDecimal("0.01")), "10.0E-3")
+  }
+
+  test("applyFormat: E- shows the exponent sign only when negative (GH-410)") {
+    assertEquals(formatWith("0.00E-00", BigDecimal("1234.5")), "1.23E03")
+    assertEquals(formatWith("0.00E-00", BigDecimal("0.0001234")), "1.23E-04")
+  }
+
+  test("applyFormat: lowercase e is preserved (GH-410)") {
+    assertEquals(formatWith("0.00e+00", BigDecimal("1234.5")), "1.23e+03")
+  }
+
+  test("applyFormat: exponent placeholders pad, never truncate (GH-410)") {
+    assertEquals(formatWith("0.0E+0", BigDecimal("1.5E+12")), "1.5E+12")
+    assertEquals(formatWith("0.00E+000", BigDecimal("1234.5")), "1.23E+003")
   }
 
   test("applyDateFormat: 12-hour noon/midnight") {

--- a/xl-core/test/src/com/tjclp/xl/sheets/SheetNamedSpec.scala
+++ b/xl-core/test/src/com/tjclp/xl/sheets/SheetNamedSpec.scala
@@ -1,0 +1,49 @@
+package com.tjclp.xl.sheets
+
+import com.tjclp.xl.{*, given}
+import munit.FunSuite
+
+/**
+ * GH-420: `Sheet.named` is THE documented factory for dynamic (runtime-`String`) sheet names.
+ *
+ * `Sheet(name)` is `transparent inline`: a string literal validates at compile time and specializes
+ * to `Sheet`, while a dynamic `String` silently specializes to `XLResult[Sheet]` — sound, but
+ * nothing at the call site hints the return type changed (it cost a field build three edit cycles).
+ * `Sheet.named` spells the `XLResult` in a plain non-inline signature so dynamic-name callers see
+ * the `.map`/`.unsafe` step coming.
+ */
+class SheetNamedSpec extends FunSuite:
+
+  test("named with a valid dynamic name yields Right, usable in a put chain") {
+    // Deliberately a runtime value (the FinAgent field repro held the name in a val).
+    val dynamic: String = List("Acquisitions").mkString
+    val result: XLResult[Sheet] = Sheet.named(dynamic).map(_.put(ref"A1", 42).put(ref"B1", "ok"))
+    result match
+      case Right(sheet) =>
+        assertEquals(sheet.name.value, "Acquisitions")
+        assertEquals(sheet.cells.get(ref"A1").map(_.value), Some(CellValue.Number(BigDecimal(42))))
+        assertEquals(sheet.cells.get(ref"B1").map(_.value), Some(CellValue.Text("ok")))
+      case Left(err) => fail(s"expected Right, got Left($err)")
+  }
+
+  test("named with an invalid name yields Left(InvalidSheetName)") {
+    val cases = List(
+      "Q1:Q2", // invalid character ':'
+      "", // empty
+      "X" * 32, // over the 31-char maximum
+      "History" // reserved by Excel
+    )
+    cases.foreach { bad =>
+      Sheet.named(bad) match
+        case Left(XLError.InvalidSheetName(name, _)) => assertEquals(name, bad)
+        case other => fail(s"expected Left(InvalidSheetName) for '$bad', got $other")
+    }
+  }
+
+  test("named agrees with the dynamic branch of the inline apply") {
+    val names = List("Sales", "Q1:Q2", "", "X" * 32, "History", "Income Statement")
+    names.foreach { s =>
+      val dynamic: String = List(s).mkString // defeat constant folding: force the runtime branch
+      assertEquals(Sheet.named(s), Sheet(dynamic): XLResult[Sheet])
+    }
+  }

--- a/xl-core/test/src/com/tjclp/xl/workbooks/DefinedNameScopeRemapSpec.scala
+++ b/xl-core/test/src/com/tjclp/xl/workbooks/DefinedNameScopeRemapSpec.scala
@@ -1,0 +1,129 @@
+package com.tjclp.xl.workbooks
+
+import com.tjclp.xl.Workbook
+import com.tjclp.xl.addressing.SheetName
+import com.tjclp.xl.sheets.Sheet
+import munit.FunSuite
+
+/**
+ * GH-434: sheet-scoped defined names (`localSheetId`) are POSITIONAL — every sheet-order mutation
+ * (removeAt / insertAt / reorder) must remap the stored indices or the names silently attach to
+ * whatever sheet now occupies their old position. Modeled print names are immune (PrintNames
+ * re-derives them from live sheet position on write); these tests pin the generic names and the
+ * deliberately-unmodelable verbatim print names that live in `metadata.definedNames`.
+ */
+class DefinedNameScopeRemapSpec extends FunSuite:
+
+  private def name(s: String): SheetName = SheetName.unsafe(s)
+
+  /** Three sheets [Alpha, Beta, Gamma] with one sheet-scoped name each plus a global name. */
+  private def workbook: Workbook =
+    val base = Workbook(Vector(Sheet(name("Alpha")), Sheet(name("Beta")), Sheet(name("Gamma"))))
+    base.copy(metadata =
+      base.metadata.copy(definedNames =
+        Vector(
+          DefinedName("AlphaLocal", "Alpha!$A$1", localSheetId = Some(0)),
+          DefinedName("BetaLocal", "Beta!$B$2", localSheetId = Some(1)),
+          DefinedName("GammaLocal", "Gamma!$C$3", localSheetId = Some(2)),
+          DefinedName("Global", "0.08", localSheetId = None)
+        )
+      )
+    )
+
+  private def scopeOf(wb: Workbook, dn: String): Option[Int] =
+    wb.metadata.definedNames.find(_.name == dn).flatMap(_.localSheetId)
+
+  test("GH-434: removeAt(0) shifts higher scopes down and drops the removed sheet's names") {
+    val wb = workbook.removeAt(0).fold(e => fail(s"removeAt failed: $e"), identity)
+    assertEquals(wb.sheetNames.map(_.value), Vector("Beta", "Gamma"))
+    assertEquals(
+      wb.metadata.definedNames.find(_.name == "AlphaLocal"),
+      None,
+      "names scoped to the removed sheet must be dropped"
+    )
+    assertEquals(scopeOf(wb, "BetaLocal"), Some(0), "Beta moved 1 -> 0")
+    assertEquals(scopeOf(wb, "GammaLocal"), Some(1), "Gamma moved 2 -> 1")
+    assertEquals(scopeOf(wb, "Global"), None, "workbook-scoped names untouched")
+  }
+
+  test("GH-434: removeAt(middle) leaves lower scopes alone") {
+    val wb = workbook.removeAt(1).fold(e => fail(s"removeAt failed: $e"), identity)
+    assertEquals(scopeOf(wb, "AlphaLocal"), Some(0))
+    assertEquals(wb.metadata.definedNames.find(_.name == "BetaLocal"), None)
+    assertEquals(scopeOf(wb, "GammaLocal"), Some(1))
+  }
+
+  test("GH-434: remove by name routes through the same remap") {
+    val wb = workbook.remove(name("Alpha")).fold(e => fail(s"remove failed: $e"), identity)
+    assertEquals(scopeOf(wb, "BetaLocal"), Some(0))
+    assertEquals(scopeOf(wb, "GammaLocal"), Some(1))
+  }
+
+  test("GH-434: insertAt(middle) shifts scopes at and above the insertion point up") {
+    val wb = workbook
+      .insertAt(1, Sheet(name("Inserted")))
+      .fold(e => fail(s"insertAt failed: $e"), identity)
+    assertEquals(wb.sheetNames.map(_.value), Vector("Alpha", "Inserted", "Beta", "Gamma"))
+    assertEquals(scopeOf(wb, "AlphaLocal"), Some(0), "below insertion point: unchanged")
+    assertEquals(scopeOf(wb, "BetaLocal"), Some(2), "Beta moved 1 -> 2")
+    assertEquals(scopeOf(wb, "GammaLocal"), Some(3), "Gamma moved 2 -> 3")
+    assertEquals(scopeOf(wb, "Global"), None)
+  }
+
+  test("GH-434: insertAt(0) shifts every scope up") {
+    val wb = workbook
+      .insertAt(0, Sheet(name("First")))
+      .fold(e => fail(s"insertAt failed: $e"), identity)
+    assertEquals(scopeOf(wb, "AlphaLocal"), Some(1))
+    assertEquals(scopeOf(wb, "BetaLocal"), Some(2))
+    assertEquals(scopeOf(wb, "GammaLocal"), Some(3))
+  }
+
+  test("GH-434: reorder applies the full permutation to every sheet-scoped name") {
+    val wb = workbook
+      .reorder(Vector(name("Gamma"), name("Alpha"), name("Beta")))
+      .fold(e => fail(s"reorder failed: $e"), identity)
+    assertEquals(wb.sheetNames.map(_.value), Vector("Gamma", "Alpha", "Beta"))
+    assertEquals(scopeOf(wb, "AlphaLocal"), Some(1), "Alpha moved 0 -> 1")
+    assertEquals(scopeOf(wb, "BetaLocal"), Some(2), "Beta moved 1 -> 2")
+    assertEquals(scopeOf(wb, "GammaLocal"), Some(0), "Gamma moved 2 -> 0")
+    assertEquals(scopeOf(wb, "Global"), None)
+  }
+
+  test("GH-434: identity reorder keeps every name where it is") {
+    val wb = workbook
+      .reorder(Vector(name("Alpha"), name("Beta"), name("Gamma")))
+      .fold(e => fail(s"reorder failed: $e"), identity)
+    assertEquals(scopeOf(wb, "AlphaLocal"), Some(0))
+    assertEquals(scopeOf(wb, "BetaLocal"), Some(1))
+    assertEquals(scopeOf(wb, "GammaLocal"), Some(2))
+  }
+
+  test("GH-434: verbatim print names (unmodelable shapes) remap like any sheet-scoped name") {
+    // Multi-range Print_Area and column-span Print_Titles never ride the PageSetup lift
+    // (PrintNames.scala keeps them in metadata verbatim) — the remap must cover them too.
+    val base = Workbook(Vector(Sheet(name("Alpha")), Sheet(name("Beta"))))
+    val wb0 = base.copy(metadata =
+      base.metadata.copy(definedNames =
+        Vector(
+          DefinedName(
+            "_xlnm.Print_Area",
+            "Beta!$A$1:$B$2,Beta!$D$1:$E$2",
+            localSheetId = Some(1)
+          ),
+          DefinedName("_xlnm.Print_Titles", "Beta!$A:$B", localSheetId = Some(1))
+        )
+      )
+    )
+    val wb = wb0.removeAt(0).fold(e => fail(s"removeAt failed: $e"), identity)
+    assertEquals(
+      wb.metadata.definedNames.map(dn => (dn.name, dn.localSheetId)),
+      Vector(
+        ("_xlnm.Print_Area", Some(0)),
+        ("_xlnm.Print_Titles", Some(0))
+      ),
+      "verbatim print names must follow their sheet across a removal"
+    )
+    // The formulas themselves are untouched (name-based, not positional)
+    assert(wb.metadata.definedNames.forall(_.formula.startsWith("Beta!")))
+  }

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/display/EvaluatingFormulaDisplaySpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/display/EvaluatingFormulaDisplaySpec.scala
@@ -107,8 +107,10 @@ class EvaluatingFormulaDisplaySpec extends FunSuite:
 
     given FormulaDisplayStrategy = EvaluatingFormulaDisplay.evaluating
 
+    // Re-pinned by GH-410: the inferred PercentDecimal is "0.00%" (ECMA-376 id 10), which
+    // renders two forced decimals — 50.00%, not the old hand-rolled single-decimal 50.0%.
     val result = excel"Ratio: ${ref"B1"}"
-    assertEquals(result, "Ratio: 50.0%")
+    assertEquals(result, "Ratio: 50.00%")
   }
 
   test("excel interpolator evaluates AVERAGE formula") {

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/Comments.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/Comments.scala
@@ -295,8 +295,13 @@ object OoxmlComments extends XmlReadable[OoxmlComments]:
    */
   private def encodeCommentText(text: RichText): Elem =
     val runElems = text.runs.map { run =>
-      // Build <rPr> if font formatting is present
-      val rPrElem = run.font.map { f =>
+      // Preserved raw <rPr> wins (byte-perfect: keeps indexed run colors, <charset>, … that
+      // the Font model cannot represent — GH-433, same pattern as SharedStrings); otherwise
+      // build <rPr> from the Font model if formatting is present.
+      val preservedRPr = run.rawRPrXml.flatMap { xmlString =>
+        XmlSecurity.parseSafe(xmlString, "comment rPr").toOption.map(stripNamespaces)
+      }
+      val rPrElem = preservedRPr.orElse(run.font.map { f =>
         val props = Seq.newBuilder[Elem]
 
         if f.bold then props += elem("b")()
@@ -315,7 +320,7 @@ object OoxmlComments extends XmlReadable[OoxmlComments]:
         props += elem("rFont", "val" -> f.name)()
 
         elem("rPr")(props.result()*)
-      }
+      })
 
       // Build <t> with xml:space="preserve" if needed (_xHHHH_-escaped per GH-288)
       val runText = escapeXstring(run.text)

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/ContentTypes.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/ContentTypes.scala
@@ -62,6 +62,19 @@ case class ContentTypes(
       (ct != ctComments && ct != ctVmlDrawing) || shippedNames.contains(partName)
     })
 
+  /**
+   * Remove the overrides naming any of `paths` (zip paths without the leading slash) — the GH-417
+   * removal-orphan prune. Unlike [[withoutOrphanCommentParts]] this is PATH-keyed, not class-keyed:
+   * a removed sheet's rel closure can include non-writer-owned classes (chart colors/style parts),
+   * whose registrations must fall with the pruned parts. Extension Defaults are untouched (they
+   * declare mappings, not parts).
+   */
+  def withoutParts(paths: Set[String]): ContentTypes =
+    if paths.isEmpty then this
+    else
+      val partNames = paths.map(p => s"/$p")
+      copy(overrides = overrides.filterNot((partName, _) => partNames.contains(partName)))
+
   def withTableOverrides(tableCount: Int): ContentTypes =
     if tableCount == 0 then this
     else

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/DirectSaxEmitter.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/DirectSaxEmitter.scala
@@ -15,6 +15,7 @@ import com.tjclp.xl.ooxml.worksheet.{
   mergeHeaderFooterElem,
   mergeAutoFilterElem,
   mergePageSetupElem,
+  mergeSheetFormatPrElem,
   mergeSheetPrElem
 }
 import java.util.Arrays
@@ -85,6 +86,10 @@ object DirectSaxEmitter:
 
       // Freeze panes + view settings (GH-258) — BEFORE cols/sheetData
       buildSheetViewsElem(None, sheet.freezePane, sheet.viewSettings).foreach(writer.writeElem)
+
+      // GH-426: sheet-default row height / column width — the CT_Worksheet slot before <cols>
+      mergeSheetFormatPrElem(None, sheet.defaultColumnWidth, sheet.defaultRowHeight)
+        .foreach(writer.writeElem)
 
       // Emit column definitions if any
       emitCols(writer, sheet)

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/XlsxReader.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/XlsxReader.scala
@@ -1094,6 +1094,9 @@ object XlsxReader:
     // Parse the tab color from <sheetPr><tabColor .../> — GH-358
     val tabColor = parseTabColor(ooxmlSheet.sheetPr)
 
+    // Parse sheet-default sizing from <sheetFormatPr> (GH-426) so read→modify→write keeps it
+    val (defaultColumnWidth, defaultRowHeight) = parseSheetFormatPr(ooxmlSheet.sheetFormatPr)
+
     // Parse conditional formatting into the typed model (GH-136); dxfId attrs resolve through
     // the styles.xml <dxfs> table. Total: unmodeled content rides through Preserved.
     val conditionalFormats =
@@ -1122,6 +1125,8 @@ object XlsxReader:
         tables = tables,
         columnProperties = columnProperties,
         rowProperties = rowProperties,
+        defaultColumnWidth = defaultColumnWidth,
+        defaultRowHeight = defaultRowHeight,
         pageSetup = pageSetup,
         freezePane = freezePane,
         viewSettings = viewSettings,
@@ -1319,6 +1324,20 @@ object XlsxReader:
         .flatMap(t => ARef.parse(t).toOption)
         .filter(_ != anchor)
       FreezePane.At(anchor, scrolledTo)
+
+  /**
+   * Parse the sheet-default column width / row height (GH-426) from `<sheetFormatPr>` as
+   * (defaultColumnWidth, defaultRowHeight). Only the two modeled attributes are lifted; everything
+   * else (baseColWidth, outlineLevelRow, ...) rides the preserved element, and the writer's
+   * identity fast-path (mergeSheetFormatPrElem) keeps the element verbatim while the modeled values
+   * are unchanged.
+   */
+  private def parseSheetFormatPr(elem: Option[Elem]): (Option[Double], Option[Double]) =
+    val attrs = elem.map(_.attributes.asAttrMap).getOrElse(Map.empty)
+    (
+      attrs.get("defaultColWidth").flatMap(_.toDoubleOption),
+      attrs.get("defaultRowHeight").flatMap(_.toDoubleOption)
+    )
 
   /**
    * Parse the sheet tab color (GH-358) from `<sheetPr><tabColor .../>`, reusing the strict dxf

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/XlsxWriter.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/XlsxWriter.scala
@@ -271,6 +271,22 @@ object XlsxWriter:
     author.map(_.trim).filter(_.nonEmpty)
 
   /**
+   * True when the comment text already leads with its own author-prefix run: the first run is
+   * exactly the author name with an optional colon (any formatting; trailing newline/space
+   * tolerated). Excel-authored comments carry such a run inside the text itself — read keeps it
+   * because it doesn't match XL's canonical `Author:` + `\n` shape — so synthesizing our prefix on
+   * top would duplicate the visible "Author:" line (GH-433).
+   */
+  private def hasLeadingAuthorPrefix(
+    text: com.tjclp.xl.richtext.RichText,
+    author: String
+  ): Boolean =
+    text.runs.headOption.exists { run =>
+      val normalized = run.text.replace("\u00A0", " ").trim // Excel can emit nbsp
+      normalized == author || normalized == s"$author:"
+    }
+
+  /**
    * Build per-sheet comment data for serialization: sheet index (0-based) -> comments to write.
    * Part paths are assigned separately — identity-mapped or freshly allocated above every
    * source-claimed number (GH-315) — never derived from the sheet index.
@@ -305,7 +321,7 @@ object XlsxWriter:
 
           // Excel displays author as part of comment text (bold first run)
           val textWithAuthor = canonicalAuthor match
-            case Some(author) =>
+            case Some(author) if !hasLeadingAuthorPrefix(comment.text, author) =>
               // Prepend author name as bold run
               val authorRun = com.tjclp.xl.richtext.TextRun(
                 s"$author:",
@@ -332,7 +348,10 @@ object XlsxWriter:
                     )
                   )
               textWithNewline
-            case None => comment.text
+            case _ =>
+              // Unauthored, or the text already leads with its own author-prefix run
+              // (file-authored comment) — never synthesize a second prefix (GH-433).
+              comment.text
 
           OoxmlComment(
             ref = ref,

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/XlsxWriter.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/XlsxWriter.scala
@@ -754,6 +754,94 @@ object XlsxWriter:
 
     regenerate.toSet
 
+  /**
+   * Resolve a relationship target against its owner part's directory to a zip path. Pure segment
+   * arithmetic — java.nio.Path would platform-mangle separators. Leading `/` targets are
+   * package-absolute; `.`/`..` segments normalize; fragments/queries are stripped; a target
+   * escaping the package root resolves to None.
+   */
+  private def resolveRelTarget(ownerPart: String, target: String): Option[String] =
+    val raw = target.takeWhile(c => c != '#' && c != '?')
+    if raw.isEmpty then None
+    else if raw.startsWith("/") then Some(raw.drop(1)).filter(_.nonEmpty)
+    else
+      val base = ownerPart.split('/').toVector.dropRight(1)
+      raw
+        .split('/')
+        .foldLeft(Option(base)) {
+          case (None, _) => None
+          case (Some(acc), "..") => if acc.isEmpty then None else Some(acc.dropRight(1))
+          case (Some(acc), "" | ".") => Some(acc)
+          case (Some(acc), seg) => Some(acc :+ seg)
+        }
+        .map(_.mkString("/"))
+        .filter(_.nonEmpty)
+
+  /**
+   * Parts orphaned by sheet removal (GH-417): everything reachable ONLY through the relationship
+   * closure of removed sheets' source parts — the drawing → chart → chart-colors/style chain, their
+   * media, and every part's `.rels` sibling. These fall out of the write instead of riding the
+   * verbatim copy loop as dead weight forever.
+   *
+   * Two guarantees bound the prune:
+   *   - a part reachable from ANY surviving part survives (a shared image stays — the survivor walk
+   *     runs over the SOURCE rels, which same-path drawing regeneration keeps verbatim, so survivor
+   *     references cannot be missed);
+   *   - only the removed sheets' closure is candidate — parts already unreferenced in the source
+   *     ride through untouched (removal-induced orphans only, never a general package GC).
+   *
+   * Removed sheets' source parts are the manifest worksheet parts no live sheet claims by identity
+   * (the GH-315 deleted-SST-refs convention: identity-keyed and rename-stable). The walk never
+   * expands THROUGH a removed worksheet part — the source workbook rels still name it, but the
+   * regenerated workbook.xml.rels will not.
+   */
+  private def removalOrphanedParts(
+    ctx: SourceContext,
+    liveSheetSourcePaths: Set[String]
+  ): Set[String] =
+    val manifestPaths = ctx.partManifest.entries.keySet
+    val deletedRoots = manifestPaths.filter(p =>
+      p.startsWith("xl/worksheets/") && !p.startsWith("xl/worksheets/_rels/") &&
+        !liveSheetSourcePaths.contains(p)
+    )
+    if deletedRoots.isEmpty then Set.empty
+    else
+      val targetsCache = mutable.Map.empty[String, Set[String]]
+      def targetsOf(partPath: String): Set[String] =
+        targetsCache.getOrElseUpdate(
+          partPath, {
+            val relsPath = partRelsPathOf(partPath)
+            if !manifestPaths.contains(relsPath) then Set.empty
+            else
+              Try(withSourceZip(ctx.content) { z =>
+                parseOptionalEntry(z, relsPath)(Relationships.fromXml)
+              }).toOption.flatten
+                .map(
+                  _.relationships
+                    .filterNot(_.targetMode.contains("External"))
+                    .flatMap(rel => resolveRelTarget(partPath, rel.target))
+                    .toSet
+                    .intersect(manifestPaths)
+                )
+                .getOrElse(Set.empty)
+          }
+        )
+
+      def closure(roots: Set[String], blocked: Set[String]): Set[String] =
+        @annotation.tailrec
+        def loop(frontier: Set[String], acc: Set[String]): Set[String] =
+          val next = frontier.flatMap(targetsOf).diff(acc).diff(blocked)
+          if next.isEmpty then acc else loop(next, acc ++ next)
+        loop(roots, roots)
+
+      def withRelsSiblings(parts: Set[String]): Set[String] =
+        parts ++ parts.map(partRelsPathOf).filter(manifestPaths.contains)
+
+      val deletedClosure = closure(deletedRoots, blocked = Set.empty)
+      val survivorRoots = manifestPaths -- withRelsSiblings(deletedClosure)
+      val survivorReachable = closure(survivorRoots, blocked = deletedRoots)
+      withRelsSiblings(deletedClosure -- survivorReachable)
+
   private def usingOrThrow[A](result: Try[A]): A =
     result match
       case Success(value) => value
@@ -1546,6 +1634,16 @@ object XlsxWriter:
     def sourceSheetRelsPath(ctx: SourceContext, idx: Int): Option[String] =
       sourceSheetPath(ctx, idx).map(partRelsPathOf)
 
+    // GH-417: after a removal, parts reachable ONLY via the removed sheet's rel closure (its
+    // drawing → chart → colors/style chain, exclusive media, their .rels) fall out of the write;
+    // anything a surviving part references stays. Pruned paths leave BOTH the copy loop
+    // (livePreservableParts below) and [Content_Types].xml (withoutParts on the final types).
+    val removalOrphans: Set[String] = sourceContext match
+      case Some(ctx) if tracker.deletedSheets.nonEmpty =>
+        removalOrphanedParts(ctx, workbook.sheets.indices.flatMap(sourceSheetPath(ctx, _)).toSet)
+      case _ => Set.empty
+    val livePreservableParts = preservableParts -- removalOrphans
+
     // Escaping must be applied to every text-bearing worksheet part; preserved sheets can contain
     // dangerous inline strings or shared-string references that would bypass WriterConfig.secure.
     val sheetsToRegenerate =
@@ -1954,14 +2052,14 @@ object XlsxWriter:
                   ctx.commentPathMapping.get(sheet.name).filter(ctx.partManifest.contains)
               }
               .flatten
-              .toSet ++ (preservableParts -- vmlPathsToSkip)
+              .toSet ++ (livePreservableParts -- vmlPathsToSkip)
           case None => Set.empty)
 
     // Content types: preserve from source when available, otherwise generate minimal.
     // GH-315: comment/VML registrations follow the EMITTED part paths (identity-mapped or freshly
     // allocated) — withEmittedCommentParts is conservative, so source-declared parts ride through
     // byte-identical and only genuinely fresh parts add overrides.
-    val contentTypes = preservedContentTypes match
+    val reconciledContentTypes = preservedContentTypes match
       case Some(preserved) =>
         // Add sharedStrings override if we're generating it but source didn't have it
         val withSst =
@@ -2013,10 +2111,15 @@ object XlsxWriter:
               .reconcile(
                 preserved,
                 model,
-                verbatimParts = preservableParts -- vmlPathsToSkip ++ vmlPathBySheet.values
+                verbatimParts = livePreservableParts -- vmlPathsToSkip ++ vmlPathBySheet.values
               )
               .withDocPropsOverrides(corePropsXml.isDefined, appPropsXml.isDefined)
           case None => model
+
+    // GH-417: registrations of removal-orphaned parts fall with the parts — including model-side
+    // re-registrations (withDrawingOverrides/withChartOverrides register every MANIFEST part) and
+    // non-writer-owned classes reconcile keeps (chart colors/style).
+    val contentTypes = reconciledContentTypes.withoutParts(removalOrphans)
 
     // GH-320: ungated like the content types (GH-314) — a metadata-modified write must keep the
     // preserved package-level rels (docProps/custom.xml and friends ride the verbatim copy loop).
@@ -2291,8 +2394,9 @@ object XlsxWriter:
       // Skip VML drawings for regenerated sheets - we regenerate VML from domain model
       // (or omit it if comments were removed); skip drawing parts superseded by same-path
       // regeneration (GH-221). vmlPathsToSkip is hoisted above (shared with GH-322).
+      // GH-417: removal-orphaned parts are already subtracted (livePreservableParts).
       sourceContext.foreach { ctx =>
-        preservableParts.foreach { path =>
+        livePreservableParts.foreach { path =>
           // vmlPathsToSkip holds the exact regeneration targets — including foreign-named VML
           // parts like openpyxl's commentsDrawing1.vml (GH-292), so no filename-prefix guard
           val shouldSkip =

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/OoxmlWorksheet.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/OoxmlWorksheet.scala
@@ -578,7 +578,12 @@ object OoxmlWorksheet extends com.tjclp.xl.ooxml.XmlReadable[OoxmlWorksheet]:
             preserved.dimension
           ), // Use calculated dimension, fallback to preserved
           buildSheetViewsElem(preserved.sheetViews, sheet.freezePane, sheet.viewSettings),
-          preserved.sheetFormatPr,
+          // GH-426: modeled sheet defaults overlay the preserved element (unmodeled attrs ride)
+          mergeSheetFormatPrElem(
+            preserved.sheetFormatPr,
+            sheet.defaultColumnWidth,
+            sheet.defaultRowHeight
+          ),
           generatedCols.orElse(preserved.cols), // Prefer domain props over preserved XML
           condFmt.getOrElse(preserved.conditionalFormatting), // GH-136: planned slot wins
           dataValidations.getOrElse(preserved.dataValidations), // GH-375: planned slot wins
@@ -616,6 +621,9 @@ object OoxmlWorksheet extends com.tjclp.xl.ooxml.XmlReadable[OoxmlWorksheet]:
           sheetPr = mergeSheetPrElem(None, sheet.pageSetup, sheet.tabColor),
           dimension = calculatedDimension,
           sheetViews = buildSheetViewsElem(None, sheet.freezePane, sheet.viewSettings),
+          // GH-426: a modeled default row height / column width materializes without source XML
+          sheetFormatPr =
+            mergeSheetFormatPrElem(None, sheet.defaultColumnWidth, sheet.defaultRowHeight),
           cols = generatedCols,
           conditionalFormatting = condFmt.getOrElse(Seq.empty), // GH-136: fresh workbooks get cf
           dataValidations = dataValidations.flatten, // GH-375: fresh workbooks get validations

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/WorksheetHelpers.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/WorksheetHelpers.scala
@@ -615,6 +615,55 @@ private[ooxml] def parseAutoFilterRef(e: Elem): Option[CellRange] =
       .orElse(ARef.parse(refText).toOption.map(r => CellRange(r, r)))
   }
 
+// ===== Sheet-default sizing (GH-426) =====
+
+/**
+ * Overlay the modeled sheet defaults (`Sheet.defaultColumnWidth` / `Sheet.defaultRowHeight`) onto
+ * the preserved `<sheetFormatPr>` element (the mergePageSetupElem precedent). Shared by both writer
+ * backends so the element serializes identically on the DOM and streaming paths.
+ *
+ *   - both fields None → passthrough (the passive default: a sheet that never had the element and
+ *     sets no defaults emits nothing; a preserved element rides verbatim)
+ *   - a modeled value equal to the parsed source attribute leaves the element untouched (identity
+ *     fast-path — zero churn when the reader populated the model from this very element)
+ *   - a model-driven defaultRowHeight also sets customHeight="1" (ECMA-376 18.3.1.81: true when the
+ *     default row height "has been manually set"), matching what Excel writes
+ *   - a FRESH element authored for a width-only model backfills defaultRowHeight="15" (the
+ *     Calibri-11 grid default) — CT_SheetFormatPr REQUIRES the attribute; preserved elements are
+ *     never healed, only overlaid
+ *
+ * Unmodeled attributes (baseColWidth, zeroHeight, thickTop/thickBottom, outlineLevelRow/Col, ...)
+ * ride through untouched.
+ */
+private[ooxml] def mergeSheetFormatPrElem(
+  existing: Option[Elem],
+  defaultColumnWidth: Option[Double],
+  defaultRowHeight: Option[Double]
+): Option[Elem] =
+  if defaultColumnWidth.isEmpty && defaultRowHeight.isEmpty then existing
+  else
+    def attrDouble(e: Elem, key: String): Option[Double] =
+      Option(e \@ key).filter(_.nonEmpty).flatMap(_.toDoubleOption)
+    val base = existing.getOrElse(XmlUtil.elem("sheetFormatPr")())
+    val withWidth =
+      defaultColumnWidth.filterNot(attrDouble(base, "defaultColWidth").contains) match
+        case Some(w) => setOrRemoveAttr(base, "defaultColWidth", Some(w.toString))
+        case None => base
+    val withHeight =
+      defaultRowHeight.filterNot(attrDouble(withWidth, "defaultRowHeight").contains) match
+        case Some(h) =>
+          setOrRemoveAttr(
+            setOrRemoveAttr(withWidth, "defaultRowHeight", Some(h.toString)),
+            "customHeight",
+            Some("1")
+          )
+        case None => withWidth
+    val withRequiredHeight =
+      if existing.isEmpty && (withHeight \@ "defaultRowHeight").isEmpty then
+        setOrRemoveAttr(withHeight, "defaultRowHeight", Some("15"))
+      else withHeight
+    Some(withRequiredHeight)
+
 // ===== Print setup authoring (GH-259, GH-266) =====
 // PageSetup is the typed model for <pageMargins>, <pageSetup>, <headerFooter>, and the
 // sheetPr/pageSetUpPr fitToPage flag. The merge helpers below overlay the modeled fields onto any

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/CommentsSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/CommentsSpec.scala
@@ -593,6 +593,177 @@ class CommentsSpec extends FunSuite:
     assertEquals(run.font.map(_.bold), Some(true))
   }
 
+  // GH-433 fixture: comment shaped like real Excel output — the author-prefix run is
+  // bold Tahoma 9 with <color indexed="81"/> and <charset/>, and the body run does NOT
+  // lead with the "\n" that XL's own canonical prefix carries (so stripAuthorPrefix
+  // deliberately leaves it in place on read).
+  private val excelAuthoredCommentsXml =
+    <comments xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+      <authors>
+        <author>Reviewer</author>
+      </authors>
+      <commentList>
+        <comment ref="A1" authorId="0">
+          <text>
+            <r><rPr><b/><sz val="9"/><color indexed="81"/><rFont val="Tahoma"/><charset val="1"/></rPr><t>Reviewer:</t></r>
+            <r><rPr><sz val="9"/><color indexed="81"/><rFont val="Tahoma"/><charset val="1"/></rPr><t xml:space="preserve"> check this figure</t></r>
+          </text>
+        </comment>
+      </commentList>
+    </comments>
+
+  /** Read the GH-433 fixture the way XlsxReader does: OOXML part → domain Comment. */
+  private def excelAuthoredDomainComment: Comment =
+    val parsed = OoxmlComments.fromXml(excelAuthoredCommentsXml) match
+      case Right(c) => c
+      case Left(err) => fail(s"Fixture parse failed: $err")
+    val domain = XlsxReader.convertToDomainComments(parsed) match
+      case Right(m) => m
+      case Left(err) => fail(s"Domain conversion failed: $err")
+    domain.get(ref"A1").getOrElse(fail("Expected comment at A1"))
+
+  private def commentsPartOf(bytes: Array[Byte]): String =
+    zipEntryString(bytes, "xl/comments1.xml")
+      .getOrElse(fail("Expected xl/comments1.xml part"))
+
+  private def parseCommentsPart(xml: String): OoxmlComments =
+    val elem = XmlSecurity.parseSafe(xml, "xl/comments1.xml") match
+      case Right(e) => e
+      case Left(err) => fail(s"Comments part parse failed: $err")
+    OoxmlComments.fromXml(elem) match
+      case Right(c) => c
+      case Left(err) => fail(s"Comments part decode failed: $err")
+
+  test("GH-433: rewrite does not synthesize a second author-prefix run") {
+    val comment = excelAuthoredDomainComment
+    // Pin the audit-verified read behavior: the foreign prefix is NOT stripped.
+    assertEquals(comment.author, Some("Reviewer"))
+    assertEquals(comment.text.runs.size, 2)
+    assertEquals(comment.text.toPlainText, "Reviewer: check this figure")
+
+    val sheet = Sheet("Sheet1").comment(ref"A1", comment)
+    val bytes = XlsxWriter.writeToBytes(Workbook(Vector(sheet))) match
+      case Right(b) => b
+      case Left(err) => fail(s"Write failed: $err")
+
+    val written = parseCommentsPart(commentsPartOf(bytes))
+    val writtenComment = written.comments.headOption.getOrElse(fail("Expected written comment"))
+
+    // Before GH-433 this came back as 3 runs reading "Reviewer:\nReviewer: check this figure".
+    assertEquals(writtenComment.text.toPlainText, "Reviewer: check this figure")
+    assertEquals(writtenComment.text.runs.size, 2)
+    assertEquals(writtenComment.text.runs.headOption.map(_.text), Some("Reviewer:"))
+  }
+
+  test("GH-433: indexed run color, font, and charset survive the rewrite") {
+    val sheet = Sheet("Sheet1").comment(ref"A1", excelAuthoredDomainComment)
+    val bytes = XlsxWriter.writeToBytes(Workbook(Vector(sheet))) match
+      case Right(b) => b
+      case Left(err) => fail(s"Write failed: $err")
+
+    val written = parseCommentsPart(commentsPartOf(bytes))
+    val runs = written.comments.headOption.map(_.text.runs).getOrElse(fail("Expected comment"))
+
+    runs.foreach { run =>
+      val rPr = run.rawRPrXml.getOrElse(fail(s"Run '${run.text}' lost its <rPr>"))
+      assert(rPr.contains("""indexed="81""""), s"<color indexed=\"81\"/> dropped from rPr: $rPr")
+      assert(rPr.contains("""val="Tahoma""""), s"Tahoma font dropped from rPr: $rPr")
+      assert(rPr.contains("charset"), s"<charset/> dropped from rPr: $rPr")
+    }
+    assertEquals(runs.headOption.flatMap(_.font.map(_.bold)), Some(true))
+  }
+
+  test("GH-433: rgb run color survives the rewrite") {
+    val richText = com.tjclp.xl.richtext.RichText(
+      Vector(
+        com.tjclp.xl.richtext.TextRun(
+          "Red note",
+          Some(
+            com.tjclp.xl.styles.font
+              .Font(name = "Calibri", sizePt = 11.0)
+              .withColor(com.tjclp.xl.styles.color.Color.Rgb(0xffff0000))
+          )
+        )
+      )
+    )
+    val comments = OoxmlComments(
+      authors = Vector("Author"),
+      comments = Vector(OoxmlComment(ref"A1", 0, richText))
+    )
+
+    val reparsed = OoxmlComments.fromXml(OoxmlComments.toXml(comments)) match
+      case Right(c) => c
+      case Left(err) => fail(s"Reparse failed: $err")
+
+    val run = reparsed.comments.headOption
+      .flatMap(_.text.runs.headOption)
+      .getOrElse(fail("Expected rich text run"))
+    assertEquals(
+      run.font.flatMap(_.color),
+      Some(com.tjclp.xl.styles.color.Color.Rgb(0xffff0000))
+    )
+  }
+
+  test("GH-433: second rewrite of an Excel-authored comment is byte-stable") {
+    val sheet = Sheet("Sheet1").comment(ref"A1", excelAuthoredDomainComment)
+    val bytes1 = XlsxWriter.writeToBytes(Workbook(Vector(sheet))) match
+      case Right(b) => b
+      case Left(err) => fail(s"First write failed: $err")
+
+    val reread = XlsxReader.readFromBytes(bytes1) match
+      case Right(wb) => wb
+      case Left(err) => fail(s"Read failed: $err")
+
+    // Touch an unrelated cell so the second write is a genuine re-serialization.
+    val touchedSheet = reread.sheets.headOption.getOrElse(fail("Expected sheet")).put(ref"Z99" -> 1)
+    val bytes2 = XlsxWriter.writeToBytes(Workbook(Vector(touchedSheet))) match
+      case Right(b) => b
+      case Left(err) => fail(s"Second write failed: $err")
+
+    assertEquals(commentsPartOf(bytes2), commentsPartOf(bytes1))
+  }
+
+  test("GH-433: prefix guard only fires on an exact author-prefix run") {
+    // A first run that merely STARTS with the author name is comment text, not a prefix:
+    // the canonical prefix must still be synthesized.
+    val comment = Comment(
+      com.tjclp.xl.richtext.RichText(Vector(com.tjclp.xl.richtext.TextRun("Alice: note"))),
+      author = Some("Alice")
+    )
+    val sheet = Sheet("Sheet1").comment(ref"A1", comment)
+    val bytes = XlsxWriter.writeToBytes(Workbook(Vector(sheet))) match
+      case Right(b) => b
+      case Left(err) => fail(s"Write failed: $err")
+
+    val written = parseCommentsPart(commentsPartOf(bytes))
+    val runs = written.comments.headOption.map(_.text.runs).getOrElse(fail("Expected comment"))
+    assertEquals(runs.headOption.map(_.text), Some("Alice:"))
+    assertEquals(runs.map(_.text).mkString, "Alice:\nAlice: note")
+  }
+
+  test("GH-433: prefix guard matches an unformatted author-prefix run") {
+    // "ANY formatting" includes none at all: an existing plain "Reviewer:" lead run
+    // must suppress synthesis too.
+    val comment = Comment(
+      com.tjclp.xl.richtext.RichText(
+        Vector(
+          com.tjclp.xl.richtext.TextRun("Reviewer:"),
+          com.tjclp.xl.richtext.TextRun("\nsee figure")
+        )
+      ),
+      author = Some("Reviewer")
+    )
+    val sheet = Sheet("Sheet1").comment(ref"A1", comment)
+    val bytes = XlsxWriter.writeToBytes(Workbook(Vector(sheet))) match
+      case Right(b) => b
+      case Left(err) => fail(s"Write failed: $err")
+
+    val written = parseCommentsPart(commentsPartOf(bytes))
+    val runs = written.comments.headOption.map(_.text.runs).getOrElse(fail("Expected comment"))
+    assertEquals(runs.size, 2)
+    assertEquals(runs.map(_.text).mkString, "Reviewer:\nsee figure")
+  }
+
   private def extractShapeIds(vml: String): Set[Int] =
     "_x0000_s(\\d+)".r.findAllMatchIn(vml).map(_.group(1).toInt).toSet
 

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/DefinedNameRoundTripSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/DefinedNameRoundTripSpec.scala
@@ -2,11 +2,13 @@ package com.tjclp.xl.ooxml
 
 import java.nio.file.Files
 
+import com.tjclp.xl.addressing.SheetName
 import com.tjclp.xl.api.*
 import com.tjclp.xl.cells.CellValue
 import com.tjclp.xl.codec.CellCodec.given
 import com.tjclp.xl.macros.ref
 import com.tjclp.xl.unsafe.*
+import com.tjclp.xl.workbooks.DefinedName
 import munit.FunSuite
 
 /**
@@ -61,4 +63,70 @@ class DefinedNameRoundTripSpec extends FunSuite:
     val reread = XlsxReader.read(out).fold(e => fail(s"read failed: $e"), identity)
     assertEquals(reread.metadata.definedNames, Vector.empty)
     Files.deleteIfExists(out)
+  }
+
+  // ===== GH-434: sheet-scoped names must keep their sheet across order mutations =====
+
+  /** Cover (idx 0) + Data (idx 1), Data carrying a sheet-scoped name, written and read back. */
+  private def scopedFixture(label: String): (java.nio.file.Path, Workbook) =
+    val base = Workbook(Sheet("Cover").put(ref"A1" -> 1), Sheet("Data").put(ref"B2" -> 2))
+    val wb0 = base.copy(metadata =
+      base.metadata.copy(definedNames =
+        Vector(DefinedName("DataLocal", "Data!$B$2", localSheetId = Some(1)))
+      )
+    )
+    val src = Files.createTempFile(s"named-scope-$label", ".xlsx")
+    src.toFile.deleteOnExit()
+    XlsxWriter.write(wb0, src).fold(e => fail(s"seed write failed: $e"), identity)
+    val read = XlsxReader.read(src).fold(e => fail(s"seed read failed: $e"), identity)
+    assertEquals(
+      read.metadata.definedNames.map(dn => (dn.name, dn.localSheetId)),
+      Vector(("DataLocal", Some(1))),
+      "fixture sanity: the scoped name must survive the seed round-trip"
+    )
+    (src, read)
+
+  private def writeReread(wb: Workbook, label: String): Workbook =
+    val out = Files.createTempFile(s"named-scope-$label-out", ".xlsx")
+    out.toFile.deleteOnExit()
+    XlsxWriter.write(wb, out).fold(e => fail(s"write failed: $e"), identity)
+    XlsxReader.read(out).fold(e => fail(s"reread failed: $e"), identity)
+
+  test("GH-434: sheet-scoped name still targets its sheet after removing the sheet above it") {
+    val (_, wb) = scopedFixture("remove")
+    val removed = wb.remove(SheetName.unsafe("Cover")).fold(e => fail(e.message), identity)
+    val reread = writeReread(removed, "remove")
+    assertEquals(reread.sheetNames.map(_.value), Vector("Data"))
+    assertEquals(
+      reread.metadata.definedNames.map(dn => (dn.name, dn.localSheetId, dn.formula)),
+      Vector(("DataLocal", Some(0), "Data!$B$2")),
+      "the name must follow Data from index 1 to index 0"
+    )
+  }
+
+  test("GH-434: sheet-scoped name still targets its sheet after insertAt-middle") {
+    val (_, wb) = scopedFixture("insert")
+    val inserted =
+      wb.insertAt(1, Sheet("Inserted")).fold(e => fail(e.message), identity)
+    val reread = writeReread(inserted, "insert")
+    assertEquals(reread.sheetNames.map(_.value), Vector("Cover", "Inserted", "Data"))
+    assertEquals(
+      reread.metadata.definedNames.map(dn => (dn.name, dn.localSheetId)),
+      Vector(("DataLocal", Some(2))),
+      "the name must follow Data from index 1 to index 2"
+    )
+  }
+
+  test("GH-434: sheet-scoped name still targets its sheet after reorder") {
+    val (_, wb) = scopedFixture("reorder")
+    val reordered = wb
+      .reorder(Vector(SheetName.unsafe("Data"), SheetName.unsafe("Cover")))
+      .fold(e => fail(e.message), identity)
+    val reread = writeReread(reordered, "reorder")
+    assertEquals(reread.sheetNames.map(_.value), Vector("Data", "Cover"))
+    assertEquals(
+      reread.metadata.definedNames.map(dn => (dn.name, dn.localSheetId)),
+      Vector(("DataLocal", Some(0))),
+      "the name must follow Data from index 1 to index 0 across the reorder"
+    )
   }

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/PageSetupRoundTripSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/PageSetupRoundTripSpec.scala
@@ -265,6 +265,78 @@ class PageSetupRoundTripSpec extends FunSuite:
     Files.deleteIfExists(out)
   }
 
+  test("GH-434: verbatim print names follow their sheet across a removal (read-remove-write)") {
+    // Column-span Print_Titles and multi-range Print_Area never ride the PageSetup lift —
+    // they stay in metadata.definedNames verbatim, so the removeAt remap is their only
+    // protection against attaching to whatever sheet slides into their old index.
+    val base = Workbook(Sheet("Cover").put(ref"A1" -> 1), Sheet("Data").put(ref"B2" -> 2))
+    val wb0 = base.copy(metadata =
+      base.metadata.copy(definedNames =
+        Vector(
+          DefinedName("_xlnm.Print_Titles", "Data!$A:$B", localSheetId = Some(1)),
+          DefinedName(
+            "_xlnm.Print_Area",
+            "Data!$A$1:$B$2,Data!$D$1:$E$2",
+            localSheetId = Some(1)
+          )
+        )
+      )
+    )
+    val src = Files.createTempFile("verbatim-remove-src", ".xlsx")
+    XlsxWriter.write(wb0, src).fold(e => fail(s"seed write failed: $e"), identity)
+    val read = XlsxReader.read(src).fold(e => fail(s"seed read failed: $e"), identity)
+    assertEquals(
+      read.metadata.definedNames.map(_.localSheetId).toSet,
+      Set(Option(1)),
+      "fixture sanity: both unmodelable names stay in metadata, scoped to Data at index 1"
+    )
+
+    val removed = read.removeAt(0).fold(e => fail(s"removeAt failed: $e"), identity)
+    val out = Files.createTempFile("verbatim-remove-out", ".xlsx")
+    XlsxWriter.write(removed, out).fold(e => fail(s"write failed: $e"), identity)
+
+    val reread = XlsxReader.read(out).fold(e => fail(s"reread failed: $e"), identity)
+    assertEquals(reread.sheetNames.map(_.value), Vector("Data"))
+    assertEquals(
+      reread.metadata.definedNames.map(dn => (dn.name, dn.localSheetId, dn.formula)).sortBy(_._1),
+      Vector(
+        ("_xlnm.Print_Area", Some(0), "Data!$A$1:$B$2,Data!$D$1:$E$2"),
+        ("_xlnm.Print_Titles", Some(0), "Data!$A:$B")
+      ),
+      "verbatim print names must follow Data from index 1 to index 0"
+    )
+    Files.deleteIfExists(src)
+    Files.deleteIfExists(out)
+  }
+
+  test("GH-434: modeled print names stay correct across a removal (re-derivation undisturbed)") {
+    // The modeled path was already immune (PrintNames.fromSheets re-derives localSheetId from
+    // live sheet position on every write) — pin it so the GH-434 remap never double-shifts it.
+    val wb0 = Workbook(
+      Sheet("Cover").put(ref"A1" -> 1),
+      Sheet("Data").put(ref"B2" -> 2).withPageSetup(PageSetup(printArea = Some(ref"A1:B2")))
+    )
+    val src = Files.createTempFile("modeled-remove-src", ".xlsx")
+    XlsxWriter.write(wb0, src).fold(e => fail(s"seed write failed: $e"), identity)
+    val read = XlsxReader.read(src).fold(e => fail(s"seed read failed: $e"), identity)
+
+    val removed = read.removeAt(0).fold(e => fail(s"removeAt failed: $e"), identity)
+    val out = Files.createTempFile("modeled-remove-out", ".xlsx")
+    XlsxWriter.write(removed, out).fold(e => fail(s"write failed: $e"), identity)
+
+    val workbookXml = zipEntryString(out, "xl/workbook.xml")
+    assert(
+      workbookXml.contains("localSheetId=\"0\""),
+      s"modeled Print_Area must re-derive to index 0: $workbookXml"
+    )
+    val reread = XlsxReader.read(out).fold(e => fail(s"reread failed: $e"), identity)
+    val data = reread("Data").fold(e => fail(s"sheet missing: $e"), identity)
+    assertEquals(data.pageSetup.flatMap(_.printArea), Some(ref"A1:B2"))
+    assertEquals(reread.metadata.definedNames, Vector.empty)
+    Files.deleteIfExists(src)
+    Files.deleteIfExists(out)
+  }
+
   test("GH-266: even/first headers+footers round-trip with differentOddEven/differentFirst") {
     val hf = HeaderFooter(
       oddHeader = Some("&LOdd Head"),

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/RemovedSheetPartPruningSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/RemovedSheetPartPruningSpec.scala
@@ -1,0 +1,297 @@
+package com.tjclp.xl.ooxml
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path, Paths}
+import java.util.zip.{ZipEntry, ZipFile, ZipOutputStream}
+import scala.jdk.CollectionConverters.*
+
+import munit.FunSuite
+
+import com.tjclp.xl.addressing.SheetName
+import com.tjclp.xl.api.*
+import com.tjclp.xl.cells.{Cell, CellValue}
+import com.tjclp.xl.drawings.TestImages
+import com.tjclp.xl.macros.ref
+import com.tjclp.xl.styles.units.Emu
+
+/**
+ * GH-417: deleting a sheet that carries charts/images used to leave the whole dependent chain —
+ * xl/drawings/drawingN.xml, xl/charts/chartN.xml, their .rels, their media, their
+ * [Content_Types].xml overrides — orphaned in the package forever (the preserved-part passthrough
+ * re-emits by name with no reachability check against a removal).
+ *
+ * The fix prunes preserved parts reachable ONLY via a removed sheet's relationship closure.
+ * Anything referenced by ANY surviving part survives (a shared image must stay — over-pruning is
+ * silent data loss), and parts that were ALREADY unreferenced in the source keep riding through
+ * (removal-induced orphans only, no general GC).
+ */
+class RemovedSheetPartPruningSpec extends FunSuite:
+
+  private val png = ImageData(TestImages.png2x3, ImageFormat.Png)
+  private val gif = ImageData(TestImages.gif2x3, ImageFormat.Gif)
+  private val extent = Extent(Emu(95250L), Emu(190500L))
+
+  private def name(s: String): SheetName = SheetName.unsafe(s)
+
+  private def write(wb: Workbook, label: String): Path =
+    val out = Files.createTempFile(s"xl-417-$label-", ".xlsx")
+    out.toFile.deleteOnExit()
+    XlsxWriter.write(wb, out).fold(err => fail(s"$label write failed: ${err.message}"), identity)
+    out
+
+  private def read(path: Path): Workbook =
+    XlsxReader.read(path).fold(err => fail(s"read failed: ${err.message}"), identity)
+
+  private def entryNames(path: Path): Set[String] =
+    val zip = new ZipFile(path.toFile)
+    try zip.entries().asScala.map(_.getName).toSet
+    finally zip.close()
+
+  private def entryBytes(path: Path, entry: String): Array[Byte] =
+    val zip = new ZipFile(path.toFile)
+    try
+      Option(zip.getEntry(entry)) match
+        case Some(e) => zip.getInputStream(e).readAllBytes()
+        case None => fail(s"zip entry $entry not found in $path (have ${entryNames(path)})")
+    finally zip.close()
+
+  private def entryText(path: Path, entry: String): String =
+    new String(entryBytes(path, entry), StandardCharsets.UTF_8)
+
+  private def ctOverridePartNames(path: Path): Set[String] =
+    val ct = scala.xml.XML.loadString(entryText(path, "[Content_Types].xml"))
+    (ct \ "Override").map(o => (o \ "@PartName").text).toSet
+
+  /** Every internal worksheet-rels relationship must resolve to a shipped entry. */
+  private def assertWorksheetRelsResolve(path: Path): Unit =
+    val names = entryNames(path)
+    names.filter(n => n.startsWith("xl/worksheets/_rels/") && n.endsWith(".rels")).foreach {
+      relsName =>
+        val xml = scala.xml.XML.loadString(entryText(path, relsName))
+        (xml \ "Relationship").foreach { rel =>
+          if (rel \ "@TargetMode").text != "External" then
+            val target = (rel \ "@Target").text
+            val cleaned = if target.startsWith("/") then target.drop(1) else target
+            val resolved =
+              if cleaned.startsWith("xl/") then cleaned
+              else
+                Paths.get("xl/worksheets").resolve(cleaned).normalize().toString.replace('\\', '/')
+            assert(
+              names.contains(resolved),
+              s"$relsName references $target -> $resolved which is MISSING from the output. " +
+                s"Entries: ${names.toVector.sorted.mkString(", ")}"
+            )
+        }
+    }
+
+  /**
+   * Copy a zip, appending extra entries and optionally patching existing ones (used to graft
+   * chart-colors parts and pre-existing orphans onto writer output).
+   */
+  private def rewriteZip(
+    src: Path,
+    label: String,
+    extra: Map[String, Array[Byte]],
+    patch: Map[String, String => String] = Map.empty
+  ): Path =
+    val out = Files.createTempFile(s"xl-417-$label-grafted-", ".xlsx")
+    out.toFile.deleteOnExit()
+    val zin = new ZipFile(src.toFile)
+    val zout = new ZipOutputStream(java.nio.file.Files.newOutputStream(out))
+    try
+      zin.entries().asScala.foreach { e =>
+        val bytes = zin.getInputStream(e).readAllBytes()
+        val patched = patch.get(e.getName) match
+          case Some(f) =>
+            f(new String(bytes, StandardCharsets.UTF_8)).getBytes(StandardCharsets.UTF_8)
+          case None => bytes
+        zout.putNextEntry(new ZipEntry(e.getName))
+        zout.write(patched)
+        zout.closeEntry()
+      }
+      extra.foreach { case (entryName, bytes) =>
+        zout.putNextEntry(new ZipEntry(entryName))
+        zout.write(bytes)
+        zout.closeEntry()
+      }
+    finally
+      zout.close()
+      zin.close()
+    out
+
+  /** Two-sheet workbook: Data (values) + Charts (a bar chart over its own cells). */
+  private def chartWorkbook: Workbook =
+    val charts = name("Charts")
+    val sheet = Sheet(charts)
+      .put(Cell(ref"A2", CellValue.Text("a")))
+      .put(Cell(ref"A3", CellValue.Text("b")))
+      .put(Cell(ref"B2", CellValue.Number(BigDecimal(3))))
+      .put(Cell(ref"B3", CellValue.Number(BigDecimal(4))))
+    val chart = Chart
+      .bar(
+        Vector(Series(DataRef(charts, ref"B2:B3"), Some(DataRef(charts, ref"A2:A3")), None)),
+        title = Some("Orphan Me")
+      )
+      .fold(e => fail(s"chart build failed: $e"), identity)
+    Workbook(
+      Vector(
+        Sheet(name("Data")).put(Cell(ref"A1", CellValue.Text("keep"))),
+        sheet.addChart(chart, ref"D2:K15")
+      )
+    )
+
+  test("GH-417: removing a chart sheet prunes the whole chart/drawing chain from the package") {
+    val src = write(chartWorkbook, "chart-chain")
+    // Fixture sanity: the chain shipped in the source
+    val srcNames = entryNames(src)
+    assert(srcNames.contains("xl/drawings/drawing1.xml"), s"fixture missing drawing: $srcNames")
+    assert(srcNames.contains("xl/charts/chart1.xml"), s"fixture missing chart: $srcNames")
+
+    val removed = read(src).remove(name("Charts")).fold(e => fail(e.message), identity)
+    val out = write(removed, "chart-chain-out")
+
+    val names = entryNames(out)
+    val leftovers = names.filter(n => n.startsWith("xl/charts/") || n.startsWith("xl/drawings/"))
+    assertEquals(
+      leftovers,
+      Set.empty[String],
+      s"chart/drawing parts must fall with their sheet, got ${names.toVector.sorted}"
+    )
+
+    // No dangling registrations either
+    val overrides = ctOverridePartNames(out)
+    assert(
+      !overrides.exists(p => p.startsWith("/xl/charts/") || p.startsWith("/xl/drawings/")),
+      s"[Content_Types].xml must not register pruned parts: $overrides"
+    )
+
+    val result = read(out)
+    assertEquals(result.sheetNames.map(_.value), Vector("Data"))
+    assertWorksheetRelsResolve(out)
+  }
+
+  test("GH-417: chart colors/style parts and their CT overrides fall with the chain") {
+    // The writer never emits chartcolorstyle parts itself — graft one onto the package the way
+    // Excel ships them (chart rels -> colors1.xml + a [Content_Types].xml override) to prove the
+    // pruning walks the chart's own rels and cleans non-writer-owned content types too.
+    val plain = write(chartWorkbook, "colors")
+    val colorsXml =
+      """<?xml version="1.0" encoding="UTF-8" standalone="yes"?><cs:colorStyle xmlns:cs="http://schemas.microsoft.com/office/drawing/2012/chartStyle" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" meth="cycle" id="10"><a:schemeClr val="accent1"/></cs:colorStyle>"""
+    val chartRels =
+      """<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.microsoft.com/office/2011/relationships/chartColorStyle" Target="colors1.xml"/></Relationships>"""
+    val ctOverride =
+      """<Override PartName="/xl/charts/colors1.xml" ContentType="application/vnd.ms-office.chartcolorstyle+xml"/>"""
+    val grafted = rewriteZip(
+      plain,
+      "colors",
+      extra = Map(
+        "xl/charts/colors1.xml" -> colorsXml.getBytes(StandardCharsets.UTF_8),
+        "xl/charts/_rels/chart1.xml.rels" -> chartRels.getBytes(StandardCharsets.UTF_8)
+      ),
+      patch = Map(
+        "[Content_Types].xml" -> (ct => ct.replace("</Types>", s"$ctOverride</Types>"))
+      )
+    )
+    assert(entryNames(grafted).contains("xl/charts/colors1.xml"))
+
+    val removed = read(grafted).remove(name("Charts")).fold(e => fail(e.message), identity)
+    val out = write(removed, "colors-out")
+
+    val names = entryNames(out)
+    assert(
+      !names.exists(n => n.startsWith("xl/charts/") || n.startsWith("xl/drawings/")),
+      s"colors/style chain must fall with the chart: ${names.toVector.sorted}"
+    )
+    assert(
+      !ctOverridePartNames(out).contains("/xl/charts/colors1.xml"),
+      s"chartcolorstyle override must be pruned: ${ctOverridePartNames(out)}"
+    )
+    assertEquals(read(out).sheetNames.map(_.value), Vector("Data"))
+  }
+
+  test("GH-417: an image shared by two sheets SURVIVES removal of one of them") {
+    val a = Sheet(name("A")).put(Cell(ref"A1", CellValue.Text("a"))).addImage(png, ref"B2", extent)
+    val b = Sheet(name("B")).put(Cell(ref"A1", CellValue.Text("b"))).addImage(png, ref"C3", extent)
+    val src = write(Workbook(Vector(a, b)), "shared-image")
+    val srcNames = entryNames(src)
+    // Fixture sanity: media dedup gives ONE media part referenced by BOTH drawing parts
+    assertEquals(
+      srcNames.count(_.startsWith("xl/media/")),
+      1,
+      s"fixture should dedup identical bytes to one media part: $srcNames"
+    )
+    assert(srcNames.contains("xl/drawings/drawing1.xml"))
+    assert(srcNames.contains("xl/drawings/drawing2.xml"))
+
+    val removed = read(src).remove(name("A")).fold(e => fail(e.message), identity)
+    val out = write(removed, "shared-image-out")
+
+    val names = entryNames(out)
+    assertEquals(
+      names.count(_.startsWith("xl/media/")),
+      1,
+      s"the shared image must SURVIVE (B still shows it): ${names.toVector.sorted}"
+    )
+    assert(
+      !names.contains("xl/drawings/drawing1.xml") &&
+        !names.contains("xl/drawings/_rels/drawing1.xml.rels"),
+      s"A's drawing part must fall with A: ${names.toVector.sorted}"
+    )
+    assert(names.contains("xl/drawings/drawing2.xml"), "B's drawing part must survive")
+
+    val result = read(out)
+    assertEquals(result.sheetNames.map(_.value), Vector("B"))
+    val pictures = result(name("B")).fold(e => fail(e.message), identity).pictures
+    assertEquals(pictures.size, 1, "B must still render its picture after A is removed")
+    assertWorksheetRelsResolve(out)
+  }
+
+  test("GH-417: media referenced only by the removed sheet is pruned; the survivor's stays") {
+    val a = Sheet(name("A")).put(Cell(ref"A1", CellValue.Text("a"))).addImage(png, ref"B2", extent)
+    val b = Sheet(name("B")).put(Cell(ref"A1", CellValue.Text("b"))).addImage(gif, ref"C3", extent)
+    val src = write(Workbook(Vector(a, b)), "exclusive-media")
+    assertEquals(entryNames(src).count(_.startsWith("xl/media/")), 2)
+
+    val removed = read(src).remove(name("A")).fold(e => fail(e.message), identity)
+    val out = write(removed, "exclusive-media-out")
+
+    val media = entryNames(out).filter(_.startsWith("xl/media/"))
+    assertEquals(
+      media.map(_.split('.').last),
+      Set("gif"),
+      s"A's exclusive png must be pruned, B's gif must stay: $media"
+    )
+    val result = read(out)
+    val pictures = result(name("B")).fold(e => fail(e.message), identity).pictures
+    assertEquals(pictures.map(_.image.format), Vector[ImageFormat](ImageFormat.Gif))
+  }
+
+  test("GH-417: pre-existing orphans ride through untouched (removal-induced pruning only)") {
+    // A part nothing references (already dead in the source) is preservation-sacred: pruning is
+    // scoped to the removed sheet's closure, never a general package GC.
+    val base = Workbook(
+      Vector(
+        Sheet(name("Data")).put(Cell(ref"A1", CellValue.Text("keep"))),
+        Sheet(name("Gone")).put(Cell(ref"A1", CellValue.Text("bye")))
+      )
+    )
+    val plain = write(base, "preexisting")
+    val grafted = rewriteZip(
+      plain,
+      "preexisting",
+      extra = Map(
+        "xl/orphanPayload.xml" -> """<?xml version="1.0"?><payload/>""".getBytes(
+          StandardCharsets.UTF_8
+        )
+      )
+    )
+
+    val removed = read(grafted).remove(name("Gone")).fold(e => fail(e.message), identity)
+    val out = write(removed, "preexisting-out")
+
+    assert(
+      entryNames(out).contains("xl/orphanPayload.xml"),
+      s"pre-existing orphan must NOT be GC'd by a sheet removal: ${entryNames(out).toVector.sorted}"
+    )
+    assertEquals(read(out).sheetNames.map(_.value), Vector("Data"))
+  }

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/SheetFormatPrRoundTripSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/SheetFormatPrRoundTripSpec.scala
@@ -1,0 +1,264 @@
+package com.tjclp.xl.ooxml
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path}
+import java.util.zip.{ZipEntry, ZipFile, ZipOutputStream}
+
+import com.tjclp.xl.addressing.Column
+import com.tjclp.xl.api.*
+import com.tjclp.xl.codec.CellCodec.given
+import com.tjclp.xl.macros.ref
+import com.tjclp.xl.sheets.ColumnProperties
+import com.tjclp.xl.unsafe.*
+import munit.FunSuite
+
+/**
+ * GH-426: `Sheet.defaultRowHeight` / `Sheet.defaultColumnWidth` serialize as `<sheetFormatPr
+ * defaultRowHeight=... defaultColWidth=...>` (the CT_Worksheet slot before `<cols>`) on BOTH writer
+ * backends, and the reader populates the model fields back from an Excel-authored element.
+ *
+ * A preserved `<sheetFormatPr>` is the dirty-write base: unmodeled attributes (baseColWidth,
+ * outlineLevelRow, ...) ride through, and unchanged modeled values keep the source element verbatim
+ * (identity fast-path — no churn). Sheets that never had the element and set no defaults must not
+ * grow one.
+ */
+class SheetFormatPrRoundTripSpec extends FunSuite:
+
+  private def zipEntryString(path: Path, entry: String): String =
+    val zf = new ZipFile(path.toFile)
+    try
+      val is = zf.getInputStream(zf.getEntry(entry))
+      try new String(is.readAllBytes(), StandardCharsets.UTF_8)
+      finally is.close()
+    finally zf.close()
+
+  private def writeRead(wb: Workbook, config: WriterConfig = WriterConfig()): (Workbook, Path) =
+    val out = Files.createTempFile("sheetformatpr", ".xlsx")
+    XlsxWriter.writeWith(wb, out, config).fold(e => fail(s"write failed: $e"), identity)
+    val reread = XlsxReader.read(out).fold(e => fail(s"read failed: $e"), identity)
+    (reread, out)
+
+  test("GH-426: defaultRowHeight round-trips and emits sheetFormatPr (DOM backend)") {
+    val wb = Workbook(
+      Sheet("Sheet1").put(ref"A1" -> 1).copy(defaultRowHeight = Some(12.75))
+    )
+    val (reread, out) = writeRead(wb)
+
+    val xml = zipEntryString(out, "xl/worksheets/sheet1.xml")
+    assert(xml.contains("<sheetFormatPr "), s"sheetFormatPr missing: $xml")
+    assert(xml.contains("defaultRowHeight=\"12.75\""), s"defaultRowHeight missing: $xml")
+    // A model-set default row height is a manually-set one (ECMA-376 18.3.1.81)
+    assert(xml.contains("customHeight=\"1\""), s"customHeight companion missing: $xml")
+    assert(
+      xml.indexOf("<dimension ") < xml.indexOf("<sheetFormatPr "),
+      s"sheetFormatPr must follow dimension: $xml"
+    )
+    assert(
+      xml.indexOf("<sheetFormatPr ") < xml.indexOf("<sheetData>"),
+      s"sheetFormatPr must precede sheetData: $xml"
+    )
+
+    val sheet = reread("Sheet1").fold(e => fail(s"sheet missing: $e"), identity)
+    assertEquals(sheet.defaultRowHeight, Some(12.75))
+    Files.deleteIfExists(out)
+  }
+
+  test(
+    "GH-426: defaultColumnWidth round-trips; width-only sheets carry required defaultRowHeight"
+  ) {
+    val wb = Workbook(
+      Sheet("Sheet1").put(ref"A1" -> 1).copy(defaultColumnWidth = Some(8.43))
+    )
+    val (reread, out) = writeRead(wb)
+
+    val xml = zipEntryString(out, "xl/worksheets/sheet1.xml")
+    assert(xml.contains("defaultColWidth=\"8.43\""), s"defaultColWidth missing: $xml")
+    // CT_SheetFormatPr REQUIRES defaultRowHeight — a fresh width-only element backfills
+    // Excel's Calibri-11 default without the customHeight flag (it was not manually set)
+    assert(xml.contains("defaultRowHeight=\"15\""), s"required defaultRowHeight missing: $xml")
+    assert(!xml.contains("customHeight="), s"backfilled height must not claim customHeight: $xml")
+
+    val sheet = reread("Sheet1").fold(e => fail(s"sheet missing: $e"), identity)
+    assertEquals(sheet.defaultColumnWidth, Some(8.43))
+    assertEquals(sheet.defaultRowHeight, Some(15.0))
+    Files.deleteIfExists(out)
+  }
+
+  test("GH-426: both defaults round-trip on the streaming backend (SaxStax direct emission)") {
+    val wb = Workbook(
+      Sheet("Sheet1")
+        .put(ref"A1" -> 1)
+        .copy(
+          defaultRowHeight = Some(12.75),
+          defaultColumnWidth = Some(8.43),
+          columnProperties = Map(Column.from0(0) -> ColumnProperties(width = Some(20.0)))
+        )
+    )
+    val (reread, out) = writeRead(wb, WriterConfig.saxStax)
+
+    val xml = zipEntryString(out, "xl/worksheets/sheet1.xml")
+    assert(xml.contains("<sheetFormatPr "), s"sheetFormatPr missing on streaming path: $xml")
+    assert(xml.contains("defaultRowHeight=\"12.75\""), s"defaultRowHeight missing: $xml")
+    assert(xml.contains("defaultColWidth=\"8.43\""), s"defaultColWidth missing: $xml")
+    assert(xml.contains("customHeight=\"1\""), s"customHeight companion missing: $xml")
+    assert(
+      xml.indexOf("<sheetFormatPr ") < xml.indexOf("<cols>"),
+      s"sheetFormatPr must precede cols (CT_Worksheet order): $xml"
+    )
+
+    val sheet = reread("Sheet1").fold(e => fail(s"sheet missing: $e"), identity)
+    assertEquals(sheet.defaultRowHeight, Some(12.75))
+    assertEquals(sheet.defaultColumnWidth, Some(8.43))
+    Files.deleteIfExists(out)
+  }
+
+  test("GH-426: Excel-authored sheetFormatPr populates the model fields on read") {
+    val src = rawWorksheetFixture(
+      """<sheetFormatPr baseColWidth="8" defaultColWidth="9.140625" defaultRowHeight="12.75" outlineLevelRow="2" outlineLevelCol="1"/>"""
+    )
+    val wb = XlsxReader.read(src).fold(e => fail(s"read failed: $e"), identity)
+    val sheet = wb("Sheet1").fold(e => fail(s"sheet missing: $e"), identity)
+    assertEquals(sheet.defaultColumnWidth, Some(9.140625))
+    assertEquals(sheet.defaultRowHeight, Some(12.75))
+    Files.deleteIfExists(src)
+  }
+
+  test("GH-426: unmodeled sheetFormatPr attrs ride a dirty write; unchanged values do not churn") {
+    val src = rawWorksheetFixture(
+      """<sheetFormatPr baseColWidth="8" defaultColWidth="9.140625" defaultRowHeight="12.75" outlineLevelRow="2" outlineLevelCol="1"/>"""
+    )
+    val wb = XlsxReader.read(src).fold(e => fail(s"read failed: $e"), identity)
+    val sheet0 = wb("Sheet1").fold(e => fail(s"sheet missing: $e"), identity)
+
+    val out = Files.createTempFile("sheetformatpr-ride", ".xlsx")
+    XlsxWriter
+      .write(wb.put(sheet0.put(ref"B1" -> 2)), out)
+      .fold(e => fail(s"write failed: $e"), identity)
+    val xml = zipEntryString(out, "xl/worksheets/sheet1.xml")
+    assert(xml.contains("baseColWidth=\"8\""), s"unmodeled attr lost on rewrite: $xml")
+    assert(xml.contains("outlineLevelRow=\"2\""), s"unmodeled attr lost on rewrite: $xml")
+    assert(xml.contains("outlineLevelCol=\"1\""), s"unmodeled attr lost on rewrite: $xml")
+    assert(xml.contains("defaultColWidth=\"9.140625\""), s"source width lost on rewrite: $xml")
+    assert(xml.contains("defaultRowHeight=\"12.75\""), s"source height lost on rewrite: $xml")
+    // Identity fast-path: values unchanged since read → no gratuitous customHeight flag
+    assert(!xml.contains("customHeight="), s"unchanged element must ride verbatim: $xml")
+    Files.deleteIfExists(src)
+    Files.deleteIfExists(out)
+  }
+
+  test("GH-426: changing defaultRowHeight on a read sheet overlays the preserved element") {
+    val src = rawWorksheetFixture("""<sheetFormatPr baseColWidth="8" defaultRowHeight="15"/>""")
+    val edited = for
+      wb <- XlsxReader.read(src)
+      sheet <- wb("Sheet1")
+    yield wb.put(sheet.copy(defaultRowHeight = Some(12.75)))
+    val wb1 = edited.fold(e => fail(s"edit failed: $e"), identity)
+
+    val out = Files.createTempFile("sheetformatpr-edit", ".xlsx")
+    XlsxWriter.write(wb1, out).fold(e => fail(s"write failed: $e"), identity)
+    val xml = zipEntryString(out, "xl/worksheets/sheet1.xml")
+    assert(xml.contains("defaultRowHeight=\"12.75\""), s"model height must win: $xml")
+    assert(xml.contains("customHeight=\"1\""), s"manually-set height needs customHeight: $xml")
+    assert(xml.contains("baseColWidth=\"8\""), s"unmodeled attr lost on overlay: $xml")
+    assert(!xml.contains("defaultRowHeight=\"15\""), s"stale source height must be replaced: $xml")
+
+    val reread = XlsxReader.read(out).fold(e => fail(s"reread failed: $e"), identity)
+    val sheet = reread("Sheet1").fold(e => fail(s"sheet missing: $e"), identity)
+    assertEquals(sheet.defaultRowHeight, Some(12.75))
+    Files.deleteIfExists(src)
+    Files.deleteIfExists(out)
+  }
+
+  test("GH-426: no gratuitous sheetFormatPr when no defaults are set (both backends)") {
+    val wb = Workbook(Sheet("Sheet1").put(ref"A1" -> 1))
+    for config <- Seq(WriterConfig(), WriterConfig.saxStax) do
+      val out = Files.createTempFile("sheetformatpr-none", ".xlsx")
+      XlsxWriter.writeWith(wb, out, config).fold(e => fail(s"write failed: $e"), identity)
+      val xml = zipEntryString(out, "xl/worksheets/sheet1.xml")
+      assert(!xml.contains("sheetFormatPr"), s"gratuitous sheetFormatPr ($config): $xml")
+      Files.deleteIfExists(out)
+  }
+
+  test("GH-426: a source sheet without sheetFormatPr stays without one across a dirty write") {
+    val src = rawWorksheetFixture("")
+    val edited = for
+      wb <- XlsxReader.read(src)
+      sheet <- wb("Sheet1")
+    yield wb.put(sheet.put(ref"B1" -> 2))
+    val wb1 = edited.fold(e => fail(s"edit failed: $e"), identity)
+
+    val out = Files.createTempFile("sheetformatpr-absent", ".xlsx")
+    XlsxWriter.write(wb1, out).fold(e => fail(s"write failed: $e"), identity)
+    val xml = zipEntryString(out, "xl/worksheets/sheet1.xml")
+    assert(!xml.contains("sheetFormatPr"), s"element must not appear uninvited: $xml")
+    Files.deleteIfExists(src)
+    Files.deleteIfExists(out)
+  }
+
+  // ========== helpers ==========
+
+  private def writeEntry(out: ZipOutputStream, name: String, content: String): Unit =
+    out.putNextEntry(new ZipEntry(name))
+    out.write(content.getBytes("UTF-8"))
+    out.closeEntry()
+
+  /**
+   * Minimal Excel-shaped single-sheet fixture with the given raw worksheet XML injected before
+   * `<sheetData>` (the SheetViewRoundTripSpec pattern) — for feeding foreign `<sheetFormatPr>`
+   * shapes the XL writer never produces.
+   */
+  private def rawWorksheetFixture(preSheetDataXml: String): Path =
+    val path = Files.createTempFile("sheetformatpr-fixture", ".xlsx")
+    val out = new ZipOutputStream(Files.newOutputStream(path))
+    out.setLevel(1)
+    try
+      writeEntry(
+        out,
+        "[Content_Types].xml",
+        """<?xml version="1.0"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+  <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+</Types>"""
+      )
+      writeEntry(
+        out,
+        "_rels/.rels",
+        """<?xml version="1.0"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>"""
+      )
+      writeEntry(
+        out,
+        "xl/workbook.xml",
+        """<?xml version="1.0"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <sheets>
+    <sheet name="Sheet1" sheetId="1" r:id="rId1"/>
+  </sheets>
+</workbook>"""
+      )
+      writeEntry(
+        out,
+        "xl/_rels/workbook.xml.rels",
+        """<?xml version="1.0"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+</Relationships>"""
+      )
+      writeEntry(
+        out,
+        "xl/worksheets/sheet1.xml",
+        s"""<?xml version="1.0"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  $preSheetDataXml
+  <sheetData>
+    <row r="1"><c r="A1"><v>1</v></c></row>
+  </sheetData>
+</worksheet>"""
+      )
+    finally out.close()
+    path


### PR DESCRIPTION
Burn-down wave 2 of 3 (plan of record 2026-07-22): nine issues across six worktree-isolated TDD clusters, pipelined adversarial review — all six approved with zero rework rounds.

## What's in it

- **numfmt-parity** (#408, #410 — serial): `StylePatcher` deletes its hand-rolled builtin-id table and delegates to `NumFmt.builtInId` (Decimal→2, Percent→9, Currency→7 — streamed styles no longer render differently from in-memory ones, including `--stream put` detected formats from #438). `NumFmtFormatter` built-in arms now render via `FormatCodeParser(NumFmt.formatCode(fmt))`, property-tested identical to the file-declared path (`PercentDecimal` now shows Excel's `15.60%`); display re-pins each justified against the ECMA-376 code.
- **cli-putpath** (#416, #422 — serial): batch `put` values[] threads the op-level `format` into every element with exact single-put semantics (in-memory + streaming); all 40 write verbs report `<verb> requires -o <out.xlsx> (or -i to modify in place)` instead of `Internal:`; `xl lint <file>` positional form accepted (exactly-one-file enforced with hints).
- **workbook-lifecycle** (#434, #417 — serial): `removeAt`/`insertAt`/`reorder` remap `DefinedName.localSheetId` (removed-sheet scopes dropped, Excel semantics); remove-sheet prunes parts reachable only via the removed sheet's rel closure — chart add → remove-sheet → zero orphaned chart/drawing parts, while a shared-image-across-two-sheets fixture keeps the image.
- **comment-fidelity** (#433): no second synthesized author-prefix run when the comment already carries one; run colors (`indexed`/raw rPr payloads) survive rewrite byte-faithfully. (Footprint note: the synthesis lived in `XlsxWriter.buildCommentsData`, not Comments.scala — the cluster extended scope deliberately and flagged it.)
- **sheetformatpr** (#426): `<sheetFormatPr>` emits on both backends from `Sheet.defaultRowHeight`/`defaultColumnWidth`, reads back, and preserves unmodeled attrs; untouched sheets stay byte-stable.
- **scripting-ergonomics** (#420): `Sheet.named(name): XLResult[Sheet]` as the documented dynamic-name path; scripting docs/skills explain the literal-vs-dynamic split (markers say "since 0.17.0").

## Gates (all green)

- `./mill __.compile` 810/810, 0 non-exhaustive-match warnings
- scalafmt CI form — no drift
- `./mill -i __.test` **1028/1028 tasks, 4,908 cases** (+72 this wave)
- `XL_ROUNDTRIP_MIN_SUCCESS=500` generative law 239/239
- `./scripts/test-examples.sh` + `./scripts/verify-skill-snippets.sh --local` green; `xl.docJar` verified

## Field-repro replays (branch-built CLI)

- values[] + `format:"0.00%"` → cells render `100.00%` (#416)
- `recalc` without `-o` → `recalc requires -o <out.xlsx> (or -i to modify in place)`; `xl lint file.xlsx` positional works (#422)
- `--stream put B1 45.5%` → styles.xml numFmtId **9** (canonical Percent; was 10) (#408)
- chart add → remove-sheet → chart/drawing parts 3 → **0** (#417)
- Excel-authored comment (own `Reviewer:` prefix run + `indexed="81"`) rewrites with exactly **one** prefix and color intact (#433)

## Integration notes

All six clusters merged conflict-free. Follow-up candidates surfaced by the wave (not filed yet, listed for triage): unknown batch `format` names are silently ignored (warnings-vector candidate); `Workbook.apply`/`upsert` have the same literal-vs-dynamic union as #420; streaming `extractStyle` doesn't carry raw numFmtId onto CellStyle; lint part-reachability check needs carve-out design (not trivial — #413 comment stands).

Closes #408
Closes #410
Closes #416
Closes #417
Closes #420
Closes #422
Closes #426
Closes #433
Closes #434

🤖 Generated with [Claude Code](https://claude.com/claude-code)