### PR TITLE
Authoring: col/row default styles (#445) + sheetView view mode/zoom variants (#446)

### DIFF
--- a/xl-core/src/com/tjclp/xl/sheets/Sheet.scala
+++ b/xl-core/src/com/tjclp/xl/sheets/Sheet.scala
@@ -886,6 +886,38 @@ final case class Sheet(
   def getRowProperties(row: Row): RowProperties =
     rowProperties.getOrElse(row, RowProperties())
 
+  /**
+   * Set a column-default style (GH-445): cells in this column with no explicit style render with
+   * `style`, and cells typed into the column later inherit it — the `<col style=>` mechanism
+   * professional workbooks use for a sheet-wide body font without touching the Normal style.
+   *
+   * The style is interned into the sheet's [[StyleRegistry]]; other column properties (width,
+   * hidden, outline) already set on the column are preserved.
+   */
+  def withColumnStyle(col: Column, style: CellStyle): Sheet =
+    val (newRegistry, styleId) = styleRegistry.register(style)
+    copy(
+      styleRegistry = newRegistry,
+      columnProperties = columnProperties.updated(
+        col,
+        getColumnProperties(col).copy(styleId = Some(styleId))
+      )
+    )
+
+  /**
+   * Set a row-default style (GH-445): the `<row s= customFormat="1">` mechanism, used for
+   * full-width spacer and rule rows. Interns the style; other row properties are preserved.
+   */
+  def withRowStyle(row: Row, style: CellStyle): Sheet =
+    val (newRegistry, styleId) = styleRegistry.register(style)
+    copy(
+      styleRegistry = newRegistry,
+      rowProperties = rowProperties.updated(
+        row,
+        getRowProperties(row).copy(styleId = Some(styleId))
+      )
+    )
+
   /** Get all non-empty cells */
   def nonEmptyCells: Iterable[Cell] =
     cells.values.filter(_.nonEmpty)

--- a/xl-core/src/com/tjclp/xl/sheets/SheetView.scala
+++ b/xl-core/src/com/tjclp/xl/sheets/SheetView.scala
@@ -1,5 +1,7 @@
 package com.tjclp.xl.sheets
 
+import com.tjclp.xl.addressing.ARef
+
 /**
  * Sheet view settings, serialized into the worksheet's `<sheetViews><sheetView .../>` element.
  *
@@ -15,21 +17,51 @@ package com.tjclp.xl.sheets
  * @param showGridLines
  *   Whether Excel draws the default cell gridlines (default: true, Excel's default)
  * @param zoomScale
- *   Zoom percentage (10-400), or None for Excel's default (100)
+ *   Zoom percentage (10-400) for the CURRENT view mode, or None for Excel's default (100)
  * @param tabSelected
  *   Whether this sheet's tab is selected in the UI (GH-372). Three-valued on write: `Some(_)`
  *   overlays the attribute, `None` leaves any preserved `tabSelected` attribute untouched. Note
  *   this is tab SELECTION (grouping), not the active sheet — that is `Workbook.activeSheetIndex`.
+ * @param view
+ *   View mode (GH-446): `"normal"`, `"pageBreakPreview"`, or `"pageLayout"`. Finance workbooks
+ *   conventionally ship in page-break preview so the print extent is visible while editing.
+ * @param zoomScaleNormal
+ *   Zoom percentage (10-400) remembered for normal view, independent of [[zoomScale]] (which
+ *   applies to whatever [[view]] is current)
+ * @param zoomScaleSheetLayoutView
+ *   Zoom percentage (10-400) remembered for page-break preview
+ * @param topLeftCell
+ *   Top-left visible cell of the view — the sheet's scroll position (GH-446). Distinct from the
+ *   freeze pane's scroll target ([[Sheet.freezeAt]]'s `scrolledTo`), which lives on `<pane>`.
  */
 final case class SheetView(
   showGridLines: Boolean = true,
   zoomScale: Option[Int] = None,
-  tabSelected: Option[Boolean] = None
+  tabSelected: Option[Boolean] = None,
+  view: Option[String] = None,
+  zoomScaleNormal: Option[Int] = None,
+  zoomScaleSheetLayoutView: Option[Int] = None,
+  topLeftCell: Option[ARef] = None
 ):
   require(
     zoomScale.forall(z => z >= 10 && z <= 400),
     s"Zoom scale must be 10-400, got: ${zoomScale.fold("None")(_.toString)}"
   )
+  require(
+    zoomScaleNormal.forall(z => z >= 10 && z <= 400),
+    s"zoomScaleNormal must be 10-400, got: ${zoomScaleNormal.fold("None")(_.toString)}"
+  )
+  require(
+    zoomScaleSheetLayoutView.forall(z => z >= 10 && z <= 400),
+    s"zoomScaleSheetLayoutView must be 10-400, got: ${zoomScaleSheetLayoutView.fold("None")(_.toString)}"
+  )
+  require(
+    view.forall(SheetView.validViews.contains),
+    s"view must be one of ${SheetView.validViews.mkString(", ")}, got: ${view.getOrElse("None")}"
+  )
 
 object SheetView:
   val default: SheetView = SheetView()
+
+  /** Legal values of the `sheetView/@view` attribute (ECMA-376 ST_SheetViewType). */
+  val validViews: Set[String] = Set("normal", "pageBreakPreview", "pageLayout")

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/Comments.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/Comments.scala
@@ -316,7 +316,11 @@ object OoxmlComments extends XmlReadable[OoxmlComments]:
           case Color.Rgb(argb) =>
             props += elem("color", "rgb" -> f"$argb%08X")()
           case Color.Theme(slot, tint) =>
-            props += elem("color", "theme" -> slot.ordinal.toString, "tint" -> tint.toString)()
+            // GH-448: themeSlotToIndex, NOT slot.ordinal (enum order swaps dark/light pairs)
+            val attrs =
+              Seq("theme" -> style.ColorHelpers.themeSlotToIndex(slot).toString) ++
+                style.OoxmlStyles.tintToken(tint).map("tint" -> _)
+            props += elem("color", attrs*)()
         }
 
         props += elem("sz", "val" -> f.sizePt.toString)()

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/DirectSaxEmitter.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/DirectSaxEmitter.scala
@@ -90,8 +90,18 @@ object DirectSaxEmitter:
       buildSheetViewsElem(None, sheet.freezePane, sheet.viewSettings).foreach(writer.writeElem)
 
       // GH-426: sheet-default row height / column width — the CT_Worksheet slot before <cols>
-      mergeSheetFormatPrElem(None, sheet.defaultColumnWidth, sheet.defaultRowHeight)
-        .foreach(writer.writeElem)
+      // GH-448: plus the outline summary attributes when any row/col carries an outlineLevel
+      locally {
+        val (maxRowOutline, maxColOutline) =
+          com.tjclp.xl.ooxml.worksheet.sheetOutlineMaxes(sheet)
+        mergeSheetFormatPrElem(
+          None,
+          sheet.defaultColumnWidth,
+          sheet.defaultRowHeight,
+          maxRowOutline,
+          maxColOutline
+        ).foreach(writer.writeElem)
+      }
 
       // Emit column definitions if any
       emitCols(writer, sheet, styleRemapping)
@@ -527,8 +537,15 @@ object DirectSaxEmitter:
         writer.endElement()
       case Color.Theme(slot, tint) =>
         writer.startElement("color")
-        writer.writeAttribute("theme", slot.ordinal.toString)
-        writer.writeAttribute("tint", tint.toString)
+        // GH-448: themeSlotToIndex, NOT slot.ordinal — the ThemeSlot enum order swaps the
+        // dark/light pairs relative to OOXML theme indices, so ordinal wrote Dark2 as Light2
+        writer.writeAttribute(
+          "theme",
+          com.tjclp.xl.ooxml.style.ColorHelpers.themeSlotToIndex(slot).toString
+        )
+        com.tjclp.xl.ooxml.style.OoxmlStyles
+          .tintToken(tint)
+          .foreach(writer.writeAttribute("tint", _))
         writer.endElement()
     }
 

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/DirectSaxEmitter.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/DirectSaxEmitter.scala
@@ -17,7 +17,8 @@ import com.tjclp.xl.ooxml.worksheet.{
   mergeAutoFilterElem,
   mergePageSetupElem,
   mergeSheetFormatPrElem,
-  mergeSheetPrElem
+  mergeSheetPrElem,
+  remappedStyleAttr
 }
 import java.util.Arrays
 
@@ -93,7 +94,7 @@ object DirectSaxEmitter:
         .foreach(writer.writeElem)
 
       // Emit column definitions if any
-      emitCols(writer, sheet)
+      emitCols(writer, sheet, styleRemapping)
 
       // Emit sheetData directly from domain cells
       emitSheetData(writer, sheet, sst, styleRemapping, escapeFormulas)
@@ -154,7 +155,7 @@ object DirectSaxEmitter:
       "org.wartremover.warts.Var"
     )
   )
-  private def emitCols(writer: SaxWriter, sheet: Sheet): Unit =
+  private def emitCols(writer: SaxWriter, sheet: Sheet, styleRemapping: Map[Int, Int]): Unit =
     val colProps = sheet.columnProperties
     if colProps.nonEmpty then
       writer.startElement("cols")
@@ -168,10 +169,11 @@ object DirectSaxEmitter:
         writer.startElement("col")
         writer.writeAttribute("min", spanStart.index1.toString)
         writer.writeAttribute("max", spanEnd.index1.toString)
-        spanProps.width.foreach { w =>
-          writer.writeAttribute("width", w.toString)
-          writer.writeAttribute("customWidth", "1")
-        }
+        // Attribute order matches Excel's own writer: width, style, customWidth (GH-445)
+        spanProps.width.foreach(w => writer.writeAttribute("width", w.toString))
+        remappedStyleAttr(spanProps.styleId, styleRemapping)
+          .foreach(s => writer.writeAttribute("style", s))
+        if spanProps.width.isDefined then writer.writeAttribute("customWidth", "1")
         if spanProps.hidden then writer.writeAttribute("hidden", "1")
         spanProps.outlineLevel.foreach(l => writer.writeAttribute("outlineLevel", l.toString))
         if spanProps.collapsed then writer.writeAttribute("collapsed", "1")
@@ -269,8 +271,14 @@ object DirectSaxEmitter:
     writer.startElement("row")
     writer.writeAttribute("r", rowIdx.toString)
 
-    // Row properties
+    // Row properties (attribute order per ECMA/Excel: r, s, customFormat, ht, customHeight, ...)
     rowProps.foreach { props =>
+      // GH-445: row-default style, remapped like cell styleIds (the SAX path is source-free,
+      // so there is no preserved attribute to overlay — emit iff the domain sets one)
+      remappedStyleAttr(props.styleId, styleRemapping).foreach { s =>
+        writer.writeAttribute("s", s)
+        writer.writeAttribute("customFormat", "1")
+      }
       props.height.foreach(h => writer.writeAttribute("ht", h.toString))
       if props.height.isDefined then writer.writeAttribute("customHeight", "1")
       if props.hidden then writer.writeAttribute("hidden", "1")

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/XlsxReader.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/XlsxReader.scala
@@ -1079,11 +1079,11 @@ object XlsxReader:
 
     // Parse column properties from <cols> element
     val columnProperties = ooxmlSheet.cols match
-      case Some(colsElem) => parseColumnProperties(colsElem)
+      case Some(colsElem) => parseColumnProperties(colsElem, styleMapping)
       case None => Map.empty[Column, ColumnProperties]
 
     // Extract row properties from OoxmlRow data
-    val rowProperties = extractRowProperties(ooxmlSheet.rows)
+    val rowProperties = extractRowProperties(ooxmlSheet.rows, styleMapping)
 
     // Parse print setup (scale/orientation/fit, margins, header/footer) — GH-259
     val pageSetup =
@@ -1162,7 +1162,10 @@ object XlsxReader:
    * Each <col> element has min/max (1-indexed) and optional width, hidden, outlineLevel, collapsed.
    * A single <col> can cover multiple columns (min="1" max="3" applies to columns A-C).
    */
-  private def parseColumnProperties(colsElem: Elem): Map[Column, ColumnProperties] =
+  private def parseColumnProperties(
+    colsElem: Elem,
+    styleMapping: Map[Int, StyleId]
+  ): Map[Column, ColumnProperties] =
     val builder = Map.newBuilder[Column, ColumnProperties]
     for colElem <- colsElem.child.collect { case e: Elem if e.label == "col" => e } do
       val attrs = colElem.attributes.asAttrMap
@@ -1175,6 +1178,9 @@ object XlsxReader:
         val props = ColumnProperties(
           width = attrs.get("width").flatMap(_.toDoubleOption),
           hidden = attrs.get("hidden").contains("1"),
+          // GH-445: column-default style — resolved through the same global→local mapping as
+          // cell styleIds so read→modify→write re-emits it instead of silently dropping it
+          styleId = attrs.get("style").flatMap(_.toIntOption).flatMap(styleMapping.get),
           outlineLevel = attrs.get("outlineLevel").flatMap(_.toIntOption),
           collapsed = attrs.get("collapsed").contains("1")
         )
@@ -1185,19 +1191,26 @@ object XlsxReader:
   /**
    * Extract row properties from parsed OoxmlRow data.
    *
-   * Only includes rows that have non-default properties (height, hidden, outlineLevel, collapsed).
+   * Only includes rows that have non-default properties (height, hidden, style, outlineLevel,
+   * collapsed).
    */
-  private def extractRowProperties(rows: Seq[OoxmlRow]): Map[Row, RowProperties] =
+  private def extractRowProperties(
+    rows: Seq[OoxmlRow],
+    styleMapping: Map[Int, StyleId]
+  ): Map[Row, RowProperties] =
     val builder = Map.newBuilder[Row, RowProperties]
     for row <- rows do
       val props = RowProperties(
         height = row.height,
         hidden = row.hidden,
+        // GH-445: row-default style (`<row s=>`), resolved like cell styleIds
+        styleId = row.style.flatMap(styleMapping.get),
         outlineLevel = row.outlineLevel,
         collapsed = row.collapsed
       )
       // Only include if not all defaults
-      if props.height.isDefined || props.hidden || props.outlineLevel.isDefined || props.collapsed
+      if props.height.isDefined || props.hidden || props.styleId.isDefined ||
+        props.outlineLevel.isDefined || props.collapsed
       then builder += (Row.from1(row.rowIndex) -> props)
     builder.result()
 
@@ -1274,26 +1287,43 @@ object XlsxReader:
     if parsed == HeaderFooter() then None else Some(parsed)
 
   /**
-   * Parse sheet view settings (GH-258/GH-372) from the first <sheetView>.
+   * Parse sheet view settings (GH-258/GH-372/GH-446) from the first <sheetView>.
    *
-   * Returns Some only when a modeled attribute (showGridLines, zoomScale, tabSelected) is present,
-   * so typical files keep viewSettings = None and the raw sheetViews XML rides through unchanged on
-   * rewrite (passive preserve). Out-of-range zoom values are dropped rather than violating the
-   * SheetView invariant.
+   * Returns Some only when a modeled attribute (showGridLines, zoomScale, tabSelected, view,
+   * zoomScaleNormal, zoomScaleSheetLayoutView, topLeftCell) is present, so typical files keep
+   * viewSettings = None and the raw sheetViews XML rides through unchanged on rewrite (passive
+   * preserve). Out-of-range zoom values and unknown view modes are dropped rather than violating
+   * the SheetView invariant.
    */
   private def parseSheetView(sheetViewsElem: Option[Elem]): Option[SheetView] =
     for
       views <- sheetViewsElem
-      view <- (views \ "sheetView").collectFirst { case e: Elem => e }
-      attrs = view.attributes.asAttrMap
+      viewElem <- (views \ "sheetView").collectFirst { case e: Elem => e }
+      attrs = viewElem.attributes.asAttrMap
       showGridLines = attrs.get("showGridLines").map(v => v != "0" && v != "false")
       zoomScale = attrs.get("zoomScale").flatMap(_.toIntOption).filter(z => z >= 10 && z <= 400)
       tabSelected = attrs.get("tabSelected").map(v => v == "1" || v == "true")
-      if showGridLines.isDefined || zoomScale.isDefined || tabSelected.isDefined
+      viewMode = attrs.get("view").filter(SheetView.validViews.contains)
+      zoomScaleNormal = attrs
+        .get("zoomScaleNormal")
+        .flatMap(_.toIntOption)
+        .filter(z => z >= 10 && z <= 400)
+      zoomScaleSheetLayoutView = attrs
+        .get("zoomScaleSheetLayoutView")
+        .flatMap(_.toIntOption)
+        .filter(z => z >= 10 && z <= 400)
+      topLeftCell = attrs.get("topLeftCell").flatMap(s => ARef.parse(s).toOption)
+      if showGridLines.isDefined || zoomScale.isDefined || tabSelected.isDefined ||
+        viewMode.isDefined || zoomScaleNormal.isDefined ||
+        zoomScaleSheetLayoutView.isDefined || topLeftCell.isDefined
     yield SheetView(
       showGridLines = showGridLines.getOrElse(true),
       zoomScale = zoomScale,
-      tabSelected = tabSelected
+      tabSelected = tabSelected,
+      view = viewMode,
+      zoomScaleNormal = zoomScaleNormal,
+      zoomScaleSheetLayoutView = zoomScaleSheetLayoutView,
+      topLeftCell = topLeftCell
     )
 
   /**

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/style/DxfCodec.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/style/DxfCodec.scala
@@ -243,11 +243,9 @@ object DxfCodec:
   private[ooxml] def colorToXml(color: Color): Elem = color match
     case Color.Rgb(argb) => elem("color", "rgb" -> f"$argb%08X")()
     case Color.Theme(slot, tint) =>
-      elem(
-        "color",
-        "theme" -> ColorHelpers.themeSlotToIndex(slot).toString,
-        "tint" -> tint.toString
-      )()
+      val attrs = Seq("theme" -> ColorHelpers.themeSlotToIndex(slot).toString) ++
+        OoxmlStyles.tintToken(tint).map("tint" -> _)
+      elem("color", attrs*)()
 
   /**
    * Excel-native dxf fill: solid via bare patternFill + bgColor (matches Excel's own cf writer).

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/style/StyleSerializer.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/style/StyleSerializer.scala
@@ -56,14 +56,7 @@ final case class OoxmlStyles(
      *   - Gray125 uses black foreground (0xFF000000) and silver background (0xFFC0C0C0)
      * DETERMINISTIC: Yes (immutable constant) ERROR CASES: None (compile-time constant)
      */
-    val defaultFills = Vector(
-      Fill.None,
-      Fill.Pattern(
-        foreground = Color.Rgb(0xff000000), // Black foreground
-        background = Color.Rgb(0xffc0c0c0), // Silver background
-        pattern = PatternType.Gray125
-      )
-    )
+    val defaultFills = Vector(Fill.None, OoxmlStyles.defaultGray125)
     // Deterministic deduplication preserving first occurrence order
     // Manual tracking ensures determinism while avoiding duplicate defaults
     val allFills = {
@@ -196,14 +189,7 @@ final case class OoxmlStyles(
       writer.endElement()
 
       // Fills (include defaults)
-      val defaultFills = Vector(
-        Fill.None,
-        Fill.Pattern(
-          foreground = Color.Rgb(0xff000000),
-          background = Color.Rgb(0xffc0c0c0),
-          pattern = PatternType.Gray125
-        )
-      )
+      val defaultFills = Vector(Fill.None, OoxmlStyles.defaultGray125)
       val allFills = {
         val builder = Vector.newBuilder[Fill]
         val seen = scala.collection.mutable.Set.empty[Fill]
@@ -290,7 +276,7 @@ final case class OoxmlStyles(
   private def fontToXml(font: Font): Elem =
     val children = Vector(
       Some(elem("name", "val" -> font.name)()),
-      Some(elem("sz", "val" -> font.sizePt.toString)()),
+      Some(elem("sz", "val" -> OoxmlStyles.fontSizeToken(font.sizePt))()),
       if font.bold then Some(elem("b")()) else None,
       if font.italic then Some(elem("i")()) else None,
       underlineToXml(font.underline),
@@ -317,13 +303,17 @@ final case class OoxmlStyles(
           )
         )
 
-      case Fill.Pattern(fg, bg, patternType) =>
-        elem("fill")(
-          elem("patternFill", "patternType" -> OoxmlStyles.patternTypeToken(patternType))(
-            colorToXml(fg).copy(label = "fgColor"), // Use colorToXml to preserve theme colors
-            colorToXml(bg).copy(label = "bgColor") // Use colorToXml to preserve theme colors
+      case fill @ Fill.Pattern(fg, bg, patternType) =>
+        // GH-448: the mandatory gray125 placeholder serializes bare, exactly as Excel writes it
+        if fill == OoxmlStyles.defaultGray125 then
+          elem("fill")(elem("patternFill", "patternType" -> "gray125")())
+        else
+          elem("fill")(
+            elem("patternFill", "patternType" -> OoxmlStyles.patternTypeToken(patternType))(
+              colorToXml(fg).copy(label = "fgColor"), // Use colorToXml to preserve theme colors
+              colorToXml(bg).copy(label = "bgColor") // Use colorToXml to preserve theme colors
+            )
           )
-        )
 
   private def borderToXml(border: Border): Elem =
     elem("border")(
@@ -347,7 +337,9 @@ final case class OoxmlStyles(
         elem("color", "rgb" -> f"$argb%08X")()
       case Color.Theme(slot, tint) =>
         val slotIdx = ColorHelpers.themeSlotToIndex(slot)
-        elem("color", "theme" -> slotIdx.toString, "tint" -> tint.toString)()
+        val attrs = Seq("theme" -> slotIdx.toString) ++
+          OoxmlStyles.tintToken(tint).map("tint" -> _)
+        elem("color", attrs*)()
 
   /**
    * Serialize alignment to XML element if non-default (ECMA-376 Part 1, section 18.8.1)
@@ -445,7 +437,7 @@ final case class OoxmlStyles(
     writer.endElement()
 
     writer.startElement("sz")
-    writer.writeAttribute("val", font.sizePt.toString)
+    writer.writeAttribute("val", OoxmlStyles.fontSizeToken(font.sizePt))
     writer.endElement()
 
     if font.bold then
@@ -482,15 +474,18 @@ final case class OoxmlStyles(
         writeColorAttributes(writer, color)
         writer.endElement()
         writer.endElement()
-      case Fill.Pattern(fg, bg, patternType) =>
+      case fill @ Fill.Pattern(fg, bg, patternType) =>
         writer.startElement("patternFill")
-        writer.writeAttribute("patternType", OoxmlStyles.patternTypeToken(patternType))
-        writer.startElement("fgColor")
-        writeColorAttributes(writer, fg)
-        writer.endElement()
-        writer.startElement("bgColor")
-        writeColorAttributes(writer, bg)
-        writer.endElement()
+        // GH-448: the mandatory gray125 placeholder serializes bare, exactly as Excel writes it
+        if fill == OoxmlStyles.defaultGray125 then writer.writeAttribute("patternType", "gray125")
+        else
+          writer.writeAttribute("patternType", OoxmlStyles.patternTypeToken(patternType))
+          writer.startElement("fgColor")
+          writeColorAttributes(writer, fg)
+          writer.endElement()
+          writer.startElement("bgColor")
+          writeColorAttributes(writer, bg)
+          writer.endElement()
         writer.endElement()
     writer.endElement()
 
@@ -522,9 +517,40 @@ final case class OoxmlStyles(
         writer.writeAttribute("rgb", f"$argb%08X")
       case Color.Theme(slot, tint) =>
         writer.writeAttribute("theme", ColorHelpers.themeSlotToIndex(slot).toString)
-        writer.writeAttribute("tint", tint.toString)
+        OoxmlStyles.tintToken(tint).foreach(writer.writeAttribute("tint", _))
 
 object OoxmlStyles:
+
+  /** Excel writes integral font sizes without a decimal point ("10", not "10.0") — GH-448. */
+  private[ooxml] def fontSizeToken(sizePt: Double): String =
+    if sizePt.isWhole then sizePt.toLong.toString else sizePt.toString
+
+  /**
+   * Excel's textual form for a theme tint (GH-448): omitted entirely when 0, otherwise up to 17
+   * significant digits of the exact binary value in plain notation (`0.79998168889431442`), never
+   * Java's shortest-round-trip form (`0.7999816888943144`). Both parse to the same Double; only the
+   * Excel form is byte-identical to Excel-authored files.
+   */
+  private[ooxml] def tintToken(tint: Double): Option[String] =
+    if tint == 0.0 then None
+    else
+      Some(
+        new java.math.BigDecimal(tint)
+          .round(new java.math.MathContext(17))
+          .stripTrailingZeros
+          .toPlainString
+      )
+
+  /**
+   * The mandatory fills[1] placeholder (ECMA-376 §18.8.21). Excel writes it BARE (`<patternFill
+   * patternType="gray125"/>`); the explicit black/silver colors here are the model-side identity
+   * only and are not serialized for this exact instance (GH-448).
+   */
+  private[ooxml] val defaultGray125: Fill = Fill.Pattern(
+    foreground = Color.Rgb(0xff000000),
+    background = Color.Rgb(0xffc0c0c0),
+    pattern = PatternType.Gray125
+  )
 
   /**
    * Canonical ST_BorderStyle token (ECMA-376 Part 1, §18.18.3) for each border style. Explicit

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/OoxmlWorksheet.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/OoxmlWorksheet.scala
@@ -485,9 +485,9 @@ object OoxmlWorksheet extends com.tjclp.xl.ooxml.XmlReadable[OoxmlWorksheet]:
           // New row - create with defaults
           OoxmlRow(rowIdx, ooxmlCells)
 
-      // Apply domain row properties (height, hidden, outlineLevel, collapsed)
+      // Apply domain row properties (height, hidden, style, outlineLevel, collapsed)
       val rowWithDomainProps = sheet.rowProperties.get(Row.from1(rowIdx)) match
-        case Some(domainProps) => applyDomainRowProps(baseRow, domainProps)
+        case Some(domainProps) => applyDomainRowProps(baseRow, domainProps, styleRemapping)
         case None => baseRow
 
       rowWithDomainProps
@@ -504,7 +504,9 @@ object OoxmlWorksheet extends com.tjclp.xl.ooxml.XmlReadable[OoxmlWorksheet]:
           val withoutSourceCells = original.copy(cells = Seq.empty)
           sheet.rowProperties
             .get(Row.from1(original.rowIndex))
-            .fold(withoutSourceCells)(props => applyDomainRowProps(withoutSourceCells, props))
+            .fold(withoutSourceCells)(props =>
+              applyDomainRowProps(withoutSourceCells, props, styleRemapping)
+            )
         }
     }
 
@@ -514,7 +516,7 @@ object OoxmlWorksheet extends com.tjclp.xl.ooxml.XmlReadable[OoxmlWorksheet]:
     val emptyRowsFromDomain = sheet.rowProperties
       .filterNot { case (row, _) => existingRowIndices.contains(row.index1) }
       .map { case (row, props) =>
-        applyDomainRowProps(OoxmlRow(row.index1, Seq.empty), props)
+        applyDomainRowProps(OoxmlRow(row.index1, Seq.empty), props, styleRemapping)
       }
       .toSeq
 
@@ -540,7 +542,7 @@ object OoxmlWorksheet extends com.tjclp.xl.ooxml.XmlReadable[OoxmlWorksheet]:
       else preservedMetadata.flatMap(_.legacyDrawing)
 
     // Generate cols from domain properties if not preserved
-    val generatedCols = buildColsElement(sheet)
+    val generatedCols = buildColsElement(sheet, styleRemapping)
 
     // Calculate actual dimension from all rows (recalculate to reflect any new cells)
     val calculatedDimension: Option[Elem] =

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/OoxmlWorksheet.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/OoxmlWorksheet.scala
@@ -581,11 +581,16 @@ object OoxmlWorksheet extends com.tjclp.xl.ooxml.XmlReadable[OoxmlWorksheet]:
           ), // Use calculated dimension, fallback to preserved
           buildSheetViewsElem(preserved.sheetViews, sheet.freezePane, sheet.viewSettings),
           // GH-426: modeled sheet defaults overlay the preserved element (unmodeled attrs ride)
-          mergeSheetFormatPrElem(
-            preserved.sheetFormatPr,
-            sheet.defaultColumnWidth,
-            sheet.defaultRowHeight
-          ),
+          {
+            val (maxRowOutline, maxColOutline) = sheetOutlineMaxes(sheet)
+            mergeSheetFormatPrElem(
+              preserved.sheetFormatPr,
+              sheet.defaultColumnWidth,
+              sheet.defaultRowHeight,
+              maxRowOutline,
+              maxColOutline
+            )
+          },
           generatedCols.orElse(preserved.cols), // Prefer domain props over preserved XML
           condFmt.getOrElse(preserved.conditionalFormatting), // GH-136: planned slot wins
           dataValidations.getOrElse(preserved.dataValidations), // GH-375: planned slot wins
@@ -624,8 +629,16 @@ object OoxmlWorksheet extends com.tjclp.xl.ooxml.XmlReadable[OoxmlWorksheet]:
           dimension = calculatedDimension,
           sheetViews = buildSheetViewsElem(None, sheet.freezePane, sheet.viewSettings),
           // GH-426: a modeled default row height / column width materializes without source XML
-          sheetFormatPr =
-            mergeSheetFormatPrElem(None, sheet.defaultColumnWidth, sheet.defaultRowHeight),
+          sheetFormatPr = {
+            val (maxRowOutline, maxColOutline) = sheetOutlineMaxes(sheet)
+            mergeSheetFormatPrElem(
+              None,
+              sheet.defaultColumnWidth,
+              sheet.defaultRowHeight,
+              maxRowOutline,
+              maxColOutline
+            )
+          },
           cols = generatedCols,
           conditionalFormatting = condFmt.getOrElse(Seq.empty), // GH-136: fresh workbooks get cf
           dataValidations = dataValidations.flatten, // GH-375: fresh workbooks get validations

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/WorksheetHelpers.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/WorksheetHelpers.scala
@@ -16,6 +16,7 @@ import com.tjclp.xl.sheets.{
   SheetView
 }
 import com.tjclp.xl.styles.color.Color
+import com.tjclp.xl.styles.units.StyleId
 
 // Default namespaces for generated worksheets. Real files capture the original scope/attributes to
 // avoid redundant declarations and preserve mc/x14/xr bindings from the source sheet.
@@ -417,28 +418,46 @@ private[ooxml] def groupConsecutiveColumns(
  * @return
  *   Some(cols element) if there are column properties, None otherwise
  */
-private[ooxml] def buildColsElement(sheet: Sheet): Option[Elem] =
+private[ooxml] def buildColsElement(
+  sheet: Sheet,
+  styleRemapping: Map[Int, Int] = Map.empty
+): Option[Elem] =
   val props = sheet.columnProperties
   if props.isEmpty then None
   else
     val spans = groupConsecutiveColumns(props)
     val colElems = spans.map { case (minCol, maxCol, p) =>
-      // Build attribute sequence (only include non-default values)
+      // Build attribute sequence (only include non-default values).
+      // Attribute order matches Excel's own writer: min, max, width, style, customWidth, ...
       val attrs = Seq.newBuilder[(String, String)]
       attrs += ("min" -> (minCol.index0 + 1).toString) // OOXML is 1-based
       attrs += ("max" -> (maxCol.index0 + 1).toString)
-      p.width.foreach { w =>
-        attrs += ("width" -> w.toString)
-        attrs += ("customWidth" -> "1")
-      }
+      p.width.foreach(w => attrs += ("width" -> w.toString))
+      // GH-445: column-default style, remapped from the sheet-local id to the workbook xf index
+      // exactly like cell styleIds. Index 0 is the workbook default — omitted, same as cells.
+      remappedStyleAttr(p.styleId, styleRemapping).foreach(s => attrs += ("style" -> s))
+      if p.width.isDefined then attrs += ("customWidth" -> "1")
       if p.hidden then attrs += ("hidden" -> "1")
       p.outlineLevel.foreach(l => attrs += ("outlineLevel" -> l.toString))
       if p.collapsed then attrs += ("collapsed" -> "1")
-      // Note: styleId would need remapping to workbook-level index (deferred)
 
       XmlUtil.elemOrdered("col", attrs.result()*)( /* no children */ )
     }
     Some(XmlUtil.elem("cols")(colElems*))
+
+/**
+ * Remap a sheet-local [[StyleId]] to its workbook-level xf index for `<col style=>` / `<row s=>`
+ * emission (GH-445). Returns None for the workbook default (index 0) or an unmapped id — the
+ * attribute is omitted rather than written as a redundant "0", mirroring the cell path.
+ */
+private[ooxml] def remappedStyleAttr(
+  styleId: Option[StyleId],
+  styleRemapping: Map[Int, Int]
+): Option[String] =
+  styleId
+    .map(sid => styleRemapping.getOrElse(sid.value, 0))
+    .filter(_ > 0)
+    .map(_.toString)
 
 // ===== Sheet view authoring (GH-258) =====
 // Shared by the DOM writer (OoxmlWorksheet) and the streaming writer (DirectSaxEmitter, GH-265)
@@ -495,21 +514,36 @@ private def applyViewSettingsOverride(
 
 /** Set the modeled view attributes on a single `<sheetView>` element. */
 private def applyViewAttrs(sheetView: Elem, view: SheetView): Elem =
+  // set-or-remove: the reader always models an in-range/legal source value for these, so a
+  // None here means "not set" and any stale source attribute must go (the zoomScale precedent)
+  def setOrRemove(e: Elem, name: String, value: Option[String]): Elem =
+    value match
+      case Some(v) => e % new UnprefixedAttribute(name, v, Null)
+      case None => e.copy(attributes = e.attributes.remove(name))
+
   val withGrid = sheetView % new UnprefixedAttribute(
     "showGridLines",
     if view.showGridLines then "1" else "0",
     Null
   )
-  val withZoom = view.zoomScale match
-    case Some(zoom) => withGrid % new UnprefixedAttribute("zoomScale", zoom.toString, Null)
-    case None => withGrid.copy(attributes = withGrid.attributes.remove("zoomScale"))
+  val withZoom = setOrRemove(withGrid, "zoomScale", view.zoomScale.map(_.toString))
+  // GH-446: view mode, per-mode zoom memories, and scroll position
+  val withMode = setOrRemove(withZoom, "view", view.view)
+  val withZoomNormal =
+    setOrRemove(withMode, "zoomScaleNormal", view.zoomScaleNormal.map(_.toString))
+  val withZoomLayout = setOrRemove(
+    withZoomNormal,
+    "zoomScaleSheetLayoutView",
+    view.zoomScaleSheetLayoutView.map(_.toString)
+  )
+  val withTopLeft = setOrRemove(withZoomLayout, "topLeftCell", view.topLeftCell.map(_.toA1))
   view.tabSelected match
     case Some(selected) =>
-      withZoom % new UnprefixedAttribute("tabSelected", if selected then "1" else "0", Null)
+      withTopLeft % new UnprefixedAttribute("tabSelected", if selected then "1" else "0", Null)
     // Three-valued (GH-372): None means "not modeled" — a preserved tabSelected attribute
     // must ride through, so it is never removed here (unlike zoomScale, where the reader
     // always models an in-range source value)
-    case None => withZoom
+    case None => withTopLeft
 
 /**
  * Apply freeze pane override to sheetViews XML.
@@ -860,7 +894,16 @@ private def stripFitToPage(existing: Option[Elem]): Option[Elem] =
  * Domain properties override existing row attributes (if any). This allows setting row height,
  * hidden state, and outline level from the domain model.
  */
-private[ooxml] def applyDomainRowProps(row: OoxmlRow, props: RowProperties): OoxmlRow =
+private[ooxml] def applyDomainRowProps(
+  row: OoxmlRow,
+  props: RowProperties,
+  styleRemapping: Map[Int, Int] = Map.empty
+): OoxmlRow =
+  // GH-445: row-default style, remapped like cell styleIds. Overlay-when-defined (the
+  // tabSelected/GH-372 precedent): a None styleId leaves any preserved `s=` attribute
+  // untouched, so source-backed rows keep their row-level style unless the domain sets one.
+  val remappedStyle =
+    props.styleId.map(sid => styleRemapping.getOrElse(sid.value, 0)).filter(_ > 0)
   row.copy(
     // A RowProperties entry is authoritative for the fields emitted here. None actively clears
     // optional source attributes; other preserved row metadata remains intact via case-class copy.
@@ -868,6 +911,7 @@ private[ooxml] def applyDomainRowProps(row: OoxmlRow, props: RowProperties): Oox
     customHeight = props.height.isDefined,
     hidden = props.hidden, // Domain always wins (allows unhide)
     outlineLevel = props.outlineLevel,
-    collapsed = props.collapsed // Domain always wins (allows uncollapse)
-    // Note: styleId would need remapping to workbook-level index (deferred)
+    collapsed = props.collapsed, // Domain always wins (allows uncollapse)
+    style = remappedStyle.orElse(row.style),
+    customFormat = row.customFormat || remappedStyle.isDefined
   )

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/WorksheetHelpers.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/WorksheetHelpers.scala
@@ -672,9 +672,13 @@ private[ooxml] def parseAutoFilterRef(e: Elem): Option[CellRange] =
 private[ooxml] def mergeSheetFormatPrElem(
   existing: Option[Elem],
   defaultColumnWidth: Option[Double],
-  defaultRowHeight: Option[Double]
+  defaultRowHeight: Option[Double],
+  maxRowOutline: Int = 0,
+  maxColOutline: Int = 0
 ): Option[Elem] =
-  if defaultColumnWidth.isEmpty && defaultRowHeight.isEmpty then existing
+  if defaultColumnWidth.isEmpty && defaultRowHeight.isEmpty &&
+    maxRowOutline == 0 && maxColOutline == 0
+  then existing
   else
     def attrDouble(e: Elem, key: String): Option[Double] =
       Option(e \@ key).filter(_.nonEmpty).flatMap(_.toDoubleOption)
@@ -692,11 +696,30 @@ private[ooxml] def mergeSheetFormatPrElem(
             Some("1")
           )
         case None => withWidth
+    // GH-448: the outline summary attributes Excel stamps when any row/col carries an
+    // outlineLevel. Set-or-remove: the reader models outline levels on every row/col, so the
+    // recomputed max IS ground truth — after an ungroup the stale summary attr must go too.
+    val withRowOutline = setOrRemoveAttr(
+      withHeight,
+      "outlineLevelRow",
+      Option.when(maxRowOutline > 0)(maxRowOutline.toString)
+    )
+    val withColOutline = setOrRemoveAttr(
+      withRowOutline,
+      "outlineLevelCol",
+      Option.when(maxColOutline > 0)(maxColOutline.toString)
+    )
     val withRequiredHeight =
-      if existing.isEmpty && (withHeight \@ "defaultRowHeight").isEmpty then
-        setOrRemoveAttr(withHeight, "defaultRowHeight", Some("15"))
-      else withHeight
+      if existing.isEmpty && (withColOutline \@ "defaultRowHeight").isEmpty then
+        setOrRemoveAttr(withColOutline, "defaultRowHeight", Some("15"))
+      else withColOutline
     Some(withRequiredHeight)
+
+/** Max row/col outline levels of a sheet's domain properties (0 = no outlining) — GH-448. */
+private[ooxml] def sheetOutlineMaxes(sheet: Sheet): (Int, Int) =
+  val rowMax = sheet.rowProperties.values.flatMap(_.outlineLevel).maxOption.getOrElse(0)
+  val colMax = sheet.columnProperties.values.flatMap(_.outlineLevel).maxOption.getOrElse(0)
+  (rowMax, colMax)
 
 // ===== Print setup authoring (GH-259, GH-266) =====
 // PageSetup is the typed model for <pageMargins>, <pageSetup>, <headerFooter>, and the

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/CanonicalXmlSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/CanonicalXmlSpec.scala
@@ -1,0 +1,114 @@
+package com.tjclp.xl.ooxml
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path}
+import java.util.zip.ZipFile
+
+import com.tjclp.xl.api.*
+import com.tjclp.xl.codec.CellCodec.given
+import com.tjclp.xl.macros.ref
+import com.tjclp.xl.sheets.syntax.withCellStyle
+import com.tjclp.xl.sheets.{ColumnProperties, RowProperties}
+import com.tjclp.xl.styles.CellStyle
+import com.tjclp.xl.styles.color.{Color, ThemeSlot}
+import com.tjclp.xl.styles.font.Font
+import munit.FunSuite
+
+/**
+ * GH-448: Excel-canonical XML forms, so an xl-authored sheet is textually identical to the same
+ * sheet authored by Excel:
+ *   - integral font sizes without a decimal point (`sz="10"`, not `sz="10.0"`)
+ *   - theme tints in Excel's ≤17-significant-digit plain form, omitted entirely when 0
+ *   - the mandatory gray125 placeholder fill written bare
+ *   - `sheetFormatPr` outline summary attributes stamped from row/col outline levels
+ *   - theme slot indices via themeSlotToIndex on EVERY path (the ThemeSlot enum order swaps
+ *     dark/light pairs relative to OOXML indices, so `slot.ordinal` wrote Dark2 as Light2)
+ */
+class CanonicalXmlSpec extends FunSuite:
+
+  private def zipEntryString(path: Path, entry: String): String =
+    val zf = new ZipFile(path.toFile)
+    try
+      val is = zf.getInputStream(zf.getEntry(entry))
+      try new String(is.readAllBytes(), StandardCharsets.UTF_8)
+      finally is.close()
+    finally zf.close()
+
+  private def written(wb: Workbook, prefix: String): Path =
+    val out = Files.createTempFile(prefix, ".xlsx")
+    XlsxWriter.write(wb, out).fold(e => fail(s"write failed: $e"), identity)
+    out
+
+  test("GH-448: integral font sizes emit without a decimal point") {
+    val wb = Workbook(
+      Sheet("Sheet1")
+        .put(ref"A1" -> 1)
+        .withCellStyle(ref"A1", CellStyle.default.withFont(Font("Times New Roman", 10.0)))
+    )
+    val out = written(wb, "canon-sz")
+    val styles = zipEntryString(out, "xl/styles.xml")
+    assert(styles.contains("<sz val=\"10\"/>"), s"integral sz must drop the decimal: $styles")
+    assert(!styles.contains("val=\"10.0\""), s"sz=10.0 must not appear: $styles")
+    Files.deleteIfExists(out)
+  }
+
+  test("GH-448: fractional font sizes keep their decimals") {
+    val wb = Workbook(
+      Sheet("Sheet1")
+        .put(ref"A1" -> 1)
+        .withCellStyle(ref"A1", CellStyle.default.withFont(Font("Arial", 10.5)))
+    )
+    val out = written(wb, "canon-szfrac")
+    val styles = zipEntryString(out, "xl/styles.xml")
+    assert(styles.contains("<sz val=\"10.5\"/>"), s"fractional sz preserved: $styles")
+    Files.deleteIfExists(out)
+  }
+
+  test("GH-448: theme tint uses Excel's 17-significant-digit plain form") {
+    val wb = Workbook(
+      Sheet("Sheet1")
+        .put(ref"A1" -> 1)
+        .withTabColor(Color.Theme(ThemeSlot.Accent1, 0.79998168889431442))
+    )
+    val out = written(wb, "canon-tint")
+    val xml = zipEntryString(out, "xl/worksheets/sheet1.xml")
+    assert(
+      xml.contains("tint=\"0.79998168889431442\""),
+      s"tint must be the 17-digit Excel form, not the shortest round-trip: $xml"
+    )
+    Files.deleteIfExists(out)
+  }
+
+  test("GH-448: a zero tint is omitted, and Dark2 maps to theme index 3 (not its ordinal)") {
+    val wb = Workbook(
+      Sheet("Sheet1").put(ref"A1" -> 1).withTabColor(Color.Theme(ThemeSlot.Dark2, 0.0))
+    )
+    val out = written(wb, "canon-tint0")
+    val xml = zipEntryString(out, "xl/worksheets/sheet1.xml")
+    assert(xml.contains("<tabColor theme=\"3\"/>"), s"bare theme=3 tabColor expected: $xml")
+    assert(!xml.contains("tint="), s"tint=0 must be omitted: $xml")
+    Files.deleteIfExists(out)
+  }
+
+  test("GH-448: the mandatory gray125 placeholder fill serializes bare") {
+    val wb = Workbook(Sheet("Sheet1").put(ref"A1" -> 1))
+    val out = written(wb, "canon-gray")
+    val styles = zipEntryString(out, "xl/styles.xml")
+    assert(
+      styles.contains("<patternFill patternType=\"gray125\"/>"),
+      s"gray125 must be bare like Excel writes it: $styles"
+    )
+    Files.deleteIfExists(out)
+  }
+
+  test("GH-448: outline summary attributes stamp onto sheetFormatPr from row/col levels") {
+    val sheet = Sheet("Sheet1")
+      .put(ref"A1" -> 1, ref"A2" -> 2)
+      .setRowProperties(ref"A2".row, RowProperties(outlineLevel = Some(1)))
+      .setColumnProperties(ref"C1".col, ColumnProperties(outlineLevel = Some(2)))
+    val out = written(Workbook(sheet), "canon-outline")
+    val xml = zipEntryString(out, "xl/worksheets/sheet1.xml")
+    assert(xml.contains("outlineLevelRow=\"1\""), s"outlineLevelRow missing: $xml")
+    assert(xml.contains("outlineLevelCol=\"2\""), s"outlineLevelCol missing: $xml")
+    Files.deleteIfExists(out)
+  }

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/ColRowStyleAuthoringSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/ColRowStyleAuthoringSpec.scala
@@ -1,0 +1,133 @@
+package com.tjclp.xl.ooxml
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path}
+import java.util.zip.ZipFile
+
+import com.tjclp.xl.api.*
+import com.tjclp.xl.codec.CellCodec.given
+import com.tjclp.xl.macros.ref
+import com.tjclp.xl.sheets.{ColumnProperties, DataValidation, RowProperties}
+import com.tjclp.xl.styles.CellStyle
+import com.tjclp.xl.styles.font.Font
+import munit.FunSuite
+
+/**
+ * GH-445: `ColumnProperties.styleId` / `RowProperties.styleId` emit as `<col style=>` and `<row s=
+ * customFormat="1">`, remapped through StyleIndex exactly like cell styleIds — on BOTH writer
+ * backends — and parse back into the model so read→modify→write keeps them.
+ *
+ * Column-default styles are how professional workbooks make a body font the sheet default without
+ * touching the Normal style; row-default styles carry full-width spacer/rule formatting.
+ */
+class ColRowStyleAuthoringSpec extends FunSuite:
+
+  private val bodyFont = Font("Times New Roman", 10.0)
+  private val ruleFont = Font("Times New Roman", 8.0)
+
+  private def zipEntryString(path: Path, entry: String): String =
+    val zf = new ZipFile(path.toFile)
+    try
+      val is = zf.getInputStream(zf.getEntry(entry))
+      try new String(is.readAllBytes(), StandardCharsets.UTF_8)
+      finally is.close()
+    finally zf.close()
+
+  /** A sheet with a styled+sized column B and a styled, cell-free spacer row 3. */
+  private def styledSheet: Sheet =
+    Sheet("Sheet1")
+      .put(ref"A1" -> 1, ref"B2" -> 2)
+      .setColumnProperties(ref"B1".col, ColumnProperties(width = Some(20.0)))
+      .withColumnStyle(ref"B1".col, CellStyle.default.withFont(bodyFont))
+      .setRowProperties(ref"A3".row, RowProperties(height = Some(5.1)))
+      .withRowStyle(ref"A3".row, CellStyle.default.withFont(ruleFont))
+
+  private def writeRead(wb: Workbook, prefix: String): (Workbook, Path) =
+    val out = Files.createTempFile(prefix, ".xlsx")
+    XlsxWriter.write(wb, out).fold(e => fail(s"write failed: $e"), identity)
+    val reread = XlsxReader.read(out).fold(e => fail(s"read failed: $e"), identity)
+    (reread, out)
+
+  private val colStylePattern =
+    """<col min="2" max="2" width="20.0" style="(\d+)" customWidth="1"/>""".r
+  private val rowStylePattern =
+    """<row r="3" s="(\d+)" customFormat="1" ht="5.1" customHeight="1"/>""".r
+
+  private def assertStyledXml(xml: String): Unit =
+    val colMatch = colStylePattern.findFirstMatchIn(xml)
+    assert(colMatch.isDefined, s"<col> must carry style= between width and customWidth: $xml")
+    assert(colMatch.exists(_.group(1).toInt > 0), "col style index must be a real xf, not 0")
+    val rowMatch = rowStylePattern.findFirstMatchIn(xml)
+    assert(rowMatch.isDefined, s"<row r=3> must carry s= + customFormat before ht: $xml")
+    assert(rowMatch.exists(_.group(1).toInt > 0), "row style index must be a real xf, not 0")
+
+  private def assertModelStyles(reread: Workbook): Unit =
+    val sheet = reread("Sheet1").fold(e => fail(s"sheet missing: $e"), identity)
+    val colFont = sheet
+      .getColumnProperties(ref"B1".col)
+      .styleId
+      .flatMap(sheet.styleRegistry.get)
+      .map(_.font)
+    assertEquals(colFont, Some(bodyFont), "column style must resolve through the registry")
+    val rowProps = sheet.getRowProperties(ref"A3".row)
+    assertEquals(rowProps.height, Some(5.1))
+    val rowFont = rowProps.styleId.flatMap(sheet.styleRegistry.get).map(_.font)
+    assertEquals(rowFont, Some(ruleFont), "row style must resolve through the registry")
+
+  test("GH-445: col style= and row s= emit and round-trip (streaming writer path)") {
+    val (reread, out) = writeRead(Workbook(styledSheet), "colrow-sax")
+    assertStyledXml(zipEntryString(out, "xl/worksheets/sheet1.xml"))
+    assertModelStyles(reread)
+    Files.deleteIfExists(out)
+  }
+
+  test("GH-445: col style= and row s= emit identically on the DOM writer path") {
+    // A data validation forces XlsxWriter off the streaming path onto the DOM writer
+    val sheet = styledSheet.withDataValidation(ref"D1:D3", DataValidation.listOf("Yes", "No"))
+    val (reread, out) = writeRead(Workbook(sheet), "colrow-dom")
+    assertStyledXml(zipEntryString(out, "xl/worksheets/sheet1.xml"))
+    assertModelStyles(reread)
+    Files.deleteIfExists(out)
+  }
+
+  test("GH-445: read → edit cell → write keeps col/row styles (no silent regeneration drop)") {
+    val src = Files.createTempFile("colrow-src", ".xlsx")
+    XlsxWriter.write(Workbook(styledSheet), src).fold(e => fail(s"seed write failed: $e"), identity)
+
+    val edited = for
+      wb <- XlsxReader.read(src)
+      sheet <- wb("Sheet1")
+    yield wb.put(sheet.put(ref"C1" -> 3))
+    val wb1 = edited.fold(e => fail(s"edit failed: $e"), identity)
+
+    val out = Files.createTempFile("colrow-out", ".xlsx")
+    XlsxWriter.write(wb1, out).fold(e => fail(s"write failed: $e"), identity)
+    assertStyledXml(zipEntryString(out, "xl/worksheets/sheet1.xml"))
+
+    val reread = XlsxReader.read(out).fold(e => fail(s"reread failed: $e"), identity)
+    assertModelStyles(reread)
+    Files.deleteIfExists(src)
+    Files.deleteIfExists(out)
+  }
+
+  test("GH-445: withColumnStyle preserves existing column properties (width survives)") {
+    val sheet = styledSheet
+    val props = sheet.getColumnProperties(ref"B1".col)
+    assertEquals(props.width, Some(20.0))
+    assert(props.styleId.isDefined, "styleId must be set alongside the width")
+  }
+
+  test("GH-445: two columns sharing one style deduplicate to the same xf index") {
+    val style = CellStyle.default.withFont(bodyFont)
+    val sheet = Sheet("Sheet1")
+      .put(ref"A1" -> 1)
+      .withColumnStyle(ref"B1".col, style)
+      .withColumnStyle(ref"C1".col, style)
+    val out = Files.createTempFile("colrow-dedupe", ".xlsx")
+    XlsxWriter.write(Workbook(sheet), out).fold(e => fail(s"write failed: $e"), identity)
+    val xml = zipEntryString(out, "xl/worksheets/sheet1.xml")
+    // Identical props on adjacent columns coalesce into ONE span with one style index
+    val span = """<col min="2" max="3" style="(\d+)"/>""".r.findFirstMatchIn(xml)
+    assert(span.isDefined, s"adjacent same-style columns must coalesce into one span: $xml")
+    Files.deleteIfExists(out)
+  }

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/OoxmlStylesSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/OoxmlStylesSpec.scala
@@ -62,22 +62,13 @@ class OoxmlStylesSpec extends FunSuite:
     val count = (fillsElem \ "@count").text.toInt
     assert(count >= 2, "Should have at least 2 fills (default fills)")
 
-    // Verify gray125 pattern has foreground and background colors
+    // GH-448: the mandatory gray125 placeholder is written BARE, exactly as Excel writes it
     val fills = xml \ "fills" \ "fill"
     val gray125Fill = fills(1)
     val patternFill = gray125Fill \ "patternFill"
-
-    // Check foreground color
-    val fgColor = patternFill \ "fgColor"
-    assert(fgColor.nonEmpty, "gray125 pattern should have fgColor")
-    val fgRgb = (fgColor \ "@rgb").text
-    assert(fgRgb.nonEmpty, "fgColor should have rgb attribute")
-
-    // Check background color
-    val bgColor = patternFill \ "bgColor"
-    assert(bgColor.nonEmpty, "gray125 pattern should have bgColor")
-    val bgRgb = (bgColor \ "@rgb").text
-    assert(bgRgb.nonEmpty, "bgColor should have rgb attribute")
+    assertEquals((patternFill \ "@patternType").text, "gray125")
+    assert((patternFill \ "fgColor").isEmpty, "bare gray125 must not carry fgColor (GH-448)")
+    assert((patternFill \ "bgColor").isEmpty, "bare gray125 must not carry bgColor (GH-448)")
 
     // Verify pattern type is gray125
     val patternType = (patternFill \ "@patternType").text
@@ -363,7 +354,7 @@ class OoxmlStylesSpec extends FunSuite:
     // Font slot 0 IS the house font (the xfId-0 cellStyleXf hardcodes fontId=0)
     val font0 = (parsed \ "fonts" \ "font").headOption.getOrElse(fail(s"no fonts: $stylesXml"))
     assertEquals((font0 \ "name" \ "@val").text, "Times New Roman", stylesXml)
-    assertEquals((font0 \ "sz" \ "@val").text, "10.0", stylesXml)
+    assertEquals((font0 \ "sz" \ "@val").text, "10", stylesXml) // GH-448: integral sz
     // Normal master record references it
     val styleXf0 = (parsed \ "cellStyleXfs" \ "xf").headOption
       .getOrElse(fail(s"no cellStyleXfs: $stylesXml"))

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/SheetFormatPrRoundTripSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/SheetFormatPrRoundTripSpec.scala
@@ -136,8 +136,12 @@ class SheetFormatPrRoundTripSpec extends FunSuite:
       .fold(e => fail(s"write failed: $e"), identity)
     val xml = zipEntryString(out, "xl/worksheets/sheet1.xml")
     assert(xml.contains("baseColWidth=\"8\""), s"unmodeled attr lost on rewrite: $xml")
-    assert(xml.contains("outlineLevelRow=\"2\""), s"unmodeled attr lost on rewrite: $xml")
-    assert(xml.contains("outlineLevelCol=\"1\""), s"unmodeled attr lost on rewrite: $xml")
+    // GH-448: outlineLevelRow/Col graduated from preserved to MODELED — they now derive from
+    // row/col outline properties (the zoomScale graduation precedent). This fixture carries the
+    // summary attrs with NO outlined rows/cols behind them, so the recomputed (consistent) form
+    // drops them; books with real outlined rows keep them (CanonicalXmlSpec, GroupingCommandSpec).
+    assert(!xml.contains("outlineLevelRow="), s"inconsistent summary attr must not survive: $xml")
+    assert(!xml.contains("outlineLevelCol="), s"inconsistent summary attr must not survive: $xml")
     assert(xml.contains("defaultColWidth=\"9.140625\""), s"source width lost on rewrite: $xml")
     assert(xml.contains("defaultRowHeight=\"12.75\""), s"source height lost on rewrite: $xml")
     // Identity fast-path: values unchanged since read → no gratuitous customHeight flag

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/SheetViewRoundTripSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/SheetViewRoundTripSpec.scala
@@ -331,6 +331,84 @@ class SheetViewRoundTripSpec extends FunSuite:
     Files.deleteIfExists(out)
   }
 
+  // ===== GH-446: view mode, per-mode zooms, scroll position =====
+
+  test("GH-446: view mode + zoom variants + topLeftCell round-trip (write → read → equality)") {
+    val view = SheetView(
+      showGridLines = false,
+      zoomScale = Some(60),
+      view = Some("pageBreakPreview"),
+      zoomScaleNormal = Some(70),
+      zoomScaleSheetLayoutView = Some(85),
+      topLeftCell = Some(ref"A14")
+    )
+    val wb = Workbook(Sheet("Sheet1").put(ref"A1" -> 1).withViewSettings(view))
+    val (reread, out) = writeRead(wb)
+
+    val sheet = reread("Sheet1").fold(e => fail(s"sheet missing: $e"), identity)
+    assertEquals(sheet.viewSettings, Some(view))
+
+    val xml = zipEntryString(out, "xl/worksheets/sheet1.xml")
+    assert(xml.contains("view=\"pageBreakPreview\""), s"view attr missing: $xml")
+    assert(xml.contains("zoomScale=\"60\""), s"zoomScale attr missing: $xml")
+    assert(xml.contains("zoomScaleNormal=\"70\""), s"zoomScaleNormal attr missing: $xml")
+    assert(
+      xml.contains("zoomScaleSheetLayoutView=\"85\""),
+      s"zoomScaleSheetLayoutView attr missing: $xml"
+    )
+    assert(xml.contains("topLeftCell=\"A14\""), s"topLeftCell attr missing: $xml")
+    Files.deleteIfExists(out)
+  }
+
+  test("GH-446: parseSheetView fires when ONLY view= is present") {
+    val src = rawWorksheetFixture(
+      """<sheetViews><sheetView view="pageBreakPreview" workbookViewId="0"/></sheetViews>"""
+    )
+    val wb = XlsxReader.read(src).fold(e => fail(s"read failed: $e"), identity)
+    val sheet = wb("Sheet1").fold(e => fail(s"sheet missing: $e"), identity)
+    assertEquals(sheet.viewSettings, Some(SheetView(view = Some("pageBreakPreview"))))
+    Files.deleteIfExists(src)
+  }
+
+  test("GH-446: an unknown foreign view value stays unmodeled (rides preservation)") {
+    val src = rawWorksheetFixture(
+      """<sheetViews><sheetView view="weirdMode" workbookViewId="0"/></sheetViews>"""
+    )
+    val wb = XlsxReader.read(src).fold(e => fail(s"read failed: $e"), identity)
+    val sheet = wb("Sheet1").fold(e => fail(s"sheet missing: $e"), identity)
+    assertEquals(sheet.viewSettings, None, "unknown view modes are outside the modeled subset")
+    Files.deleteIfExists(src)
+  }
+
+  test("GH-446: illegal view mode is rejected at construction") {
+    intercept[IllegalArgumentException](SheetView(view = Some("bogus")))
+    intercept[IllegalArgumentException](SheetView(zoomScaleNormal = Some(5)))
+    intercept[IllegalArgumentException](SheetView(zoomScaleSheetLayoutView = Some(500)))
+  }
+
+  test("GH-446: view mode + freeze pane share ONE sheetView (pane keeps its own topLeftCell)") {
+    val view = SheetView(
+      showGridLines = false,
+      view = Some("pageBreakPreview"),
+      zoomScaleSheetLayoutView = Some(60)
+    )
+    val wb = Workbook(
+      Sheet("Sheet1").put(ref"A1" -> "H", ref"A2" -> 1).freezeAt(ref"G13").withViewSettings(view)
+    )
+    val (reread, out) = writeRead(wb)
+    val sheet = reread("Sheet1").fold(e => fail(s"sheet missing: $e"), identity)
+    assertEquals(sheet.viewSettings, Some(view))
+
+    val xml = zipEntryString(out, "xl/worksheets/sheet1.xml")
+    val sheetViewCount = xml.sliding("<sheetView ".length).count(_ == "<sheetView ")
+    assertEquals(sheetViewCount, 1, s"expected one sheetView element: $xml")
+    assert(xml.contains("view=\"pageBreakPreview\""), s"view attr missing: $xml")
+    assert(xml.contains("xSplit=\"6\""), s"freeze xSplit missing: $xml")
+    assert(xml.contains("ySplit=\"12\""), s"freeze ySplit missing: $xml")
+    assert(xml.contains("topLeftCell=\"G13\""), s"pane topLeftCell missing: $xml")
+    Files.deleteIfExists(out)
+  }
+
   // ========== helpers ==========
 
   private def writeEntry(out: ZipOutputStream, name: String, content: String): Unit =


### PR DESCRIPTION
Closes #445, closes #446.

## What

**#445 — `<col style=>` / `<row s=>` emission.** `ColumnProperties.styleId` and `RowProperties.styleId` existed in the model but the writer deferred them. Now:
- Emitted on both writer backends (DOM `WorksheetHelpers.buildColsElement` + `DirectSaxEmitter.emitCols`/`emitRow`), remapped through `StyleIndex` exactly like cell styleIds via a shared `remappedStyleAttr` helper; index 0 omitted, matching the cell path. Attribute order matches Excel's writer (`min, max, width, style, customWidth, …`; `r, s, customFormat, ht, …`).
- **Reader now parses them back** (through the same global→local `styleMapping` as cells). Without this, any read→modify→write regenerated `<cols>` from reader-populated `ColumnProperties` and silently dropped the source's column styles — the new spec pins that regression.
- `applyDomainRowProps` overlays the row style when defined and leaves a preserved `s=` untouched when `None` (the GH-372 `tabSelected` three-valued precedent).
- Ergonomics: `Sheet.withColumnStyle(col, style)` / `Sheet.withRowStyle(row, style)` intern into the sheet's `StyleRegistry` and merge with existing col/row properties.

This is the mechanism real workbooks use to make a body font the sheet default without touching the Normal style (every `<col>` carries `style=`).

**#446 — `SheetView` view mode + zoom variants.** `view` (`normal | pageBreakPreview | pageLayout`, validated), `zoomScaleNormal`, `zoomScaleSheetLayoutView` (10–400 validated), and `topLeftCell` are now authorable: set-or-remove on write (the `zoomScale` precedent), parsed back by `parseSheetView`, and unknown foreign `view` values stay unmodeled and ride preservation.

## Tests

- New `ColRowStyleAuthoringSpec`: emission + model round-trip on **both** writer paths (a data validation forces the DOM writer), the read→edit→write preservation regression, props merging, and same-style span coalescing.
- `SheetViewRoundTripSpec` +5: full GH-446 round-trip, only-`view=` foreign parse, unknown-mode passthrough, constructor validation, one-`sheetView`-element invariant with freeze panes.
- Full suite green locally (`./mill __.test`, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Round 2 (4836a6ce): closes #448 + a cross-backend theme-index bug.** Excel-canonical XML forms — integral `sz` (no decimal), tints in Excel's ≤17-significant-digit plain form with `tint="0"` omitted, bare gray125 placeholder, and `sheetFormatPr` outline summary attrs derived from row/col outline levels (set-or-remove; the fixture pinning inconsistent summary attrs was updated — they graduated from preserved to modeled, the zoomScale precedent). Also fixes `DirectSaxEmitter`/`Comments` serializing theme colors via `slot.ordinal`, which swapped the dark/light pairs (a Dark2 tab written through the SAX path came out Light2). New `CanonicalXmlSpec` (6 cases); full suite green.

Closes #448.