### PR TITLE
chore(release): Bump version to 0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.0] "Parity" - 2026-07-29
+
 CLI & fidelity correctness wave (wave 20): display parity between every
 numFmt path, batch/CLI ergonomics, sheet-lifecycle bookkeeping, and the
 remaining comment/sheet-default round-trip gaps.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ```scala 3 raw
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.16.0
+//> using dep com.tjclp::xl:0.17.0
 
 import com.tjclp.xl.{*, given}
 
@@ -55,13 +55,13 @@ import com.tjclp.xl.{*, given}
 
 ```scala 3 ignore
 // build.mill — single dependency for everything
-def ivyDeps = Agg(ivy"com.tjclp::xl:0.16.0")
+def ivyDeps = Agg(ivy"com.tjclp::xl:0.17.0")
 
 // Or individual modules for minimal footprint:
-// ivy"com.tjclp::xl-core:0.16.0"        — Pure domain model only
-// ivy"com.tjclp::xl-ooxml:0.16.0"       — Add OOXML read/write
-// ivy"com.tjclp::xl-cats-effect:0.16.0" — Add IO streaming
-// ivy"com.tjclp::xl-evaluator:0.16.0"   — Add formula evaluation
+// ivy"com.tjclp::xl-core:0.17.0"        — Pure domain model only
+// ivy"com.tjclp::xl-ooxml:0.17.0"       — Add OOXML read/write
+// ivy"com.tjclp::xl-cats-effect:0.17.0" — Add IO streaming
+// ivy"com.tjclp::xl-evaluator:0.17.0"   — Add formula evaluation
 ```
 
 ### Basic Usage

--- a/build.mill
+++ b/build.mill
@@ -14,7 +14,7 @@ val organization = "com.tjclp"
 /** Shared build configuration constants */
 object BuildConfig {
   /** Project version: CI sets PUBLISH_VERSION; local builds use this fallback */
-  val version: String = sys.env.getOrElse("PUBLISH_VERSION", "0.16.0")
+  val version: String = sys.env.getOrElse("PUBLISH_VERSION", "0.17.0")
 
   /** JVM options to silence Scala 3 LazyVals sun.misc.Unsafe deprecation warnings (JDK 21+) */
   val lazyValsJvmArgs: Seq[String] = Seq(

--- a/docs/QUICK-START.md
+++ b/docs/QUICK-START.md
@@ -12,19 +12,19 @@ import mill._, scalalib._
 
 object myproject extends ScalaModule {
   def scalaVersion = "3.8.3"
-  def ivyDeps = Agg(ivy"com.tjclp::xl:0.16.0")
+  def ivyDeps = Agg(ivy"com.tjclp::xl:0.17.0")
 }
 ```
 
 ### With sbt (build.sbt)
 ```scala
 scalaVersion := "3.8.3"
-libraryDependencies += "com.tjclp" %% "xl" % "0.16.0"
+libraryDependencies += "com.tjclp" %% "xl" % "0.17.0"
 ```
 
 ### With Scala CLI
 ```scala
-//> using dep com.tjclp::xl:0.16.0
+//> using dep com.tjclp::xl:0.17.0
 ```
 
 ### Individual Modules (Optional)
@@ -44,7 +44,7 @@ For scripts, skip the build setup entirely: a two-line `scala-cli` header and ON
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.16.0
+//> using dep com.tjclp::xl:0.17.0
 
 import com.tjclp.xl.scripting.{*, given}
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,12 +1,19 @@
 # XL Project Status
 
-**Last Updated**: 2026-07-29 (0.16.0)
+**Last Updated**: 2026-07-29 (0.17.0)
 
 ## Current State
 
 > **For detailed phase completion status and roadmap, see [plan/roadmap.md](plan/roadmap.md)**
 
 ### What Works (Production-Ready)
+
+**New in 0.17.0** (2026-07-29):
+- ✅ **numFmt parity everywhere** (#408, #410) — StylePatcher delegates to NumFmt.builtInId (streamed Decimal/Percent/Currency ids 2/9/7 match in-memory); NumFmtFormatter built-in arms render via FormatCodeParser (PercentDecimal shows Excel's 15.60%)
+- ✅ **Batch values[] op-level format** (#416) + **usage errors name flags, lint positional file** (#422)
+- ✅ **Sheet lifecycle bookkeeping** (#434, #417) — localSheetId remap on remove/insert/reorder; removal-orphan chart/drawing part pruning (shared parts survive)
+- ✅ **Comment round-trip fidelity** (#433) — no duplicate author prefix; run colors survive via raw rPr preservation
+- ✅ **sheetFormatPr write path** (#426) + **Sheet.named dynamic factory** (#420)
 
 **New in 0.16.0** (2026-07-29):
 - ✅ **Array/data-table formula records survive rewrites** (#430) — `<f t="array" ref>` and `<f t="dataTable" ref dt2D dtr r1 r2 del1 del2 ca/>` are modeled per cell (`FormulaKind` on `CellValue.Formula`) and re-emit byte-exactly through dirty sheet regeneration on every writer (DOM, SAX, streaming); two-variable Data Tables no longer bake to static grids on `put`. DataTable caches are pinned (recalc/copy/eval never parse the derived `TABLE(...)` display text); StructuralEditor shifts record payloads and degrades tearing edits to cached constants; CLI shows `{=TABLE(A1,A2)}` braces + JSON `formulaKind`, and `putf` rejects top-level `TABLE(` (authoring lands with #419); new `formula-records.xlsx` corpus fixture rides every round-trip/parity law

--- a/docs/plan/roadmap.md
+++ b/docs/plan/roadmap.md
@@ -12,7 +12,7 @@
 
 **Current Status**: Production-ready with **108 formula functions** (incl. dynamic arrays SEQUENCE/SORT/UNIQUE/FILTER and OFFSET), **structural editing** (insert/delete rows & columns with formula rewriting), the **scripting prelude** (`com.tjclp.xl.scripting`), whole-workbook `recalculate`, named-range & hyperlink authoring, **typed charts + embedded pictures** (0.12.0), **conditional formatting** (0.12.1), SAX streaming (36% faster than POI), Excel tables, and full OOXML round-trip. 4,836 tests passing.
 
-**Current Version**: **0.16.0 "Bedrock"** (released 2026-07-29)
+**Current Version**: **0.17.0 "Parity"** (released 2026-07-29)
 
 ---
 
@@ -60,6 +60,10 @@ Phased: (a) verbatim chart/drawing preservation proven by the wave-2 fixture cor
 ### v0.12.1 "Clean Sweep" — wave 7 (Released 2026-06-11)
 
 Every remaining open issue closed in one wave. **Conditional formatting** ([#136](https://github.com/TJC-LP/xl/issues/136)) is the headline — typed cellIs/expression/colorScale/dataBar/top10/text rules + `dxf` differential formats, `sheet.conditionalFormat` authoring with auto-priority, structural-edit range shifting, unmodeled families preserved byte-faithfully — alongside twelve fidelity/writer fixes: openpyxl comment subdirectory dialect (#292), RichText SST keying (#303), exact surgical SST counts (#304), `[Content_Types]` preservation (#314), identity-keyed source mappings (#315), activeTab (#294), fitToPage tri-state (#284), `Cell.comment` deprecated→`Sheet.comments` (#295). Codec `put` paths 2.4x faster (#297).
+
+### v0.17.0 "Parity" — wave 20 (Released 2026-07-29)
+
+Burn-down wave 2 of 3 (PR #440, six worktree-isolated TDD clusters, zero rework rounds, zero merge conflicts): **numFmt parity across every path** ([#408](https://github.com/TJC-LP/xl/issues/408) StylePatcher delegates to `NumFmt.builtInId` — streamed styles match in-memory ids 2/9/7; [#410](https://github.com/TJC-LP/xl/issues/410) NumFmtFormatter built-in arms render via FormatCodeParser, property-tested identical), **batch values[] op-level format** ([#416](https://github.com/TJC-LP/xl/issues/416)), **usage errors name their flags + lint positional file** ([#422](https://github.com/TJC-LP/xl/issues/422)), **localSheetId remap on sheet order mutations** ([#434](https://github.com/TJC-LP/xl/issues/434)), **removal-orphan part pruning** ([#417](https://github.com/TJC-LP/xl/issues/417)), **comment author-prefix dedup + run-color preservation** ([#433](https://github.com/TJC-LP/xl/issues/433)), **`<sheetFormatPr>` write path** ([#426](https://github.com/TJC-LP/xl/issues/426)), and **`Sheet.named`** ([#420](https://github.com/TJC-LP/xl/issues/420)). Remaining: wave 21 "authoring" (#411 #418 #419 #421 #423 #424 #425 #432) → 0.18.0 = tracker zero (+#435 follow-up).
 
 ### v0.16.0 "Bedrock" — wave 19 + #437/#438 (Released 2026-07-29)
 

--- a/docs/reference/scripting.md
+++ b/docs/reference/scripting.md
@@ -33,7 +33,7 @@ release bump is a mechanical substitution):
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.16.0
+//> using dep com.tjclp::xl:0.17.0
 import com.tjclp.xl.scripting.{*, given}
 
 val sheet = Sheet("Demo").put(ref"A1", "Hello").put(ref"B1", 42)
@@ -51,7 +51,7 @@ read and write is pure values.
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.16.0
+//> using dep com.tjclp::xl:0.17.0
 import com.tjclp.xl.scripting.{*, given}
 
 val wb = Excel.read("input.xlsx")
@@ -130,7 +130,7 @@ intended instead of surprising the chain:
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.16.0
+//> using dep com.tjclp::xl:0.17.0
 import com.tjclp.xl.scripting.{*, given}
 
 val region = Seq("North", "East").mkString(" ")                     // runtime name
@@ -138,7 +138,7 @@ val sheet = Sheet.named(region).map(_.put(ref"A1", "ready")).unsafe // XLResult,
 Excel.write(Workbook(sheet), "/tmp/named.xlsx")
 ```
 
-On ≤0.16.0 (no `named`), make the union explicit at the call site with an ascription:
+On ≤0.17.0 (no `named`), make the union explicit at the call site with an ascription:
 `val s: XLResult[Sheet] = Sheet(nm)`.
 
 Prefer **total navigation** over interpolated refs in loops — no `Either` at all:
@@ -196,7 +196,7 @@ throw — they are collected per cell.
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.16.0
+//> using dep com.tjclp::xl:0.17.0
 import com.tjclp.xl.scripting.{*, given}
 
 val title = CellStyle.default.bold.size(14.0).center
@@ -328,7 +328,7 @@ them explicitly:
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.16.0
+//> using dep com.tjclp::xl:0.17.0
 import com.tjclp.xl.scripting.{*, given}
 import com.tjclp.xl.sheets.{HeaderFooter, PageMargins, PageSetup, SheetView}
 
@@ -382,7 +382,7 @@ the whole workbook:
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.16.0
+//> using dep com.tjclp::xl:0.17.0
 import com.tjclp.xl.scripting.{*, given}
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global

--- a/examples/README.md
+++ b/examples/README.md
@@ -170,7 +170,7 @@ chmod +x examples/my_example.sc
 ./examples/my_example.sc
 ```
 
-The `project.scala` file centralizes dependencies (`com.tjclp::xl:0.16.0`) for all examples.
+The `project.scala` file centralizes dependencies (`com.tjclp::xl:0.17.0`) for all examples.
 
 ## Scripting Prelude & Skill
 

--- a/examples/project.scala
+++ b/examples/project.scala
@@ -2,4 +2,4 @@
 //> using repository ivy2Local
 
 // XL aggregate - includes all modules (core, ooxml, cats-effect, evaluator)
-//> using dep com.tjclp::xl:0.16.0
+//> using dep com.tjclp::xl:0.17.0

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "xl",
   "description": "LLM-friendly Excel tooling: the xl CLI for reading, writing, styling, and analyzing spreadsheets (xl-cli skill), plus type-safe Scala scripting against the xl library via scala-cli for bulk transformations, pipelines, and formula models (xl-scripting skill).",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "author": {
     "name": "TJC L.P.",
     "url": "https://github.com/TJC-LP"

--- a/plugin/skills/xl-scripting/SKILL.md
+++ b/plugin/skills/xl-scripting/SKILL.md
@@ -38,7 +38,7 @@ The canonical header for every script (this is the single source of truth — re
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.16.0
+//> using dep com.tjclp::xl:0.17.0
 
 import com.tjclp.xl.scripting.{*, given}
 
@@ -104,7 +104,7 @@ wb.update("Sales", f).unsafe                       // throws structured XLExcept
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.16.0
+//> using dep com.tjclp::xl:0.17.0
 import com.tjclp.xl.scripting.{*, given}
 
 val wb = Excel.read("input.xlsx")
@@ -255,7 +255,7 @@ Or lean on totality so there is nothing to unwrap: literal refs, `upsert`, range
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.16.0
+//> using dep com.tjclp::xl:0.17.0
 import com.tjclp.xl.scripting.{*, given}
 import java.nio.file.{Files, Paths}
 import scala.jdk.CollectionConverters.*
@@ -277,7 +277,7 @@ println(s"merged ${inputs.size} files, ${merged.sheets.size} sheets")
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.16.0
+//> using dep com.tjclp::xl:0.17.0
 import com.tjclp.xl.scripting.{*, given}
 
 val data = List(("North", 125000.50), ("South", 98000.25), ("West", 143500.00))
@@ -305,7 +305,7 @@ println(if result.isClean then "✓ report written" else result.errors.map(_.ren
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.16.0
+//> using dep com.tjclp::xl:0.17.0
 import com.tjclp.xl.scripting.{*, given}
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
@@ -337,7 +337,7 @@ Switch to streaming above ~100k rows; `Excel.read` loads the whole workbook. Str
 - **`Excel.write` does NOT recalculate** — freshly built `fx"…"` cells are written with no cached values, so Excel-before-recalc, openpyxl `data_only`, pandas, and previewers all show blanks. Since 0.13.0 the one-call fix is **`Excel.writeRecalculated(wb, path)`** ([#360](https://github.com/TJC-LP/xl/issues/360)): it recalculates, writes the cached workbook (even when some formulas fail — errors are data), and returns the `RecalcResult` (inspect `result.errors` / `result.isClean`). For fail-hard pipelines that must abort *before* anything lands on disk, keep the explicit `val result = wb.recalculate(); …; Excel.write(result.workbook, path)` pattern. On ≤0.12.x, `writeRecalculated` is unavailable — recalculate then write `result.workbook` (a single pass suffices on 0.12.5+).
 - **Percent postfix works since 0.13.0** ([#355](https://github.com/TJC-LP/xl/issues/355)): `fx"=A1*10%"`, `fx"=10%"`, `fx"=(1+5%)^2"` parse, evaluate (`10%` → exact `0.1`), broadcast over ranges, and print back byte-identically (never rewritten to `/100`). On ≤0.12.x the parser rejects `%` — write `/100` there. External-workbook refs (`[2]Book!A1`) parse and pin their Excel-written caches **since 0.12.6** ([#353](https://github.com/TJC-LP/xl/issues/353)): `recalculate()` preserves those cells verbatim and dependents compute from the caches (uncached external cells yield a per-cell error); on ≤0.12.5 they fail to parse entirely — compute from cached values there.
 - **Runtime column handles for `setColumnProperties`** ([#361](https://github.com/TJC-LP/xl/issues/361), since 0.13.0): fold over letters computed at runtime with `Column.parse("D")` (`Either[String, Column]`; trailing row digits tolerated, so `"D1"` works) — e.g. `Column.parse(letter).map(c => sheet.setColumnProperties(c, ColumnProperties(width = Some(w))))`. A runtime `RefType` also exposes `.col` (`RefType.parse(s).map(_.col)`). On ≤0.12.x only the compile-time `ref"D1".col` existed — set widths with literal refs per column there.
-- **`Sheet(name)` with a runtime name returns `XLResult[Sheet]`, not `Sheet`** ([#420](https://github.com/TJC-LP/xl/issues/420)): the factory is `transparent inline` — a string literal validates at compile time and returns `Sheet`, while a name held in a `val` makes the very same call return `XLResult[Sheet]`, so a chained `.put(...)` type-errors with nothing at the call site to warn you. For dynamic names use **`Sheet.named(name)`** (since 0.17.0) — identical validation, `XLResult` spelled in the signature: `Sheet.named(nm).map(_.put(ref"A1", 1))`. On ≤0.16.0, make the union explicit with an ascription: `val s: XLResult[Sheet] = Sheet(nm)`.
+- **`Sheet(name)` with a runtime name returns `XLResult[Sheet]`, not `Sheet`** ([#420](https://github.com/TJC-LP/xl/issues/420)): the factory is `transparent inline` — a string literal validates at compile time and returns `Sheet`, while a name held in a `val` makes the very same call return `XLResult[Sheet]`, so a chained `.put(...)` type-errors with nothing at the call site to warn you. For dynamic names use **`Sheet.named(name)`** (since 0.17.0) — identical validation, `XLResult` spelled in the signature: `Sheet.named(nm).map(_.put(ref"A1", 1))`. On ≤0.17.0, make the union explicit with an ascription: `val s: XLResult[Sheet] = Sheet(nm)`.
 
 ## Reference
 

--- a/plugin/skills/xl-scripting/reference/RECIPES.md
+++ b/plugin/skills/xl-scripting/reference/RECIPES.md
@@ -10,7 +10,7 @@ Apply a 5% price increase to column C of every workbook in a directory, in place
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.16.0
+//> using dep com.tjclp::xl:0.17.0
 import com.tjclp.xl.scripting.{*, given}
 import java.nio.file.{Files, Paths}
 import scala.jdk.CollectionConverters.*
@@ -42,7 +42,7 @@ Read rows into case classes; collect per-cell validation failures into a new Iss
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.16.0
+//> using dep com.tjclp::xl:0.17.0
 import com.tjclp.xl.scripting.{*, given}
 
 final case class Order(id: Int, customer: String, amount: BigDecimal)
@@ -76,7 +76,7 @@ Three-year projection with growth formulas; fail the script if any formula error
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.16.0
+//> using dep com.tjclp::xl:0.17.0
 import com.tjclp.xl.scripting.{*, given}
 
 val header = CellStyle.default.bold.size(12.0).center
@@ -111,7 +111,7 @@ Stack the data rows of every input file under one header.
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.16.0
+//> using dep com.tjclp::xl:0.17.0
 import com.tjclp.xl.scripting.{*, given}
 import java.nio.file.{Files, Paths}
 import scala.jdk.CollectionConverters.*
@@ -147,7 +147,7 @@ println(s"combined ${files.size} files, ${combined.cells.size} cells")
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.16.0
+//> using dep com.tjclp::xl:0.17.0
 import com.tjclp.xl.scripting.{*, given}
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
@@ -176,7 +176,7 @@ println("✓ filtered (constant memory)")
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.16.0
+//> using dep com.tjclp::xl:0.17.0
 import com.tjclp.xl.scripting.{*, given}
 
 val before = Excel.read("before.xlsx")
@@ -204,7 +204,7 @@ else
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.16.0
+//> using dep com.tjclp::xl:0.17.0
 import com.tjclp.xl.scripting.{*, given}
 import java.nio.file.{Files, Paths}
 import scala.jdk.CollectionConverters.*
@@ -232,7 +232,7 @@ cell ships a cached value for `data_only` readers, pandas, and Excel-before-reca
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.16.0
+//> using dep com.tjclp::xl:0.17.0
 import com.tjclp.xl.scripting.{*, given}
 
 val reps = List(("Alice", 120000.0), ("Bob", 98000.0), ("Carol", 143500.0))
@@ -267,7 +267,7 @@ frozen header, a list-dropdown data validation, and a provenance comment — no 
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.16.0
+//> using dep com.tjclp::xl:0.17.0
 import com.tjclp.xl.scripting.{*, given}
 import com.tjclp.xl.sheets.SheetView // SheetView lives one import deeper than the prelude
 

--- a/xl-core/src/com/tjclp/xl/workbooks/WorkbookMetadata.scala
+++ b/xl-core/src/com/tjclp/xl/workbooks/WorkbookMetadata.scala
@@ -27,7 +27,7 @@ final case class WorkbookMetadata(
   modified: Option[java.time.LocalDateTime] = None,
   lastModifiedBy: Option[String] = None,
   application: Option[String] = Some("XL - Pure Scala 3.8 Excel Library"),
-  appVersion: Option[String] = Some("0.16.0"),
+  appVersion: Option[String] = Some("0.17.0"),
   theme: ThemePalette = ThemePalette.office,
   definedNames: Vector[DefinedName] = Vector.empty,
   sheetStates: Map[SheetName, Option[String]] = Map.empty,

--- a/xl/src/com/tjclp/xl/scripting.scala
+++ b/xl/src/com/tjclp/xl/scripting.scala
@@ -4,7 +4,7 @@ package com.tjclp.xl
  * Scripting prelude: everything a script needs in one import.
  *
  * {{{
- * //> using dep com.tjclp::xl:0.16.0
+ * //> using dep com.tjclp::xl:0.17.0
  * import com.tjclp.xl.scripting.{*, given}
  *
  * val wb = Excel.read("input.xlsx")


### PR DESCRIPTION
Release 0.17.0 "Parity" — wave 20 (#440): numFmt parity across every path, batch/arg ergonomics, sheet-lifecycle bookkeeping, comment/sheetFormatPr round-trip, Sheet.named.

38 pins bumped across the 11 version-bearing files; CHANGELOG heading cut; STATUS/roadmap records added. Verified: compile 810/810, test-examples (drift guard), verify-skill-snippets --local (Sheet.named "since 0.17.0" markers now true), no stale 0.16.0 pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)