### PR TITLE
chore(release): Bump version to 0.18.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.1] "Canon" - 2026-08-03
+
+Authoring epilogue (wave 21 patch): the col/row default-style house
+mechanism becomes authorable and readable, sheet view modes land, and
+the writer's XML forms become byte-canonical with Excel's own.
+
+### Added
+
+- **Column/row default styles** (#445): `ColumnProperties.styleId` /
+  `RowProperties.styleId` now emit on BOTH writer backends
+  (`<col style=>`, `<row s= customFormat="1">`), remapped through
+  StyleIndex exactly like cell styleIds — and the reader parses them
+  back, so read→modify→write no longer silently drops a source's
+  column styles. New `Sheet.withColumnStyle` / `Sheet.withRowStyle`
+  intern into the StyleRegistry and merge with existing col/row
+  properties. This is the mechanism professional workbooks use for a
+  sheet-wide body font without touching the Normal style.
+- **Sheet view modes + zoom variants** (#446): `SheetView.view`
+  (`normal | pageBreakPreview | pageLayout`, validated),
+  `zoomScaleNormal`, `zoomScaleSheetLayoutView`, and `topLeftCell` are
+  authorable (set-or-remove on write, the zoomScale precedent), parsed
+  back, and unknown foreign view values ride preservation. Finance
+  books conventionally ship in page-break preview so the print extent
+  is visible while editing.
+
+### Changed
+
+- **Excel-canonical XML forms** (#448): integral `sz` without a
+  decimal point (`sz="10"`), theme tints in Excel's
+  ≤17-significant-digit plain form with `tint="0"` omitted entirely,
+  the mandatory gray125 placeholder fill written bare, and
+  `sheetFormatPr` outline summary attributes (`outlineLevelRow/Col`)
+  derived from actual row/col outline levels (graduated from preserved
+  to modeled, the zoomScale precedent).
+
+### Fixed
+
+- **Theme-index swap on the SAX path** (#448): `DirectSaxEmitter` and
+  `Comments` serialized theme colors via `slot.ordinal`, which swaps
+  the dark/light pairs relative to OOXML theme indices — a Dark2 tab
+  written through the streaming path came out Light2. Both paths now
+  go through `themeSlotToIndex`.
+
 ## [0.18.0] "Quill" - 2026-07-29
 
 Authoring wave (wave 21, burn-down finale): the house sensitivity engine
@@ -184,7 +227,7 @@ what Excel refuses.
   writer backends, with structural edits shifting record payload geometry.
   Display renders a derived `TABLE(r1, r2)` text; evaluator treats
   uncached data-table cells as totals-safe. Follow-ups filed as #435.
-- **Bytes-based reads preserve like path reads** (#412): 
+- **Bytes-based reads preserve like path reads** (#412):
   `XlsxReader.readFromBytes` constructed no `SourceContext`, so
   read-bytes→write dropped every preserved-but-unmodeled workbook child
   (`externalReferences`, `workbookProtection`, `pivotCaches`, …) and

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ```scala 3 raw
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.18.0
+//> using dep com.tjclp::xl:0.18.1
 
 import com.tjclp.xl.{*, given}
 
@@ -55,13 +55,13 @@ import com.tjclp.xl.{*, given}
 
 ```scala 3 ignore
 // build.mill — single dependency for everything
-def ivyDeps = Agg(ivy"com.tjclp::xl:0.18.0")
+def ivyDeps = Agg(ivy"com.tjclp::xl:0.18.1")
 
 // Or individual modules for minimal footprint:
-// ivy"com.tjclp::xl-core:0.18.0"        — Pure domain model only
-// ivy"com.tjclp::xl-ooxml:0.18.0"       — Add OOXML read/write
-// ivy"com.tjclp::xl-cats-effect:0.18.0" — Add IO streaming
-// ivy"com.tjclp::xl-evaluator:0.18.0"   — Add formula evaluation
+// ivy"com.tjclp::xl-core:0.18.1"        — Pure domain model only
+// ivy"com.tjclp::xl-ooxml:0.18.1"       — Add OOXML read/write
+// ivy"com.tjclp::xl-cats-effect:0.18.1" — Add IO streaming
+// ivy"com.tjclp::xl-evaluator:0.18.1"   — Add formula evaluation
 ```
 
 ### Basic Usage

--- a/build.mill
+++ b/build.mill
@@ -14,7 +14,7 @@ val organization = "com.tjclp"
 /** Shared build configuration constants */
 object BuildConfig {
   /** Project version: CI sets PUBLISH_VERSION; local builds use this fallback */
-  val version: String = sys.env.getOrElse("PUBLISH_VERSION", "0.18.0")
+  val version: String = sys.env.getOrElse("PUBLISH_VERSION", "0.18.1")
 
   /** JVM options to silence Scala 3 LazyVals sun.misc.Unsafe deprecation warnings (JDK 21+) */
   val lazyValsJvmArgs: Seq[String] = Seq(

--- a/docs/QUICK-START.md
+++ b/docs/QUICK-START.md
@@ -12,19 +12,19 @@ import mill._, scalalib._
 
 object myproject extends ScalaModule {
   def scalaVersion = "3.8.3"
-  def ivyDeps = Agg(ivy"com.tjclp::xl:0.18.0")
+  def ivyDeps = Agg(ivy"com.tjclp::xl:0.18.1")
 }
 ```
 
 ### With sbt (build.sbt)
 ```scala
 scalaVersion := "3.8.3"
-libraryDependencies += "com.tjclp" %% "xl" % "0.18.0"
+libraryDependencies += "com.tjclp" %% "xl" % "0.18.1"
 ```
 
 ### With Scala CLI
 ```scala
-//> using dep com.tjclp::xl:0.18.0
+//> using dep com.tjclp::xl:0.18.1
 ```
 
 ### Individual Modules (Optional)
@@ -44,7 +44,7 @@ For scripts, skip the build setup entirely: a two-line `scala-cli` header and ON
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.18.0
+//> using dep com.tjclp::xl:0.18.1
 
 import com.tjclp.xl.scripting.{*, given}
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,12 +1,17 @@
 # XL Project Status
 
-**Last Updated**: 2026-07-29 (0.18.0)
+**Last Updated**: 2026-08-03 (0.18.1)
 
 ## Current State
 
 > **For detailed phase completion status and roadmap, see [plan/roadmap.md](plan/roadmap.md)**
 
 ### What Works (Production-Ready)
+
+**New in 0.18.1** (2026-08-03):
+- ✅ **Column/row default styles** (#445) — `<col style=>` / `<row s= customFormat="1">` emit on both writer backends (StyleIndex-remapped like cell styleIds) AND parse back, so read→modify→write keeps source column styles; `Sheet.withColumnStyle`/`withRowStyle` author the sheet-wide-body-font-without-Normal mechanism
+- ✅ **Sheet view modes** (#446) — `SheetView.view` (normal/pageBreakPreview/pageLayout) + `zoomScaleNormal`/`zoomScaleSheetLayoutView`/`topLeftCell`, set-or-remove with foreign values riding preservation
+- ✅ **Excel-canonical XML forms** (#448) — integral `sz`, 17-sig-digit plain tints (`tint="0"` omitted), bare gray125, derived `outlineLevelRow/Col` summary attrs; **theme-index swap fixed** — SAX path + comments wrote Dark2 as Light2 via `slot.ordinal`
 
 **New in 0.18.0** (2026-07-29):
 - ✅ **Two-variable Data Table authoring** (#419) — `sheet.dataTable(range, rowInput, colInput)` authors native `<f t="dataTable">` records with autoNoTable-safe cache seeding (design-panel-verified against Excel fixtures); the house sensitivity engine is authorable

--- a/docs/plan/roadmap.md
+++ b/docs/plan/roadmap.md
@@ -12,7 +12,7 @@
 
 **Current Status**: Production-ready with **109 formula functions** (incl. dynamic arrays SEQUENCE/SORT/UNIQUE/FILTER and OFFSET), **structural editing** (insert/delete rows & columns with formula rewriting), the **scripting prelude** (`com.tjclp.xl.scripting`), whole-workbook `recalculate`, named-range & hyperlink authoring, **typed charts + embedded pictures** (0.12.0), **conditional formatting** (0.12.1), SAX streaming (36% faster than POI), Excel tables, and full OOXML round-trip. 5,047 tests passing.
 
-**Current Version**: **0.18.0 "Quill"** (released 2026-07-29)
+**Current Version**: **0.18.1 "Canon"** (released 2026-08-03)
 
 ---
 
@@ -60,6 +60,10 @@ Phased: (a) verbatim chart/drawing preservation proven by the wave-2 fixture cor
 ### v0.12.1 "Clean Sweep" — wave 7 (Released 2026-06-11)
 
 Every remaining open issue closed in one wave. **Conditional formatting** ([#136](https://github.com/TJC-LP/xl/issues/136)) is the headline — typed cellIs/expression/colorScale/dataBar/top10/text rules + `dxf` differential formats, `sheet.conditionalFormat` authoring with auto-priority, structural-edit range shifting, unmodeled families preserved byte-faithfully — alongside twelve fidelity/writer fixes: openpyxl comment subdirectory dialect (#292), RichText SST keying (#303), exact surgical SST counts (#304), `[Content_Types]` preservation (#314), identity-keyed source mappings (#315), activeTab (#294), fitToPage tri-state (#284), `Cell.comment` deprecated→`Sheet.comments` (#295). Codec `put` paths 2.4x faster (#297).
+
+### v0.18.1 "Canon" — wave 21 epilogue (Released 2026-08-03)
+
+Patch release (PR #447): **col/row default styles** ([#445](https://github.com/TJC-LP/xl/issues/445) — `<col style=>`/`<row s=>` emission on both backends + read-back, `Sheet.withColumnStyle`/`withRowStyle`), **sheet view modes** ([#446](https://github.com/TJC-LP/xl/issues/446) — `view`/`zoomScaleNormal`/`zoomScaleSheetLayoutView`/`topLeftCell`), **Excel-canonical XML forms** ([#448](https://github.com/TJC-LP/xl/issues/448) — integral `sz`, plain-form tints, bare gray125, derived outline summary attrs) + the cross-backend `slot.ordinal` theme-index swap fix (Dark2-as-Light2 on the SAX path).
 
 ### v0.18.0 "Quill" — wave 21 (Released 2026-07-29)
 

--- a/docs/reference/scripting.md
+++ b/docs/reference/scripting.md
@@ -33,7 +33,7 @@ release bump is a mechanical substitution):
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.18.0
+//> using dep com.tjclp::xl:0.18.1
 import com.tjclp.xl.scripting.{*, given}
 
 val sheet = Sheet("Demo").put(ref"A1", "Hello").put(ref"B1", 42)
@@ -51,7 +51,7 @@ read and write is pure values.
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.18.0
+//> using dep com.tjclp::xl:0.18.1
 import com.tjclp.xl.scripting.{*, given}
 
 val wb = Excel.read("input.xlsx")
@@ -130,7 +130,7 @@ intended instead of surprising the chain:
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.18.0
+//> using dep com.tjclp::xl:0.18.1
 import com.tjclp.xl.scripting.{*, given}
 
 val region = Seq("North", "East").mkString(" ")                     // runtime name
@@ -196,7 +196,7 @@ throw — they are collected per cell.
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.18.0
+//> using dep com.tjclp::xl:0.18.1
 import com.tjclp.xl.scripting.{*, given}
 
 val title = CellStyle.default.bold.size(14.0).center
@@ -328,7 +328,7 @@ them explicitly:
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.18.0
+//> using dep com.tjclp::xl:0.18.1
 import com.tjclp.xl.scripting.{*, given}
 import com.tjclp.xl.sheets.{HeaderFooter, PageMargins, PageSetup, SheetView}
 
@@ -382,7 +382,7 @@ the whole workbook:
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.18.0
+//> using dep com.tjclp::xl:0.18.1
 import com.tjclp.xl.scripting.{*, given}
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global

--- a/examples/README.md
+++ b/examples/README.md
@@ -170,7 +170,7 @@ chmod +x examples/my_example.sc
 ./examples/my_example.sc
 ```
 
-The `project.scala` file centralizes dependencies (`com.tjclp::xl:0.18.0`) for all examples.
+The `project.scala` file centralizes dependencies (`com.tjclp::xl:0.18.1`) for all examples.
 
 ## Scripting Prelude & Skill
 

--- a/examples/project.scala
+++ b/examples/project.scala
@@ -2,4 +2,4 @@
 //> using repository ivy2Local
 
 // XL aggregate - includes all modules (core, ooxml, cats-effect, evaluator)
-//> using dep com.tjclp::xl:0.18.0
+//> using dep com.tjclp::xl:0.18.1

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "xl",
   "description": "LLM-friendly Excel tooling: the xl CLI for reading, writing, styling, and analyzing spreadsheets (xl-cli skill), plus type-safe Scala scripting against the xl library via scala-cli for bulk transformations, pipelines, and formula models (xl-scripting skill).",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "author": {
     "name": "TJC L.P.",
     "url": "https://github.com/TJC-LP"

--- a/plugin/skills/xl-scripting/SKILL.md
+++ b/plugin/skills/xl-scripting/SKILL.md
@@ -38,7 +38,7 @@ The canonical header for every script (this is the single source of truth — re
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.18.0
+//> using dep com.tjclp::xl:0.18.1
 
 import com.tjclp.xl.scripting.{*, given}
 
@@ -104,7 +104,7 @@ wb.update("Sales", f).unsafe                       // throws structured XLExcept
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.18.0
+//> using dep com.tjclp::xl:0.18.1
 import com.tjclp.xl.scripting.{*, given}
 
 val wb = Excel.read("input.xlsx")
@@ -236,7 +236,7 @@ Native Excel `TABLE()` two-variable data tables (0.18.0) — the house sensitivi
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.18.0
+//> using dep com.tjclp::xl:0.18.1
 import com.tjclp.xl.scripting.{*, given}
 
 val model = Sheet("Sensitivity")
@@ -282,7 +282,7 @@ Or lean on totality so there is nothing to unwrap: literal refs, `upsert`, range
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.18.0
+//> using dep com.tjclp::xl:0.18.1
 import com.tjclp.xl.scripting.{*, given}
 import java.nio.file.{Files, Paths}
 import scala.jdk.CollectionConverters.*
@@ -304,7 +304,7 @@ println(s"merged ${inputs.size} files, ${merged.sheets.size} sheets")
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.18.0
+//> using dep com.tjclp::xl:0.18.1
 import com.tjclp.xl.scripting.{*, given}
 
 val data = List(("North", 125000.50), ("South", 98000.25), ("West", 143500.00))
@@ -332,7 +332,7 @@ println(if result.isClean then "✓ report written" else result.errors.map(_.ren
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.18.0
+//> using dep com.tjclp::xl:0.18.1
 import com.tjclp.xl.scripting.{*, given}
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global

--- a/plugin/skills/xl-scripting/reference/RECIPES.md
+++ b/plugin/skills/xl-scripting/reference/RECIPES.md
@@ -10,7 +10,7 @@ Apply a 5% price increase to column C of every workbook in a directory, in place
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.18.0
+//> using dep com.tjclp::xl:0.18.1
 import com.tjclp.xl.scripting.{*, given}
 import java.nio.file.{Files, Paths}
 import scala.jdk.CollectionConverters.*
@@ -42,7 +42,7 @@ Read rows into case classes; collect per-cell validation failures into a new Iss
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.18.0
+//> using dep com.tjclp::xl:0.18.1
 import com.tjclp.xl.scripting.{*, given}
 
 final case class Order(id: Int, customer: String, amount: BigDecimal)
@@ -76,7 +76,7 @@ Three-year projection with growth formulas; fail the script if any formula error
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.18.0
+//> using dep com.tjclp::xl:0.18.1
 import com.tjclp.xl.scripting.{*, given}
 
 val header = CellStyle.default.bold.size(12.0).center
@@ -111,7 +111,7 @@ Stack the data rows of every input file under one header.
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.18.0
+//> using dep com.tjclp::xl:0.18.1
 import com.tjclp.xl.scripting.{*, given}
 import java.nio.file.{Files, Paths}
 import scala.jdk.CollectionConverters.*
@@ -147,7 +147,7 @@ println(s"combined ${files.size} files, ${combined.cells.size} cells")
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.18.0
+//> using dep com.tjclp::xl:0.18.1
 import com.tjclp.xl.scripting.{*, given}
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
@@ -176,7 +176,7 @@ println("✓ filtered (constant memory)")
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.18.0
+//> using dep com.tjclp::xl:0.18.1
 import com.tjclp.xl.scripting.{*, given}
 
 val before = Excel.read("before.xlsx")
@@ -204,7 +204,7 @@ else
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.18.0
+//> using dep com.tjclp::xl:0.18.1
 import com.tjclp.xl.scripting.{*, given}
 import java.nio.file.{Files, Paths}
 import scala.jdk.CollectionConverters.*
@@ -232,7 +232,7 @@ cell ships a cached value for `data_only` readers, pandas, and Excel-before-reca
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.18.0
+//> using dep com.tjclp::xl:0.18.1
 import com.tjclp.xl.scripting.{*, given}
 
 val reps = List(("Alice", 120000.0), ("Bob", 98000.0), ("Carol", 143500.0))
@@ -267,7 +267,7 @@ frozen header, a list-dropdown data validation, and a provenance comment — no 
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.18.0
+//> using dep com.tjclp::xl:0.18.1
 import com.tjclp.xl.scripting.{*, given}
 import com.tjclp.xl.sheets.SheetView // SheetView lives one import deeper than the prelude
 

--- a/xl-core/src/com/tjclp/xl/workbooks/WorkbookMetadata.scala
+++ b/xl-core/src/com/tjclp/xl/workbooks/WorkbookMetadata.scala
@@ -35,7 +35,7 @@ final case class WorkbookMetadata(
   modified: Option[java.time.LocalDateTime] = None,
   lastModifiedBy: Option[String] = None,
   application: Option[String] = Some("XL - Pure Scala 3.8 Excel Library"),
-  appVersion: Option[String] = Some("0.18.0"),
+  appVersion: Option[String] = Some("0.18.1"),
   theme: ThemePalette = ThemePalette.office,
   definedNames: Vector[DefinedName] = Vector.empty,
   sheetStates: Map[SheetName, Option[String]] = Map.empty,

--- a/xl/src/com/tjclp/xl/scripting.scala
+++ b/xl/src/com/tjclp/xl/scripting.scala
@@ -4,7 +4,7 @@ package com.tjclp.xl
  * Scripting prelude: everything a script needs in one import.
  *
  * {{{
- * //> using dep com.tjclp::xl:0.18.0
+ * //> using dep com.tjclp::xl:0.18.1
  * import com.tjclp.xl.scripting.{*, given}
  *
  * val wb = Excel.read("input.xlsx")


### PR DESCRIPTION
Version bump for the **0.18.1 "Canon"** patch release (wave-21 epilogue, PR #447): col/row default styles (#445), sheet view modes (#446), Excel-canonical XML forms + theme-index swap fix (#448).

Same file set as the 0.18.0 bump (#444): dep strings, build.mill default, plugin.json, WorkbookMetadata.appVersion, CHANGELOG/STATUS/roadmap sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)