### PR TITLE
Wave 23: field-QC burn-down — CalcPr-honoring seeder, convergence signal, printer parens, JAXP limits, <f> canon, lint FP, -i message

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,6 +119,49 @@ jobs:
             exit 1
           fi
 
+      # GH-457: name-bloated workbooks (tens of thousands of definedNames, multi-MB single-line
+      # workbook.xml) must read on the native image. Its baked-in JAXP defaults
+      # (jdk.xml.maxGeneralEntitySizeLimit=100000) rejected the workbook.xml document entity with
+      # JAXP00010003 on every verb, and -Djdk.xml.* flags cannot reach the binary — the factory
+      # now lifts the entity-size limits per parser, which this gate proves end-to-end.
+      - name: Smoke test native binary on name-bloated workbook (GH-457)
+        shell: bash
+        run: |
+          BIN="out/xl-cli/nativeImage.dest/native-executable${{ matrix.extension }}"
+          PY=$(command -v python3 || command -v python)
+          "$PY" - <<'EOF'
+          import zipfile
+
+          src = 'xl-ooxml/test/resources/fixtures/small-values.xlsx'
+          dst = 'name-bloated.xlsx'
+          names = ''.join(
+              f'<definedName name="n{i}">Sheet1!$A${(i % 100) + 1}</definedName>'
+              for i in range(120000)
+          )
+          with zipfile.ZipFile(src) as zin, \
+                  zipfile.ZipFile(dst, 'w', zipfile.ZIP_DEFLATED) as zout:
+              for item in zin.infolist():
+                  data = zin.read(item.filename)
+                  if item.filename == 'xl/workbook.xml':
+                      text = data.decode('utf-8')
+                      data = text.replace(
+                          '</workbook>',
+                          f'<definedNames>{names}</definedNames></workbook>'
+                      ).encode('utf-8')
+                  zout.writestr(item, data)
+          EOF
+
+          set +e
+          OUTPUT=$("$BIN" -f name-bloated.xlsx sheets 2>&1)
+          STATUS=$?
+          set -e
+          echo "$OUTPUT"
+          if [ "$STATUS" -ne 0 ] || echo "$OUTPUT" | grep -q "JAXP000"; then
+            echo "::error::native binary cannot read a name-bloated workbook (GH-457)"
+            exit 1
+          fi
+          rm -f name-bloated.xlsx
+
       - name: Rename binary (Unix)
         if: runner.os != 'Windows'
         run: mv out/xl-cli/nativeImage.dest/native-executable xl-${{ steps.version.outputs.version }}-${{ matrix.platform }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,11 +156,13 @@ jobs:
           STATUS=$?
           set -e
           echo "$OUTPUT"
+          # Clean up BEFORE gating: the multi-MB fixture must never linger in the workspace for
+          # the later rename/upload steps, whichever way the gate goes.
+          rm -f name-bloated.xlsx
           if [ "$STATUS" -ne 0 ] || echo "$OUTPUT" | grep -q "JAXP000"; then
             echo "::error::native binary cannot read a name-bloated workbook (GH-457)"
             exit 1
           fi
-          rm -f name-bloated.xlsx
 
       - name: Rename binary (Unix)
         if: runner.os != 'Windows'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,10 @@ and corruption bug the TJC field QC surfaced on real banker books.
   recalculation finally distinguishes convergence from `maxIter`
   exhaustion — `iterateCycles` computed both and threw them away.
   Defaults (`converged = true`, `iterationsUsed = 0`) keep every
-  existing construction site and consumer source-compatible. The CLI
+  existing construction site and consumer source-compatible (note:
+  adding case-class fields changes `apply`/`unapply`/`copy` signatures,
+  so this is binary-incompatible for `xl-evaluator` consumers compiled
+  against 0.19.0). The CLI
   recalc summary renders them: `; converged in N iterative round(s)`
   or `; WARNING: iterative calculation exhausted N round(s) without
   converging (last values kept)`.
@@ -38,10 +41,15 @@ and corruption bug the TJC field QC surfaced on real banker books.
   bit-identical fast path. `xl recalc` now auto-derives iteration from
   the file's declared calcPr (the CLI honors the file like Excel; the
   library `recalculate()` default stays opt-in), and `--tables` prints
-  the seed warnings.
+  the seed warnings. A `Skipped` warning surfaces interiors left
+  unseeded (axis/member evaluation failure, or the per-table iteration
+  budget that guards against hostile `iterateCount` declarations), and
+  one seeding run pins a single volatile generation — `NOW()`/`TODAY()`
+  cannot straddle values mid-table.
 - **`formula-leading-equals` lint** (#456): flags `<f>` text stored
   with a leading `=` (non-spec; openpyxl reads it back as `==…`) —
-  re-writing the file with xl heals it.
+  re-writing the file with xl heals it. One bounded finding per sheet
+  part (first 5 refs + total count), DOM/SAX finding-identical.
 
 ### Fixed
 
@@ -59,15 +67,19 @@ and corruption bug the TJC field QC surfaced on real banker books.
   comparisons now parse left-associatively (`(a=b)=c`, Excel parity).
   Belt-and-braces: structural edits no longer reprint formulas on
   sheets that neither are the edit target nor reference it — untouched
-  sheets ride byte-identical at the model level.
+  formula text rides byte-identical at the model level, while cached
+  values of formulas transitively dependent (cross-sheet, through any
+  chain) on the edited sheet are invalidated so no stale `<v>` can
+  ship.
 - **Native image could not open name-bloated real workbooks** (#457):
   legacy banker books carrying 37k–110k `definedName` entries (multi-MB
   single-line workbook.xml) tripped JAXP's 100KB
   `maxGeneralEntitySizeLimit` on every verb, and `-Djdk.xml.*` has no
   effect on the native binary. The shared `XmlSecurity` parser factory
-  now lifts the size limits on the parser itself (safe: doctype is
-  already disallowed, so entity-expansion attacks remain structurally
-  impossible), covering all SAX sites and `parseSafe`; the one drifted
+  now raises the size limits on the parser itself to a finite 2GB
+  fail-closed ceiling (safe: doctype is already disallowed, so
+  entity-expansion attacks remain structurally impossible), covering
+  all SAX sites and `parseSafe`; the one drifted
   inline factory in the CLI streaming path was collapsed onto it. The
   release workflow gained a native smoke gate that reads a
   120k-definedNames book.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,88 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Wave 23: the post-0.19.0 field-QC burn-down — every silent-wrong-number
+and corruption bug the TJC field QC surfaced on real banker books.
+
+### Added
+
+- **`RecalcResult.converged` + `iterationsUsed`** (#454): iterative
+  recalculation finally distinguishes convergence from `maxIter`
+  exhaustion — `iterateCycles` computed both and threw them away.
+  Defaults (`converged = true`, `iterationsUsed = 0`) keep every
+  existing construction site and consumer source-compatible. The CLI
+  recalc summary renders them: `; converged in N iterative round(s)`
+  or `; WARNING: iterative calculation exhausted N round(s) without
+  converging (last values kept)`.
+- **Data-table seeding honors CalcPr on circular books** (#453): the
+  seeder's per-axis what-if substitution previously pinned circular
+  precedents at their loaded caches, so every interior seeded the base
+  value — silently FLAT sensitivity grids. Now, when a table's corner
+  depends on the workbook's cyclic core: with `<calcPr iterate="1"/>`
+  declared (or an explicit `IterativeCalc`), each axis combination runs
+  a narrowed Jacobi fixpoint over just the relevant cycle members
+  (what-if input cells stay pinned to their axis values, breaking the
+  cycle through them exactly as Excel's substitution does); without
+  iterate declared, the table is skipped untouched — the interior stays
+  uncached so `data-table-unseeded` lints dirty instead of shipping
+  flat. New `seedDataTablesReport()` returns
+  `DataTableSeedReport(workbook, warnings)` with `CircularNotIterated`
+  (naming the cycle) and `NotConverged` warnings; explicit
+  `seedDataTables(IterativeCalc)` overloads added. Acyclic books take a
+  bit-identical fast path. `xl recalc` now auto-derives iteration from
+  the file's declared calcPr (the CLI honors the file like Excel; the
+  library `recalculate()` default stays opt-in), and `--tables` prints
+  the seed warnings.
+- **`formula-leading-equals` lint** (#456): flags `<f>` text stored
+  with a leading `=` (non-spec; openpyxl reads it back as `==…`) —
+  re-writing the file with xl heals it.
+
+### Fixed
+
+- **insert-rows dropped grouping parentheses — workbook-wide, silent,
+  semantic** (#455): `FormulaPrinter` printed the right operand of
+  every left-associative binary operator at the operator's own
+  precedence with a strict `>` paren guard, so right-nested
+  same-precedence children lost their parens on reprint:
+  `=E13/(E12*E14)` → `=E15/E14*E16` (1.0 → 4.0) after a structural
+  edit. Right operands now print one level tighter, fixing
+  insert/delete-rows/cols, `putf --from` dragging, `copy`, `batch`,
+  and the streaming writer in one pass. The `parse ∘ print = id`
+  round-trip law is now pinned by a recursive expression generator
+  (the old property only used flat literal operands). Chained
+  comparisons now parse left-associatively (`(a=b)=c`, Excel parity).
+  Belt-and-braces: structural edits no longer reprint formulas on
+  sheets that neither are the edit target nor reference it — untouched
+  sheets ride byte-identical at the model level.
+- **Native image could not open name-bloated real workbooks** (#457):
+  legacy banker books carrying 37k–110k `definedName` entries (multi-MB
+  single-line workbook.xml) tripped JAXP's 100KB
+  `maxGeneralEntitySizeLimit` on every verb, and `-Djdk.xml.*` has no
+  effect on the native binary. The shared `XmlSecurity` parser factory
+  now lifts the size limits on the parser itself (safe: doctype is
+  already disallowed, so entity-expansion attacks remain structurally
+  impossible), covering all SAX sites and `parseSafe`; the one drifted
+  inline factory in the CLI streaming path was collapsed onto it. The
+  release workflow gained a native smoke gate that reads a
+  120k-definedNames book.
+- **Scripting formula writer emitted a leading `=` inside `<f>`**
+  (#456): `fx"=B4*2"` serialized as `<f>=B4*2</f>` while the CLI path
+  wrote clean; all `<f>` emission sites (DOM, SAX, streaming) now strip
+  the leading `=` — one canonical serialization for both authoring
+  paths, and re-writing legacy files heals them.
+- **lint false-positived Excel's xlPathMissing external links**
+  (#458): the Microsoft external-link-path variants (`xlPathMissing`,
+  `xlLibraryPath`, `xlStartupPath`, `xlAltStartupPath`) — which Excel
+  itself writes for broken/special external-book paths — now resolve as
+  valid `externalBook` targets instead of `wrong-rel-type` findings,
+  so "lint must exit 0" ship gates stop false-alarming on pass-through
+  edits of real books.
+- **`-i` success messages printed the temp file** (#464): every
+  in-place verb (`recalc`, `put`, `putf`, … ~40 commands) reported
+  `Saved: ./.xl-inplace-….xlsx` — a path that no longer exists after
+  the atomic move — instead of the target. `runWithOutput` now threads
+  the display path, fixing the whole family at one seam.
+
 ## [0.19.0] "Canon" - 2026-08-03
 
 Tracker-zero release: the wave-21 epilogue (col/row default styles, sheet

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1224,6 +1224,8 @@ xl -f deliverable.xlsx lint && echo "safe to send"
   legacyDrawing, hyperlink, tablePart, …) with no entry in the paired `.rels`
 - **`wrong-rel-type`** — the `r:id` resolves, but to a relationship of the wrong type
 - **`missing-part`** — the relationship target part is absent from the package
+- **`formula-leading-equals`** — `<f>` text stored with the display form's leading `=`
+  (non-spec; strict readers like openpyxl misread it — re-writing the file with xl heals it)
 
 **Exit codes** (diff-tool convention): `0` no findings · `1` findings reported · `2` error
 (unreadable file, malformed core part).

--- a/docs/reference/scripting.md
+++ b/docs/reference/scripting.md
@@ -250,6 +250,8 @@ For Excel-style format inheritance on formula entry, use the opt-in
 | `excelErrors` | (0.14.0) `Vector[(SheetName, ARef, CellError)]` — cells whose cached result is an Excel error value, sorted; inspect when you want to surface `#DIV/0!`s without treating them as host failures |
 | `isClean` | `true` when `errors.isEmpty` — a workbook full of cached `#DIV/0!`s is "clean" (the recalculation succeeded; the errors are data) |
 | `toEither` | `Right(workbook)` when clean, `Left(errors)` otherwise — for fail-hard pipelines |
+| `converged` | (0.20.0) `false` iff an iterative run exhausted `maxIter` without every cycle member's \|Δ\| dropping below `maxChange` — the last-round values are kept (Excel semantics, `errors` stays empty), so gate on this after any large circular perturbation. Non-iterative runs report `true` |
+| `iterationsUsed` | (0.20.0) iterative rounds actually run: `0` when no iteration happened, `maxIter` on exhaustion, otherwise the round that converged |
 
 Reference cycles are **isolated**: the participants and their downstream dependents are reported
 (e.g. `Model!A7: Formula error in '=B7': Circular reference` via `CellEvalError.render`) while

--- a/plugin/skills/xl-cli/SKILL.md
+++ b/plugin/skills/xl-cli/SKILL.md
@@ -114,7 +114,7 @@ xl -f <file> -o <out> recalc --tables                 # Also seed data-table int
 xl -f a.xlsx diff -g b.xlsx --format markdown          # Workbook diff (exit 0 identical, 1 differs)
 xl -f a.xlsx diff -g b.xlsx --format json              # Stable JSON schema for tooling
 xl -f out.xlsx lint                                    # Validate package structure before sending (exit 0 clean, 1 findings) (0.15.0+)
-                                                       # Rules: child-order, unresolved-rel-id, wrong-rel-type, missing-part, missing-content-type, ref-out-of-bounds, data-table-torn, data-table-unseeded (last two: 0.19.0)
+                                                       # Rules: child-order, unresolved-rel-id, wrong-rel-type, missing-part, missing-content-type, ref-out-of-bounds, data-table-torn, data-table-unseeded (0.19.0), formula-leading-equals (0.20.0)
 xl -f <file> -s <sheet> filter --where "B > 100 AND D = TRUE" --header --format csv
 xl -f <file> -s <sheet> filter --where "Name LIKE 'Acme%'" --columns A,C:E --limit 20
 ```

--- a/xl-cats-effect/src/com/tjclp/xl/io/StreamingXmlWriter.scala
+++ b/xl-cats-effect/src/com/tjclp/xl/io/StreamingXmlWriter.scala
@@ -270,9 +270,10 @@ object StreamingXmlWriter:
               XmlEvent.EndTag(QName("f"))
             )
           case _ =>
+            // GH-456: <f> carries the expression, never the display form's leading '='
             List(
               XmlEvent.StartTag(QName("f"), recordAttrs, false),
-              XmlEvent.XmlString(expr, false),
+              XmlEvent.XmlString(expr.stripPrefix("="), false),
               XmlEvent.EndTag(QName("f"))
             )
         val cachedEvents = cachedValue.toList.flatMap {

--- a/xl-cats-effect/src/com/tjclp/xl/io/streaming/StreamingTransform.scala
+++ b/xl-cats-effect/src/com/tjclp/xl/io/streaming/StreamingTransform.scala
@@ -174,7 +174,8 @@ object StreamingTransform:
             FormulaKindCodec.toAttrs(kind).foreach { case (name, v) =>
               writer.writeAttribute(name, v)
             }
-            writer.writeCharacters(expr)
+            // GH-456: <f> carries the expression, never the display form's leading '='
+            writer.writeCharacters(expr.stripPrefix("="))
             writer.endElement()
         cachedValue.foreach(cv => writeCachedValue(writer, cv))
 

--- a/xl-cats-effect/test/src/com/tjclp/xl/io/streaming/StreamingFormulaLeadingEqualsSpec.scala
+++ b/xl-cats-effect/test/src/com/tjclp/xl/io/streaming/StreamingFormulaLeadingEqualsSpec.scala
@@ -1,0 +1,71 @@
+package com.tjclp.xl.io.streaming
+
+import java.io.ByteArrayOutputStream
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path}
+import java.util.zip.ZipFile
+
+import cats.effect.IO
+import munit.CatsEffectSuite
+
+import com.tjclp.xl.cells.CellValue
+import com.tjclp.xl.io.{ExcelIO, RowData}
+import com.tjclp.xl.ooxml.StaxSaxWriter
+
+/**
+ * GH-456: the streaming writers are `<f>` emission boundaries too — a scripting-authored
+ * `CellValue.Formula("=A1*2", ...)` must serialize as `<f>A1*2</f>` (the OOXML store carries the
+ * expression without the display form's leading '='), matching the in-memory writers.
+ */
+class StreamingFormulaLeadingEqualsSpec extends CatsEffectSuite:
+
+  private val excel = ExcelIO.instance[IO]
+
+  private def tempXlsx(label: String): Path =
+    val p = Files.createTempFile(s"xl-stream-leading-eq-$label-", ".xlsx")
+    p.toFile.deleteOnExit()
+    p
+
+  private def entryText(path: Path, name: String): String =
+    val zip = new ZipFile(path.toFile)
+    try
+      Option(zip.getEntry(name)) match
+        case Some(e) => new String(zip.getInputStream(e).readAllBytes(), StandardCharsets.UTF_8)
+        case None => fail(s"zip entry $name not found")
+    finally zip.close()
+
+  test("writeStream (StreamingXmlWriter) strips the leading '=' from <f> (GH-456)") {
+    val path = tempXlsx("write")
+    val rows = fs2.Stream
+      .emits(
+        List(
+          RowData(1, Map(0 -> CellValue.Number(2))),
+          RowData(2, Map(0 -> CellValue.Formula("=A1*2", None)))
+        )
+      )
+      .covary[IO]
+    rows.through(excel.writeStream(path, "Data")).compile.drain.map { _ =>
+      val sheetXml = entryText(path, "xl/worksheets/sheet1.xml")
+      assert(sheetXml.contains("<f>A1*2</f>"), sheetXml)
+      assert(!sheetXml.contains("<f>="), sheetXml)
+    }
+  }
+
+  test("StreamingTransform.writeCellContent strips the leading '=' from <f> (GH-456)") {
+    val out = new ByteArrayOutputStream()
+    val writer = StaxSaxWriter.create(out)
+    writer.startElement("c")
+    StreamingTransform.writeCellContent(writer, CellValue.Formula("=A1*2", None))
+    writer.endElement()
+    writer.flush()
+    val xml = out.toString("UTF-8")
+    assert(xml.contains("<f>A1*2</f>"), xml)
+
+    val clean = new ByteArrayOutputStream()
+    val cleanWriter = StaxSaxWriter.create(clean)
+    cleanWriter.startElement("c")
+    StreamingTransform.writeCellContent(cleanWriter, CellValue.Formula("IF(A1=1,2,3)", None))
+    cleanWriter.endElement()
+    cleanWriter.flush()
+    assert(clean.toString("UTF-8").contains("<f>IF(A1=1,2,3)</f>"), clean.toString("UTF-8"))
+  }

--- a/xl-cli/src/com/tjclp/xl/cli/Main.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/Main.scala
@@ -78,7 +78,7 @@ object Main
       (fileOpt, outputOpt.orNone, inPlaceOpt, backendOpt, maxSizeOpt, streamOpt, sheetsCmd).mapN {
         (file, outOpt, inPlace, backend, maxSize, stream, cmd) =>
           runWithOutput(outOpt, inPlace, file) { (out, display) =>
-            run(file, None, out, display, backend, maxSize, stream, cmd)
+            runResult(file, None, out, display, backend, maxSize, stream, cmd)
           }
       }
 
@@ -116,7 +116,7 @@ object Main
         sheetWriteSubcmds
       ).mapN { (file, sheet, outOpt, inPlace, backend, maxSize, stream, cmd) =>
         runWithOutput(outOpt, inPlace, file) { (out, display) =>
-          run(file, sheet, out, display, backend, maxSize, stream, cmd)
+          runResult(file, sheet, out, display, backend, maxSize, stream, cmd)
         }
       }
 
@@ -1581,8 +1581,30 @@ EXAMPLES:
     stream: Boolean,
     cmd: CliCommand
   ): IO[ExitCode] =
+    runResult(
+      filePath,
+      sheetNameOpt,
+      outputOpt,
+      displayOpt,
+      backendOpt,
+      maxSizeOpt,
+      stream,
+      cmd
+    ).flatMap(printRunResult)
+
+  /** Execute and render a command without printing, so in-place writes can commit first. */
+  private def runResult(
+    filePath: Path,
+    sheetNameOpt: Option[String],
+    outputOpt: Option[Path],
+    displayOpt: Option[Path],
+    backendOpt: Option[XmlBackend],
+    maxSizeOpt: Option[Long],
+    stream: Boolean,
+    cmd: CliCommand
+  ): IO[(ExitCode, String)] =
     execute(filePath, sheetNameOpt, outputOpt, backendOpt, maxSizeOpt, stream, cmd).attempt
-      .flatMap {
+      .map {
         case Right(output) =>
           // In-place writes (-i) target a temp file that is atomically moved onto the
           // input after the command succeeds; success messages must name the user-visible
@@ -1591,10 +1613,13 @@ EXAMPLES:
             case (Some(write), Some(display)) if write != display =>
               output.replace(write.toString, display.toString)
             case _ => output
-          IO.println(rendered).as(ExitCode.Success)
+          (ExitCode.Success, rendered)
         case Left(err) =>
-          IO.println(Format.errorSimple(err.getMessage)).as(ExitCode.Error)
+          (ExitCode.Error, Format.errorSimple(err.getMessage))
       }
+
+  private def printRunResult(result: (ExitCode, String)): IO[ExitCode] =
+    IO.println(result._2).as(result._1)
 
   private def runInfo(): IO[ExitCode] =
     IO.println(formatFunctionList()).as(ExitCode.Success)
@@ -2600,9 +2625,9 @@ EXAMPLES:
   /**
    * Dispatch `run` with effective output path from --output / --in-place flags.
    *
-   * The callback receives (writePath, displayPath): the path the command must write to and the path
-   * user-facing messages must name. They differ only for `-i`, where writes go to a temp file that
-   * is moved onto the input after success (GH-464).
+   * The callback receives (writePath, displayPath) and returns the exit code plus rendered output
+   * without printing it. The paths differ only for `-i`, where writes go to a temp file that is
+   * moved onto the input before the successful output is printed (GH-464).
    *
    * Cases:
    *   - `-o` only: writes directly to the output path
@@ -2615,14 +2640,14 @@ EXAMPLES:
     outOpt: Option[Path],
     inPlace: Boolean,
     file: Path
-  )(execute: (Option[Path], Option[Path]) => IO[ExitCode]): IO[ExitCode] =
+  )(execute: (Option[Path], Option[Path]) => IO[(ExitCode, String)]): IO[ExitCode] =
     (outOpt, inPlace) match
       case (Some(_), true) =>
         IO.println(
           Format.errorSimple("--in-place (-i) and --output (-o) are mutually exclusive")
         ).as(ExitCode.Error)
-      case (Some(out), false) => execute(Some(out), Some(out))
-      case (None, false) => execute(None, None)
+      case (Some(out), false) => execute(Some(out), Some(out)).flatMap(printRunResult)
+      case (None, false) => execute(None, None).flatMap(printRunResult)
       case (None, true) =>
         val tmpDir = Option(file.getParent).getOrElse(java.nio.file.Paths.get("."))
         val tmpResource = cats.effect.Resource.make(
@@ -2631,7 +2656,7 @@ EXAMPLES:
 
         tmpResource.use { tmp =>
           execute(Some(tmp), Some(file)).flatMap {
-            case ExitCode.Success =>
+            case result @ (ExitCode.Success, _) =>
               // Atomic move: same directory guarantees same filesystem on POSIX/NTFS
               IO.blocking(
                 java.nio.file.Files.move(
@@ -2639,10 +2664,10 @@ EXAMPLES:
                   file,
                   java.nio.file.StandardCopyOption.REPLACE_EXISTING
                 )
-              ).as(ExitCode.Success)
-            case other =>
+              ) *> printRunResult(result)
+            case result =>
               // Non-success exit: leave original file alone; Resource cleans up temp
-              IO.pure(other)
+              printRunResult(result)
           }
         }
 

--- a/xl-cli/src/com/tjclp/xl/cli/Main.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/Main.scala
@@ -69,7 +69,7 @@ object Main
     // Note: --stream not supported for workbook-level commands (need full metadata)
     val workbookSubcmds = namesCmd
     val workbookOpts = (fileOpt, maxSizeOpt, workbookSubcmds).mapN { (file, maxSize, cmd) =>
-      run(file, None, None, None, maxSize, false, cmd)
+      run(file, None, None, None, None, maxSize, false, cmd)
     }
 
     // Sheets command: --file required, --output optional (required for hide/show, not for list)
@@ -77,8 +77,8 @@ object Main
     val sheetsOpts =
       (fileOpt, outputOpt.orNone, inPlaceOpt, backendOpt, maxSizeOpt, streamOpt, sheetsCmd).mapN {
         (file, outOpt, inPlace, backend, maxSize, stream, cmd) =>
-          runWithOutput(outOpt, inPlace, file) { out =>
-            run(file, None, out, backend, maxSize, stream, cmd)
+          runWithOutput(outOpt, inPlace, file) { (out, display) =>
+            run(file, None, out, display, backend, maxSize, stream, cmd)
           }
       }
 
@@ -96,7 +96,7 @@ object Main
 
     val sheetReadOnlyOpts = (fileOpt, sheetOpt, maxSizeOpt, streamOpt, sheetReadOnlySubcmds).mapN {
       (file, sheet, maxSize, stream, cmd) =>
-        run(file, sheet, None, None, maxSize, stream, cmd)
+        run(file, sheet, None, None, None, maxSize, stream, cmd)
     }
 
     // Sheet-level write: --file, --sheet, and --output (required)
@@ -115,8 +115,8 @@ object Main
         streamOpt,
         sheetWriteSubcmds
       ).mapN { (file, sheet, outOpt, inPlace, backend, maxSize, stream, cmd) =>
-        runWithOutput(outOpt, inPlace, file) { out =>
-          run(file, sheet, out, backend, maxSize, stream, cmd)
+        runWithOutput(outOpt, inPlace, file) { (out, display) =>
+          run(file, sheet, out, display, backend, maxSize, stream, cmd)
         }
       }
 
@@ -1573,6 +1573,7 @@ EXAMPLES:
     filePath: Path,
     sheetNameOpt: Option[String],
     outputOpt: Option[Path],
+    displayOpt: Option[Path],
     backendOpt: Option[XmlBackend],
     maxSizeOpt: Option[Long],
     stream: Boolean,
@@ -1581,7 +1582,14 @@ EXAMPLES:
     execute(filePath, sheetNameOpt, outputOpt, backendOpt, maxSizeOpt, stream, cmd).attempt
       .flatMap {
         case Right(output) =>
-          IO.println(output).as(ExitCode.Success)
+          // In-place writes (-i) target a temp file that is atomically moved onto the
+          // input after the command succeeds; success messages must name the user-visible
+          // path, not the temp file that no longer exists by the time it is read (GH-464).
+          val rendered = (outputOpt, displayOpt) match
+            case (Some(write), Some(display)) if write != display =>
+              output.replace(write.toString, display.toString)
+            case _ => output
+          IO.println(rendered).as(ExitCode.Success)
         case Left(err) =>
           IO.println(Format.errorSimple(err.getMessage)).as(ExitCode.Error)
       }
@@ -2590,6 +2598,10 @@ EXAMPLES:
   /**
    * Dispatch `run` with effective output path from --output / --in-place flags.
    *
+   * The callback receives (writePath, displayPath): the path the command must write to and the path
+   * user-facing messages must name. They differ only for `-i`, where writes go to a temp file that
+   * is moved onto the input after success (GH-464).
+   *
    * Cases:
    *   - `-o` only: writes directly to the output path
    *   - `-i` only: writes to a sibling temp file then atomically moves onto input. If the command
@@ -2601,14 +2613,14 @@ EXAMPLES:
     outOpt: Option[Path],
     inPlace: Boolean,
     file: Path
-  )(execute: Option[Path] => IO[ExitCode]): IO[ExitCode] =
+  )(execute: (Option[Path], Option[Path]) => IO[ExitCode]): IO[ExitCode] =
     (outOpt, inPlace) match
       case (Some(_), true) =>
         IO.println(
           Format.errorSimple("--in-place (-i) and --output (-o) are mutually exclusive")
         ).as(ExitCode.Error)
-      case (Some(out), false) => execute(Some(out))
-      case (None, false) => execute(None)
+      case (Some(out), false) => execute(Some(out), Some(out))
+      case (None, false) => execute(None, None)
       case (None, true) =>
         val tmpDir = Option(file.getParent).getOrElse(java.nio.file.Paths.get("."))
         val tmpResource = cats.effect.Resource.make(
@@ -2616,7 +2628,7 @@ EXAMPLES:
         )(tmp => IO.blocking(java.nio.file.Files.deleteIfExists(tmp)).void)
 
         tmpResource.use { tmp =>
-          execute(Some(tmp)).flatMap {
+          execute(Some(tmp), Some(file)).flatMap {
             case ExitCode.Success =>
               // Atomic move: same directory guarantees same filesystem on POSIX/NTFS
               IO.blocking(

--- a/xl-cli/src/com/tjclp/xl/cli/Main.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/Main.scala
@@ -583,6 +583,8 @@ lenient reader accepts silently:
   - data-table records whose grid was torn by an unguarded edit, and
     uncached table interiors in a calcMode="autoNoTable" book (they open
     BLANK — refresh them with `xl recalc --tables`)
+  - formula text stored with a leading '=' inside <f> (non-spec; strict
+    readers misread it — re-writing the file with xl heals it)
 
 USAGE:
   xl lint report.xlsx
@@ -592,7 +594,7 @@ USAGE:
 FINDING CATEGORIES:
   child-order | unresolved-rel-id | wrong-rel-type | missing-part |
   missing-content-type | ref-out-of-bounds | data-table-torn |
-  data-table-unseeded
+  data-table-unseeded | formula-leading-equals
 
 EXIT CODES:
   0 = no findings (package structure is clean)

--- a/xl-cli/src/com/tjclp/xl/cli/commands/StreamingWriteCommands.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/commands/StreamingWriteCommands.scala
@@ -3,7 +3,6 @@ package com.tjclp.xl.cli.commands
 import java.nio.charset.StandardCharsets
 import java.nio.file.Path
 import java.util.zip.ZipFile
-import javax.xml.parsers.SAXParserFactory
 
 import cats.effect.IO
 import com.tjclp.xl.api.Workbook
@@ -873,19 +872,12 @@ object StreamingWriteCommands:
         if worksheetEntry == null then
           throw new Exception(s"Worksheet not found while loading metadata: $worksheetPath")
 
-        val parserFactory = SAXParserFactory.newInstance()
-        parserFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)
-        parserFactory.setFeature("http://xml.org/sax/features/external-general-entities", false)
-        parserFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false)
-        parserFactory.setFeature(
-          "http://apache.org/xml/features/nonvalidating/load-external-dtd",
-          false
-        )
-        parserFactory.setXIncludeAware(false)
-        parserFactory.setNamespaceAware(true)
-        val parser = parserFactory.newSAXParser()
+        // GH-350/GH-457: build from the shared hardened factory (doctype-strip + lifted JAXP
+        // entity-size limits) instead of re-inlining the XXE posture per-site.
+        val parser = XmlSecurity.secureSaxParserFactory().newSAXParser()
 
-        val inputStream = zipFile.getInputStream(worksheetEntry)
+        val inputStream =
+          XmlSecurity.stripLeadingDoctypeStream(zipFile.getInputStream(worksheetEntry))
         try
           val handler = new DefaultHandler:
             override def startElement(

--- a/xl-cli/src/com/tjclp/xl/cli/commands/WriteCommands.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/commands/WriteCommands.scala
@@ -849,13 +849,21 @@ object WriteCommands:
     val errorValues =
       if errorValueCount == 0 then ""
       else s" ($errorValueCount error ${if errorValueCount == 1 then "value" else "values"})"
-    if result.isClean then s"Recalculated $formulaCount $formulasLabel$errorValues"
+    // GH-454: surface the iterative-calculation verdict — maxIter exhaustion keeps the last
+    // values (Excel semantics, no error) so the summary is the only place it becomes visible.
+    val convergence =
+      if !result.converged then
+        s"; WARNING: iterative calculation exhausted ${result.iterationsUsed} round(s) without converging (last values kept)"
+      else if result.iterationsUsed > 0 then
+        s"; converged in ${result.iterationsUsed} iterative round(s)"
+      else ""
+    if result.isClean then s"Recalculated $formulaCount $formulasLabel$errorValues$convergence"
     else
       val maxShown = 3
       val shown = result.errors.take(maxShown).map(_.render).mkString("; ")
       val ellipsis = if result.errors.size > maxShown then "; ..." else ""
       val errorsLabel = if result.errors.size == 1 then "error" else "errors"
-      s"Recalculated $formulaCount $formulasLabel$errorValues; ${result.errors.size} $errorsLabel ($shown$ellipsis)"
+      s"Recalculated $formulaCount $formulasLabel$errorValues; ${result.errors.size} $errorsLabel ($shown$ellipsis)$convergence"
 
   /**
    * Apply multiple operations atomically (JSON from stdin or file).

--- a/xl-cli/src/com/tjclp/xl/cli/commands/WriteCommands.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/commands/WriteCommands.scala
@@ -917,6 +917,12 @@ object WriteCommands:
    *   evaluates `TABLE(...)` implicitly (GH-353/GH-430). Seeding runs AFTER the recalculation so
    *   each table substitutes into freshly computed precedents; formulas that READ a seeded interior
    *   are not re-evaluated in the same pass.
+   *
+   * GH-453: the CLI honors the FILE's declared calculation settings, like Excel opening the book —
+   * `<calcPr iterate="1"/>` turns on bounded iterative evaluation of declared cycles (the
+   * library-level `recalculate()` default stays opt-in). Tables that depend on a cycle seed
+   * per-axis fixpoints; without the declaration they are left unseeded with a WARNING line in the
+   * summary (exit stays 0 — warnings are data conditions, not tool failures).
    */
   def recalc(
     wb: Workbook,
@@ -925,19 +931,34 @@ object WriteCommands:
     stream: Boolean = false,
     seedTables: Boolean = false
   ): IO[String] =
-    val result = wb.recalculate()
-    val prepared =
-      if !seedTables then IO.pure(result.workbook)
+    val iterOpt = wb.metadata.calcPr.filter(_.iterativeCalculation).map(IterativeCalc.fromCalcPr)
+    val result = iterOpt.fold(wb.recalculate())(it => wb.recalculate(Clock.system, it))
+    val prepared: IO[(Workbook, Vector[SeedTableWarning])] =
+      if !seedTables then IO.pure((result.workbook, Vector.empty))
       else
         IO.fromEither(
-          result.workbook.seedDataTables().left.map(err => new Exception(err.message))
-        )
-    prepared.flatMap { workbook =>
+          result.workbook
+            .seedDataTablesReport()
+            .left
+            .map(err => new Exception(err.message))
+        ).map(report => (report.workbook, report.warnings))
+    prepared.flatMap { case (workbook, warnings) =>
       writeWorkbook(workbook, outputPath, config, stream).map { _ =>
         val tableNote = if seedTables then "\nSeeded data table interior caches" else ""
-        s"${formatRecalcSummary(result)}$tableNote\n${saveSuffix(outputPath, stream)}"
+        val warningLines = warnings.map(w => s"\n${renderSeedWarning(w)}").mkString
+        s"${formatRecalcSummary(result)}$tableNote$warningLines\n${saveSuffix(outputPath, stream)}"
       }
     }
+
+  /** GH-453: one summary line per seeding warning (reported, never thrown — exit stays 0). */
+  private def renderSeedWarning(warning: SeedTableWarning): String = warning match
+    case SeedTableWarning.CircularNotIterated(sheet, ref, cycle) =>
+      s"WARNING: data table ${ref.toA1} on '${sheet.value}' depends on a circular reference " +
+        s"(${cycle.mkString(", ")}) but iterative calculation is not declared " +
+        "(<calcPr iterate=\"1\"/>) — left unseeded"
+    case SeedTableWarning.NotConverged(sheet, ref, combinations, maxIter) =>
+      s"WARNING: data table ${ref.toA1} on '${sheet.value}': $combinations axis combination(s) " +
+        s"did not converge within $maxIter round(s); last-round values seeded"
 
   /**
    * Fill cells with source value/formula (Excel Ctrl+D/Ctrl+R).

--- a/xl-cli/src/com/tjclp/xl/cli/commands/WriteCommands.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/commands/WriteCommands.scala
@@ -959,6 +959,9 @@ object WriteCommands:
     case SeedTableWarning.NotConverged(sheet, ref, combinations, maxIter) =>
       s"WARNING: data table ${ref.toA1} on '${sheet.value}': $combinations axis combination(s) " +
         s"did not converge within $maxIter round(s); last-round values seeded"
+    case SeedTableWarning.Skipped(sheet, ref, cells, reason) =>
+      s"WARNING: data table ${ref.toA1} on '${sheet.value}': $cells interior cell(s) left " +
+        s"unseeded — $reason"
 
   /**
    * Fill cells with source value/formula (Excel Ctrl+D/Ctrl+R).

--- a/xl-cli/test/src/com/tjclp/xl/cli/BatchPutSpec.scala
+++ b/xl-cli/test/src/com/tjclp/xl/cli/BatchPutSpec.scala
@@ -234,6 +234,32 @@ class BatchPutSpec extends FunSuite:
       case other => fail(s"Expected Formula with $$A$$1, got $other")
   }
 
+  test("GH-455: putf dragging keeps grouping parens around a product divisor") {
+    val wb = Workbook(
+      Sheet("Test")
+        .put(ARef.from0(0, 0), CellValue.Number(BigDecimal("4")))
+        .put(ARef.from0(1, 0), CellValue.Number(BigDecimal("2")))
+        .put(ARef.from0(2, 0), CellValue.Number(BigDecimal("2")))
+    )
+
+    val result = WriteCommands
+      .putFormula(wb, Some(wb.sheets.head), "D1:D3", List("=A1/(B1*C1)"), outputPath, config)
+      .unsafeRunSync()
+
+    assert(result.contains("with anchor-aware dragging"))
+
+    val imported = ExcelIO.instance[IO].read(outputPath).unsafeRunSync()
+    val sheet = imported.sheets.head
+    // Dragging reprints through FormulaPrinter: the divisor group must survive, or the
+    // formula silently changes value (A2/B2*C2 is (A2/B2)*C2, not A2/(B2*C2)).
+    sheet.cells.get(ARef.from0(3, 0)).map(_.value) match
+      case Some(CellValue.Formula(formula, _, _)) => assertEquals(formula, "A1/(B1*C1)")
+      case other => fail(s"Expected Formula, got $other")
+    sheet.cells.get(ARef.from0(3, 1)).map(_.value) match
+      case Some(CellValue.Formula(formula, _, _)) => assertEquals(formula, "A2/(B2*C2)")
+      case other => fail(s"Expected Formula, got $other")
+  }
+
   test("putf: batch formulas mode (no dragging)") {
     val wb = Workbook(
       Sheet("Test")

--- a/xl-cli/test/src/com/tjclp/xl/cli/BatchRecalcSpec.scala
+++ b/xl-cli/test/src/com/tjclp/xl/cli/BatchRecalcSpec.scala
@@ -503,6 +503,111 @@ class BatchRecalcSpec extends FunSuite:
       case other => fail(s"expected Recalc(false), got $other")
   }
 
+  // ===== GH-453/GH-454: recalc honors the file's declared calcPr; --tables on circular books =====
+
+  /**
+   * Canonical circular fixture (GH-453): C1=100, B1=C1+B2, B2=$A$1*(C1+B1)/2 over rate input A1,
+   * corner F9=IFERROR(B1/2,0), 1-var column table F10:F12 with left axis E10:E12 =
+   * 0.002/0.004/0.006. Analytic per-axis interiors 50.1001/50.2004/50.3009 (strictly increasing);
+   * flat interiors are the GH-453 bug.
+   */
+  private def circularTableWorkbook(calcPr: Option[com.tjclp.xl.workbooks.CalcPr]): Workbook =
+    val kind: com.tjclp.xl.cells.FormulaKind.DataTable = com.tjclp.xl.cells.FormulaKind.DataTable(
+      ref = CellRange.parse("F10:F12").fold(err => fail(err), identity),
+      dt2D = false,
+      dtr = false,
+      r1 = Some(ref"A1"),
+      r2 = None
+    )
+    val sheet = Sheet("Data")
+      .put(ref"A1" -> 0, ref"C1" -> 100)
+      .put(ref"B1", CellValue.Formula("C1+B2"))
+      .put(ref"B2", CellValue.Formula("$A$1*(C1+B1)/2"))
+      .put(ref"F9", CellValue.Formula("IFERROR(B1/2,0)"))
+      .put(ref"E10" -> 0.002, ref"E11" -> 0.004, ref"E12" -> 0.006)
+      .put(ref"F10", CellValue.dataTable(kind, None))
+    calcPr.fold(Workbook(sheet))(cp => Workbook(sheet).withCalcPr(cp))
+
+  private val iterateTight = com.tjclp.xl.workbooks.CalcPr(
+    iterativeCalculation = true,
+    Some(200),
+    Some(BigDecimal("0.0000001"))
+  )
+
+  /** Interior value as BigDecimal, reading plain values or record caches. */
+  private def interiorDec(wb: Workbook, a1: ARef): Option[BigDecimal] =
+    wb.sheets.head.cells.get(a1).map(_.value).flatMap {
+      case CellValue.Number(n) => Some(n)
+      case CellValue.Formula(_, Some(CellValue.Number(n)), _) => Some(n)
+      case _ => None
+    }
+
+  test("GH-453: recalc --tables on an iterate-declared circular book seeds varied interiors") {
+    val out = tempXlsx()
+    val summary = WriteCommands
+      .recalc(circularTableWorkbook(Some(iterateTight)), out, config, false, true)
+      .unsafeRunSync()
+    // GH-454 verification instrument: the declared settings were honored and converged.
+    assert(summary.contains("converged in"), s"summary: $summary")
+    assert(!summary.contains("Circular reference"), s"summary: $summary")
+    assert(!summary.contains("WARNING"), s"summary: $summary")
+    val seeded = readBack(out)
+    val values =
+      Vector(ref"F10", ref"F11", ref"F12").map(r =>
+        interiorDec(seeded, r).getOrElse(fail(s"${r.toA1} must seed"))
+      )
+    assertEquals(
+      values.distinct.size,
+      3,
+      s"interiors must vary per axis — flat interiors are the GH-453 bug: $values"
+    )
+    values.zip(Vector(50.1001001, 50.2004008, 50.3009027)).foreach { (v, expected) =>
+      assert((v.toDouble - expected).abs < 1e-4, s"interior $v, expected ~$expected")
+    }
+    Files.deleteIfExists(out)
+  }
+
+  test("GH-453: recalc without iterate declared keeps the circular-error posture") {
+    val out = tempXlsx()
+    val summary =
+      WriteCommands.recalc(circularTableWorkbook(None), out, config).unsafeRunSync()
+    assert(summary.contains("Circular reference"), s"summary: $summary")
+    assert(!summary.contains("converged in"), s"summary: $summary")
+    Files.deleteIfExists(out)
+  }
+
+  test("GH-453: recalc --tables without iterate warns and leaves the circular table unseeded") {
+    val out = tempXlsx()
+    val summary = WriteCommands
+      .recalc(circularTableWorkbook(None), out, config, false, true)
+      .unsafeRunSync()
+    assert(summary.contains("depends on a circular reference"), s"summary: $summary")
+    assert(summary.contains("left unseeded"), s"summary: $summary")
+    assert(summary.contains("Saved:"), s"exit must stay clean: $summary")
+    val written = readBack(out)
+    assertEquals(interiorDec(written, ref"F10"), None, "record cache must stay absent")
+    assertEquals(interiorDec(written, ref"F11"), None)
+    assertEquals(interiorDec(written, ref"F12"), None)
+    Files.deleteIfExists(out)
+  }
+
+  test("GH-454: exhausted iterative declaration renders the non-convergence WARNING") {
+    val wb = Workbook(
+      Sheet("Data")
+        .put(ref"B1", CellValue.Formula("1-B2"))
+        .put(ref"B2", CellValue.Formula("1-B1"))
+    ).withCalcPr(com.tjclp.xl.workbooks.CalcPr(iterativeCalculation = true, Some(5), None))
+    val out = tempXlsx()
+    val summary = WriteCommands.recalc(wb, out, config).unsafeRunSync()
+    assert(
+      summary.contains(
+        "WARNING: iterative calculation exhausted 5 round(s) without converging"
+      ),
+      s"summary: $summary"
+    )
+    Files.deleteIfExists(out)
+  }
+
   test("recalc command reports formula errors without failing (exit stays clean)") {
     val wb = Workbook(
       Sheet("Data")

--- a/xl-cli/test/src/com/tjclp/xl/cli/BatchRecalcSpec.scala
+++ b/xl-cli/test/src/com/tjclp/xl/cli/BatchRecalcSpec.scala
@@ -591,6 +591,19 @@ class BatchRecalcSpec extends FunSuite:
     Files.deleteIfExists(out)
   }
 
+  test("GH-453: recalc --tables renders the Skipped warning for unseedable interiors") {
+    // The axis value feeding F10 references a missing sheet: the seeder leaves that interior
+    // unseeded and reports one Skipped — the summary must surface it instead of reading clean.
+    val base = circularTableWorkbook(Some(iterateTight))
+    val broken = base.sheets.headOption.getOrElse(fail("missing sheet"))
+    val wb = base.put(broken.put(ref"E10", CellValue.Formula("Missing!A1")))
+    val out = tempXlsx()
+    val summary = WriteCommands.recalc(wb, out, config, false, true).unsafeRunSync()
+    assert(summary.contains("1 interior cell(s) left unseeded"), s"summary: $summary")
+    assert(summary.contains("Saved:"), s"exit must stay clean: $summary")
+    Files.deleteIfExists(out)
+  }
+
   test("GH-454: exhausted iterative declaration renders the non-convergence WARNING") {
     val wb = Workbook(
       Sheet("Data")

--- a/xl-cli/test/src/com/tjclp/xl/cli/InPlaceSpec.scala
+++ b/xl-cli/test/src/com/tjclp/xl/cli/InPlaceSpec.scala
@@ -1,5 +1,7 @@
 package com.tjclp.xl.cli
 
+import java.io.{ByteArrayOutputStream, PrintStream}
+import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Path}
 
 import cats.effect.{ExitCode, IO}
@@ -18,6 +20,7 @@ import com.tjclp.xl.macros.ref
  *   - `-i` + `-o` together is an error (mutually exclusive)
  *   - A failed execution leaves the original file untouched and cleans up the temp
  *   - A successful execution produces the expected output in place
+ *   - Success messages name the user-visible target, never the temp file (GH-464)
  */
 @SuppressWarnings(
   Array(
@@ -44,32 +47,38 @@ class InPlaceSpec extends CatsEffectSuite:
       excel.write(wb, tempFile) *> test(tempFile)
     }
 
-  test("runWithOutput: -o alone passes the output path through") {
+  test("runWithOutput: -o alone passes the output path through as write and display") {
     val file = Path.of("/tmp/input.xlsx")
     val out = Path.of("/tmp/output.xlsx")
     var captured: Option[Path] = None
+    var capturedDisplay: Option[Path] = None
     Main
-      .runWithOutput(Some(out), inPlace = false, file) { received =>
+      .runWithOutput(Some(out), inPlace = false, file) { (received, display) =>
         captured = received
+        capturedDisplay = display
         IO.pure(ExitCode.Success)
       }
       .map { code =>
         assertEquals(code, ExitCode.Success)
         assertEquals(captured, Some(out))
+        assertEquals(capturedDisplay, Some(out))
       }
   }
 
   test("runWithOutput: neither flag passes None through") {
     val file = Path.of("/tmp/input.xlsx")
     var captured: Option[Path] = Some(Path.of("/sentinel"))
+    var capturedDisplay: Option[Path] = Some(Path.of("/sentinel"))
     Main
-      .runWithOutput(None, inPlace = false, file) { received =>
+      .runWithOutput(None, inPlace = false, file) { (received, display) =>
         captured = received
+        capturedDisplay = display
         IO.pure(ExitCode.Success)
       }
       .map { code =>
         assertEquals(code, ExitCode.Success)
         assertEquals(captured, None)
+        assertEquals(capturedDisplay, None)
       }
   }
 
@@ -77,7 +86,7 @@ class InPlaceSpec extends CatsEffectSuite:
     val file = Path.of("/tmp/input.xlsx")
     val out = Path.of("/tmp/output.xlsx")
     Main
-      .runWithOutput(Some(out), inPlace = true, file)(_ => IO.pure(ExitCode.Success))
+      .runWithOutput(Some(out), inPlace = true, file)((_, _) => IO.pure(ExitCode.Success))
       .map { code => assertEquals(code, ExitCode.Error) }
   }
 
@@ -85,9 +94,11 @@ class InPlaceSpec extends CatsEffectSuite:
     withTempExcelFile { tempFile =>
       // Capture the actual path we were asked to write to (should NOT be tempFile)
       var writePath: Option[Path] = None
-      val result = Main.runWithOutput(None, inPlace = true, tempFile) { outOpt =>
+      val result = Main.runWithOutput(None, inPlace = true, tempFile) { (outOpt, displayOpt) =>
         val out = outOpt.get
         writePath = Some(out)
+        // Messages must be rendered against the original file, not the temp (GH-464)
+        assertEquals(displayOpt, Some(tempFile))
         // Verify we're writing to a temp file, not the original
         assert(out != tempFile, s"In-place should write to temp, got: $out")
         assert(
@@ -118,7 +129,7 @@ class InPlaceSpec extends CatsEffectSuite:
   test("runWithOutput: -i leaves original untouched on error exit") {
     withTempExcelFile { tempFile =>
       var writePath: Option[Path] = None
-      val result = Main.runWithOutput(None, inPlace = true, tempFile) { outOpt =>
+      val result = Main.runWithOutput(None, inPlace = true, tempFile) { (outOpt, _) =>
         writePath = outOpt
         // Simulate a failure: return Error exit code without writing anything useful
         IO.pure(ExitCode.Error)
@@ -141,7 +152,7 @@ class InPlaceSpec extends CatsEffectSuite:
   test("runWithOutput: -i leaves original untouched when execute throws") {
     withTempExcelFile { tempFile =>
       var writePath: Option[Path] = None
-      val result = Main.runWithOutput(None, inPlace = true, tempFile) { outOpt =>
+      val result = Main.runWithOutput(None, inPlace = true, tempFile) { (outOpt, _) =>
         writePath = outOpt
         IO.raiseError(new RuntimeException("simulated crash"))
       }
@@ -155,5 +166,71 @@ class InPlaceSpec extends CatsEffectSuite:
         assert(outcome.isLeft, "Expected error to propagate")
         assertEquals(a1, Some(CellValue.Text("Hello")))
         assert(!tempExists, "Temp file should be cleaned up on exception")
+    }
+  }
+
+  // ========== Success message names the target, not the temp (GH-464) ==========
+
+  private def xlCommand = com.monovore.decline.Command("xl", "test")(Main.main)
+
+  /** Parse a full CLI invocation and run it, capturing everything printed to stdout. */
+  private def runCliCaptured(args: String*): IO[(ExitCode, String)] =
+    IO.fromEither(
+      xlCommand.parse(args, Map.empty).left.map(help => new Exception(help.toString))
+    ).flatMap { io =>
+      IO.blocking(new ByteArrayOutputStream()).flatMap { baos =>
+        IO.blocking {
+          val prev = System.out
+          System.setOut(new PrintStream(baos, true, StandardCharsets.UTF_8))
+          prev
+        }.bracket(_ => io)(prev => IO.blocking(System.setOut(prev)))
+          .map(code => (code, baos.toString(StandardCharsets.UTF_8)))
+      }
+    }
+
+  test("-i recalc: success message names the original file, not the temp (GH-464)") {
+    withTempExcelFile { tempFile =>
+      runCliCaptured("-f", tempFile.toString, "-i", "recalc").map { case (code, out) =>
+        assertEquals(code, ExitCode.Success)
+        assert(out.contains(s"Saved: $tempFile"), s"expected 'Saved: $tempFile' in:\n$out")
+        assert(!out.contains(".xl-inplace-"), s"message leaks the temp path:\n$out")
+      }
+    }
+  }
+
+  test("-i put: success message names the original file, not the temp (GH-464)") {
+    withTempExcelFile { tempFile =>
+      runCliCaptured("-f", tempFile.toString, "-s", "Test", "-i", "put", "A2", "99").map {
+        case (code, out) =>
+          assertEquals(code, ExitCode.Success)
+          assert(out.contains(s"Saved: $tempFile"), s"expected 'Saved: $tempFile' in:\n$out")
+          assert(!out.contains(".xl-inplace-"), s"message leaks the temp path:\n$out")
+      }
+    }
+  }
+
+  test("-o put: success message still names the -o target (GH-464 regression guard)") {
+    withTempExcelFile { tempFile =>
+      IO.blocking {
+        val out = Files.createTempFile("xl-inplace-test-out-", ".xlsx")
+        Files.deleteIfExists(out)
+        out.toFile.deleteOnExit()
+        out
+      }.flatMap { outFile =>
+        runCliCaptured(
+          "-f",
+          tempFile.toString,
+          "-s",
+          "Test",
+          "-o",
+          outFile.toString,
+          "put",
+          "A2",
+          "99"
+        ).map { case (code, out) =>
+          assertEquals(code, ExitCode.Success)
+          assert(out.contains(s"Saved: $outFile"), s"expected 'Saved: $outFile' in:\n$out")
+        }
+      }
     }
   }

--- a/xl-cli/test/src/com/tjclp/xl/cli/InPlaceSpec.scala
+++ b/xl-cli/test/src/com/tjclp/xl/cli/InPlaceSpec.scala
@@ -56,7 +56,7 @@ class InPlaceSpec extends CatsEffectSuite:
       .runWithOutput(Some(out), inPlace = false, file) { (received, display) =>
         captured = received
         capturedDisplay = display
-        IO.pure(ExitCode.Success)
+        IO.pure((ExitCode.Success, "ok"))
       }
       .map { code =>
         assertEquals(code, ExitCode.Success)
@@ -73,7 +73,7 @@ class InPlaceSpec extends CatsEffectSuite:
       .runWithOutput(None, inPlace = false, file) { (received, display) =>
         captured = received
         capturedDisplay = display
-        IO.pure(ExitCode.Success)
+        IO.pure((ExitCode.Success, "ok"))
       }
       .map { code =>
         assertEquals(code, ExitCode.Success)
@@ -86,7 +86,7 @@ class InPlaceSpec extends CatsEffectSuite:
     val file = Path.of("/tmp/input.xlsx")
     val out = Path.of("/tmp/output.xlsx")
     Main
-      .runWithOutput(Some(out), inPlace = true, file)((_, _) => IO.pure(ExitCode.Success))
+      .runWithOutput(Some(out), inPlace = true, file)((_, _) => IO.pure((ExitCode.Success, "ok")))
       .map { code => assertEquals(code, ExitCode.Error) }
   }
 
@@ -109,7 +109,7 @@ class InPlaceSpec extends CatsEffectSuite:
         val wb = Workbook(
           Vector(Sheet("Test").put(ref"A1", CellValue.Text("Updated")))
         )
-        excel.write(wb, out).as(ExitCode.Success)
+        excel.write(wb, out).as((ExitCode.Success, "saved"))
       }
 
       for
@@ -132,7 +132,7 @@ class InPlaceSpec extends CatsEffectSuite:
       val result = Main.runWithOutput(None, inPlace = true, tempFile) { (outOpt, _) =>
         writePath = outOpt
         // Simulate a failure: return Error exit code without writing anything useful
-        IO.pure(ExitCode.Error)
+        IO.pure((ExitCode.Error, "failed"))
       }
 
       for
@@ -173,20 +173,47 @@ class InPlaceSpec extends CatsEffectSuite:
 
   private def xlCommand = com.monovore.decline.Command("xl", "test")(Main.main)
 
+  private def captureStdout[A](io: IO[A]): IO[(A, String)] =
+    IO.blocking(new ByteArrayOutputStream()).flatMap { baos =>
+      IO.blocking {
+        val prev = System.out
+        System.setOut(new PrintStream(baos, true, StandardCharsets.UTF_8))
+        prev
+      }.bracket(_ => io)(prev => IO.blocking(System.setOut(prev)))
+        .map(result => (result, baos.toString(StandardCharsets.UTF_8)))
+    }
+
   /** Parse a full CLI invocation and run it, capturing everything printed to stdout. */
   private def runCliCaptured(args: String*): IO[(ExitCode, String)] =
     IO.fromEither(
       xlCommand.parse(args, Map.empty).left.map(help => new Exception(help.toString))
-    ).flatMap { io =>
-      IO.blocking(new ByteArrayOutputStream()).flatMap { baos =>
-        IO.blocking {
-          val prev = System.out
-          System.setOut(new PrintStream(baos, true, StandardCharsets.UTF_8))
-          prev
-        }.bracket(_ => io)(prev => IO.blocking(System.setOut(prev)))
-          .map(code => (code, baos.toString(StandardCharsets.UTF_8)))
+    ).flatMap(captureStdout)
+
+  test("runWithOutput: failed final replacement prints no success message") {
+    IO.blocking {
+      val destination = Files.createTempDirectory("xl-inplace-move-failure-")
+      Files.writeString(destination.resolve("keep"), "keep")
+      destination
+    }.bracket { destination =>
+      val attempted = Main
+        .runWithOutput(None, inPlace = true, destination) { (outOpt, _) =>
+          val out = outOpt.get
+          IO.blocking(Files.writeString(out, "replacement"))
+            .as((ExitCode.Success, s"Saved: $destination"))
+        }
+        .attempt
+      captureStdout(attempted).map { case (outcome, stdout) =>
+        assert(outcome.isLeft, "replacing a non-empty directory must fail")
+        assert(!stdout.contains("Saved:"), s"success was printed before replacement:\n$stdout")
+        assert(Files.isDirectory(destination), "failed replacement must preserve the destination")
       }
+    } { destination =>
+      IO.blocking {
+        Files.deleteIfExists(destination.resolve("keep"))
+        Files.deleteIfExists(destination)
+      }.void
     }
+  }
 
   test("-i recalc: success message names the original file, not the temp (GH-464)") {
     withTempExcelFile { tempFile =>

--- a/xl-evaluator/src/com/tjclp/xl/exports.scala
+++ b/xl-evaluator/src/com/tjclp/xl/exports.scala
@@ -54,6 +54,8 @@ object formulaExports:
   // GH-419: explicit data-table cache seeding (autoNoTable books never recompute tables on open)
   export formula.eval.DataTableSeeder
   export formula.eval.DataTableSeeder.*
+  // GH-453: seeding report + per-table warnings for circular books
+  export formula.eval.{DataTableSeedReport, SeedTableWarning}
 
   // DependentRecalculation extension methods (GH-163)
   // Note: Extension methods with default parameters must be imported directly,

--- a/xl-evaluator/src/com/tjclp/xl/formula/eval/DataTableSeeder.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/eval/DataTableSeeder.scala
@@ -327,8 +327,13 @@ object DataTableSeeder:
           val toStrip = stripBySheet.getOrElse(s.name, Set.empty)
           if toStrip.isEmpty then s else SheetEvaluator.stripFormulaCaches(s, toStrip)
         }
+        // The what-if substitution PINS the input cells (Excel semantics): a cycle running
+        // through an input is broken there, so the inputs are never Jacobi members — they stay
+        // the plain axis values overlaid in step (2). (stripSet already excludes relevantCore,
+        // hence the pinned inputs.) The reduced set may even be acyclic after pinning;
+        // jacobiFixpoint still converges (prev-round reads settle in <= |members|+1 rounds).
         val members: List[(QualifiedRef, Int, String)] =
-          relevantCore.toList
+          (relevantCore -- inputQ).toList
             .flatMap { q =>
               sheetIndex.get(q.sheet).map { idx =>
                 val expr = wb(q.sheet).toOption.flatMap(_.cells.get(q.ref)).map(_.value) match

--- a/xl-evaluator/src/com/tjclp/xl/formula/eval/DataTableSeeder.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/eval/DataTableSeeder.scala
@@ -410,7 +410,12 @@ object DataTableSeeder:
         val notConverged =
           if unconverged > 0 then
             Vector(
-              SeedTableWarning.NotConverged(sheet.name, kind.ref, unconverged, iterative.maxIter)
+              SeedTableWarning.NotConverged(
+                sheet.name,
+                kind.ref,
+                unconverged,
+                math.max(1, iterative.maxIter)
+              )
             )
           else Vector.empty
         // GH-453 (review follow-up): unseeded cells must be VISIBLE in the report — one Skipped
@@ -466,25 +471,31 @@ object DataTableSeeder:
           // (3) fixpoint the relevant cycle members under this axis combination
           val (results, converged, _) =
             WorkbookEvaluator.jacobiFixpoint(wb, overlaid, members, iterative, clock, None)
-          // (4) fold member values in as plain values, then evaluate the source formula
-          val folded = members.foldLeft(Option(overlaid)) { case (accOpt, (q, idx, _)) =>
-            accOpt.flatMap { sheets =>
-              results.get(q) match
-                case Some(Right(v)) => Some(sheets.updated(idx, sheets(idx).put(q.ref, v)))
-                case _ => None // tolerant: a failing member leaves this cell untouched
+          val sourceQ = QualifiedRef(sheet.name, sourceRef)
+          if members.exists((q, _, _) => q == sourceQ) then
+            // The source formula itself was fixpointed. Re-evaluating it after folding the final
+            // member values would advance it by one extra Jacobi round.
+            results.get(sourceQ).flatMap(_.toOption).map(value => (value, converged))
+          else
+            // (4) fold member values in as plain values, then evaluate the source formula
+            val folded = members.foldLeft(Option(overlaid)) { case (accOpt, (q, idx, _)) =>
+              accOpt.flatMap { sheets =>
+                results.get(q) match
+                  case Some(Right(v)) => Some(sheets.updated(idx, sheets(idx).put(q.ref, v)))
+                  case _ => None // tolerant: a failing member leaves this cell untouched
+              }
             }
-          }
-          folded.flatMap { sheets =>
-            SheetEvaluator
-              .evaluateFormula(sheets(tableIdx))(
-                expression,
-                clock,
-                Some(wb.copy(sheets = sheets)),
-                None
-              )
-              .toOption
-              .map(value => (value, converged))
-          }
+            folded.flatMap { sheets =>
+              SheetEvaluator
+                .evaluateFormula(sheets(tableIdx))(
+                  expression,
+                  clock,
+                  Some(wb.copy(sheets = sheets)),
+                  None
+                )
+                .toOption
+                .map(value => (value, converged))
+            }
         }
       case _ =>
         // Empty or non-formula source cell: Excel caches 0 (fixture-verified bytes).

--- a/xl-evaluator/src/com/tjclp/xl/formula/eval/DataTableSeeder.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/eval/DataTableSeeder.scala
@@ -4,8 +4,35 @@ import com.tjclp.xl.addressing.{ARef, CellRange, SheetName}
 import com.tjclp.xl.cells.{CellValue, FormulaKind}
 import com.tjclp.xl.error.{XLError, XLResult}
 import com.tjclp.xl.formula.Clock
+import com.tjclp.xl.formula.graph.DependencyGraph
+import com.tjclp.xl.formula.graph.DependencyGraph.QualifiedRef
 import com.tjclp.xl.sheets.Sheet
 import com.tjclp.xl.workbooks.Workbook
+
+/**
+ * GH-453: per-table diagnostics from a seeding run — see [[DataTableSeedReport]]. Warnings are
+ * ordered sheet order then record-ref row-major, matching the seeding order.
+ */
+enum SeedTableWarning derives CanEqual:
+  /**
+   * The table's source formula depends on a reference cycle but iterative calculation is not
+   * available (neither declared via `<calcPr iterate="1"/>` nor passed explicitly): the table is
+   * left entirely untouched — interiors stay uncached, so the data-table-unseeded lint still fires.
+   * `cycle` renders the members as `'Sheet'!A1`, sorted, capped at 8.
+   */
+  case CircularNotIterated(sheet: SheetName, ref: CellRange, cycle: Vector[String])
+
+  /**
+   * `combinations` axis combinations exhausted `maxIter` rounds without every cycle member's |Δ|
+   * dropping below `maxChange`; their last-round values were seeded (Excel semantics).
+   */
+  case NotConverged(sheet: SheetName, ref: CellRange, combinations: Int, maxIter: Int)
+
+/** GH-453: the seeded workbook plus every per-table warning the run produced. */
+final case class DataTableSeedReport(
+  workbook: Workbook,
+  warnings: Vector[SeedTableWarning]
+) derives CanEqual
 
 /**
  * Explicit cache seeding for data-table interiors (GH-419).
@@ -33,6 +60,24 @@ import com.tjclp.xl.workbooks.Workbook
  * Upstream formulas keep the landed pinned-cache doctrine: a cached precedent reads via its cache.
  * Cells are computed row-major against the group's base sheet, so results are order-independent
  * within a group; groups seed in row-major record-ref order, sheets in workbook order.
+ *
+ * GH-453 — circular books: a table whose source formula transitively depends on a reference cycle
+ * cannot use the pinned-cache substitution (the what-if never propagates through the cycle and
+ * every interior would silently seed the base value — FLAT). Such tables gate three ways:
+ *   - source precedents disjoint from the cyclic core: today's pinned-cache path, bit-identical;
+ *   - cycle reached AND iterative calculation available: each axis combination fixpoints the
+ *     relevant cycle members (Jacobi, [[WorkbookEvaluator.jacobiFixpoint]]) on TEMP sheets whose
+ *     stale downstream caches are stripped, then evaluates the source formula off the converged
+ *     values — `maxIter` exhaustion seeds the last-round values (Excel semantics) and reports
+ *     [[SeedTableWarning.NotConverged]];
+ *   - cycle reached AND no iterative calculation: the table is skipped untouched and reports
+ *     [[SeedTableWarning.CircularNotIterated]] — never a Left (tolerant-Right doctrine).
+ *
+ * Iterative settings auto-derive from the book's own `<calcPr iterate="1"/>` (or pass an
+ * [[IterativeCalc]] explicitly). Auto-derivation is safe HERE, unlike `recalculate()`'s opt-in
+ * posture (see [[IterativeCalc]]): the acyclic path is bit-identical with or without settings, the
+ * cyclic-without-settings path leaves the table untouched, and the only behavior that changes is
+ * the previously silently-wrong flat seeding.
  */
 object DataTableSeeder:
 
@@ -45,9 +90,12 @@ object DataTableSeeder:
 
   extension (wb: Workbook)
 
-    /** Seed every data table on every sheet (system clock). */
+    /**
+     * Seed every data table on every sheet (system clock), honoring the book's own
+     * `<calcPr iterate="1"/>` for tables that depend on a reference cycle.
+     */
     def seedDataTables(): XLResult[Workbook] =
-      Right(wb.sheets.foldLeft(wb)((acc, sheet) => seedSheet(acc, sheet.name, None, Clock.system)))
+      Right(seedWorkbook(wb, None, Clock.system, declaredIterative(wb))._1)
 
     /** Seed every data table on one sheet: `Left(SheetNotFound)` for a bad name. */
     @annotation.targetName("seedDataTablesSheet")
@@ -56,7 +104,8 @@ object DataTableSeeder:
 
     /**
      * Seed the data tables on one sheet whose record ref intersects `only` (`None` = all), with an
-     * explicit clock for volatile source formulas.
+     * explicit clock for volatile source formulas. Iterative settings auto-derive from the book's
+     * `<calcPr>`.
      */
     @annotation.targetName("seedDataTablesScoped")
     def seedDataTables(
@@ -64,27 +113,99 @@ object DataTableSeeder:
       only: Option[CellRange],
       clock: Clock
     ): XLResult[Workbook] =
-      if wb.sheets.exists(_.name == sheetName) then Right(seedSheet(wb, sheetName, only, clock))
+      seedDataTables(sheetName, only, clock, declaredIterative(wb))
+
+    /**
+     * GH-453: seed every data table with explicit iterative settings (system clock) — overrides
+     * whatever the book's `<calcPr>` declares (including its absence).
+     */
+    @annotation.targetName("seedDataTablesIterative")
+    def seedDataTables(iterative: IterativeCalc): XLResult[Workbook] =
+      Right(seedWorkbook(wb, None, Clock.system, Some(iterative))._1)
+
+    /**
+     * GH-453: scoped seeding with explicit iterative settings — `None` disables iteration entirely
+     * (circular tables then skip with a warning in the report-producing variants).
+     */
+    @annotation.targetName("seedDataTablesScopedIterative")
+    def seedDataTables(
+      sheetName: SheetName,
+      only: Option[CellRange],
+      clock: Clock,
+      iterative: Option[IterativeCalc]
+    ): XLResult[Workbook] =
+      if wb.sheets.exists(_.name == sheetName) then
+        Right(seedWorkbook(wb, Some((sheetName, only)), clock, iterative)._1)
       else Left(XLError.SheetNotFound(sheetName.value))
 
-  private def seedSheet(
+    /**
+     * GH-453: whole-book seeding that also returns the per-table warnings (circular tables skipped
+     * for lack of iteration, non-converged axis combinations). Iterative settings auto-derive from
+     * the book's `<calcPr>`.
+     */
+    def seedDataTablesReport(): XLResult[DataTableSeedReport] =
+      seedDataTablesReport(Clock.system, declaredIterative(wb))
+
+    /** GH-453: whole-book seeding report with an explicit clock and iterative settings. */
+    @annotation.targetName("seedDataTablesReportIterative")
+    def seedDataTablesReport(
+      clock: Clock,
+      iterative: Option[IterativeCalc]
+    ): XLResult[DataTableSeedReport] =
+      val (seeded, warnings) = seedWorkbook(wb, None, clock, iterative)
+      Right(DataTableSeedReport(seeded, warnings))
+
+  /** The book's own iterative-calculation declaration, if any. */
+  private def declaredIterative(wb: Workbook): Option[IterativeCalc] =
+    wb.metadata.calcPr.filter(_.iterativeCalculation).map(IterativeCalc.fromCalcPr)
+
+  /** Workbook-level graph facts shared by every group of one seeding run (GH-453). */
+  private final case class CycleContext(
+    deps: Map[QualifiedRef, Set[QualifiedRef]],
+    dependents: Map[QualifiedRef, Set[QualifiedRef]],
+    core: Set[QualifiedRef]
+  )
+
+  /**
+   * Seed the scoped sheets (`None` = whole book) in workbook order, collecting warnings.
+   *
+   * The dependency graph derives at most once per run, lazily — only when a record group exists on
+   * a scoped sheet. Reusing it across groups is sound: seeding writes only plain interior values
+   * and record caches, neither of which are graph nodes (`fromWorkbookBounded` excludes DataTable
+   * kinds).
+   */
+  private def seedWorkbook(
     wb: Workbook,
-    sheetName: SheetName,
-    only: Option[CellRange],
-    clock: Clock
-  ): Workbook =
-    wb.sheets.find(_.name == sheetName) match
-      case None => wb
-      case Some(sheet) =>
-        val groups = recordGroups(sheet).filter { case (ref, _) => only.forall(_.intersects(ref)) }
-        if groups.isEmpty then wb
-        else
-          val seeded = groups.foldLeft(sheet) { case (acc, (_, kind)) =>
-            seedGroup(wb.put(acc), acc, kind, clock)
-          }
-          // Only a real change may mark the sheet modified — a no-op seed (already-correct
-          // caches, or nothing but skips) must keep the verbatim-copy write fidelity.
-          if seeded == sheet then wb else wb.put(seeded)
+    scope: Option[(SheetName, Option[CellRange])],
+    clock: Clock,
+    iterative: Option[IterativeCalc]
+  ): (Workbook, Vector[SeedTableWarning]) =
+    val targets: Vector[SheetName] = scope match
+      case Some((name, _)) => Vector(name)
+      case None => wb.sheets.map(_.name)
+    val only = scope.flatMap(_._2)
+    lazy val cycles: CycleContext =
+      val (deps, dependents) = DependencyGraph.fromWorkbookBounded(wb)
+      CycleContext(deps, dependents, DependencyGraph.qualifiedCyclicNodes(deps))
+    targets.foldLeft((wb, Vector.empty[SeedTableWarning])) { case ((accWb, warns), name) =>
+      accWb.sheets.find(_.name == name) match
+        case None => (accWb, warns)
+        case Some(sheet) =>
+          val groups =
+            recordGroups(sheet).filter { case (ref, _) => only.forall(_.intersects(ref)) }
+          if groups.isEmpty then (accWb, warns)
+          else
+            val (seeded, groupWarns) =
+              groups.foldLeft((sheet, Vector.empty[SeedTableWarning])) {
+                case ((acc, ws), (_, kind)) =>
+                  val (next, w) = seedGroup(accWb.put(acc), acc, kind, clock, iterative, cycles)
+                  (next, ws ++ w)
+              }
+            // Only a real change may mark the sheet modified — a no-op seed (already-correct
+            // caches, or nothing but skips) must keep the verbatim-copy write fidelity.
+            val nextWb = if seeded == sheet then accWb else accWb.put(seeded)
+            (nextWb, warns ++ groupWarns)
+    }
 
   /**
    * Record groups by record ref, row-major; the representative kind comes from the group's
@@ -106,8 +227,10 @@ object DataTableSeeder:
     wb: Workbook,
     sheet: Sheet,
     kind: FormulaKind.DataTable,
-    clock: Clock
-  ): Sheet =
+    clock: Clock,
+    iterative: Option[IterativeCalc],
+    cycles: => CycleContext
+  ): (Sheet, Vector[SeedTableWarning]) =
     val interior = kind.ref
     val startRow = interior.start.row.index0
     val startCol = interior.start.col.index0
@@ -120,21 +243,192 @@ object DataTableSeeder:
           case (Some(r1), _) if !kind.dt2D => Some((r1, None))
           case _ => None // missing required input(s)
     inputs match
-      case None => sheet // skip untouched
+      case None => (sheet, Vector.empty) // skip untouched
       case Some((input1, input2)) =>
-        // Fold the interior iterator directly — O(1) beyond the accumulating sheet, never a
-        // materialized extent. Every cell computes against the group's base `sheet`, so
-        // interleaving the puts stays order-independent.
-        interior.cellsRowMajor.foldLeft(sheet) { (acc, cellRef) =>
-          computeCell(wb, sheet, kind, cellRef, input1, input2, clock) match
-            case None => acc // tolerant: leave the cell untouched
-            case Some(value) =>
-              acc.cells.get(cellRef).map(_.value) match
-                case Some(record @ CellValue.Formula(_, _, _: FormulaKind.DataTable)) =>
-                  acc.put(cellRef, record.copy(cachedValue = Some(value))) // shape-preserving
-                case Some(_: CellValue.Formula) => acc // never overwrite a real formula
-                case _ => acc.put(cellRef, value)
+        // GH-453 gate: does the source formula transitively depend on a reference cycle?
+        val ctx = cycles
+        val srcQ = sourceRefs(kind).map(r => QualifiedRef(sheet.name, r))
+        val closure =
+          if ctx.core.isEmpty then Set.empty[QualifiedRef]
+          else DependencyGraph.qualifiedTransitivePrecedents(ctx.deps, srcQ) ++ srcQ
+        val relevantCore = ctx.core.intersect(closure)
+        if relevantCore.isEmpty then
+          // Acyclic path: today's pinned-cache substitution, bit-identical (no stripping).
+          val seeded = interior.cellsRowMajor.foldLeft(sheet) { (acc, cellRef) =>
+            computeCell(wb, sheet, kind, cellRef, input1, input2, clock) match
+              case None => acc // tolerant: leave the cell untouched
+              case Some(value) => writeInterior(acc, cellRef, value)
+          }
+          (seeded, Vector.empty)
+        else
+          iterative match
+            case None =>
+              // Refuse loudly, never Left: the table stays untouched (interiors uncached, so
+              // the data-table-unseeded lint still fires) and the report names the cycle.
+              val warning =
+                SeedTableWarning.CircularNotIterated(
+                  sheet.name,
+                  interior,
+                  renderCycle(relevantCore)
+                )
+              (sheet, Vector(warning))
+            case Some(it) =>
+              seedGroupIterative(
+                wb,
+                sheet,
+                kind,
+                input1,
+                input2,
+                clock,
+                it,
+                ctx,
+                relevantCore,
+                closure
+              )
+
+  /**
+   * GH-453: per-axis-combination Jacobi fixpoint for a table whose source formula depends on the
+   * cyclic core. The REAL workbook is never touched — everything happens on temp sheets:
+   *
+   *   1. temp sheets strip exactly `stripSet` — the cells BETWEEN the what-if inputs / cycle and
+   *      the source formula (their loaded caches are stale under the substitution); cycle members
+   *      are never stripped (the fixpoint overlays them) and DataTable record caches stay pinned
+   *      per GH-430 (`stripFormulaCaches` guards them);
+   *   2. per interior cell: axis values evaluate against the group's base sheet exactly like the
+   *      acyclic path, overlay into the input cells on the temp sheets, the relevant cycle members
+   *      fixpoint via [[WorkbookEvaluator.jacobiFixpoint]] (previous-round reads, 0-seeded, strict
+   *      |Δ| < maxChange, pinned clock), converged values fold in as plain values, and the source
+   *      formula evaluates off them;
+   *   3. a Left anywhere stays tolerant — that cell is left untouched, seeding continues.
+   */
+  private def seedGroupIterative(
+    wb: Workbook,
+    sheet: Sheet,
+    kind: FormulaKind.DataTable,
+    input1: ARef,
+    input2: Option[ARef],
+    clock: Clock,
+    iterative: IterativeCalc,
+    ctx: CycleContext,
+    relevantCore: Set[QualifiedRef],
+    closure: Set[QualifiedRef]
+  ): (Sheet, Vector[SeedTableWarning]) =
+    val sheetIndex: Map[SheetName, Int] = wb.sheets.zipWithIndex.map((s, i) => s.name -> i).toMap
+    sheetIndex.get(sheet.name) match
+      case None => (sheet, Vector.empty) // defensive: wb always contains `sheet`
+      case Some(tableIdx) =>
+        val inputQ = (Set(input1) ++ input2).map(r => QualifiedRef(sheet.name, r))
+        val stripSet =
+          DependencyGraph
+            .qualifiedTransitiveDependents(ctx.dependents, inputQ ++ relevantCore)
+            .intersect(closure) -- relevantCore
+        val stripBySheet = stripSet.groupMap(_.sheet)(_.ref)
+        val prepared: Vector[Sheet] = wb.sheets.map { s =>
+          val toStrip = stripBySheet.getOrElse(s.name, Set.empty)
+          if toStrip.isEmpty then s else SheetEvaluator.stripFormulaCaches(s, toStrip)
         }
+        val members: List[(QualifiedRef, Int, String)] =
+          relevantCore.toList
+            .flatMap { q =>
+              sheetIndex.get(q.sheet).map { idx =>
+                val expr = wb(q.sheet).toOption.flatMap(_.cells.get(q.ref)).map(_.value) match
+                  case Some(CellValue.Formula(e, _, _)) => e
+                  case _ => q.ref.toA1
+                (q, idx, expr)
+              }
+            }
+            .sortBy((q, _, _) => (q.sheet.value, q.ref.toA1))
+        // One seeding run is one volatile generation, like one recalculation (GH-373).
+        val pinnedClock = Clock.fixed(clock.today(), clock.now())
+
+        val (seeded, unconverged) =
+          kind.ref.cellsRowMajor.foldLeft((sheet, 0)) { case ((acc, fails), cellRef) =>
+            val computed = computeCellIterative(
+              wb,
+              sheet,
+              kind,
+              cellRef,
+              input1,
+              input2,
+              clock,
+              iterative,
+              prepared,
+              tableIdx,
+              members,
+              pinnedClock
+            )
+            computed match
+              case None => (acc, fails) // tolerant: leave the cell untouched
+              case Some((value, converged)) =>
+                (writeInterior(acc, cellRef, value), if converged then fails else fails + 1)
+          }
+        val warnings =
+          if unconverged > 0 then
+            Vector(
+              SeedTableWarning.NotConverged(sheet.name, kind.ref, unconverged, iterative.maxIter)
+            )
+          else Vector.empty
+        (seeded, warnings)
+
+  /** One interior cell's circular what-if value plus its convergence verdict (GH-453). */
+  private def computeCellIterative(
+    wb: Workbook,
+    sheet: Sheet,
+    kind: FormulaKind.DataTable,
+    cellRef: ARef,
+    input1: ARef,
+    input2: Option[ARef],
+    clock: Clock,
+    iterative: IterativeCalc,
+    prepared: Vector[Sheet],
+    tableIdx: Int,
+    members: List[(QualifiedRef, Int, String)],
+    pinnedClock: Clock
+  ): Option[(CellValue, Boolean)] =
+    val (sourceRef, overlayRefs) = whatIfGeometry(kind, cellRef, input1, input2)
+    sheet.cells.get(sourceRef).map(_.value) match
+      case Some(CellValue.Formula(expression, _, _)) =>
+        // (1) axis values evaluate against the group's base sheet, exactly like the acyclic path
+        val overlays = overlayRefs.foldLeft(Option(Vector.empty[(ARef, CellValue)])) {
+          case (acc, (inputRef, axisRef)) =>
+            acc.flatMap { vs =>
+              SheetEvaluator
+                .evaluateCell(sheet)(axisRef, clock, Some(wb))
+                .toOption
+                .map(axisValue => vs :+ (inputRef -> axisValue))
+            }
+        }
+        overlays.flatMap { axisValues =>
+          // (2) overlay the axis values into the input cells on the PREPARED temp sheets
+          val overlaid = axisValues.foldLeft(prepared) { case (sheets, (inputRef, v)) =>
+            sheets.updated(tableIdx, sheets(tableIdx).put(inputRef, v))
+          }
+          // (3) fixpoint the relevant cycle members under this axis combination
+          val (results, converged, _) =
+            WorkbookEvaluator.jacobiFixpoint(wb, overlaid, members, iterative, pinnedClock, None)
+          // (4) fold member values in as plain values, then evaluate the source formula
+          val folded = members.foldLeft(Option(overlaid)) { case (accOpt, (q, idx, _)) =>
+            accOpt.flatMap { sheets =>
+              results.get(q) match
+                case Some(Right(v)) => Some(sheets.updated(idx, sheets(idx).put(q.ref, v)))
+                case _ => None // tolerant: a failing member leaves this cell untouched
+            }
+          }
+          folded.flatMap { sheets =>
+            SheetEvaluator
+              .evaluateFormula(sheets(tableIdx))(
+                expression,
+                clock,
+                Some(wb.copy(sheets = sheets)),
+                None
+              )
+              .toOption
+              .map(value => (value, converged))
+          }
+        }
+      case _ =>
+        // Empty or non-formula source cell: Excel caches 0 (fixture-verified bytes).
+        Some((CellValue.Number(BigDecimal(0)), true))
 
   /** One interior cell's what-if value; `None` leaves the cell untouched (tolerant). */
   private def computeCell(
@@ -146,25 +440,7 @@ object DataTableSeeder:
     input2: Option[ARef],
     clock: Clock
   ): Option[CellValue] =
-    val interior = kind.ref
-    val startRow = interior.start.row.index0
-    val startCol = interior.start.col.index0
-    val col = cellRef.col.index0
-    val row = cellRef.row.index0
-    val topAxis = ARef.from0(col, startRow - 1)
-    val leftAxis = ARef.from0(startCol - 1, row)
-
-    // D4 geometry: the source formula and which axis feeds which input.
-    val sourceRef =
-      if kind.dt2D then ARef.from0(startCol - 1, startRow - 1) // corner
-      else if kind.dtr then ARef.from0(startCol - 1, row) // row-oriented: left of THIS row
-      else ARef.from0(col, startRow - 1) // column-oriented: above THIS column
-    val overlayRefs: Vector[(ARef, ARef)] =
-      input2 match
-        case Some(colInput) => Vector(input1 -> topAxis, colInput -> leftAxis) // 2-D
-        case None if kind.dtr => Vector(input1 -> topAxis) // 1-D row-oriented
-        case None => Vector(input1 -> leftAxis) // 1-D column-oriented
-
+    val (sourceRef, overlayRefs) = whatIfGeometry(kind, cellRef, input1, input2)
     sheet.cells.get(sourceRef).map(_.value) match
       case Some(CellValue.Formula(expression, _, _)) =>
         val overlaid = overlayRefs.foldLeft(Option(sheet)) { case (acc, (inputRef, axisRef)) =>
@@ -183,3 +459,56 @@ object DataTableSeeder:
       case _ =>
         // Empty or non-formula source cell: Excel caches 0 (fixture-verified bytes).
         Some(CellValue.Number(BigDecimal(0)))
+
+  /**
+   * D4 geometry shared by both substitution paths: the source formula cell for this interior cell,
+   * and which axis value feeds which input cell.
+   */
+  private def whatIfGeometry(
+    kind: FormulaKind.DataTable,
+    cellRef: ARef,
+    input1: ARef,
+    input2: Option[ARef]
+  ): (ARef, Vector[(ARef, ARef)]) =
+    val interior = kind.ref
+    val startRow = interior.start.row.index0
+    val startCol = interior.start.col.index0
+    val col = cellRef.col.index0
+    val row = cellRef.row.index0
+    val topAxis = ARef.from0(col, startRow - 1)
+    val leftAxis = ARef.from0(startCol - 1, row)
+    val sourceRef =
+      if kind.dt2D then ARef.from0(startCol - 1, startRow - 1) // corner
+      else if kind.dtr then ARef.from0(startCol - 1, row) // row-oriented: left of THIS row
+      else ARef.from0(col, startRow - 1) // column-oriented: above THIS column
+    val overlayRefs: Vector[(ARef, ARef)] =
+      input2 match
+        case Some(colInput) => Vector(input1 -> topAxis, colInput -> leftAxis) // 2-D
+        case None if kind.dtr => Vector(input1 -> topAxis) // 1-D row-oriented
+        case None => Vector(input1 -> leftAxis) // 1-D column-oriented
+    (sourceRef, overlayRefs)
+
+  /** Every distinct source-formula cell the interior's what-if substitution reads. */
+  private def sourceRefs(kind: FormulaKind.DataTable): Set[ARef] =
+    val interior = kind.ref
+    val startRow = interior.start.row.index0
+    val startCol = interior.start.col.index0
+    if kind.dt2D then Set(ARef.from0(startCol - 1, startRow - 1))
+    else if kind.dtr then
+      (startRow to interior.end.row.index0).map(r => ARef.from0(startCol - 1, r)).toSet
+    else (startCol to interior.end.col.index0).map(c => ARef.from0(c, startRow - 1)).toSet
+
+  /** Shape-preserving interior write shared by both paths (see the object scaladoc). */
+  private def writeInterior(acc: Sheet, cellRef: ARef, value: CellValue): Sheet =
+    acc.cells.get(cellRef).map(_.value) match
+      case Some(record @ CellValue.Formula(_, _, _: FormulaKind.DataTable)) =>
+        acc.put(cellRef, record.copy(cachedValue = Some(value))) // shape-preserving
+      case Some(_: CellValue.Formula) => acc // never overwrite a real formula
+      case _ => acc.put(cellRef, value)
+
+  /** Cycle members rendered `'Sheet'!A1`, sorted, capped at 8 (GH-453 warning payload). */
+  private def renderCycle(core: Set[QualifiedRef]): Vector[String] =
+    core.toVector
+      .sortBy(q => (q.sheet.value, q.ref.toA1))
+      .take(8)
+      .map(q => s"${SheetName.quoteForFormula(q.sheet.value)}!${q.ref.toA1}")

--- a/xl-evaluator/src/com/tjclp/xl/formula/eval/DataTableSeeder.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/eval/DataTableSeeder.scala
@@ -28,6 +28,14 @@ enum SeedTableWarning derives CanEqual:
    */
   case NotConverged(sheet: SheetName, ref: CellRange, combinations: Int, maxIter: Int)
 
+  /**
+   * GH-453 (review follow-up): `cells` interior cells were left UNSEEDED on the iterated path — an
+   * axis value or cycle member failed to evaluate for those cells, or the whole table was skipped
+   * by the iterative-seeding budget guard (see `DataTableSeeder.MaxIterativeSeedBudget`). `reason`
+   * is a short human-readable cause. Without this case a fully-skipped table reads as a clean run.
+   */
+  case Skipped(sheet: SheetName, ref: CellRange, cells: Int, reason: String)
+
 /** GH-453: the seeded workbook plus every per-table warning the run produced. */
 final case class DataTableSeedReport(
   workbook: Workbook,
@@ -88,6 +96,17 @@ object DataTableSeeder:
    */
   private val MaxInteriorArea: Long = 1000000L
 
+  /**
+   * GH-453 (review follow-up): per-table cost cap for the ITERATED path, in cycle-member
+   * evaluations (`interior cells × maxIter × relevant cycle members`). `maxIter` is file-controlled
+   * (`<calcPr iterateCount=…/>`), so a hostile or misconfigured book can declare effectively
+   * unbounded work per table. A table whose worst-case cost exceeds this generous bound skips
+   * untouched and reports [[SeedTableWarning.Skipped]] naming the budget. 20,000,000 member
+   * evaluations is orders beyond any real circular sensitivity table (the 20x20 battery in the spec
+   * costs 400 × 100 × 2 = 80,000).
+   */
+  private val MaxIterativeSeedBudget: Long = 20000000L
+
   extension (wb: Workbook)
 
     /**
@@ -104,8 +123,8 @@ object DataTableSeeder:
 
     /**
      * Seed the data tables on one sheet whose record ref intersects `only` (`None` = all), with an
-     * explicit clock for volatile source formulas. Iterative settings auto-derive from the book's
-     * `<calcPr>`.
+     * explicit clock for volatile source formulas (read ONCE — one seeding run is one volatile
+     * generation). Iterative settings auto-derive from the book's `<calcPr>`.
      */
     @annotation.targetName("seedDataTablesScoped")
     def seedDataTables(
@@ -184,6 +203,10 @@ object DataTableSeeder:
       case Some((name, _)) => Vector(name)
       case None => wb.sheets.map(_.name)
     val only = scope.flatMap(_._2)
+    // GH-453 (review follow-up): ONE seeding run is ONE volatile generation — the clock is pinned
+    // once per run and used for axis values, member fixpoints AND source formulas, on both the
+    // iterated and the acyclic paths. Lazy: a run that seeds nothing never reads the clock.
+    lazy val pinnedClock: Clock = Clock.fixed(clock.today(), clock.now())
     lazy val cycles: CycleContext =
       val (deps, dependents) = DependencyGraph.fromWorkbookBounded(wb)
       CycleContext(deps, dependents, DependencyGraph.qualifiedCyclicNodes(deps))
@@ -198,7 +221,8 @@ object DataTableSeeder:
             val (seeded, groupWarns) =
               groups.foldLeft((sheet, Vector.empty[SeedTableWarning])) {
                 case ((acc, ws), (_, kind)) =>
-                  val (next, w) = seedGroup(accWb.put(acc), acc, kind, clock, iterative, cycles)
+                  val (next, w) =
+                    seedGroup(accWb.put(acc), acc, kind, pinnedClock, iterative, cycles)
                   (next, ws ++ w)
               }
             // Only a real change may mark the sheet modified — a no-op seed (already-correct
@@ -273,18 +297,33 @@ object DataTableSeeder:
                 )
               (sheet, Vector(warning))
             case Some(it) =>
-              seedGroupIterative(
-                wb,
-                sheet,
-                kind,
-                input1,
-                input2,
-                clock,
-                it,
-                ctx,
-                relevantCore,
-                closure
-              )
+              // GH-453 (review follow-up): the iterated path's worst case costs
+              // interiorCells × maxIter × |members| member-evaluations, and maxIter comes from
+              // the FILE. A table past the budget skips untouched — loudly, via Skipped.
+              val interiorCells = interior.width.toLong * interior.height.toLong
+              val rounds = math.max(1, it.maxIter)
+              val cost = BigInt(interiorCells) * BigInt(rounds) * BigInt(relevantCore.size)
+              if cost > BigInt(MaxIterativeSeedBudget) then
+                val reason =
+                  s"iterative seeding budget exceeded: $interiorCells interior cells x " +
+                    s"$rounds max rounds x ${relevantCore.size} cycle members > " +
+                    s"$MaxIterativeSeedBudget member-evaluations"
+                val warning =
+                  SeedTableWarning.Skipped(sheet.name, interior, interiorCells.toInt, reason)
+                (sheet, Vector(warning))
+              else
+                seedGroupIterative(
+                  wb,
+                  sheet,
+                  kind,
+                  input1,
+                  input2,
+                  clock,
+                  it,
+                  ctx,
+                  relevantCore,
+                  closure
+                )
 
   /**
    * GH-453: per-axis-combination Jacobi fixpoint for a table whose source formula depends on the
@@ -297,9 +336,11 @@ object DataTableSeeder:
    *   2. per interior cell: axis values evaluate against the group's base sheet exactly like the
    *      acyclic path, overlay into the input cells on the temp sheets, the relevant cycle members
    *      fixpoint via [[WorkbookEvaluator.jacobiFixpoint]] (previous-round reads, 0-seeded, strict
-   *      |Δ| < maxChange, pinned clock), converged values fold in as plain values, and the source
-   *      formula evaluates off them;
-   *   3. a Left anywhere stays tolerant — that cell is left untouched, seeding continues.
+   *      |Δ| < maxChange, the run's pinned clock), converged values fold in as plain values, and
+   *      the source formula evaluates off them;
+   *   3. a Left anywhere stays tolerant — that cell is left untouched and seeding continues, but
+   *      the table reports ONE [[SeedTableWarning.Skipped]] counting the unseeded cells (a
+   *      fully-skipped table must never read as a clean run).
    */
   private def seedGroupIterative(
     wb: Workbook,
@@ -343,11 +384,11 @@ object DataTableSeeder:
               }
             }
             .sortBy((q, _, _) => (q.sheet.value, q.ref.toA1))
-        // One seeding run is one volatile generation, like one recalculation (GH-373).
-        val pinnedClock = Clock.fixed(clock.today(), clock.now())
-
-        val (seeded, unconverged) =
-          kind.ref.cellsRowMajor.foldLeft((sheet, 0)) { case ((acc, fails), cellRef) =>
+        // The clock arrives pinned from seedWorkbook: one seeding run is one volatile
+        // generation, like one recalculation (GH-373) — axis values, member fixpoints and
+        // source formulas all read the same instant.
+        val (seeded, unconverged, skipped) =
+          kind.ref.cellsRowMajor.foldLeft((sheet, 0, 0)) { case ((acc, fails, skips), cellRef) =>
             val computed = computeCellIterative(
               wb,
               sheet,
@@ -359,23 +400,38 @@ object DataTableSeeder:
               iterative,
               prepared,
               tableIdx,
-              members,
-              pinnedClock
+              members
             )
             computed match
-              case None => (acc, fails) // tolerant: leave the cell untouched
+              case None => (acc, fails, skips + 1) // tolerant: leave the cell untouched
               case Some((value, converged)) =>
-                (writeInterior(acc, cellRef, value), if converged then fails else fails + 1)
+                (writeInterior(acc, cellRef, value), if converged then fails else fails + 1, skips)
           }
-        val warnings =
+        val notConverged =
           if unconverged > 0 then
             Vector(
               SeedTableWarning.NotConverged(sheet.name, kind.ref, unconverged, iterative.maxIter)
             )
           else Vector.empty
-        (seeded, warnings)
+        // GH-453 (review follow-up): unseeded cells must be VISIBLE in the report — one Skipped
+        // per table counting them (axis-value or cycle-member evaluation failures).
+        val skippedWarning =
+          if skipped > 0 then
+            Vector(
+              SeedTableWarning.Skipped(
+                sheet.name,
+                kind.ref,
+                skipped,
+                "axis value or cycle-member evaluation failed"
+              )
+            )
+          else Vector.empty
+        (seeded, notConverged ++ skippedWarning)
 
-  /** One interior cell's circular what-if value plus its convergence verdict (GH-453). */
+  /**
+   * One interior cell's circular what-if value plus its convergence verdict (GH-453). `clock` is
+   * the run's pinned clock — axis, fixpoint and source evaluations share one volatile generation.
+   */
   private def computeCellIterative(
     wb: Workbook,
     sheet: Sheet,
@@ -387,8 +443,7 @@ object DataTableSeeder:
     iterative: IterativeCalc,
     prepared: Vector[Sheet],
     tableIdx: Int,
-    members: List[(QualifiedRef, Int, String)],
-    pinnedClock: Clock
+    members: List[(QualifiedRef, Int, String)]
   ): Option[(CellValue, Boolean)] =
     val (sourceRef, overlayRefs) = whatIfGeometry(kind, cellRef, input1, input2)
     sheet.cells.get(sourceRef).map(_.value) match
@@ -410,7 +465,7 @@ object DataTableSeeder:
           }
           // (3) fixpoint the relevant cycle members under this axis combination
           val (results, converged, _) =
-            WorkbookEvaluator.jacobiFixpoint(wb, overlaid, members, iterative, pinnedClock, None)
+            WorkbookEvaluator.jacobiFixpoint(wb, overlaid, members, iterative, clock, None)
           // (4) fold member values in as plain values, then evaluate the source formula
           val folded = members.foldLeft(Option(overlaid)) { case (accOpt, (q, idx, _)) =>
             accOpt.flatMap { sheets =>

--- a/xl-evaluator/src/com/tjclp/xl/formula/eval/Recalc.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/eval/Recalc.scala
@@ -81,11 +81,21 @@ object IterativeCalc:
  * @param errors
  *   Per-cell COULD-NOT-EVALUATE host failures only: parse errors, unknown functions, missing
  *   sheets, cycle participants, and cells blocked by a cycle
+ * @param converged
+ *   GH-454: false iff an iterative run exhausted `maxIter` rounds without every cycle member's
+ *   |Δ| dropping below `maxChange` — the last-round values are still kept (Excel semantics) but
+ *   callers can now gate instead of mistaking exhaustion for stationarity. Non-iterative runs
+ *   (default `recalculate()`, or iterative settings on an acyclic workbook) report true.
+ * @param iterationsUsed
+ *   GH-454: iterative rounds actually run (0 when no iteration happened). Equals `maxIter` on
+ *   exhaustion; on convergence it is the round that converged, in (0, maxIter]
  */
 final case class RecalcResult(
   workbook: Workbook,
   evaluated: Map[SheetName, Map[ARef, CellValue]],
-  errors: Vector[CellEvalError]
+  errors: Vector[CellEvalError],
+  converged: Boolean = true,
+  iterationsUsed: Int = 0
 ) derives CanEqual:
 
   /**

--- a/xl-evaluator/src/com/tjclp/xl/formula/eval/StructuralEditor.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/eval/StructuralEditor.scala
@@ -113,26 +113,43 @@ object StructuralEditor:
                 // (visible, deterministic).
                 (ref, cell.copy(value = cachedOpt.getOrElse(CellValue.Empty)))
         case f @ CellValue.Formula(formulaStr, _, kind) =>
-          FormulaParser.parse(formulaStr) match
-            case Right(expr) =>
-              FormulaShifter.shiftStructural(expr, shiftLocal, editedSheet, isRow, at, delta) match
-                case Some(shiftedExpr) =>
-                  // GH-427: the model's canonical formula form is equals-free (the reader strips
-                  // the '='; the writer serializes the string VERBATIM into <f>, where a leading
-                  // '=' is a spec deviation openpyxl reads back as '==...').
-                  //
-                  // A structural edit invalidates formula caches even when every parsed reference
-                  // survives: a shortened range can produce a different aggregate, and moving a
-                  // cell changes position-sensitive formulas such as ROW(). Leave the expression
-                  // evaluatable and uncached so the next recalculation cannot expose stale data.
-                  val newStr = FormulaPrinter.print(shiftedExpr, includeEquals = false)
-                  val newKind = shiftedArrayKind(kind, shiftLocal, isRow, at, delta)
-                  (ref, cell.copy(value = CellValue.Formula(newStr, None, newKind)))
-                case None =>
-                  (ref, cell.copy(value = CellValue.Error(CellError.Ref)))
-            // Preserve unparseable text rather than guessing at a rewrite, but invalidate its
-            // cache too: the edit may have moved the cell or changed a dynamically-read value.
-            case Left(_) => (ref, cell.copy(value = f.copy(cachedValue = None)))
+          // GH-455: a formula on a NON-edited sheet participates only through sheet-qualified
+          // references to the edited sheet. Everything else must ride byte-identical — text AND
+          // cached value: reprinting canonicalizes text it has no business touching. The text
+          // gate skips the parse entirely (any real reference spells the sheet name in the
+          // formula text); the AST gate settles the false positives exactly.
+          if !shiftLocal && !mentionsSheet(formulaStr, editedSheet) then (ref, cell)
+          else
+            FormulaParser.parse(formulaStr) match
+              case Right(expr)
+                  if !shiftLocal && !FormulaShifter.referencesSheet(expr, editedSheet) =>
+                (ref, cell)
+              case Right(expr) =>
+                FormulaShifter.shiftStructural(
+                  expr,
+                  shiftLocal,
+                  editedSheet,
+                  isRow,
+                  at,
+                  delta
+                ) match
+                  case Some(shiftedExpr) =>
+                    // GH-427: the model's canonical formula form is equals-free (the reader strips
+                    // the '='; the writer serializes the string VERBATIM into <f>, where a leading
+                    // '=' is a spec deviation openpyxl reads back as '==...').
+                    //
+                    // A structural edit invalidates formula caches even when every parsed reference
+                    // survives: a shortened range can produce a different aggregate, and moving a
+                    // cell changes position-sensitive formulas such as ROW(). Leave the expression
+                    // evaluatable and uncached so the next recalculation cannot expose stale data.
+                    val newStr = FormulaPrinter.print(shiftedExpr, includeEquals = false)
+                    val newKind = shiftedArrayKind(kind, shiftLocal, isRow, at, delta)
+                    (ref, cell.copy(value = CellValue.Formula(newStr, None, newKind)))
+                  case None =>
+                    (ref, cell.copy(value = CellValue.Error(CellError.Ref)))
+              // Preserve unparseable text rather than guessing at a rewrite, but invalidate its
+              // cache too: the edit may have moved the cell or changed a dynamically-read value.
+              case Left(_) => (ref, cell.copy(value = f.copy(cachedValue = None)))
         case _ => (ref, cell)
     }
     sheet.copy(
@@ -142,6 +159,18 @@ object StructuralEditor:
       dataValidations =
         rewriteDvFormulas(sheet.dataValidations, shiftLocal, editedSheet, isRow, at, delta)
     )
+
+  /**
+   * GH-455: conservative text pre-filter for the non-edited-sheet fast path — false means the
+   * formula text cannot contain a reference to `editedSheet`, so parsing is pointless. Quoted sheet
+   * names double their apostrophes in formula text (`'It''s'!A1`), so undouble before the
+   * case-insensitive scan (matching the shifter's `equalsIgnoreCase` convention). False positives
+   * (the name inside a string literal, say) are settled exactly by the AST gate.
+   */
+  private def mentionsSheet(formula: String, editedSheet: String): Boolean =
+    val text = formula.replace("''", "'")
+    val n = editedSheet.length
+    (0 to text.length - n).exists(i => text.regionMatches(true, i, editedSheet, 0, n))
 
   // ========== GH-430: record-payload geometry (FormulaKind ref/r1/r2 shifting) ==========
 
@@ -225,12 +254,18 @@ object StructuralEditor:
     at: Int,
     delta: Int
   ): String =
-    FormulaParser.parse(s"=$formula") match
-      case Right(expr) =>
-        FormulaShifter.shiftStructural(expr, shiftLocal, editedSheet, isRow, at, delta) match
-          case Some(shifted) => FormulaPrinter.print(shifted, includeEquals = false)
-          case None => "#REF!"
-      case Left(_) => formula
+    // GH-455: same non-participation gates as the cell-formula path — a CF/DV formula on a
+    // non-edited sheet that cannot reference the edited sheet rides byte-identical.
+    if !shiftLocal && !mentionsSheet(formula, editedSheet) then formula
+    else
+      FormulaParser.parse(s"=$formula") match
+        case Right(expr) if !shiftLocal && !FormulaShifter.referencesSheet(expr, editedSheet) =>
+          formula
+        case Right(expr) =>
+          FormulaShifter.shiftStructural(expr, shiftLocal, editedSheet, isRow, at, delta) match
+            case Some(shifted) => FormulaPrinter.print(shifted, includeEquals = false)
+            case None => "#REF!"
+        case Left(_) => formula
 
   /**
    * GH-136: rewrite TYPED conditional-format formula text (CellIs.formula1/formula2,

--- a/xl-evaluator/src/com/tjclp/xl/formula/eval/StructuralEditor.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/eval/StructuralEditor.scala
@@ -60,7 +60,13 @@ object StructuralEditor:
     lazy val staleCaches: Set[QualifiedRef] =
       val (_, dependents) = DependencyGraph.fromWorkbookBounded(wb)
       val seeds = dependents.keySet.filter(_.sheet == target)
-      DependencyGraph.qualifiedTransitiveDependents(dependents, seeds)
+      // A dynamic reference can reach the edited sheet without contributing a static graph edge.
+      // Conservatively invalidate every dynamic cell and its static dependent closure: the edit
+      // may have changed what its unchanged reference text resolves to.
+      val dynamic = wb.sheets.iterator.flatMap { s =>
+        DependencyGraph.dynamicCells(s).iterator.map(r => QualifiedRef(s.name, r))
+      }.toSet
+      dynamic ++ DependencyGraph.qualifiedTransitiveDependents(dependents, seeds ++ dynamic)
     val updatedSheets = wb.sheets.map { s =>
       // 1. Pure cell/merge/property shift — only on the edited sheet. Its own typed charts
       //    (anchors + same-sheet data refs) are handled INSIDE the shift (GH-222).

--- a/xl-evaluator/src/com/tjclp/xl/formula/eval/StructuralEditor.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/eval/StructuralEditor.scala
@@ -1,10 +1,14 @@
 package com.tjclp.xl.formula.eval
 
+import scala.annotation.tailrec
+
 import com.tjclp.xl.workbooks.Workbook
 import com.tjclp.xl.sheets.{DataValidation, DvKind, Sheet}
 import com.tjclp.xl.addressing.{ARef, CellRange, Column, Row, SheetName}
-import com.tjclp.xl.cells.{CellError, CellValue, FormulaKind}
+import com.tjclp.xl.cells.{Cell, CellError, CellValue, FormulaKind}
 import com.tjclp.xl.cf.{CfRule, Cfvo, ConditionalFormat}
+import com.tjclp.xl.formula.graph.DependencyGraph
+import com.tjclp.xl.formula.graph.DependencyGraph.QualifiedRef
 import com.tjclp.xl.formula.parser.FormulaParser
 import com.tjclp.xl.formula.printer.{FormulaPrinter, FormulaShifter}
 
@@ -47,6 +51,16 @@ object StructuralEditor:
     delta: Int
   ): Workbook =
     val editedName = target.value
+    // GH-455 follow-up: the non-participation fast path below keeps formula TEXT byte-identical,
+    // but a cached VALUE can be stale even when the text never names the edited sheet —
+    // Sheet2!Y ==X*2 over Sheet2!X =='Sheet1'!A1 reads Sheet1 two hops away. Invalidate the cache
+    // of every formula transitively dependent (cross-sheet, through any chain) on any cell of the
+    // edited sheet. One PRE-edit graph build per edit, forced lazily and only when a
+    // non-participating formula actually rides the fast path (the CLI path recalculates after).
+    lazy val staleCaches: Set[QualifiedRef] =
+      val (_, dependents) = DependencyGraph.fromWorkbookBounded(wb)
+      val seeds = dependents.keySet.filter(_.sheet == target)
+      DependencyGraph.qualifiedTransitiveDependents(dependents, seeds)
     val updatedSheets = wb.sheets.map { s =>
       // 1. Pure cell/merge/property shift — only on the edited sheet. Its own typed charts
       //    (anchors + same-sheet data refs) are handled INSIDE the shift (GH-222).
@@ -63,7 +77,15 @@ object StructuralEditor:
           s.shiftChartRefs(editedName, isRow, at, delta)
       // 2. Rewrite formula references on every sheet (local refs only on the edited sheet;
       //    sheet-qualified refs to the edited sheet on all sheets).
-      rewriteFormulas(shifted, shiftLocal = s.name == target, editedName, isRow, at, delta)
+      rewriteFormulas(
+        shifted,
+        shiftLocal = s.name == target,
+        editedName,
+        isRow,
+        at,
+        delta,
+        stale = r => staleCaches.contains(QualifiedRef(s.name, r))
+      )
     }
     // A structural edit can touch any sheet's formulas (cross-sheet refs), so mark every sheet
     // modified — otherwise the writer's clean/verbatim fast-path would copy stale bytes from the
@@ -78,8 +100,15 @@ object StructuralEditor:
     editedSheet: String,
     isRow: Boolean,
     at: Int,
-    delta: Int
+    delta: Int,
+    stale: ARef => Boolean
   ): Sheet =
+    // GH-455 follow-up: a non-participating formula keeps its TEXT byte-identical, but a cached
+    // value that transitively reads the edited sheet is stale and must drop (the writer would
+    // otherwise emit it into <v>). Independent formulas keep text AND cache untouched.
+    def keepNonParticipant(ref: ARef, cell: Cell, f: CellValue.Formula): Cell =
+      if f.cachedValue.isDefined && stale(ref) then cell.copy(value = f.copy(cachedValue = None))
+      else cell
     val updatedCells = sheet.cells.map { case (ref, cell) =>
       cell.value match
         // GH-430: a data-table record's payload (ref/r1/r2) is LOCAL sheet geometry — it moves
@@ -114,16 +143,18 @@ object StructuralEditor:
                 (ref, cell.copy(value = cachedOpt.getOrElse(CellValue.Empty)))
         case f @ CellValue.Formula(formulaStr, _, kind) =>
           // GH-455: a formula on a NON-edited sheet participates only through sheet-qualified
-          // references to the edited sheet. Everything else must ride byte-identical — text AND
-          // cached value: reprinting canonicalizes text it has no business touching. The text
+          // references to the edited sheet. Everything else rides byte-identical in TEXT
+          // (reprinting canonicalizes text it has no business touching), and keeps its cached
+          // value too unless it transitively depends on the edited sheet (`stale`). The text
           // gate skips the parse entirely (any real reference spells the sheet name in the
           // formula text); the AST gate settles the false positives exactly.
-          if !shiftLocal && !mentionsSheet(formulaStr, editedSheet) then (ref, cell)
+          if !shiftLocal && !mentionsSheet(formulaStr, editedSheet) then
+            (ref, keepNonParticipant(ref, cell, f))
           else
             FormulaParser.parse(formulaStr) match
               case Right(expr)
                   if !shiftLocal && !FormulaShifter.referencesSheet(expr, editedSheet) =>
-                (ref, cell)
+                (ref, keepNonParticipant(ref, cell, f))
               case Right(expr) =>
                 FormulaShifter.shiftStructural(
                   expr,
@@ -163,14 +194,36 @@ object StructuralEditor:
   /**
    * GH-455: conservative text pre-filter for the non-edited-sheet fast path — false means the
    * formula text cannot contain a reference to `editedSheet`, so parsing is pointless. Quoted sheet
-   * names double their apostrophes in formula text (`'It''s'!A1`), so undouble before the
-   * case-insensitive scan (matching the shifter's `equalsIgnoreCase` convention). False positives
-   * (the name inside a string literal, say) are settled exactly by the AST gate.
+   * names double their apostrophes in formula text (`'It''s'!A1`), so a doubled apostrophe in the
+   * formula matches a single apostrophe in the name — collapsed inline during the case-insensitive
+   * scan (matching the shifter's `equalsIgnoreCase` convention) instead of allocating an undoubled
+   * copy per formula per sheet per edit. False positives (the name inside a string literal, say)
+   * are settled exactly by the AST gate.
    */
   private def mentionsSheet(formula: String, editedSheet: String): Boolean =
-    val text = formula.replace("''", "'")
     val n = editedSheet.length
-    (0 to text.length - n).exists(i => text.regionMatches(true, i, editedSheet, 0, n))
+    val len = formula.length
+    // String.regionMatches(ignoreCase = true) equality: exact, or upper, or lower match.
+    def charsMatch(a: Char, b: Char): Boolean =
+      a == b || Character.toUpperCase(a) == Character.toUpperCase(b) ||
+        Character.toLowerCase(a) == Character.toLowerCase(b)
+    @tailrec
+    def matchesAt(fi: Int, pi: Int): Boolean =
+      if pi >= n then true
+      else if fi >= len then false
+      else
+        val fc = formula.charAt(fi)
+        if !charsMatch(fc, editedSheet.charAt(pi)) then false
+        else
+          // A matched apostrophe consumes its doubled partner ('' in text is ' in the name).
+          val step = if fc == '\'' && fi + 1 < len && formula.charAt(fi + 1) == '\'' then 2 else 1
+          matchesAt(fi + step, pi + 1)
+    @tailrec
+    def scan(i: Int): Boolean =
+      if i >= len then false
+      else if matchesAt(i, 0) then true
+      else scan(i + 1)
+    n == 0 || scan(0)
 
   // ========== GH-430: record-payload geometry (FormulaKind ref/r1/r2 shifting) ==========
 

--- a/xl-evaluator/src/com/tjclp/xl/formula/eval/WorkbookEvaluator.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/eval/WorkbookEvaluator.scala
@@ -349,7 +349,10 @@ object WorkbookEvaluator:
           preOrder,
           (initialSheets, Map.empty[SheetName, Map[ARef, CellValue]], Vector.empty[CellEvalError])
         )
-        val iterated = iterativeOpt match
+        // GH-454: the fixpoint's convergence verdict and round count surface on RecalcResult —
+        // exhaustion of maxIter must be distinguishable from stationarity. Non-iterative runs
+        // report (converged = true, iterationsUsed = 0): no iteration happened.
+        val (iterated, converged, iterationsUsed) = iterativeOpt match
           case Some(iterative) if cyclicCore.nonEmpty =>
             iterateCycles(
               wb,
@@ -361,7 +364,7 @@ object WorkbookEvaluator:
               formulaText,
               preState
             )
-          case _ => preState
+          case _ => (preState, true, 0)
         val (_, evaluated, evalErrors) = evalPass(postOrder, iterated)
 
         // Cache computed values into formula cells on the original sheets; failed cells stay
@@ -398,7 +401,9 @@ object WorkbookEvaluator:
         RecalcResult(
           workbook = workbookWithCaches,
           evaluated = wb.sheets.map(s => s.name -> evaluated.getOrElse(s.name, Map.empty)).toMap,
-          errors = cycleErrors ++ blockedErrors ++ evalErrors
+          errors = cycleErrors ++ blockedErrors ++ evalErrors,
+          converged = converged,
+          iterationsUsed = iterationsUsed
         )
 
   /**
@@ -427,7 +432,7 @@ object WorkbookEvaluator:
     sheetIndex: Map[SheetName, Int],
     formulaText: QualifiedRef => String,
     state: (Vector[Sheet], Map[SheetName, Map[ARef, CellValue]], Vector[CellEvalError])
-  ): (Vector[Sheet], Map[SheetName, Map[ARef, CellValue]], Vector[CellEvalError]) =
+  ): ((Vector[Sheet], Map[SheetName, Map[ARef, CellValue]], Vector[CellEvalError]), Boolean, Int) =
     val (baseSheets, acc0, errs0) = state
     // Deterministic member order: Jacobi values are order-independent (all reads see the
     // previous round), but error vectors and sheet folds must be stable run to run.
@@ -437,6 +442,49 @@ object WorkbookEvaluator:
         .sortBy((q, _, _) => (q.sheet.value, q.ref.toA1))
 
     val pinnedClock = Clock.fixed(clock.today(), clock.now())
+    val (finalResults, converged, rounds) =
+      jacobiFixpoint(wb, baseSheets, members, iterative, pinnedClock, rngOpt)
+    // Fold the fixpoint into the pass state: successful members write their value into the temp
+    // sheets (post-pass dependents read them) and the evaluated map (they cache at the end);
+    // failed members keep their original uncached formula cell, so dependents recursively
+    // evaluate and surface the underlying error — the same posture as a failed acyclic cell.
+    val folded = members.foldLeft((baseSheets, acc0, errs0)) {
+      case ((sheets, acc, errs), (q, idx, _)) =>
+        finalResults.get(q) match
+          case Some(Right(value)) =>
+            (
+              sheets.updated(idx, sheets(idx).put(q.ref, value)),
+              acc.updated(q.sheet, acc.getOrElse(q.sheet, Map.empty) + (q.ref -> value)),
+              errs
+            )
+          case Some(Left(error)) => (sheets, acc, errs :+ CellEvalError(q.sheet, q.ref, error))
+          case None => (sheets, acc, errs) // unreachable: every member evaluates every round
+    }
+    (folded, converged, rounds)
+
+  /**
+   * The shared Jacobi fixpoint engine (GH-373/GH-453/GH-454): iterate `members` against
+   * `baseSheets` until every member's |Δ| < `maxChange` (strict) or `maxIter` rounds.
+   *
+   * Each member is `(qualified ref, index of its sheet in baseSheets, formula text)`. Members seed
+   * to 0; each round overlays every member's cell with `Formula(expr, Some(previousValue))` so
+   * every reference to a member — including self-references — reads the previous round's value
+   * while `evaluateCell` re-evaluates the formula text. Callers pin the clock BEFORE calling (one
+   * fixpoint is one volatile generation). A member that throws holds its previous value for later
+   * rounds (GH-388 degradation) and reports its Left only from the final round.
+   *
+   * Returns (final per-member results, converged verdict, rounds actually run — `maxIter` on
+   * exhaustion). Used by both `recalculate(IterativeCalc)` and the data-table seeder's circular
+   * what-if substitution.
+   */
+  private[eval] def jacobiFixpoint(
+    wb: Workbook,
+    baseSheets: Vector[Sheet],
+    members: List[(QualifiedRef, Int, String)],
+    iterative: IterativeCalc,
+    pinnedClock: Clock,
+    rngOpt: Option[Rng]
+  ): (Map[QualifiedRef, Either[XLError, CellValue]], Boolean, Int) =
     val zero: CellValue = CellValue.Number(BigDecimal(0))
     val seed: Map[QualifiedRef, CellValue] = members.map((q, _, _) => q -> zero).toMap
     val maxRounds = math.max(1, iterative.maxIter)
@@ -454,13 +502,13 @@ object WorkbookEvaluator:
     def loop(
       round: Int,
       prev: Map[QualifiedRef, CellValue]
-    ): Map[QualifiedRef, Either[XLError, CellValue]] =
+    ): (Map[QualifiedRef, Either[XLError, CellValue]], Boolean, Int) =
       val overlaid = members.foldLeft(baseSheets) { case (sheets, (q, idx, expr)) =>
         sheets.updated(idx, sheets(idx).put(q.ref, CellValue.Formula(expr, prev.get(q))))
       }
       val tempWb = wb.copy(sheets = overlaid)
       val results: Map[QualifiedRef, Either[XLError, CellValue]] =
-        members.map { (q, idx, _) =>
+        members.map { (q, idx, expr) =>
           val tempSheet = overlaid(idx)
           val evaluatedCell =
             try
@@ -469,9 +517,7 @@ object WorkbookEvaluator:
                 case None => tempSheet.evaluateCell(q.ref, pinnedClock, Some(tempWb))
             catch
               case NonFatal(e) =>
-                Left(
-                  XLError.FormulaError(formulaText(q), s"Evaluation threw ${e.getClass.getName}")
-                )
+                Left(XLError.FormulaError(expr, s"Evaluation threw ${e.getClass.getName}"))
           q -> evaluatedCell
         }.toMap
       val converged = members.forall { (q, _, _) =>
@@ -479,7 +525,7 @@ object WorkbookEvaluator:
           case Right(next) => changeBelowThreshold(prev.getOrElse(q, zero), next)
           case Left(_) => false
       }
-      if converged || round >= maxRounds then results
+      if converged || round >= maxRounds then (results, converged, round)
       else
         // A throwing/failing member holds its previous value for the next round so the rest of
         // the core keeps converging (GH-388 degradation, not unwinding).
@@ -488,19 +534,4 @@ object WorkbookEvaluator:
         }.toMap
         loop(round + 1, next)
 
-    val finalResults = loop(1, seed)
-    // Fold the fixpoint into the pass state: successful members write their value into the temp
-    // sheets (post-pass dependents read them) and the evaluated map (they cache at the end);
-    // failed members keep their original uncached formula cell, so dependents recursively
-    // evaluate and surface the underlying error — the same posture as a failed acyclic cell.
-    members.foldLeft((baseSheets, acc0, errs0)) { case ((sheets, acc, errs), (q, idx, _)) =>
-      finalResults.get(q) match
-        case Some(Right(value)) =>
-          (
-            sheets.updated(idx, sheets(idx).put(q.ref, value)),
-            acc.updated(q.sheet, acc.getOrElse(q.sheet, Map.empty) + (q.ref -> value)),
-            errs
-          )
-        case Some(Left(error)) => (sheets, acc, errs :+ CellEvalError(q.sheet, q.ref, error))
-        case None => (sheets, acc, errs) // unreachable: every member evaluates every round
-    }
+    loop(1, seed)

--- a/xl-evaluator/src/com/tjclp/xl/formula/graph/DependencyGraph.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/graph/DependencyGraph.scala
@@ -1060,6 +1060,17 @@ object DependencyGraph:
     transitiveDependentsOf(dependents, refs)
 
   /**
+   * GH-453: transitive PRECEDENTS over the workbook-level graph (excludes the starting refs) — the
+   * same generic reachability BFS run over the FORWARD edge map instead of the reverse one. Used by
+   * the data-table seeder to gate a table's source formula on the cyclic core.
+   */
+  def qualifiedTransitivePrecedents(
+    dependencies: Map[QualifiedRef, Set[QualifiedRef]],
+    refs: Set[QualifiedRef]
+  ): Set[QualifiedRef] =
+    transitiveDependentsOf(dependencies, refs)
+
+  /**
    * GH-346: Kahn order over the workbook-level graph. Left carries the nodes that could not be
    * ordered (cycle participants and their downstream); callers that prune cycles first only reach
    * Left as a defensive-totality path.

--- a/xl-evaluator/src/com/tjclp/xl/formula/parser/FormulaParser.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/parser/FormulaParser.scala
@@ -6,7 +6,7 @@ import com.tjclp.xl.formula.{Arity}
 
 import com.tjclp.xl.{ARef, Anchor, CellRange, SheetName}
 import com.tjclp.xl.addressing.RefParser
-import com.tjclp.xl.cells.Cell
+import com.tjclp.xl.cells.{Cell, CellValue}
 import com.tjclp.xl.codec
 
 import scala.annotation.tailrec
@@ -269,121 +269,80 @@ object FormulaParser:
     }
 
   /**
-   * Parse comparison operators: =, <>, <, <=, >, >=
+   * Parse comparison operators: =, <>, <, <=, >, >= (left-associative).
+   *
+   * GH-455: chained comparisons fold LEFT like Excel's equal-precedence rule (`=1=1=TRUE` is
+   * `(1=1)=TRUE`); right-recursion here would build right-nested ASTs that the printer must then
+   * parenthesize, destroying byte-fidelity of untouched chained formulas on every rewrite.
+   *
+   * GH-233: PolyRef operands resolve polymorphically so =A1=B1 / =IF(A1=B1,…) evaluate instead of
+   * erroring with "Unresolved PolyRef". GH-335: the comparable decoder preserves emptiness so empty
+   * cells equal 0 / "" / FALSE like Excel, compares text lexicographically, and ranks number < text
+   * < logical (numeric-only coercion would reject text operands).
    */
   @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
   private def parseComparison(state: ParserState): ParseResult[TExpr[?]] =
+    def mk(op: (TExpr[CellValue], TExpr[CellValue]) => TExpr[Boolean])(
+      l: TExpr[?],
+      r: TExpr[?]
+    ): TExpr[?] =
+      op(TExpr.asComparableValueExpr(l), TExpr.asComparableValueExpr(r))
     parseConcatenation(state).flatMap { case (left, s1) =>
-      val s2 = skipWhitespace(s1)
-      s2.currentChar match
-        case Some('=') =>
-          val s3 = skipWhitespace(s2.advance())
-          descend(s3).flatMap { sd =>
-            parseComparison(sd).map { case (right, s4) =>
-              // GH-233: resolve PolyRef operands polymorphically so =A1=B1 / =IF(A1=B1,…)
-              // evaluate instead of erroring with "Unresolved PolyRef". GH-335: the comparable
-              // decoder preserves emptiness so empty cells equal 0 / "" / FALSE like Excel.
-              (
-                TExpr.Eq(TExpr.asComparableValueExpr(left), TExpr.asComparableValueExpr(right)),
-                s4.copy(depth = s3.depth)
-              )
-            }
-          }
-        case Some('<') =>
-          s2.advance().currentChar match
-            case Some('>') => // <>
-              val s3 = skipWhitespace(s2.advance(2))
-              descend(s3).flatMap { sd =>
-                parseComparison(sd).map { case (right, s4) =>
-                  // GH-233/GH-335: resolve PolyRef operands so =A1<>B1 evaluates (see Eq above).
-                  (
-                    TExpr
-                      .Neq(TExpr.asComparableValueExpr(left), TExpr.asComparableValueExpr(right)),
-                    s4.copy(depth = s3.depth)
-                  )
-                }
-              }
-            case Some('=') => // <=
-              val s3 = skipWhitespace(s2.advance(2))
-              descend(s3).flatMap { sd =>
-                parseComparison(sd).map { case (right, s4) =>
-                  // GH-335: resolve operands polymorphically (like Eq) — Excel compares text
-                  // lexicographically and ranks number < text < logical, so numeric-only
-                  // coercion would reject text operands.
-                  (
-                    TExpr.Lte(
-                      TExpr.asComparableValueExpr(left),
-                      TExpr.asComparableValueExpr(right)
-                    ),
-                    s4.copy(depth = s3.depth)
-                  )
-                }
-              }
-            case _ => // <
-              val s3 = skipWhitespace(s2.advance())
-              descend(s3).flatMap { sd =>
-                parseComparison(sd).map { case (right, s4) =>
-                  // GH-335: polymorphic operands (see Lte above)
-                  (
-                    TExpr.Lt(TExpr.asComparableValueExpr(left), TExpr.asComparableValueExpr(right)),
-                    s4.copy(depth = s3.depth)
-                  )
-                }
-              }
-        case Some('>') =>
-          s2.advance().currentChar match
-            case Some('=') => // >=
-              val s3 = skipWhitespace(s2.advance(2))
-              descend(s3).flatMap { sd =>
-                parseComparison(sd).map { case (right, s4) =>
-                  // GH-335: polymorphic operands (see Lte above)
-                  (
-                    TExpr.Gte(
-                      TExpr.asComparableValueExpr(left),
-                      TExpr.asComparableValueExpr(right)
-                    ),
-                    s4.copy(depth = s3.depth)
-                  )
-                }
-              }
-            case _ => // >
-              val s3 = skipWhitespace(s2.advance())
-              descend(s3).flatMap { sd =>
-                parseComparison(sd).map { case (right, s4) =>
-                  // GH-335: polymorphic operands (see Lte above)
-                  (
-                    TExpr.Gt(TExpr.asComparableValueExpr(left), TExpr.asComparableValueExpr(right)),
-                    s4.copy(depth = s3.depth)
-                  )
-                }
-              }
-        case _ => Right((left, s2))
+      @tailrec
+      def loop(acc: TExpr[?], s: ParserState): ParseResult[TExpr[?]] =
+        val s2 = skipWhitespace(s)
+        // (chars consumed, node constructor); None = no comparison operator here
+        val operator: Option[(Int, (TExpr[?], TExpr[?]) => TExpr[?])] = s2.currentChar match
+          case Some('=') => Some((1, mk(TExpr.Eq.apply)))
+          case Some('<') =>
+            s2.advance().currentChar match
+              case Some('>') => Some((2, mk(TExpr.Neq.apply)))
+              case Some('=') => Some((2, mk(TExpr.Lte.apply)))
+              case _ => Some((1, mk(TExpr.Lt.apply)))
+          case Some('>') =>
+            s2.advance().currentChar match
+              case Some('=') => Some((2, mk(TExpr.Gte.apply)))
+              case _ => Some((1, mk(TExpr.Gt.apply)))
+          case _ => None
+        operator match
+          case None => Right((acc, s2))
+          case Some((consumed, build)) =>
+            // GH-56: each chained comparison deepens the AST spine — count it (see parseAddSub).
+            descend(s2) match
+              case Left(err) => Left(err)
+              case Right(sd) =>
+                val s3 = skipWhitespace(sd.advance(consumed))
+                parseConcatenation(s3) match
+                  case Right((right, s4)) => loop(build(acc, right), s4)
+                  case Left(err) => Left(err)
+      loop(left, s1)
     }
 
   /**
-   * Parse concatenation operator: & (left-associative)
+   * Parse concatenation operator: & (left-associative).
    *
    * Excel's & operator joins strings: "Hello" & "World" → "HelloWorld" Operands are coerced to
-   * strings via asStringExpr.
+   * strings via asStringExpr. GH-455: chained & folds LEFT (Excel's equal-precedence rule), so
+   * `=A1&B1&C1` round-trips without the printer inventing grouping parens.
    */
   private def parseConcatenation(state: ParserState): ParseResult[TExpr[?]] =
     parseAddSub(state).flatMap { case (left, s1) =>
-      val s2 = skipWhitespace(s1)
-      s2.currentChar match
-        case Some('&') =>
-          val s3 = skipWhitespace(s2.advance())
-          descend(s3).flatMap { sd =>
-            parseConcatenation(sd).map { case (right, s4) =>
-              (
-                TExpr.Concat(
-                  TExpr.asStringExpr(left),
-                  TExpr.asStringExpr(right)
-                ),
-                s4.copy(depth = s3.depth)
-              )
-            }
-          }
-        case _ => Right((left, s2))
+      @tailrec
+      def loop(acc: TExpr[?], s: ParserState): ParseResult[TExpr[?]] =
+        val s2 = skipWhitespace(s)
+        s2.currentChar match
+          case Some('&') =>
+            // GH-56: each chained segment deepens the AST spine — count it (see parseAddSub).
+            descend(s2) match
+              case Left(err) => Left(err)
+              case Right(sd) =>
+                val s3 = skipWhitespace(sd.advance())
+                parseAddSub(s3) match
+                  case Right((right, s4)) =>
+                    loop(TExpr.Concat(TExpr.asStringExpr(acc), TExpr.asStringExpr(right)), s4)
+                  case Left(err) => Left(err)
+          case _ => Right((acc, s2))
+      loop(left, s1)
     }
 
   /**

--- a/xl-evaluator/src/com/tjclp/xl/formula/printer/FormulaPrinter.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/printer/FormulaPrinter.scala
@@ -99,9 +99,14 @@ object FormulaPrinter:
       case TExpr.ExternalRange(index, name, range) =>
         s"${formatExternalSheet(index, name)}!${formatRange(range)}"
 
-      // Arithmetic operators
+      // Arithmetic operators.
+      //
+      // GH-455: left-associative operators print their RIGHT operand one level tighter, so a
+      // right-nested child at the SAME precedence keeps its grouping parens: Div(a, Mul(b, c))
+      // prints a/(b*c), never a/b*c (which re-parses as (a/b)*c — a different value). The parser
+      // has no Paren node, so the grouping the printer emits is the only grouping there is.
       case TExpr.Add(x, y) =>
-        val result = s"${printExpr(x, Precedence.AddSub)}+${printExpr(y, Precedence.AddSub)}"
+        val result = s"${printExpr(x, Precedence.AddSub)}+${printExpr(y, Precedence.AddSub + 1)}"
         parenthesizeIf(result, precedence > Precedence.AddSub)
 
       case TExpr.Sub(TExpr.Lit(n: BigDecimal), y) if n == BigDecimal(0) =>
@@ -110,15 +115,15 @@ object FormulaPrinter:
         parenthesizeIf(result, precedence > Precedence.Unary)
 
       case TExpr.Sub(x, y) =>
-        val result = s"${printExpr(x, Precedence.AddSub)}-${printExpr(y, Precedence.AddSub)}"
+        val result = s"${printExpr(x, Precedence.AddSub)}-${printExpr(y, Precedence.AddSub + 1)}"
         parenthesizeIf(result, precedence > Precedence.AddSub)
 
       case TExpr.Mul(x, y) =>
-        val result = s"${printExpr(x, Precedence.MulDiv)}*${printExpr(y, Precedence.MulDiv)}"
+        val result = s"${printExpr(x, Precedence.MulDiv)}*${printExpr(y, Precedence.MulDiv + 1)}"
         parenthesizeIf(result, precedence > Precedence.MulDiv)
 
       case TExpr.Div(x, y) =>
-        val result = s"${printExpr(x, Precedence.MulDiv)}/${printExpr(y, Precedence.MulDiv)}"
+        val result = s"${printExpr(x, Precedence.MulDiv)}/${printExpr(y, Precedence.MulDiv + 1)}"
         parenthesizeIf(result, precedence > Precedence.MulDiv)
 
       case TExpr.Pow(x, y) =>
@@ -144,40 +149,40 @@ object FormulaPrinter:
         val result = s"${printExpr(e, Precedence.Percent)}%"
         parenthesizeIf(result, precedence > Precedence.Percent)
 
-      // String operators
+      // String operators (GH-455: right operand one level tighter, see arithmetic note)
       case TExpr.Concat(x, y) =>
-        val result = s"${printExpr(x, Precedence.Concat)}&${printExpr(y, Precedence.Concat)}"
+        val result = s"${printExpr(x, Precedence.Concat)}&${printExpr(y, Precedence.Concat + 1)}"
         parenthesizeIf(result, precedence > Precedence.Concat)
 
-      // Comparison operators
+      // Comparison operators (GH-455: right operand one level tighter, see arithmetic note)
       case TExpr.Eq(x, y) =>
         val result =
-          s"${printExpr(x, Precedence.Comparison)}=${printExpr(y, Precedence.Comparison)}"
+          s"${printExpr(x, Precedence.Comparison)}=${printExpr(y, Precedence.Comparison + 1)}"
         parenthesizeIf(result, precedence > Precedence.Comparison)
 
       case TExpr.Neq(x, y) =>
         val result =
-          s"${printExpr(x, Precedence.Comparison)}<>${printExpr(y, Precedence.Comparison)}"
+          s"${printExpr(x, Precedence.Comparison)}<>${printExpr(y, Precedence.Comparison + 1)}"
         parenthesizeIf(result, precedence > Precedence.Comparison)
 
       case TExpr.Lt(x, y) =>
         val result =
-          s"${printExpr(x, Precedence.Comparison)}<${printExpr(y, Precedence.Comparison)}"
+          s"${printExpr(x, Precedence.Comparison)}<${printExpr(y, Precedence.Comparison + 1)}"
         parenthesizeIf(result, precedence > Precedence.Comparison)
 
       case TExpr.Lte(x, y) =>
         val result =
-          s"${printExpr(x, Precedence.Comparison)}<=${printExpr(y, Precedence.Comparison)}"
+          s"${printExpr(x, Precedence.Comparison)}<=${printExpr(y, Precedence.Comparison + 1)}"
         parenthesizeIf(result, precedence > Precedence.Comparison)
 
       case TExpr.Gt(x, y) =>
         val result =
-          s"${printExpr(x, Precedence.Comparison)}>${printExpr(y, Precedence.Comparison)}"
+          s"${printExpr(x, Precedence.Comparison)}>${printExpr(y, Precedence.Comparison + 1)}"
         parenthesizeIf(result, precedence > Precedence.Comparison)
 
       case TExpr.Gte(x, y) =>
         val result =
-          s"${printExpr(x, Precedence.Comparison)}>=${printExpr(y, Precedence.Comparison)}"
+          s"${printExpr(x, Precedence.Comparison)}>=${printExpr(y, Precedence.Comparison + 1)}"
         parenthesizeIf(result, precedence > Precedence.Comparison)
 
       // Type conversions (print transparently - ToInt is internal)

--- a/xl-evaluator/src/com/tjclp/xl/formula/printer/FormulaShifter.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/printer/FormulaShifter.scala
@@ -268,6 +268,61 @@ object FormulaShifter:
   // ============================================================================
 
   /**
+   * GH-455: true when `expr` contains a sheet-qualified reference to `editedSheet`
+   * (case-insensitive, matching [[shiftStructural]]'s convention). Nodes the structural shift
+   * treats as identity — local refs on a non-edited sheet, external refs, defined names (including
+   * sheet-qualified ones) — do not count: a formula for which this is false is provably untouched
+   * by a structural edit of `editedSheet` from another sheet, so callers can skip the
+   * parse→shift→reprint cycle and keep its text and cached value byte-identical.
+   */
+  @SuppressWarnings(Array("org.wartremover.warts.Var"))
+  def referencesSheet(expr: TExpr[?], editedSheet: String): Boolean =
+    import TExpr.*
+    def matches(sheet: com.tjclp.xl.SheetName): Boolean =
+      sheet.value.equalsIgnoreCase(editedSheet)
+    def goLoc(location: RangeLocation): Boolean = location match
+      case RangeLocation.CrossSheet(sheet, _) => matches(sheet)
+      case RangeLocation.Local(_) | RangeLocation.External(_, _, _) | RangeLocation.Name(_, _) =>
+        false
+    def go(e: TExpr[?]): Boolean = e match
+      case SheetRef(sheet, _, _, _) => matches(sheet)
+      case SheetPolyRef(sheet, _, _) => matches(sheet)
+      case SheetRange(sheet, _) => matches(sheet)
+      case Aggregate(_, location) => goLoc(location)
+      case call: Call[?] =>
+        var found = false
+        call.spec.argSpec.map(call.args)(
+          arg => { if go(arg) then found = true; arg },
+          loc => { if goLoc(loc) then found = true; loc },
+          range => range
+        )
+        found
+      case Add(x, y) => go(x) || go(y)
+      case Sub(x, y) => go(x) || go(y)
+      case Mul(x, y) => go(x) || go(y)
+      case Div(x, y) => go(x) || go(y)
+      case Pow(x, y) => go(x) || go(y)
+      case Concat(x, y) => go(x) || go(y)
+      case Eq(x, y) => go(x) || go(y)
+      case Neq(x, y) => go(x) || go(y)
+      case Lt(x, y) => go(x) || go(y)
+      case Lte(x, y) => go(x) || go(y)
+      case Gt(x, y) => go(x) || go(y)
+      case Gte(x, y) => go(x) || go(y)
+      case ToInt(inner) => go(inner)
+      case UnaryPlus(inner) => go(inner)
+      case Percent(inner) => go(inner)
+      case DateToSerial(inner) => go(inner)
+      case DateTimeToSerial(inner) => go(inner)
+      case Coerced(inner, _) => go(inner)
+      case Let(bindings, body) => bindings.exists((_, value) => go(value)) || go(body)
+      case Lit(_) | Ref(_, _, _) | PolyRef(_, _) | RangeRef(_) | ExternalRef(_, _, _, _) |
+          ExternalRange(_, _, _) | BindingRef(_) | NameRef(_) | SheetNameRef(_, _) |
+          CoercedBindingRef(_, _) =>
+        false
+    go(expr)
+
+  /**
    * Structurally shift references in `expr` for a row/column insert (delta > 0) or delete (delta <
    * 0). Returns None when the formula references a fully-deleted cell or range.
    */

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/DataTableSeederSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/DataTableSeederSpec.scala
@@ -423,6 +423,39 @@ class DataTableSeederSpec extends FunSuite:
     )
   }
 
+  test("GH-453: a cyclic source seeds its last Jacobi round without one extra evaluation") {
+    // F9 is both the table source and a self-cycle member. From the zero seed with A1 pinned to 1,
+    // its two Jacobi rounds are 2 then 3; evaluating F9 once more would incorrectly seed 3.5.
+    val sheet = Sheet("S")
+      .put(ref"A1", num(0))
+      .put(ref"F9", CellValue.Formula("F9/2+A1+1"))
+      .put(ref"E10", num(1))
+      .put(ref"F10", CellValue.dataTable(colKind("F10:F10", "A1"), None))
+    val wb = Workbook(sheet).withCalcPr(CalcPr(iterativeCalculation = true, Some(2), None))
+    val report = wb.seedDataTablesReport().fold(err => fail(s"report failed: $err"), identity)
+    val out = sheetNamed(report.workbook, "S")
+    assertEquals(interiorNum(out, ref"F10"), Some(BigDecimal(3)))
+    assertEquals(
+      report.warnings,
+      Vector(SeedTableWarning.NotConverged(SheetName.unsafe("S"), range("F10:F10"), 1, 2))
+    )
+  }
+
+  test("GH-453: NotConverged reports the normalized one-round minimum") {
+    val sheet = Sheet("S")
+      .put(ref"A1", num(0))
+      .put(ref"F9", CellValue.Formula("F9+1"))
+      .put(ref"E10", num(1))
+      .put(ref"F10", CellValue.dataTable(colKind("F10:F10", "A1"), None))
+    val wb = Workbook(sheet).withCalcPr(CalcPr(iterativeCalculation = true, Some(0), None))
+    val report = wb.seedDataTablesReport().fold(err => fail(s"report failed: $err"), identity)
+    assertEquals(interiorNum(sheetNamed(report.workbook, "S"), ref"F10"), Some(BigDecimal(1)))
+    assertEquals(
+      report.warnings,
+      Vector(SeedTableWarning.NotConverged(SheetName.unsafe("S"), range("F10:F10"), 1, 1))
+    )
+  }
+
   test("GH-453: re-seeding is a no-op and source cycle-member cells are never mutated") {
     val wb = Workbook(circularTableSheet).withCalcPr(tightCalcPr)
     val first = wb.seedDataTables().fold(err => fail(s"seeding failed: $err"), identity)

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/DataTableSeederSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/DataTableSeederSpec.scala
@@ -13,7 +13,7 @@ import com.tjclp.xl.cells.{CellError, CellValue}
 import com.tjclp.xl.error.XLError
 import com.tjclp.xl.ooxml.{TestFixtures, XlsxReader, XlsxWriter}
 import com.tjclp.xl.sheets.Sheet
-import com.tjclp.xl.workbooks.Workbook
+import com.tjclp.xl.workbooks.{CalcPr, Workbook}
 
 /**
  * GH-419 DataTableSeeder: explicit, tolerant cache seeding for data-table interiors. The
@@ -292,6 +292,183 @@ class DataTableSeederSpec extends FunSuite:
       .seedDataTables()
       .fold(err => fail(s"oversized records must skip tolerantly, not fail the op: $err"), identity)
     assertEquals(sheetNamed(seeded, "S")(ref"B2").value, sheet(ref"B2").value)
+  }
+
+  // ===== GH-453: circular books — seeding honors the book's CalcPr / an explicit IterativeCalc =====
+
+  /**
+   * Canonical circular fixture: C1=100 (plain), B1=C1+B2, B2=$A$1*(C1+B1)/2 (declared-cycle
+   * average-balance idiom over rate input A1), corner F9=IFERROR(B1/2,0), 1-var column table
+   * F10:F12 over input A1 with left axis E10:E12 = 0.002/0.004/0.006. Analytic per-axis fixpoint:
+   * B1 = (100+50r)/(1-r/2), interior = B1/2 — 50.1001/50.2004/50.3009, strictly increasing.
+   * Pre-GH-453 every interior silently seeded the base value (FLAT).
+   */
+  private def circularTableSheet: Sheet =
+    Sheet("S")
+      .put(ref"A1", num(0))
+      .put(ref"C1", num(100))
+      .put(ref"B1", CellValue.Formula("C1+B2"))
+      .put(ref"B2", CellValue.Formula("$A$1*(C1+B1)/2"))
+      .put(ref"F9", CellValue.Formula("IFERROR(B1/2,0)"))
+      .put(ref"E10", CellValue.Number(BigDecimal("0.002")))
+      .put(ref"E11", CellValue.Number(BigDecimal("0.004")))
+      .put(ref"E12", CellValue.Number(BigDecimal("0.006")))
+      .put(ref"F10", CellValue.dataTable(colKind("F10:F12", "A1"), None))
+
+  private val tightCalcPr =
+    CalcPr(iterativeCalculation = true, Some(200), Some(BigDecimal("0.0000001")))
+
+  private val analyticInteriors = Vector(50.1001001, 50.2004008, 50.3009027)
+  private val interiorRefs = Vector(ref"F10", ref"F11", ref"F12")
+
+  private def interiorNum(sheet: Sheet, r: ARef): Option[BigDecimal] =
+    sheet.cells.get(r).map(_.value).flatMap {
+      case CellValue.Number(n) => Some(n)
+      case CellValue.Formula(_, Some(CellValue.Number(n)), _) => Some(n)
+      case _ => None
+    }
+
+  test("GH-453: declared-cycle table seeds per-axis fixpoints under the book's calcPr") {
+    val wb = Workbook(circularTableSheet).withCalcPr(tightCalcPr)
+    val seeded = wb.seedDataTables().fold(err => fail(s"seeding failed: $err"), identity)
+    val out = sheetNamed(seeded, "S")
+    val values = interiorRefs.map(r => interiorNum(out, r).getOrElse(fail(s"${r.toA1} must seed")))
+    values.zip(analyticInteriors).foreach { (v, expected) =>
+      assert(
+        (v.toDouble - expected).abs < 1e-4,
+        s"interior $v must be within 1e-4 of the analytic fixpoint $expected"
+      )
+    }
+    assertEquals(
+      values.distinct.size,
+      3,
+      s"interiors must be pairwise distinct — flat interiors are the GH-453 bug: $values"
+    )
+  }
+
+  test("GH-453: no calcPr -> table skipped untouched, one CircularNotIterated names the cycle") {
+    val wb = Workbook(circularTableSheet)
+    val report = wb.seedDataTablesReport().fold(err => fail(s"report failed: $err"), identity)
+    val out = sheetNamed(report.workbook, "S")
+    // Skip keeps interiors uncached, so the data-table-unseeded lint still fires downstream.
+    assertEquals(out(ref"F10").value, CellValue.dataTable(colKind("F10:F12", "A1"), None))
+    assertEquals(out.cells.get(ref"F11"), None)
+    assertEquals(out.cells.get(ref"F12"), None)
+    assertEquals(
+      report.warnings,
+      Vector(
+        SeedTableWarning.CircularNotIterated(
+          SheetName.unsafe("S"),
+          range("F10:F12"),
+          Vector("S!B1", "S!B2")
+        )
+      )
+    )
+    // The tolerant-Right doctrine holds on the plain overload too: Right, untouched.
+    val plain = wb.seedDataTables().fold(err => fail(s"must stay Right: $err"), identity)
+    assertEquals(sheetNamed(plain, "S").cells.get(ref"F11"), None)
+  }
+
+  test("GH-453: explicit IterativeCalc overload overrides an absent calcPr") {
+    val wb = Workbook(circularTableSheet) // no calcPr declared
+    val seeded = wb
+      .seedDataTables(IterativeCalc(200, BigDecimal("0.0000001")))
+      .fold(err => fail(s"seeding failed: $err"), identity)
+    val out = sheetNamed(seeded, "S")
+    val mid = interiorNum(out, ref"F11").getOrElse(fail("F11 must seed"))
+    assert((mid.toDouble - 50.2004008).abs < 1e-4, s"F11=$mid, expected ~50.2004008")
+  }
+
+  test("GH-453: acyclic table on a cyclic book still seeds while the cyclic one skips") {
+    val sheet = circularTableSheet
+      .put(ref"H9", CellValue.Formula("$A$1*10"))
+      .put(ref"G10", num(5))
+      .put(ref"H10", CellValue.dataTable(colKind("H10:H10", "A1"), None))
+    val report =
+      Workbook(sheet).seedDataTablesReport().fold(err => fail(s"report failed: $err"), identity)
+    val out = sheetNamed(report.workbook, "S")
+    assertEquals(
+      out(ref"H10").value,
+      CellValue.dataTable(colKind("H10:H10", "A1"), Some(CellValue.Number(BigDecimal(50))))
+    )
+    assertEquals(out.cells.get(ref"F11"), None, "the cyclic table must stay unseeded")
+    report.warnings match
+      case Vector(SeedTableWarning.CircularNotIterated(_, tableRef, _)) =>
+        assertEquals(tableRef, range("F10:F12"))
+      case other => fail(s"expected exactly one CircularNotIterated, got $other")
+  }
+
+  test("GH-453: non-convergent cycle seeds last-round values and reports NotConverged") {
+    // B1/B2 oscillate with period 2 from the (0,0) seed: rounds alternate (1,1)/(0,0);
+    // round 5 lands on (1,1) — deterministic last-round values, per Excel.
+    val sheet = Sheet("S")
+      .put(ref"A1", num(0))
+      .put(ref"B1", CellValue.Formula("1-B2"))
+      .put(ref"B2", CellValue.Formula("1-B1"))
+      .put(ref"F9", CellValue.Formula("B1"))
+      .put(ref"E10", num(1))
+      .put(ref"E11", num(2))
+      .put(ref"E12", num(3))
+      .put(ref"F10", CellValue.dataTable(colKind("F10:F12", "A1"), None))
+    val wb = Workbook(sheet).withCalcPr(CalcPr(iterativeCalculation = true, Some(5), None))
+    val report = wb.seedDataTablesReport().fold(err => fail(s"report failed: $err"), identity)
+    val out = sheetNamed(report.workbook, "S")
+    interiorRefs.foreach { r =>
+      assertEquals(interiorNum(out, r), Some(BigDecimal(1)), s"${r.toA1} must seed the last round")
+    }
+    assertEquals(
+      report.warnings,
+      Vector(SeedTableWarning.NotConverged(SheetName.unsafe("S"), range("F10:F12"), 3, 5))
+    )
+  }
+
+  test("GH-453: re-seeding is a no-op and source cycle-member cells are never mutated") {
+    val wb = Workbook(circularTableSheet).withCalcPr(tightCalcPr)
+    val first = wb.seedDataTables().fold(err => fail(s"seeding failed: $err"), identity)
+    val second = first.seedDataTables().fold(err => fail(s"re-seeding failed: $err"), identity)
+    assertEquals(second, first, "a re-seed must be a no-op (deterministic fixpoints)")
+    val out = sheetNamed(first, "S")
+    // The what-if lives entirely on temp sheets: cycle members and the input keep their
+    // original uncached formulas / value.
+    assertEquals(out(ref"B1").value, CellValue.Formula("C1+B2"))
+    assertEquals(out(ref"B2").value, CellValue.Formula("$A$1*(C1+B1)/2"))
+    assertEquals(out(ref"A1").value, num(0))
+  }
+
+  test("GH-453: 20x20 two-var battery over a small cycle stays within budget") {
+    // 400 axis combinations x a 2-member fixpoint: guards the narrowed-iteration design —
+    // a full-book recalculation per combination would blow this budget.
+    val interior = range("D5:W24")
+    val rowAxis = (0 until 20).foldLeft(Sheet("S")) { (s, i) =>
+      s.put(ARef.from0(3 + i, 3), num(i + 1)) // D4..W4 -> input A1
+    }
+    val bothAxes = (0 until 20).foldLeft(rowAxis) { (s, j) =>
+      s.put(ARef.from0(2, 4 + j), num(j + 1)) // C5..C24 -> input A2
+    }
+    val twoVar: FormulaKind.DataTable = FormulaKind.DataTable(
+      ref = interior,
+      dt2D = true,
+      dtr = false,
+      r1 = Some(aref("A1")),
+      r2 = Some(aref("A2"))
+    )
+    val sheet = bothAxes
+      .put(ref"A1", num(0))
+      .put(ref"A2", num(0))
+      .put(ref"Y1", CellValue.Formula("(Y2+$A$1)/2"))
+      .put(ref"Y2", CellValue.Formula("Y1/2"))
+      .put(ref"C4", CellValue.Formula("Y1+$A$2")) // corner: cycle fixpoint Y1 = (2/3)*A1
+      .put(ref"D5", CellValue.dataTable(twoVar, None))
+    val wb = Workbook(sheet).withCalcPr(CalcPr(iterativeCalculation = true, Some(100), None))
+    val startNanos = System.nanoTime()
+    val report = wb.seedDataTablesReport().fold(err => fail(s"report failed: $err"), identity)
+    val elapsedSeconds = (System.nanoTime() - startNanos) / 1e9
+    assert(elapsedSeconds < 30.0, s"seeding took ${elapsedSeconds}s, budget is 30s")
+    assertEquals(report.warnings, Vector.empty)
+    val out = sheetNamed(report.workbook, "S")
+    // Spot-check E6 (row axis 2 -> A1, col axis 2 -> A2): (2/3)*2 + 2 = 10/3
+    val e6 = interiorNum(out, ref"E6").getOrElse(fail("E6 must seed"))
+    assert((e6.toDouble - 10.0 / 3.0).abs < 1e-2, s"E6=$e6, expected ~${10.0 / 3.0}")
   }
 
   @SuppressWarnings(Array("org.wartremover.warts.Var", "org.wartremover.warts.While"))

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/DataTableSeederSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/DataTableSeederSpec.scala
@@ -3,6 +3,7 @@ package com.tjclp.xl.formula
 import java.io.ByteArrayInputStream
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
+import java.time.{LocalDate, LocalDateTime}
 import java.util.zip.ZipInputStream
 
 import munit.FunSuite
@@ -458,6 +459,80 @@ class DataTableSeederSpec extends FunSuite:
         s"${r.toA1} must reflect the pinned axis value, not the unperturbed cycle fixpoint"
       )
     }
+  }
+
+  // ===== GH-453 review follow-ups: one volatile generation, Skipped visibility, budget guard =====
+
+  /** Every now() read ticks one second — exposes a second volatile generation mid-seed. */
+  @SuppressWarnings(Array("org.wartremover.warts.Var"))
+  private final class TickingClock extends Clock:
+    private var ticks = 0
+    def today(): LocalDate = LocalDate.of(2026, 1, 1)
+    def now(): LocalDateTime =
+      ticks += 1
+      LocalDateTime.of(2026, 1, 1, 0, 0, 0).plusSeconds(ticks.toLong)
+
+  test("GH-453: NOW() corner seeds ONE volatile generation across the interior (acyclic path)") {
+    val sheet = Sheet("S")
+      .put(ref"A1", num(0))
+      .put(ref"F9", CellValue.Formula("NOW()"))
+      .put(ref"E10", num(1))
+      .put(ref"E11", num(2))
+      .put(ref"E12", num(3))
+      .put(ref"F10", CellValue.dataTable(colKind("F10:F12", "A1"), None))
+    val seeded = Workbook(sheet)
+      .seedDataTables(SheetName.unsafe("S"), None, new TickingClock)
+      .fold(err => fail(s"seeding failed: $err"), identity)
+    val out = sheetNamed(seeded, "S")
+    val values = interiorRefs.map { r =>
+      out.cells.get(r).map(_.value) match
+        case Some(CellValue.Formula(_, Some(v), _)) => v
+        case Some(v) => v
+        case None => fail(s"${r.toA1} must seed")
+    }
+    assertEquals(
+      values.distinct.size,
+      1,
+      s"one seeding run is one volatile generation — interiors must agree: $values"
+    )
+  }
+
+  test("GH-453: iterated-path axis failure leaves cells untouched and reports one Skipped") {
+    // E10 (the axis value feeding F10) references a missing sheet: its evaluation is a host
+    // failure, so F10 stays unseeded — the report must SAY so instead of reading clean.
+    val sheet = circularTableSheet.put(ref"E10", CellValue.Formula("Missing!A1"))
+    val wb = Workbook(sheet).withCalcPr(tightCalcPr)
+    val report = wb.seedDataTablesReport().fold(err => fail(s"report failed: $err"), identity)
+    val out = sheetNamed(report.workbook, "S")
+    assertEquals(out(ref"F10").value, CellValue.dataTable(colKind("F10:F12", "A1"), None))
+    assert(interiorNum(out, ref"F11").isDefined, "F11 must still seed")
+    assert(interiorNum(out, ref"F12").isDefined, "F12 must still seed")
+    report.warnings match
+      case Vector(SeedTableWarning.Skipped(sheet, tableRef, cells, reason)) =>
+        assertEquals(sheet, SheetName.unsafe("S"))
+        assertEquals(tableRef, range("F10:F12"))
+        assertEquals(cells, 1)
+        assert(reason.nonEmpty, "the Skipped warning must carry a reason")
+      case other => fail(s"expected exactly one Skipped, got $other")
+  }
+
+  test("GH-453: iterated table whose worst-case cost blows the budget skips with a Skipped") {
+    // 3 interiors x 50,000,000 declared rounds x 2 cycle members = 3e8 member-evaluations —
+    // far past the budget; the table must skip untouched instead of honoring a hostile calcPr.
+    val wb = Workbook(circularTableSheet)
+      .withCalcPr(CalcPr(iterativeCalculation = true, Some(50000000), None))
+    val report = wb.seedDataTablesReport().fold(err => fail(s"report failed: $err"), identity)
+    val out = sheetNamed(report.workbook, "S")
+    assertEquals(out(ref"F10").value, CellValue.dataTable(colKind("F10:F12", "A1"), None))
+    assertEquals(out.cells.get(ref"F11"), None)
+    assertEquals(out.cells.get(ref"F12"), None)
+    report.warnings match
+      case Vector(SeedTableWarning.Skipped(sheet, tableRef, cells, reason)) =>
+        assertEquals(sheet, SheetName.unsafe("S"))
+        assertEquals(tableRef, range("F10:F12"))
+        assertEquals(cells, 3)
+        assert(reason.contains("budget"), s"the reason must name the budget: $reason")
+      case other => fail(s"expected exactly one Skipped, got $other")
   }
 
   test("GH-453: 20x20 two-var battery over a small cycle stays within budget") {

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/DataTableSeederSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/DataTableSeederSpec.scala
@@ -435,6 +435,31 @@ class DataTableSeederSpec extends FunSuite:
     assertEquals(out(ref"A1").value, num(0))
   }
 
+  test("GH-453: input cell inside the cycle stays pinned to the axis value (no silent flat)") {
+    // The cycle runs THROUGH the what-if input: A1=B1/2, B1=A1+10. Excel semantics: the axis
+    // substitution pins the input cell, breaking the cycle through it — interiors are 11/12/13,
+    // NOT the unperturbed fixpoint B1=20 repeated (the silent-FLAT failure class of GH-453).
+    val sheet = Sheet("S")
+      .put(ref"A1", CellValue.Formula("B1/2"))
+      .put(ref"B1", CellValue.Formula("A1+10"))
+      .put(ref"F9", CellValue.Formula("B1"))
+      .put(ref"E10", num(1))
+      .put(ref"E11", num(2))
+      .put(ref"E12", num(3))
+      .put(ref"F10", CellValue.dataTable(colKind("F10:F12", "A1"), None))
+    val wb = Workbook(sheet).withCalcPr(tightCalcPr)
+    val report = wb.seedDataTablesReport().fold(err => fail(s"report failed: $err"), identity)
+    assertEquals(report.warnings, Vector.empty)
+    val out = sheetNamed(report.workbook, "S")
+    interiorRefs.zip(Vector(11, 12, 13)).foreach { (r, expected) =>
+      assertEquals(
+        interiorNum(out, r),
+        Some(BigDecimal(expected)),
+        s"${r.toA1} must reflect the pinned axis value, not the unperturbed cycle fixpoint"
+      )
+    }
+  }
+
   test("GH-453: 20x20 two-var battery over a small cycle stays within budget") {
     // 400 axis combinations x a 2-member fixpoint: guards the narrowed-iteration design —
     // a full-book recalculation per combination would blow this budget.

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/FormulaParserSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/FormulaParserSpec.scala
@@ -1889,3 +1889,97 @@ class FormulaParserSpec extends ScalaCheckSuite:
       case Left(_) => ()
       case Right(expr) => fail(s"'=A$$B' should not parse, got $expr")
   }
+
+  // ==================== GH-455: right-nested same-precedence grouping ====================
+  // The parser has no Paren node — grouping survives ONLY through the AST shape, so the
+  // printer must parenthesize a RIGHT operand at the same precedence level as its
+  // left-associative parent: Div(a, Mul(b,c)) is a/(b*c), never a/b*c (which re-parses as
+  // (a/b)*c — a different value). Every reference rewrite (insert-rows, putf --from, copy)
+  // reprints through FormulaPrinter, so this is the semantic-damage site of GH-455.
+
+  test("GH-455: division with a product divisor keeps its parens (=E13/(E12*E14))") {
+    assertPreserved("=E13/(E12*E14)")
+  }
+
+  test("GH-455: nested grouped divisor keeps both paren layers (=E12/((E13+E14)/2))") {
+    assertPreserved("=E12/((E13+E14)/2)")
+  }
+
+  test("GH-455: subtraction of a grouped sum keeps its parens (=E12-(E13+E14))") {
+    assertPreserved("=E12-(E13+E14)")
+  }
+
+  test("GH-455: right-nested same-op groups keep parens (associativity is not reshaped)") {
+    assertPreserved("=A1+(B1+C1)")
+    assertPreserved("=A1*(B1*C1)")
+    assertPreserved("=A1/(B1/C1)")
+    assertPreserved("=A1-(B1-C1)")
+    assertPreserved("=A1&(B1&C1)")
+  }
+
+  test("GH-455: cross-sheet refs inside a grouped divisor keep parens") {
+    assertPreserved("=A!E13/(A!E12*A!E14)")
+  }
+
+  test("GH-455: grouped sum under ROUND inside IF keeps its parens") {
+    FormulaParser.parse("=IF(ROUND(E12-(E13+E14),0)=0,\"Yes\",\"No\")") match
+      case Right(expr) =>
+        // Call args print with the canonical ", " separator; the inner grouping must survive.
+        assertEquals(FormulaPrinter.print(expr), "=IF(ROUND(E12-(E13+E14), 0)=0, \"Yes\", \"No\")")
+      case Left(err) => fail(s"issue formula should parse: $err")
+  }
+
+  test("GH-455: right operand of looser precedence still needs no parens") {
+    assertPreserved("=A1+B1*C1") // Mul right of Add: tighter, bare
+    assertPreserved("=A1*B1^C1") // Pow right of Mul: tighter, bare
+    assertPreserved("=A1&B1+C1") // Add right of Concat: tighter, bare
+    assertPreserved("=A1>B1+C1") // Add right of comparison: tighter, bare
+  }
+
+  test("GH-455: right-nested comparisons keep parens for all six operators") {
+    for op <- List("=", "<>", "<", "<=", ">", ">=") do
+      val source = s"=A1${op}(B1${op}C1)"
+      FormulaParser.parse(source) match
+        case Right(expr) =>
+          assertEquals(FormulaPrinter.print(expr), source, s"grouping lost for '$op'")
+        case Left(err) => fail(s"$source should parse: $err")
+  }
+
+  /**
+   * GH-455: fully parenthesized random arithmetic over literals and refs. Parsing discards the
+   * (redundant-after-shape) parens; printing minimal parens must preserve the SHAPE, so a second
+   * parse yields the identical AST. Comparing two parser-produced ASTs keeps Ref.decode equality
+   * meaningful (the parser resolves refs through shared per-call-site decoders).
+   */
+  private def genGroupedSource(depth: Int): Gen[String] =
+    val leaf: Gen[String] = Gen.oneOf(
+      Gen.choose(1, 99).map(_.toString),
+      for
+        col <- Gen.alphaUpperChar
+        row <- Gen.choose(1, 99)
+      yield s"$col$row"
+    )
+    if depth <= 0 then leaf
+    else
+      Gen.frequency(
+        1 -> leaf,
+        4 -> (for
+          l <- genGroupedSource(depth - 1)
+          r <- genGroupedSource(depth - 1)
+          op <- Gen.oneOf("+", "-", "*", "/", "^", "&")
+        yield s"($l$op$r)")
+      )
+
+  property("GH-455: parse ∘ print = id for recursive mixed-operator expressions") {
+    forAll(genGroupedSource(4)) { source =>
+      FormulaParser.parse(s"=$source") match
+        case Right(e1) =>
+          val printed = FormulaPrinter.print(e1)
+          val reparsed = FormulaParser.parse(printed)
+          assertEquals(reparsed, Right(e1), s"source '=$source' printed as '$printed'")
+          // Structure-level check too, independent of decoder identity
+          reparsed.map(FormulaPrinter.printWithTypes) ==
+            Right(FormulaPrinter.printWithTypes(e1))
+        case Left(err) => fail(s"fully parenthesized '=$source' should parse: $err")
+    }
+  }

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/FormulaParserSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/FormulaParserSpec.scala
@@ -1936,6 +1936,30 @@ class FormulaParserSpec extends ScalaCheckSuite:
     assertPreserved("=A1>B1+C1") // Add right of comparison: tighter, bare
   }
 
+  test("GH-455: chained comparison folds LEFT — =1=1=TRUE parses as Eq(Eq(1,1),TRUE)") {
+    FormulaParser.parse("=1=1=TRUE") match
+      case Right(TExpr.Eq(TExpr.Eq(TExpr.Lit(a), TExpr.Lit(b)), TExpr.Lit(c))) =>
+        assertEquals[Any, Any](a, BigDecimal(1))
+        assertEquals[Any, Any](b, BigDecimal(1))
+        assertEquals[Any, Any](c, true)
+      case Right(other) => fail(s"expected the left-folded shape Eq(Eq(1,1),TRUE), got $other")
+      case Left(err) => fail(s"'=1=1=TRUE' should parse: $err")
+    // The left fold is paren-free on reprint; a right fold would print '=1=(1=TRUE)'.
+    assertPreserved("=1=1=TRUE")
+  }
+
+  test("GH-455: chained comparison evaluates its Boolean left slot (=1=1=TRUE is TRUE)") {
+    val result = for
+      expr <- FormulaParser.parse("=1=1=TRUE")
+      value <- Evaluator.eval(expr, Sheet("Test"))
+    yield value
+    assertEquals(result, Right(true))
+  }
+
+  test("GH-455: chained concat stays a paren-free left fold on round-trip (=A1&B1&C1)") {
+    assertPreserved("=A1&B1&C1")
+  }
+
   test("GH-455: right-nested comparisons keep parens for all six operators") {
     for op <- List("=", "<>", "<", "<=", ">", ">=") do
       val source = s"=A1${op}(B1${op}C1)"
@@ -1978,8 +2002,11 @@ class FormulaParserSpec extends ScalaCheckSuite:
           val reparsed = FormulaParser.parse(printed)
           assertEquals(reparsed, Right(e1), s"source '=$source' printed as '$printed'")
           // Structure-level check too, independent of decoder identity
-          reparsed.map(FormulaPrinter.printWithTypes) ==
-            Right(FormulaPrinter.printWithTypes(e1))
+          assertEquals(
+            reparsed.map(FormulaPrinter.printWithTypes),
+            Right(FormulaPrinter.printWithTypes(e1)),
+            s"typed shape must survive the round-trip of '=$source'"
+          )
         case Left(err) => fail(s"fully parenthesized '=$source' should parse: $err")
     }
   }

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/IterativeRecalcSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/IterativeRecalcSpec.scala
@@ -162,6 +162,41 @@ class IterativeRecalcSpec extends FunSuite:
     )
   }
 
+  test("GH-454: convergent cycle reports converged=true with iterationsUsed in (0, maxIter]") {
+    val result = convergentPair.recalculate(IterativeCalc(100, BigDecimal("0.001")))
+    assert(result.converged, "a fixpointed cycle must report converged")
+    assert(
+      result.iterationsUsed > 0 && result.iterationsUsed <= 100,
+      s"iterationsUsed must count the rounds actually run, got ${result.iterationsUsed}"
+    )
+  }
+
+  test("GH-454: exhausted maxIter reports converged=false and iterationsUsed == maxIter") {
+    // Same oscillator as the non-convergence test above: values are kept (Excel semantics)
+    // but the result must now SAY it under-converged — exhaustion was previously
+    // indistinguishable from convergence (the field bug: a stale debt schedule with r.errors
+    // empty).
+    val sheet = Sheet(SheetName.unsafe("S"))
+      .put(a1, formula("=1-B1"))
+      .put(b1, formula("=A1"))
+    val result = Workbook(sheet).recalculate(IterativeCalc(10, BigDecimal("0.001")))
+    assert(result.errors.isEmpty, "non-convergence still must NOT error")
+    assert(!result.converged, "maxIter exhaustion must report converged=false")
+    assertEquals(result.iterationsUsed, 10)
+  }
+
+  test("GH-454: non-iterative runs report converged=true, iterationsUsed=0") {
+    // Default path (cycle errors instead of iterating): no iteration happened.
+    val defaultRun = convergentPair.recalculate()
+    assert(defaultRun.converged)
+    assertEquals(defaultRun.iterationsUsed, 0)
+    // Acyclic workbook under iterative settings: nothing to iterate.
+    val acyclic = Workbook(Sheet(SheetName.unsafe("S")).put(a1, num(1)).put(b1, formula("=A1*2")))
+    val acyclicRun = acyclic.recalculate(IterativeCalc(100, BigDecimal("0.001")))
+    assert(acyclicRun.converged)
+    assertEquals(acyclicRun.iterationsUsed, 0)
+  }
+
   test("GH-373: IterativeCalc.fromCalcPr uses Excel defaults when attributes are absent") {
     assertEquals(
       IterativeCalc.fromCalcPr(CalcPr(iterativeCalculation = true)),

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/StructuralDvSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/StructuralDvSpec.scala
@@ -101,3 +101,13 @@ class StructuralDvSpec extends FunSuite:
       )
     )
   }
+
+  test("GH-455: a DV formula on a non-participating sheet rides byte-identical") {
+    val data = new Sheet(name = SheetName.unsafe("Data"))
+    val report = new Sheet(name = SheetName.unsafe("Report"))
+      // Non-canonical spelling (lowercase call, extra spaces): a reprint would rewrite it.
+      .withDataValidation(ref"C2:C9", DataValidation.custom("C2 < sum($F$5:$F$9)"))
+    val r = StructuralEditor
+      .insertRows(Workbook(Vector(data, report)), SheetName.unsafe("Data"), at = 0, count = 3)
+    assertEquals(dvKinds(sheetNamed(r, "Report")), Vector(DvKind.Custom("C2 < sum($F$5:$F$9)")))
+  }

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/StructuralFormulaSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/StructuralFormulaSpec.scala
@@ -271,6 +271,50 @@ class StructuralFormulaSpec extends FunSuite:
     assertEquals(rep(ref"B3").value, CellValue.Formula("IF(A1,1,0)", cached))
   }
 
+  test("GH-455: a two-hop cross-sheet dependent keeps its text but drops its stale cache") {
+    val alpha = new Sheet(name = SheetName.unsafe("Alpha")).put(ref"A1", num(10))
+    val beta = new Sheet(name = SheetName.unsafe("Beta"))
+      .put(ref"A1", num(3))
+      .put(ref"X1", CellValue.Formula("Alpha!A1", Some(num(10)))) // hop 1: names Alpha
+      .put(ref"Y1", CellValue.Formula("X1*2", Some(num(20)))) // hop 2: never names Alpha
+      .put(ref"Z1", CellValue.Formula("A1*3", Some(num(9)))) // independent control
+    val r = StructuralEditor.insertRows(
+      Workbook(Vector(alpha, beta)),
+      SheetName.unsafe("Alpha"),
+      at = 0,
+      count = 1
+    )
+    val out = sheetNamed(r, "Beta")
+    // Hop 1 participates: rewritten and uncached (existing behavior).
+    assertEquals(out(ref"X1").value, CellValue.Formula("Alpha!A2", None))
+    // Hop 2 rides byte-identical in TEXT, but its cache transitively read Alpha: stale, dropped.
+    assertEquals(out(ref"Y1").value, CellValue.Formula("X1*2", None))
+    // Genuinely independent formula keeps text AND cache untouched.
+    assertEquals(out(ref"Z1").value, CellValue.Formula("A1*3", Some(num(9))))
+  }
+
+  test("GH-455: a three-hop chain across three sheets is cache-invalidated end to end") {
+    val alpha = new Sheet(name = SheetName.unsafe("Alpha")).put(ref"A1", num(10))
+    val beta = new Sheet(name = SheetName.unsafe("Beta"))
+      .put(ref"B1", CellValue.Formula("Alpha!A1", Some(num(10))))
+    val gamma = new Sheet(name = SheetName.unsafe("Gamma"))
+      .put(ref"C1", CellValue.Formula("Beta!B1*2", Some(num(20)))) // hop 2: never names Alpha
+      .put(ref"D1", CellValue.Formula("C1+1", Some(num(21)))) // hop 3: local ref only
+      .put(ref"C2", num(5))
+      .put(ref"E1", CellValue.Formula("C2*2", Some(num(10)))) // independent control
+    val r = StructuralEditor.insertRows(
+      Workbook(Vector(alpha, beta, gamma)),
+      SheetName.unsafe("Alpha"),
+      at = 0,
+      count = 2
+    )
+    val out = sheetNamed(r, "Gamma")
+    assertEquals(sheetNamed(r, "Beta")(ref"B1").value, CellValue.Formula("Alpha!A3", None))
+    assertEquals(out(ref"C1").value, CellValue.Formula("Beta!B1*2", None))
+    assertEquals(out(ref"D1").value, CellValue.Formula("C1+1", None))
+    assertEquals(out(ref"E1").value, CellValue.Formula("C2*2", Some(num(10))))
+  }
+
   test("GH-455: a non-edited sheet MENTIONING the edited sheet still rewrites (and only then)") {
     val data = new Sheet(name = SheetName.unsafe("Data"))
     val report = new Sheet(name = SheetName.unsafe("Report"))

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/StructuralFormulaSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/StructuralFormulaSpec.scala
@@ -184,3 +184,109 @@ class StructuralFormulaSpec extends FunSuite:
     assertEquals(s2(ref"B1").value, formulaCell("INDIRECT(\"A5\")"))
     assertEquals(s2(ref"C1").value, formulaCell("INDIRECT(A6)"))
   }
+
+  // ===== GH-455: grouping parens survive the rewrite; untouched sheets ride byte-identical =====
+
+  private def num(i: Int): CellValue = CellValue.Number(BigDecimal(i))
+
+  test("GH-455: insert rows keeps grouping parens and the evaluated value (=E13/(E12*E14))") {
+    val s = new Sheet(name = S)
+      .put(ref"E12", num(2))
+      .put(ref"E13", num(4))
+      .put(ref"E14", num(2))
+      .put(ref"G1", formulaCell("=E13/(E12*E14)"))
+    val before = Workbook(Vector(s)).evaluateFormula("=E13/(E12*E14)", "S")
+    assertEquals(before, Right(num(1)))
+    val r = StructuralEditor.insertRows(Workbook(Vector(s)), S, at = 2, count = 2)
+    val s2 = sheetNamed(r, "S")
+    assertEquals(s2(ref"G1").value, formulaCell("E15/(E14*E16)"))
+    assertEquals(r.evaluateFormula("=E15/(E14*E16)", "S"), before)
+  }
+
+  test("GH-455: insert rows keeps the nested grouped divisor (=E12/((E13+E14)/2))") {
+    val s = new Sheet(name = S)
+      .put(ref"E12", num(6))
+      .put(ref"E13", num(2))
+      .put(ref"E14", num(4))
+      .put(ref"G1", formulaCell("=E12/((E13+E14)/2)"))
+    val before = Workbook(Vector(s)).evaluateFormula("=E12/((E13+E14)/2)", "S")
+    assertEquals(before, Right(num(2)))
+    val r = StructuralEditor.insertRows(Workbook(Vector(s)), S, at = 2, count = 2)
+    val s2 = sheetNamed(r, "S")
+    assertEquals(s2(ref"G1").value, formulaCell("E14/((E15+E16)/2)"))
+    assertEquals(r.evaluateFormula("=E14/((E15+E16)/2)", "S"), before)
+  }
+
+  test("GH-455: insert rows keeps the grouped sum inside IF/ROUND (tie-out stays 'Yes')") {
+    val s = new Sheet(name = S)
+      .put(ref"E12", num(6))
+      .put(ref"E13", num(2))
+      .put(ref"E14", num(4))
+      .put(ref"G1", formulaCell("=IF(ROUND(E12-(E13+E14),0)=0,\"Yes\",\"No\")"))
+    val r = StructuralEditor.insertRows(Workbook(Vector(s)), S, at = 2, count = 2)
+    val s2 = sheetNamed(r, "S")
+    assertEquals(
+      s2(ref"G1").value,
+      formulaCell("IF(ROUND(E14-(E15+E16), 0)=0, \"Yes\", \"No\")")
+    )
+    assertEquals(
+      r.evaluateFormula("=IF(ROUND(E14-(E15+E16), 0)=0, \"Yes\", \"No\")", "S"),
+      Right(CellValue.Text("Yes"))
+    )
+  }
+
+  test("GH-455: cross-sheet grouped divisor on a non-edited sheet keeps its parens") {
+    val a = new Sheet(name = SheetName.unsafe("A"))
+      .put(ref"E12", num(2))
+      .put(ref"E13", num(4))
+      .put(ref"E14", num(2))
+    val b = new Sheet(name = SheetName.unsafe("B"))
+      .put(ref"B1", formulaCell("=A!E13/(A!E12*A!E14)"))
+    val r = StructuralEditor.insertRows(Workbook(Vector(a, b)), SheetName.unsafe("A"), 2, 2)
+    assertEquals(sheetNamed(r, "B")(ref"B1").value, formulaCell("A!E15/(A!E14*A!E16)"))
+    assertEquals(r.evaluateFormula("=A!E15/(A!E14*A!E16)", "B"), Right(num(1)))
+  }
+
+  test("GH-455: formulas on a non-participating sheet are byte-identical after insert-rows") {
+    val cached = Some(num(7))
+    val data = new Sheet(name = SheetName.unsafe("Data")).put(ref"A1", num(1))
+    val other = new Sheet(name = SheetName.unsafe("Other")).put(ref"A1", num(7))
+    val report = new Sheet(name = SheetName.unsafe("Report"))
+      .put(ref"B1", CellValue.Formula("C1/(A1*D1)", cached)) // local refs only
+      .put(ref"B2", CellValue.Formula("SUM(Other!A1:A5)", cached)) // refs a DIFFERENT sheet
+      .put(
+        ref"B3",
+        CellValue.Formula("IF(A1,1,0)", cached)
+      ) // would canonicalize to ", " if reprinted
+    val r = StructuralEditor.insertRows(
+      Workbook(Vector(data, other, report)),
+      SheetName.unsafe("Data"),
+      at = 0,
+      count = 3
+    )
+    val rep = sheetNamed(r, "Report")
+    // Text AND cached values ride untouched: the sheet does not participate in the edit.
+    assertEquals(rep(ref"B1").value, CellValue.Formula("C1/(A1*D1)", cached))
+    assertEquals(rep(ref"B2").value, CellValue.Formula("SUM(Other!A1:A5)", cached))
+    assertEquals(rep(ref"B3").value, CellValue.Formula("IF(A1,1,0)", cached))
+  }
+
+  test("GH-455: a non-edited sheet MENTIONING the edited sheet still rewrites (and only then)") {
+    val data = new Sheet(name = SheetName.unsafe("Data"))
+    val report = new Sheet(name = SheetName.unsafe("Report"))
+      .put(ref"B1", CellValue.Formula("Data!A5*2", Some(num(7)))) // participates: rewritten
+      .put(ref"B2", CellValue.Formula("\"Data\"&C1", Some(CellValue.Text("Datax")))) // text only
+    val r = StructuralEditor.insertRows(
+      Workbook(Vector(data, report)),
+      SheetName.unsafe("Data"),
+      at = 2,
+      count = 1
+    )
+    val rep = sheetNamed(r, "Report")
+    assertEquals(rep(ref"B1").value, CellValue.Formula("Data!A6*2", None))
+    // Mentions "Data" only inside a string literal: the AST gate proves non-participation.
+    assertEquals(
+      rep(ref"B2").value,
+      CellValue.Formula("\"Data\"&C1", Some(CellValue.Text("Datax")))
+    )
+  }

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/StructuralFormulaSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/StructuralFormulaSpec.scala
@@ -315,6 +315,25 @@ class StructuralFormulaSpec extends FunSuite:
     assertEquals(out(ref"E1").value, CellValue.Formula("C2*2", Some(num(10))))
   }
 
+  test("GH-455: cross-sheet dynamic refs and their dependents drop stale caches") {
+    val alpha = new Sheet(name = SheetName.unsafe("Alpha")).put(ref"A1", num(10))
+    val beta = new Sheet(name = SheetName.unsafe("Beta"))
+      .put(ref"X1", CellValue.Formula("INDIRECT(\"Alpha!A1\")", Some(num(10))))
+      .put(ref"Y1", CellValue.Formula("X1*2", Some(num(20))))
+      .put(ref"Z1", CellValue.Formula("1+2", Some(num(3))))
+    val r = StructuralEditor.insertRows(
+      Workbook(Vector(alpha, beta)),
+      SheetName.unsafe("Alpha"),
+      at = 0,
+      count = 1
+    )
+    val out = sheetNamed(r, "Beta")
+    // INDIRECT text is data and stays byte-identical, but now resolves to the newly empty A1.
+    assertEquals(out(ref"X1").value, CellValue.Formula("INDIRECT(\"Alpha!A1\")", None))
+    assertEquals(out(ref"Y1").value, CellValue.Formula("X1*2", None))
+    assertEquals(out(ref"Z1").value, CellValue.Formula("1+2", Some(num(3))))
+  }
+
   test("GH-455: a non-edited sheet MENTIONING the edited sheet still rewrites (and only then)") {
     val data = new Sheet(name = SheetName.unsafe("Data"))
     val report = new Sheet(name = SheetName.unsafe("Report"))

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/DirectSaxEmitter.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/DirectSaxEmitter.scala
@@ -430,7 +430,8 @@ object DirectSaxEmitter:
             FormulaKindCodec.toAttrs(kind).foreach { case (name, v) =>
               writer.writeAttribute(name, v)
             }
-            writer.writeCharacters(expr)
+            // GH-456: <f> carries the expression, never the display form's leading '='
+            writer.writeCharacters(expr.stripPrefix("="))
             writer.endElement()
         emitCachedValue(writer, cachedValue)
 

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/lint/WorkbookLint.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/lint/WorkbookLint.scala
@@ -52,6 +52,12 @@ enum LintCategory derives CanEqual:
   /** An uncached data-table interior in a `calcMode="autoNoTable"` book — opens BLANK (GH-442). */
   case DataTableUnseeded
 
+  /**
+   * `<f>` text stored with the display form's leading '=' — non-spec, misreads in strict tools
+   * (GH-456).
+   */
+  case FormulaLeadingEquals
+
   /** Stable kebab-case identifier used in CLI text and JSON output. */
   def slug: String = this match
     case LintCategory.ChildOrder => "child-order"
@@ -62,6 +68,7 @@ enum LintCategory derives CanEqual:
     case LintCategory.RefOutOfBounds => "ref-out-of-bounds"
     case LintCategory.DataTableTorn => "data-table-torn"
     case LintCategory.DataTableUnseeded => "data-table-unseeded"
+    case LintCategory.FormulaLeadingEquals => "formula-leading-equals"
 
 /**
  * A single structural lint finding.
@@ -99,6 +106,8 @@ final case class Finding(
  *     never recomputes tables (GH-442) — the only checks here that are silently WRONG output rather
  *     than an Excel repair: Excel refuses these edits in the UI, so a file carrying one was written
  *     past its own guards
+ *   - `<f>` text stored with the display form's leading '=' (GH-456) — non-spec; Excel tolerates it
+ *     but strict readers (openpyxl) misread it, and re-writing the file with xl heals it
  *
  * Lint runs on the RAW ZIP PARTS, never on the parsed domain model — a full read would
  * repair/normalize the very structure lint inspects (the reader silently falls back on unresolved
@@ -436,7 +445,7 @@ object WorkbookLint:
                   parts,
                   parentDir(path)
                 ) ++
-                scan.boundsFindings ++
+                scan.boundsFindings ++ scan.formulaFindings ++
                 dataTableFindings(path, scan.dataTables, autoNoTable) ++ tableResult._1
           (
             found._1 ++ findings,
@@ -474,6 +483,20 @@ object WorkbookLint:
     }
 
   // ===== externalLink parts (GH-413 item 2) =====
+
+  /**
+   * Valid `<externalBook r:id>` target types: the ECMA externalLinkPath plus the Microsoft
+   * xlExternalLinkPath variants Excel itself writes for broken/special external-book paths (GH-458)
+   * — a real in-the-wild state, not a corruption class. The expectedTypes membership test fires
+   * before the TargetMode=External bail-out, so the set must carry all of them.
+   */
+  private val externalLinkPathTypes: Set[String] = Set(
+    XmlUtil.relTypeExternalLinkPath,
+    XmlUtil.relTypeXlPathMissing,
+    XmlUtil.relTypeXlLibraryPath,
+    XmlUtil.relTypeXlStartupPath,
+    XmlUtil.relTypeXlAltStartupPath
+  )
 
   /**
    * Lint each externalLink part reachable from a resolved workbook `externalReference`: the part's
@@ -523,8 +546,8 @@ object WorkbookLint:
                 relIdOf(book),
                 None,
                 relIdRequired = true,
-                Set(XmlUtil.relTypeExternalLinkPath),
-                "externalLinkPath"
+                externalLinkPathTypes,
+                "externalLinkPath (or a Microsoft xlExternalLinkPath variant)"
               )
             }
             checkRelRefs(path, refs, rels, relsPath, parts, parentDir(path))
@@ -662,14 +685,15 @@ object WorkbookLint:
   /**
    * Everything the per-part checks need, produced identically by the DOM and SAX scanners: root
    * label, ordered main-namespace top-level labels (with positions among all top-level elements),
-   * the captured r:id-bearing elements, the ref/sqref bounds findings, and the data-table record
-   * state accumulated over sheetData (GH-442).
+   * the captured r:id-bearing elements, the ref/sqref bounds findings, the leading-'=' formula
+   * findings (GH-456), and the data-table record state accumulated over sheetData (GH-442).
    */
   private final case class SheetScan(
     rootLabel: String,
     mainChildLabels: Vector[(String, Int)],
     captures: Vector[CapturedRef],
     boundsFindings: Vector[Finding],
+    formulaFindings: Vector[Finding],
     dataTables: Vector[RecordFacts]
   )
 
@@ -710,10 +734,12 @@ object WorkbookLint:
           XmlUtil.getAttrOpt(e, attr).toList.flatMap(refBoundsFindings(part, e.label, attr, _))
         }
       }
-    val dataTables = nestedElems(root, "sheetData", "row")
+    val cellObs = nestedElems(root, "sheetData", "row")
       .flatMap(childElems(_, "c"))
-      .foldLeft(Vector.empty[RecordFacts])((acc, cell) => observeCell(acc, domCellObs(cell)))
-    SheetScan(root.label, mainChildLabelsOf(root), captures, bounds, dataTables)
+      .map(domCellObs)
+    val dataTables = cellObs.foldLeft(Vector.empty[RecordFacts])(observeCell)
+    val formulaEq = cellObs.flatMap(formulaEqualsFindings(part, _))
+    SheetScan(root.label, mainChildLabelsOf(root), captures, bounds, formulaEq, dataTables)
 
   /** One `<c>` element's data-table facts (DOM side of the parity pair). */
   private def domCellObs(cell: Elem): CellObs =
@@ -723,7 +749,8 @@ object WorkbookLint:
       record =
         formula.flatMap(f => dataTableKindOf(XmlUtil.getAttrOpt(f, "t"), XmlUtil.getAttrOpt(f, _))),
       hasFormula = formula.isDefined,
-      hasValue = childElems(cell, "v").nonEmpty || childElems(cell, "is").nonEmpty
+      hasValue = childElems(cell, "v").nonEmpty || childElems(cell, "is").nonEmpty,
+      leadingEquals = formula.exists(_.text.startsWith("="))
     )
 
   /**
@@ -759,12 +786,23 @@ object WorkbookLint:
       private val labels = Vector.newBuilder[(String, Int)]
       private val captures = Vector.newBuilder[CapturedRef]
       private val bounds = Vector.newBuilder[Finding]
+      private val formulaEq = Vector.newBuilder[Finding]
       private var dataTables: Vector[RecordFacts] = Vector.empty
       private var cell: Option[CellObs] = None
+      // True while inside the current cell's FIRST <f> and no text chunk has arrived yet, so
+      // characters() inspects exactly the first character of the formula text (GH-456).
+      private var awaitingFormulaText = false
 
       def result: Option[SheetScan] =
         rootLabel.map(
-          SheetScan(_, labels.result(), captures.result(), bounds.result(), dataTables)
+          SheetScan(
+            _,
+            labels.result(),
+            captures.result(),
+            bounds.result(),
+            formulaEq.result(),
+            dataTables
+          )
         )
 
       override def startElement(
@@ -792,10 +830,13 @@ object WorkbookLint:
               ref = Option(atts.getValue("", "r")).flatMap(ARef.parse(_).toOption),
               record = None,
               hasFormula = false,
-              hasValue = false
+              hasValue = false,
+              leadingEquals = false
             )
           )
         else if depth == 4 && parents.headOption.contains("c") then
+          // GH-456: only the cell's first <f> is observed, matching domCellObs's headOption
+          if label == "f" && cell.exists(!_.hasFormula) then awaitingFormulaText = true
           cell = cell.map { open =>
             if label == "f" && !open.hasFormula then
               open.copy(
@@ -816,12 +857,21 @@ object WorkbookLint:
         parents = label :: parents
         depth += 1
 
+      override def characters(ch: Array[Char], start: Int, length: Int): Unit =
+        if awaitingFormulaText && length > 0 then
+          awaitingFormulaText = false
+          if ch(start) == '=' then cell = cell.map(_.copy(leadingEquals = true))
+
       override def endElement(uri: String, localName: String, qName: String): Unit =
         val label = if localName.nonEmpty then localName else qName
         parents = parents.drop(1)
         depth -= 1
+        if label == "f" then awaitingFormulaText = false
         if depth == 3 && label == "c" then
-          cell.foreach(obs => dataTables = observeCell(dataTables, obs))
+          cell.foreach { obs =>
+            dataTables = observeCell(dataTables, obs)
+            formulaEq ++= formulaEqualsFindings(part, obs)
+          }
           cell = None
 
       private def relIdIn(atts: Attributes): Option[String] =
@@ -837,8 +887,28 @@ object WorkbookLint:
     ref: Option[ARef],
     record: Option[FormulaKind.DataTable],
     hasFormula: Boolean,
-    hasValue: Boolean
+    hasValue: Boolean,
+    leadingEquals: Boolean
   )
+
+  /**
+   * GH-456: `<f>` text beginning with '=' — the display form leaked into the store. Excel/LO
+   * tolerate it, but strict readers (openpyxl) read the formula back doubled ("==B4*2") and
+   * formula-text diff tooling sees phantom differences. Shared by both scanners for parity.
+   */
+  private def formulaEqualsFindings(part: String, obs: CellObs): Vector[Finding] =
+    if !obs.leadingEquals then Vector.empty
+    else
+      Vector(
+        Finding(
+          part,
+          LintCategory.FormulaLeadingEquals,
+          obs.ref.fold("<f>")(r => s"""<c r="${r.toA1}"><f>"""),
+          "Formula text is stored with a leading '=' — OOXML carries the expression without it, " +
+            "and strict readers (openpyxl) see a doubled '=' formula; re-writing the file with " +
+            "xl heals it"
+        )
+      )
 
   /**
    * Accumulated facts for one data-table record, keyed by the record's own `ref`. Every field is a

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/lint/WorkbookLint.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/lint/WorkbookLint.scala
@@ -107,7 +107,9 @@ final case class Finding(
  *     than an Excel repair: Excel refuses these edits in the UI, so a file carrying one was written
  *     past its own guards
  *   - `<f>` text stored with the display form's leading '=' (GH-456) — non-spec; Excel tolerates it
- *     but strict readers (openpyxl) misread it, and re-writing the file with xl heals it
+ *     but strict readers (openpyxl) misread it, and re-writing the file with xl heals it.
+ *     Aggregated to ONE finding per sheet part (first-5 cell sample + total count) so a legacy book
+ *     where every formula offends stays bounded
  *
  * Lint runs on the RAW ZIP PARTS, never on the parsed domain model — a full read would
  * repair/normalize the very structure lint inspects (the reader silently falls back on unresolved
@@ -685,8 +687,8 @@ object WorkbookLint:
   /**
    * Everything the per-part checks need, produced identically by the DOM and SAX scanners: root
    * label, ordered main-namespace top-level labels (with positions among all top-level elements),
-   * the captured r:id-bearing elements, the ref/sqref bounds findings, the leading-'=' formula
-   * findings (GH-456), and the data-table record state accumulated over sheetData (GH-442).
+   * the captured r:id-bearing elements, the ref/sqref bounds findings, the aggregated leading-'='
+   * formula finding (GH-456), and the data-table record state accumulated over sheetData (GH-442).
    */
   private final case class SheetScan(
     rootLabel: String,
@@ -738,7 +740,10 @@ object WorkbookLint:
       .flatMap(childElems(_, "c"))
       .map(domCellObs)
     val dataTables = cellObs.foldLeft(Vector.empty[RecordFacts])(observeCell)
-    val formulaEq = cellObs.flatMap(formulaEqualsFindings(part, _))
+    val formulaEq = formulaEqualsFindings(
+      part,
+      cellObs.foldLeft(LeadingEqualsFacts.empty)(_.add(_))
+    )
     SheetScan(root.label, mainChildLabelsOf(root), captures, bounds, formulaEq, dataTables)
 
   /** One `<c>` element's data-table facts (DOM side of the parity pair). */
@@ -786,7 +791,7 @@ object WorkbookLint:
       private val labels = Vector.newBuilder[(String, Int)]
       private val captures = Vector.newBuilder[CapturedRef]
       private val bounds = Vector.newBuilder[Finding]
-      private val formulaEq = Vector.newBuilder[Finding]
+      private var leadingEq: LeadingEqualsFacts = LeadingEqualsFacts.empty
       private var dataTables: Vector[RecordFacts] = Vector.empty
       private var cell: Option[CellObs] = None
       // True while inside the current cell's FIRST <f> and no text chunk has arrived yet, so
@@ -800,7 +805,7 @@ object WorkbookLint:
             labels.result(),
             captures.result(),
             bounds.result(),
-            formulaEq.result(),
+            formulaEqualsFindings(part, leadingEq),
             dataTables
           )
         )
@@ -870,7 +875,7 @@ object WorkbookLint:
         if depth == 3 && label == "c" then
           cell.foreach { obs =>
             dataTables = observeCell(dataTables, obs)
-            formulaEq ++= formulaEqualsFindings(part, obs)
+            leadingEq = leadingEq.add(obs)
           }
           cell = None
 
@@ -891,22 +896,50 @@ object WorkbookLint:
     leadingEquals: Boolean
   )
 
+  /** Sample size for the aggregated leading-'=' finding: the first N offending cells (GH-456). */
+  private val leadingEqualsSampleSize = 5
+
+  /**
+   * Accumulated leading-'=' facts for ONE sheet part (GH-456): the total offender count plus the
+   * first [[leadingEqualsSampleSize]] offending cells in document order. Aggregation is bounded by
+   * construction — a legacy book where EVERY formula carries '=' (the exact population the rule
+   * targets) yields one finding per part, never one per cell. Folded identically by both scanners
+   * for parity. A `<c>` without `r` still counts; its sample slot renders as a bare `<f>`.
+   */
+  private final case class LeadingEqualsFacts(sample: Vector[Option[ARef]], count: Long):
+    def add(obs: CellObs): LeadingEqualsFacts =
+      if !obs.leadingEquals then this
+      else
+        LeadingEqualsFacts(
+          if sample.sizeIs < leadingEqualsSampleSize then sample :+ obs.ref else sample,
+          count + 1
+        )
+
+  private object LeadingEqualsFacts:
+    val empty: LeadingEqualsFacts = LeadingEqualsFacts(Vector.empty, 0L)
+
   /**
    * GH-456: `<f>` text beginning with '=' — the display form leaked into the store. Excel/LO
    * tolerate it, but strict readers (openpyxl) read the formula back doubled ("==B4*2") and
-   * formula-text diff tooling sees phantom differences. Shared by both scanners for parity.
+   * formula-text diff tooling sees phantom differences. ONE finding per part carrying the first
+   * [[leadingEqualsSampleSize]] cell refs and the total count; the locator names the first
+   * offending cell so the finding stays actionable without re-deriving it.
    */
-  private def formulaEqualsFindings(part: String, obs: CellObs): Vector[Finding] =
-    if !obs.leadingEquals then Vector.empty
+  private def formulaEqualsFindings(part: String, facts: LeadingEqualsFacts): Vector[Finding] =
+    if facts.count == 0L then Vector.empty
     else
+      val shown = facts.sample.map(_.fold("<f>")(_.toA1))
+      val cells =
+        if facts.count > shown.size then s"first ${shown.size}: ${shown.mkString(", ")}, …"
+        else shown.mkString(", ")
       Vector(
         Finding(
           part,
           LintCategory.FormulaLeadingEquals,
-          obs.ref.fold("<f>")(r => s"""<c r="${r.toA1}"><f>"""),
-          "Formula text is stored with a leading '=' — OOXML carries the expression without it, " +
-            "and strict readers (openpyxl) see a doubled '=' formula; re-writing the file with " +
-            "xl heals it"
+          facts.sample.headOption.flatten.fold("<f>")(r => s"""<c r="${r.toA1}"><f>"""),
+          s"${facts.count} formula(s) stored with a leading '=' ($cells) — OOXML carries the " +
+            "expression without it, and strict readers (openpyxl) see a doubled '=' formula; " +
+            "re-writing the file with xl heals it"
         )
       )
 

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/OoxmlCell.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/OoxmlCell.scala
@@ -69,7 +69,8 @@ case class OoxmlCell(
               FormulaKindCodec.toAttrs(kind).foreach { case (name, v) =>
                 writer.writeAttribute(name, v)
               }
-              writer.writeCharacters(expr)
+              // GH-456: <f> carries the expression, never the display form's leading '='
+              writer.writeCharacters(expr.stripPrefix("="))
               writer.endElement() // f
           // Write cached value if present
           cachedValue.foreach {
@@ -286,9 +287,10 @@ case class OoxmlCell(
         // Write formula element. GH-430: record attrs via the shared codec in schema order
         // (elemOrdered keeps the given order); dataTable records carry no text.
         val recordAttrs = FormulaKindCodec.toAttrs(kind)
+        // GH-456: <f> carries the expression, never the display form's leading '='
         val formulaElem = kind match
           case _: FormulaKind.DataTable => elemOrdered("f", recordAttrs*)()
-          case _ => elemOrdered("f", recordAttrs*)(Text(expr))
+          case _ => elemOrdered("f", recordAttrs*)(Text(expr.stripPrefix("=")))
         // Write cached value if present
         val cachedElem = cachedValue.flatMap {
           case CellValue.Number(num) => Some(elem("v")(Text(XmlUtil.plainNumber(num))))

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/xml.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/xml.scala
@@ -71,6 +71,15 @@ object XmlUtil:
   // The externalLink part's own <externalBook r:id> target (GH-413)
   val relTypeExternalLinkPath =
     "http://schemas.openxmlformats.org/officeDocument/2006/relationships/externalLinkPath"
+  // Microsoft externalLinkPath variants Excel writes for broken/special external-book paths (GH-458)
+  val relTypeXlPathMissing =
+    "http://schemas.microsoft.com/office/2006/relationships/xlExternalLinkPath/xlPathMissing"
+  val relTypeXlLibraryPath =
+    "http://schemas.microsoft.com/office/2006/relationships/xlExternalLinkPath/xlLibraryPath"
+  val relTypeXlStartupPath =
+    "http://schemas.microsoft.com/office/2006/relationships/xlExternalLinkPath/xlStartupPath"
+  val relTypeXlAltStartupPath =
+    "http://schemas.microsoft.com/office/2006/relationships/xlExternalLinkPath/xlAltStartupPath"
   val relTypeChartsheet =
     "http://schemas.openxmlformats.org/officeDocument/2006/relationships/chartsheet"
   val relTypeDialogsheet =

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/xml.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/xml.scala
@@ -501,12 +501,75 @@ object XmlUtil:
 
 object XmlSecurity:
   /**
+   * JAXP entity-SIZE limit properties lifted (set to 0 = unlimited) on every parser built by
+   * [[secureSaxParserFactory]] (GH-457): real workbooks accumulate tens of thousands of
+   * definedNames (multi-MB single-line workbook.xml), and JAXP builds that default these limits to
+   * 100KB — the GraalVM the native image is built from, where `-Djdk.xml.*` cannot reach the binary
+   * — reject the document entity with JAXP00010003 on every verb. Lifting SIZE limits is safe
+   * because doctype declarations are rejected outright (`disallow-doctype-decl`), so no general
+   * entity can ever be defined and entity-expansion attacks remain structurally impossible;
+   * `entityExpansionLimit` is deliberately left at its default. Each limit lists its legacy Oracle
+   * URI first (recognized on every mainstream JDK), then the modern `jdk.xml.` name.
+   */
+  private val liftedEntitySizeLimits: List[List[String]] = List(
+    List(
+      "http://www.oracle.com/xml/jaxp/properties/maxGeneralEntitySizeLimit",
+      "jdk.xml.maxGeneralEntitySizeLimit"
+    ),
+    List(
+      "http://www.oracle.com/xml/jaxp/properties/totalEntitySizeLimit",
+      "jdk.xml.totalEntitySizeLimit"
+    )
+  )
+
+  /** Set each lifted limit under the first property name the parser recognizes (GH-457). */
+  private def liftEntitySizeLimits(parser: javax.xml.parsers.SAXParser): Unit =
+    liftedEntitySizeLimits.foreach { aliases =>
+      val _ = aliases.exists { name =>
+        try
+          parser.setProperty(name, "0")
+          true
+        catch
+          // Tolerate exotic parsers that don't know the JAXP limit properties: hardening
+          // features above still apply; only the limit-lifting is best-effort.
+          case _: org.xml.sax.SAXNotRecognizedException => false
+          case _: org.xml.sax.SAXNotSupportedException => false
+      }
+    }
+
+  /**
+   * Delegating factory so every call site building parsers via
+   * `secureSaxParserFactory().newSAXParser()` inherits the GH-457 limit-lifting automatically — the
+   * JAXP limits are parser properties, not factory features, so they cannot be carried by the
+   * underlying factory itself.
+   */
+  private final class SecureFactory(underlying: javax.xml.parsers.SAXParserFactory)
+      extends javax.xml.parsers.SAXParserFactory:
+    override def newSAXParser(): javax.xml.parsers.SAXParser =
+      val parser = underlying.newSAXParser()
+      liftEntitySizeLimits(parser)
+      parser
+    override def setFeature(name: String, value: Boolean): Unit = underlying.setFeature(name, value)
+    override def getFeature(name: String): Boolean = underlying.getFeature(name)
+    override def setNamespaceAware(awareness: Boolean): Unit =
+      underlying.setNamespaceAware(awareness)
+    override def isNamespaceAware(): Boolean = underlying.isNamespaceAware()
+    override def setValidating(validating: Boolean): Unit = underlying.setValidating(validating)
+    override def isValidating(): Boolean = underlying.isValidating()
+    override def setXIncludeAware(state: Boolean): Unit = underlying.setXIncludeAware(state)
+    override def isXIncludeAware(): Boolean = underlying.isXIncludeAware()
+    override def setSchema(schema: javax.xml.validation.Schema): Unit =
+      underlying.setSchema(schema)
+    override def getSchema(): javax.xml.validation.Schema = underlying.getSchema()
+
+  /**
    * SAXParserFactory carrying the XXE hardening posture shared by EVERY parse surface: doctype
    * declarations rejected, external general/parameter entities and external DTD loading disabled,
    * XInclude off, namespaces on. Streaming SAX sites (worksheet/SST/dimension readers, streaming
    * transforms) must build their parsers from this factory so the hardening cannot drift per-site
    * (GH-350) — pair it with [[stripLeadingDoctypeStream]] on the input so benign doctypes still
-   * read.
+   * read. Parsers it creates additionally have the JAXP entity-SIZE limits lifted so name-bloated
+   * multi-MB core parts read on the native image (GH-457, see [[liftedEntitySizeLimits]]).
    */
   def secureSaxParserFactory(): javax.xml.parsers.SAXParserFactory =
     val factory = javax.xml.parsers.SAXParserFactory.newInstance()
@@ -516,7 +579,7 @@ object XmlSecurity:
     factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
     factory.setXIncludeAware(false)
     factory.setNamespaceAware(true)
-    factory
+    new SecureFactory(factory)
 
   /**
    * Thread-local pool of XXE-safe SAX parsers for performance.

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/xml.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/xml.scala
@@ -510,17 +510,27 @@ object XmlUtil:
 
 object XmlSecurity:
   /**
-   * JAXP entity-SIZE limit properties lifted (set to 0 = unlimited) on every parser built by
+   * Finite ceiling the JAXP entity-SIZE limits are raised to (GH-457): 2,000,000,000 bytes —
+   * comfortably above any real workbook.xml (field books with 100k+ definedNames are single-digit
+   * MB) and far above the 100KB JAXP default, yet FINITE so the parser still fails closed on a
+   * truly pathological document entity. `"0"` would mean unlimited — no backstop at all — so a
+   * crafted input could drive unbounded parse work; a large finite ceiling keeps the GH-457 fix
+   * while preserving a hard upper bound.
+   */
+  private[ooxml] val EntitySizeLimitCeiling: Int = 2_000_000_000
+
+  /**
+   * JAXP entity-SIZE limit properties raised to [[EntitySizeLimitCeiling]] on every parser built by
    * [[secureSaxParserFactory]] (GH-457): real workbooks accumulate tens of thousands of
    * definedNames (multi-MB single-line workbook.xml), and JAXP builds that default these limits to
    * 100KB — the GraalVM the native image is built from, where `-Djdk.xml.*` cannot reach the binary
-   * — reject the document entity with JAXP00010003 on every verb. Lifting SIZE limits is safe
+   * — reject the document entity with JAXP00010003 on every verb. Raising SIZE limits is safe
    * because doctype declarations are rejected outright (`disallow-doctype-decl`), so no general
    * entity can ever be defined and entity-expansion attacks remain structurally impossible;
    * `entityExpansionLimit` is deliberately left at its default. Each limit lists its legacy Oracle
    * URI first (recognized on every mainstream JDK), then the modern `jdk.xml.` name.
    */
-  private val liftedEntitySizeLimits: List[List[String]] = List(
+  private val raisedEntitySizeLimits: List[List[String]] = List(
     List(
       "http://www.oracle.com/xml/jaxp/properties/maxGeneralEntitySizeLimit",
       "jdk.xml.maxGeneralEntitySizeLimit"
@@ -531,16 +541,16 @@ object XmlSecurity:
     )
   )
 
-  /** Set each lifted limit under the first property name the parser recognizes (GH-457). */
-  private def liftEntitySizeLimits(parser: javax.xml.parsers.SAXParser): Unit =
-    liftedEntitySizeLimits.foreach { aliases =>
+  /** Set each raised limit under the first property name the parser recognizes (GH-457). */
+  private def raiseEntitySizeLimits(parser: javax.xml.parsers.SAXParser): Unit =
+    raisedEntitySizeLimits.foreach { aliases =>
       val _ = aliases.exists { name =>
         try
-          parser.setProperty(name, "0")
+          parser.setProperty(name, EntitySizeLimitCeiling.toString)
           true
         catch
           // Tolerate exotic parsers that don't know the JAXP limit properties: hardening
-          // features above still apply; only the limit-lifting is best-effort.
+          // features above still apply; only the limit-raising is best-effort.
           case _: org.xml.sax.SAXNotRecognizedException => false
           case _: org.xml.sax.SAXNotSupportedException => false
       }
@@ -548,7 +558,7 @@ object XmlSecurity:
 
   /**
    * Delegating factory so every call site building parsers via
-   * `secureSaxParserFactory().newSAXParser()` inherits the GH-457 limit-lifting automatically — the
+   * `secureSaxParserFactory().newSAXParser()` inherits the GH-457 limit-raising automatically — the
    * JAXP limits are parser properties, not factory features, so they cannot be carried by the
    * underlying factory itself.
    */
@@ -556,7 +566,7 @@ object XmlSecurity:
       extends javax.xml.parsers.SAXParserFactory:
     override def newSAXParser(): javax.xml.parsers.SAXParser =
       val parser = underlying.newSAXParser()
-      liftEntitySizeLimits(parser)
+      raiseEntitySizeLimits(parser)
       parser
     override def setFeature(name: String, value: Boolean): Unit = underlying.setFeature(name, value)
     override def getFeature(name: String): Boolean = underlying.getFeature(name)
@@ -577,8 +587,9 @@ object XmlSecurity:
    * XInclude off, namespaces on. Streaming SAX sites (worksheet/SST/dimension readers, streaming
    * transforms) must build their parsers from this factory so the hardening cannot drift per-site
    * (GH-350) — pair it with [[stripLeadingDoctypeStream]] on the input so benign doctypes still
-   * read. Parsers it creates additionally have the JAXP entity-SIZE limits lifted so name-bloated
-   * multi-MB core parts read on the native image (GH-457, see [[liftedEntitySizeLimits]]).
+   * read. Parsers it creates additionally have the JAXP entity-SIZE limits raised to a large finite
+   * ceiling so name-bloated multi-MB core parts read on the native image (GH-457, see
+   * [[raisedEntitySizeLimits]]).
    */
   def secureSaxParserFactory(): javax.xml.parsers.SAXParserFactory =
     val factory = javax.xml.parsers.SAXParserFactory.newInstance()

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/FormulaInjectionSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/FormulaInjectionSpec.scala
@@ -235,10 +235,11 @@ class FormulaInjectionSpec extends FunSuite:
         case Right(readWb) =>
           val readSheet = readWb.sheets.head
 
-          // Formula cells should NOT be escaped (they're actual formulas)
+          // Formula cells should NOT be escaped (they're actual formulas). GH-456: the writer
+          // canonicalizes away the display form's leading '=', so the read-back is bare.
           readSheet.cells.get(ref"A1").map(_.value) match
             case Some(CellValue.Formula(expr, _, _)) =>
-              assertEquals(expr, "=A2+A3", "Formula should not be escaped")
+              assertEquals(expr, "A2+A3", "Formula should not be escaped")
             case other => fail(s"Expected Formula, got: $other")
 
     finally Files.deleteIfExists(tempFile)

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/FormulaLeadingEqualsSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/FormulaLeadingEqualsSpec.scala
@@ -1,0 +1,103 @@
+package com.tjclp.xl.ooxml
+
+import java.io.ByteArrayOutputStream
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path}
+import java.util.zip.ZipFile
+
+import scala.xml.XML
+
+import com.tjclp.xl.api.*
+import com.tjclp.xl.cells.CellValue
+import com.tjclp.xl.codec.CellCodec.given
+import com.tjclp.xl.macros.ref
+import com.tjclp.xl.ooxml.worksheet.OoxmlCell
+import com.tjclp.xl.ooxml.writer.{WriterConfig, XmlBackend}
+import munit.FunSuite
+
+/**
+ * GH-456: `<f>` carries the formula EXPRESSION, never the display form's leading '='. The
+ * scripting/API path stores `fx"=B4*2"` verbatim (in-memory tolerance of both shapes is by design),
+ * so EVERY writer must canonicalize at the `<f>` emission boundary — otherwise scripting-authored
+ * books ship `<f>=B4*2</f>` (non-spec; openpyxl reads it back as "==B4*2"). Strip ONCE and leading
+ * only: interior '=' (comparisons) must never be touched.
+ */
+class FormulaLeadingEqualsSpec extends FunSuite:
+
+  private val leadingEq = CellValue.Formula("=B4*2", None)
+
+  private def tempXlsx(label: String): Path =
+    val p = Files.createTempFile(s"xl-leading-eq-$label-", ".xlsx")
+    p.toFile.deleteOnExit()
+    p
+
+  private def entryText(path: Path, name: String): String =
+    val zip = new ZipFile(path.toFile)
+    try
+      Option(zip.getEntry(name)) match
+        case Some(e) => new String(zip.getInputStream(e).readAllBytes(), StandardCharsets.UTF_8)
+        case None => fail(s"zip entry $name not found")
+    finally zip.close()
+
+  private def writtenSheetXml(backend: XmlBackend, value: CellValue): String =
+    val sheet = Sheet("Data").put(ref"B4" -> 2).put(ref"C4", value)
+    val path = tempXlsx(backend.toString.toLowerCase)
+    XlsxWriter
+      .writeWith(Workbook(Vector(sheet)), path, WriterConfig(backend = backend))
+      .fold(err => fail(s"write failed: $err"), identity)
+    entryText(path, "xl/worksheets/sheet1.xml")
+
+  test("GH-456: ScalaXml backend writes fx-style formula without the leading '='") {
+    val xml = writtenSheetXml(XmlBackend.ScalaXml, leadingEq)
+    assert(xml.contains("<f>B4*2</f>"), xml)
+    assert(!xml.contains("<f>="), xml)
+  }
+
+  test("GH-456: SaxStax backend (DirectSaxEmitter) writes fx-style formula without the '='") {
+    val xml = writtenSheetXml(XmlBackend.SaxStax, leadingEq)
+    assert(xml.contains("<f>B4*2</f>"), xml)
+    assert(!xml.contains("<f>="), xml)
+  }
+
+  test("GH-456: cached value is untouched by the canonicalization") {
+    val xml =
+      writtenSheetXml(XmlBackend.ScalaXml, CellValue.Formula("=B4*2", Some(CellValue.Number(4))))
+    assert(xml.contains("<f>B4*2</f>"), xml)
+    assert(xml.contains("<v>4</v>"), xml)
+  }
+
+  test("GH-456: interior '=' is never stripped (leading only, once)") {
+    val xml = writtenSheetXml(XmlBackend.ScalaXml, CellValue.Formula("=IF(A1=1,2,3)", None))
+    assert(xml.contains("<f>IF(A1=1,2,3)</f>"), xml)
+  }
+
+  test("GH-456: already-clean expression is written verbatim (CLI putf parity)") {
+    val xml = writtenSheetXml(XmlBackend.SaxStax, CellValue.Formula("SUM(A1:A2)", None))
+    assert(xml.contains("<f>SUM(A1:A2)</f>"), xml)
+  }
+
+  test("GH-456: OoxmlCell.toXml (DOM path) strips the leading '='") {
+    val cell = OoxmlCell(ref"C4", leadingEq, None, "")
+    assertEquals((cell.toXml \ "f").text, "B4*2")
+  }
+
+  test("GH-456: OoxmlCell.writeSax strips the leading '='") {
+    val out = new ByteArrayOutputStream()
+    val writer = StaxSaxWriter.create(out)
+    OoxmlCell(ref"C4", leadingEq, None, "").writeSax(writer)
+    writer.flush()
+    val xml = XML.loadString(out.toString("UTF-8"))
+    assertEquals((xml \ "f").text, "B4*2")
+  }
+
+  test("GH-456: written book reads back with the canonical expression (round-trip heals)") {
+    val sheet = Sheet("Data").put(ref"B4" -> 2).put(ref"C4", leadingEq)
+    val path = tempXlsx("roundtrip")
+    XlsxWriter
+      .write(Workbook(Vector(sheet)), path)
+      .fold(err => fail(s"write failed: $err"), identity)
+    val wb = XlsxReader.read(path).fold(err => fail(s"read failed: $err"), identity)
+    wb.sheets(0)(ref"C4").value match
+      case CellValue.Formula(expr, _, _) => assertEquals(expr, "B4*2")
+      case other => fail(s"expected formula at C4, got $other")
+  }

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/OoxmlRoundTripSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/OoxmlRoundTripSpec.scala
@@ -415,7 +415,8 @@ class OoxmlRoundTripSpec extends FunSuite:
 
     readWb.sheets(0)(ref"B1").value match
       case CellValue.Formula(expr, Some(CellValue.Number(n)), _) =>
-        assertEquals(expr, "=A1*2")
+        // GH-456: the writer strips the display form's leading '=' — the store is canonical
+        assertEquals(expr, "A1*2")
         assertEquals(n, BigDecimal(42))
       case other => fail(s"Unexpected: $other")
   }

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/SecuritySpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/SecuritySpec.scala
@@ -345,6 +345,164 @@ class SecuritySpec extends FunSuite:
     assertEquals(XmlSecurity.stripLeadingDoctype(in), "<?xml version=\"1.0\"?>\n\n\n\n<x/>")
   }
 
+  // --- GH-457: JAXP entity-size limits must not reject name-bloated (multi-MB) workbook.xml ---
+
+  /**
+   * Single-line workbook.xml whose <definedNames> block is inflated past `minBytes` — the shape of
+   * legacy banker books (37k-110k names) that trips jdk.xml.maxGeneralEntitySizeLimit=100000 on the
+   * native image (GH-457).
+   */
+  private def nameBloatedWorkbookXml(minBytes: Int): String =
+    val sb = new StringBuilder
+    sb.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
+    sb.append("<workbook xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\"")
+    sb.append(" xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\">")
+    sb.append("<sheets><sheet name=\"Sheet1\" sheetId=\"1\" r:id=\"rId1\"/></sheets>")
+    sb.append("<definedNames>")
+    var i = 0
+    while sb.length < minBytes do
+      sb.append(s"<definedName name=\"n$i\">Sheet1!$$A$$${(i % 100) + 1}</definedName>")
+      i += 1
+    sb.append("</definedNames></workbook>")
+    sb.toString
+
+  /**
+   * Run `body` with the jdk.xml entity-size system properties pinned to the 100k default the native
+   * image bakes in — parsers created while these are set inherit the limits unless the factory
+   * explicitly lifts them (the GH-457 fix).
+   */
+  private def withRestrictedJaxpLimits[A](body: => A): A =
+    val keys = List("jdk.xml.maxGeneralEntitySizeLimit", "jdk.xml.totalEntitySizeLimit")
+    val saved = keys.map(k => k -> Option(System.getProperty(k)))
+    keys.foreach(k => System.setProperty(k, "100000"))
+    try body
+    finally
+      saved.foreach {
+        case (k, Some(v)) => System.setProperty(k, v)
+        case (k, None) => System.clearProperty(k)
+      }
+
+  /**
+   * Run `body` on a fresh thread: XmlSecurity's parser pool is a ThreadLocal, so this forces the
+   * pooled parser to be created while [[withRestrictedJaxpLimits]]'s properties are in effect
+   * (parsers already pooled on the test thread would predate them).
+   */
+  private def onFreshThread[A](body: => A): A =
+    @volatile var out: Option[Either[Throwable, A]] = None
+    val t = new Thread(() =>
+      out = Some(
+        try Right(body)
+        catch case e: Throwable => Left(e)
+      )
+    )
+    t.start()
+    t.join()
+    out match
+      case Some(Right(a)) => a
+      case Some(Left(e)) => throw e
+      case None => fail("worker thread did not complete")
+
+  test("GH-457: secure parser lifts JAXP entity-size limits (property pin + bloated parse)") {
+    val xml = nameBloatedWorkbookXml(150_000)
+    withRestrictedJaxpLimits {
+      val parser = XmlSecurity.secureSaxParserFactory().newSAXParser()
+      // The parser must carry limit=0 (unlimited) even when the environment restricts it — this
+      // is the exact mechanism that fixes the native image, where the baked-in parser default is
+      // 100000 and -Djdk.xml.* cannot reach the binary (GH-457).
+      val prefix = "http://www.oracle.com/xml/jaxp/properties/"
+      assertEquals(
+        String.valueOf(parser.getProperty(s"${prefix}maxGeneralEntitySizeLimit")),
+        "0",
+        "maxGeneralEntitySizeLimit must be lifted on parsers from secureSaxParserFactory"
+      )
+      assertEquals(
+        String.valueOf(parser.getProperty(s"${prefix}totalEntitySizeLimit")),
+        "0",
+        "totalEntitySizeLimit must be lifted on parsers from secureSaxParserFactory"
+      )
+      // On JAXP builds that count the document entity against the limit (JDK 24-era Xerces, the
+      // GraalVM the native image is built from) this parse throws JAXP00010003 without the fix.
+      parser.parse(
+        new org.xml.sax.InputSource(new java.io.StringReader(xml)),
+        new org.xml.sax.helpers.DefaultHandler
+      )
+    }
+  }
+
+  test("GH-457: parseSafe reads >100KB workbook.xml under native-image JAXP limits") {
+    val xml = nameBloatedWorkbookXml(150_000)
+    withRestrictedJaxpLimits {
+      onFreshThread {
+        XmlSecurity.parseSafe(xml, "xl/workbook.xml") match
+          case Right(elem) => assertEquals(elem.label, "workbook")
+          case Left(err) => fail(s"name-bloated workbook.xml must parse: ${err.message}")
+      }
+    }
+  }
+
+  test("GH-457: full read + metadata read of a name-bloated xlsx under native-image JAXP limits") {
+    val workbookXml = nameBloatedWorkbookXml(150_000)
+
+    val contentTypes = """<?xml version="1.0" encoding="UTF-8"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+  <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+</Types>"""
+
+    val rels = """<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>"""
+
+    val workbookRels = """<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+</Relationships>"""
+
+    val sheet1 = """<?xml version="1.0" encoding="UTF-8"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <dimension ref="A1"/>
+  <sheetData/>
+</worksheet>"""
+
+    val baos = ByteArrayOutputStream()
+    val zos = ZipOutputStream(baos)
+
+    def addEntry(name: String, content: String): Unit =
+      zos.putNextEntry(ZipEntry(name))
+      zos.write(content.getBytes(StandardCharsets.UTF_8))
+      zos.closeEntry()
+
+    addEntry("[Content_Types].xml", contentTypes)
+    addEntry("_rels/.rels", rels)
+    addEntry("xl/workbook.xml", workbookXml)
+    addEntry("xl/_rels/workbook.xml.rels", workbookRels)
+    addEntry("xl/worksheets/sheet1.xml", sheet1)
+    zos.close()
+
+    val tempFile = tempDir.resolve("name-bloated.xlsx")
+    Files.write(tempFile, baos.toByteArray)
+
+    withRestrictedJaxpLimits {
+      onFreshThread {
+        XlsxReader.read(tempFile) match
+          case Right(workbook) => assertEquals(workbook.sheets.size, 1)
+          case Left(err) => fail(s"name-bloated xlsx must load fully: $err")
+
+        com.tjclp.xl.ooxml.metadata.WorkbookMetadataReader.read(tempFile) match
+          case Right(meta) =>
+            assertEquals(meta.sheets.size, 1)
+            assert(
+              meta.definedNames.size > 1000,
+              s"expected the bloated name block, got ${meta.definedNames.size} names"
+            )
+          case Left(err) => fail(s"metadata read of name-bloated xlsx must succeed: $err")
+      }
+    }
+  }
+
   test("XlsxReader rejects comment relationship path traversal") {
     val workbookXml = """<?xml version="1.0" encoding="UTF-8"?>
 <workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/SecuritySpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/SecuritySpec.scala
@@ -369,7 +369,13 @@ class SecuritySpec extends FunSuite:
   /**
    * Run `body` with the jdk.xml entity-size system properties pinned to the 100k default the native
    * image bakes in — parsers created while these are set inherit the limits unless the factory
-   * explicitly lifts them (the GH-457 fix).
+   * explicitly raises them (the GH-457 fix).
+   *
+   * This mutates GLOBAL System properties, which is safe here because no other suite can observe
+   * the restricted window: Mill 1.1's `testParallelism` work-stealing scheduler forks runner JVMs
+   * that each execute test CLASSES sequentially (suites never share a JVM concurrently), and munit
+   * runs a suite's tests sequentially within the suite. If either of those ever changes, this
+   * helper must gain cross-suite isolation (a shared lock or suite-level serialization).
    */
   private def withRestrictedJaxpLimits[A](body: => A): A =
     val keys = List("jdk.xml.maxGeneralEntitySizeLimit", "jdk.xml.totalEntitySizeLimit")
@@ -402,23 +408,38 @@ class SecuritySpec extends FunSuite:
       case Some(Left(e)) => throw e
       case None => fail("worker thread did not complete")
 
-  test("GH-457: secure parser lifts JAXP entity-size limits (property pin + bloated parse)") {
+  /**
+   * Read a JAXP limit property under each of its aliases (legacy Oracle URI, modern jdk.xml name),
+   * tolerating parsers that recognize only one — mirroring the production code's alias tolerance.
+   */
+  private def readLimitAliases(
+    parser: javax.xml.parsers.SAXParser,
+    localName: String
+  ): List[String] =
+    List(s"http://www.oracle.com/xml/jaxp/properties/$localName", s"jdk.xml.$localName").flatMap {
+      name =>
+        try Option(parser.getProperty(name)).map(String.valueOf(_))
+        catch
+          case _: org.xml.sax.SAXNotRecognizedException => None
+          case _: org.xml.sax.SAXNotSupportedException => None
+    }
+
+  test("GH-457: secure parser raises JAXP entity-size limits (property pin + bloated parse)") {
     val xml = nameBloatedWorkbookXml(150_000)
+    val ceiling = XmlSecurity.EntitySizeLimitCeiling.toString
     withRestrictedJaxpLimits {
       val parser = XmlSecurity.secureSaxParserFactory().newSAXParser()
-      // The parser must carry limit=0 (unlimited) even when the environment restricts it — this
-      // is the exact mechanism that fixes the native image, where the baked-in parser default is
-      // 100000 and -Djdk.xml.* cannot reach the binary (GH-457).
-      val prefix = "http://www.oracle.com/xml/jaxp/properties/"
-      assertEquals(
-        String.valueOf(parser.getProperty(s"${prefix}maxGeneralEntitySizeLimit")),
-        "0",
-        "maxGeneralEntitySizeLimit must be lifted on parsers from secureSaxParserFactory"
+      // The parser must carry the finite fail-closed ceiling even when the environment restricts
+      // it — this is the exact mechanism that fixes the native image, where the baked-in parser
+      // default is 100000 and -Djdk.xml.* cannot reach the binary (GH-457). At least one alias
+      // must read the ceiling back: a JDK knowing only the jdk.xml name is still conformant.
+      assert(
+        readLimitAliases(parser, "maxGeneralEntitySizeLimit").contains(ceiling),
+        "maxGeneralEntitySizeLimit must be raised to the ceiling on parsers from secureSaxParserFactory"
       )
-      assertEquals(
-        String.valueOf(parser.getProperty(s"${prefix}totalEntitySizeLimit")),
-        "0",
-        "totalEntitySizeLimit must be lifted on parsers from secureSaxParserFactory"
+      assert(
+        readLimitAliases(parser, "totalEntitySizeLimit").contains(ceiling),
+        "totalEntitySizeLimit must be raised to the ceiling on parsers from secureSaxParserFactory"
       )
       // On JAXP builds that count the document entity against the limit (JDK 24-era Xerces, the
       // GraalVM the native image is built from) this parse throws JAXP00010003 without the fix.

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/WorkbookEquivalence.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/WorkbookEquivalence.scala
@@ -301,7 +301,9 @@ object WorkbookEquivalence:
   ): Option[String] =
     (expected, actual) match
       case (CellValue.Formula(expExpr, _, _), CellValue.Formula(actExpr, _, _)) =>
-        Option.when(expExpr != actExpr)(
+        // GH-456: the writer canonicalizes away the display form's leading '=', so the
+        // round-trip law holds modulo that normalization (the model tolerates both shapes)
+        Option.when(expExpr.stripPrefix("=") != actExpr.stripPrefix("="))(
           s"$sheet!${ref.toA1}: formula text mismatch: expected '$expExpr', actual '$actExpr'"
         )
       case (CellValue.Number(exp), CellValue.Number(act)) =>

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/lint/WorkbookLintSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/lint/WorkbookLintSpec.scala
@@ -603,6 +603,39 @@ class WorkbookLintSpec extends FunSuite:
     assert(findings.head.message.contains("externalLinkPath"), findings.head.toString)
   }
 
+  // ===== GH-458: Microsoft xlExternalLinkPath variants are valid externalBook targets =====
+
+  /** Excel writes these for broken/special external-book paths — a real in-the-wild state. */
+  private def msVariantRelsXml(variant: String): String = externalLinkRelsXml.replace(
+    "http://schemas.openxmlformats.org/officeDocument/2006/relationships/externalLinkPath",
+    s"http://schemas.microsoft.com/office/2006/relationships/xlExternalLinkPath/$variant"
+  )
+
+  test("GH-458: externalBook rel typed xlPathMissing (Microsoft variant) is not flagged") {
+    val findings = lintOf(
+      externalParts +
+        ("xl/externalLinks/_rels/externalLink1.xml.rels" -> msVariantRelsXml("xlPathMissing"))
+    )
+    assertEquals(findings, Vector.empty[Finding])
+  }
+
+  test("GH-458: externalBook rel typed xlLibraryPath (Microsoft variant) is not flagged") {
+    val findings = lintOf(
+      externalParts +
+        ("xl/externalLinks/_rels/externalLink1.xml.rels" -> msVariantRelsXml("xlLibraryPath"))
+    )
+    assertEquals(findings, Vector.empty[Finding])
+  }
+
+  test("GH-458: a genuinely wrong externalBook rel type (image) still flags WrongRelType") {
+    val findings = lintOf(
+      externalParts +
+        ("xl/externalLinks/_rels/externalLink1.xml.rels" -> wrongTypeExternalBookRelsXml)
+    )
+    assertEquals(findings.map(_.category), Vector(LintCategory.WrongRelType))
+    assert(findings.head.message.contains("image"), findings.head.toString)
+  }
+
   // ===== GH-413 (3): [Content_Types].xml registration =====
 
   private val stylesOverrideLine =
@@ -950,6 +983,48 @@ class WorkbookLintSpec extends FunSuite:
     finally Files.deleteIfExists(output)
   }
 
+  // ===== GH-456: <f> text carrying the display form's leading '=' =====
+
+  private val leadingEqualsSheetXml = worksheetWith(
+    """<sheetData>
+    <row r="1"><c r="A1"><v>2</v></c><c r="B1"><f>=A1*2</f><v>4</v></c></row>
+  </sheetData>"""
+  )
+
+  private val cleanFormulaSheetXml = worksheetWith(
+    """<sheetData>
+    <row r="1"><c r="A1"><v>2</v></c><c r="B1"><f>A1*2</f><v>4</v></c></row>
+  </sheetData>"""
+  )
+
+  test("GH-456: <f> text starting with '=' is flagged as FormulaLeadingEquals") {
+    val findings = lintOf(baseParts + ("xl/worksheets/sheet1.xml" -> leadingEqualsSheetXml))
+    assertEquals(findings.map(_.category), Vector(LintCategory.FormulaLeadingEquals))
+    val f = findings.head
+    assertEquals(f.part, "xl/worksheets/sheet1.xml")
+    assert(f.locator.contains("B1"), s"locator should carry the cell ref: $f")
+    assert(f.message.contains("re-writing"), s"message should say a re-write heals it: $f")
+  }
+
+  test("GH-456: clean <f> text produces no findings") {
+    assertEquals(
+      lintOf(baseParts + ("xl/worksheets/sheet1.xml" -> cleanFormulaSheetXml)),
+      Vector.empty[Finding]
+    )
+  }
+
+  test("GH-456: streaming mode flags the leading '=' identically") {
+    assertEquals(
+      lintStreamOf(baseParts + ("xl/worksheets/sheet1.xml" -> leadingEqualsSheetXml)),
+      lintOf(baseParts + ("xl/worksheets/sheet1.xml" -> leadingEqualsSheetXml))
+    )
+    assertEquals(
+      lintStreamOf(baseParts + ("xl/worksheets/sheet1.xml" -> leadingEqualsSheetXml))
+        .map(_.category),
+      Vector(LintCategory.FormulaLeadingEquals)
+    )
+  }
+
   // ===== GH-413 (4): O(1) SAX scanning mode =====
 
   private def lintStreamOf(parts: Map[String, String]): Vector[Finding] =
@@ -998,7 +1073,15 @@ class WorkbookLintSpec extends FunSuite:
     "overwritten data-table corner" -> dtParts(overwrittenCornerSheetXml),
     "unseeded autoNoTable data table" -> autoNoTableParts(unseededDataTableSheetXml),
     "partly seeded autoNoTable data table" -> autoNoTableParts(partlySeededDataTableSheetXml),
-    "torn autoNoTable data table" -> autoNoTableParts(tornInteriorSheetXml)
+    "torn autoNoTable data table" -> autoNoTableParts(tornInteriorSheetXml),
+    // GH-456: <f> text observation must agree between the DOM and SAX scanners
+    "leading-equals formula" ->
+      (baseParts + ("xl/worksheets/sheet1.xml" -> leadingEqualsSheetXml)),
+    "clean formula text" -> (baseParts + ("xl/worksheets/sheet1.xml" -> cleanFormulaSheetXml)),
+    // GH-458: Microsoft xlExternalLinkPath variants resolve clean in both modes
+    "ms xlPathMissing external" ->
+      (externalParts +
+        ("xl/externalLinks/_rels/externalLink1.xml.rels" -> msVariantRelsXml("xlPathMissing")))
   )
 
   test("GH-413: lintStreamBytes agrees with lintBytes on every fixture (SAX/DOM parity)") {

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/lint/WorkbookLintSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/lint/WorkbookLintSpec.scala
@@ -997,12 +997,41 @@ class WorkbookLintSpec extends FunSuite:
   </sheetData>"""
   )
 
+  /** Seven offending formulas in document order A1, B1, C1, A2, B2, C2, A3. */
+  private val manyLeadingEqualsSheetXml = worksheetWith(
+    """<sheetData>
+    <row r="1"><c r="A1"><f>=1</f></c><c r="B1"><f>=2</f></c><c r="C1"><f>=3</f></c></row>
+    <row r="2"><c r="A2"><f>=4</f></c><c r="B2"><f>=5</f></c><c r="C2"><f>=6</f></c></row>
+    <row r="3"><c r="A3"><f>=7</f></c></row>
+  </sheetData>"""
+  )
+
   test("GH-456: <f> text starting with '=' is flagged as FormulaLeadingEquals") {
     val findings = lintOf(baseParts + ("xl/worksheets/sheet1.xml" -> leadingEqualsSheetXml))
     assertEquals(findings.map(_.category), Vector(LintCategory.FormulaLeadingEquals))
     val f = findings.head
     assertEquals(f.part, "xl/worksheets/sheet1.xml")
-    assert(f.locator.contains("B1"), s"locator should carry the cell ref: $f")
+    assert(f.locator.contains("B1"), s"locator should carry the first offending cell: $f")
+    assert(f.message.contains("1 formula(s)"), s"message should carry the total count: $f")
+    assert(f.message.contains("B1"), s"message should name the offending cell: $f")
+    assert(f.message.contains("re-writing"), s"message should say a re-write heals it: $f")
+  }
+
+  test("GH-456: leading-'=' findings aggregate to ONE finding per part (first 5 + total count)") {
+    val findings = lintOf(baseParts + ("xl/worksheets/sheet1.xml" -> manyLeadingEqualsSheetXml))
+    assertEquals(findings.map(_.category), Vector(LintCategory.FormulaLeadingEquals))
+    val f = findings.head
+    assertEquals(f.part, "xl/worksheets/sheet1.xml")
+    // Locator names the FIRST offending cell so the finding is actionable without re-deriving it.
+    assert(f.locator.contains("A1"), s"locator should carry the first offending cell: $f")
+    assert(f.message.contains("7 formula(s)"), s"message should carry the total count: $f")
+    assert(
+      f.message.contains("first 5: A1, B1, C1, A2, B2"),
+      s"message should sample the first 5 offending cells in document order: $f"
+    )
+    // The sample is bounded: cells past the first 5 never appear (no unbounded finding growth).
+    assert(!f.message.contains("C2"), s"message must not carry cells past the sample: $f")
+    assert(!f.message.contains("A3"), s"message must not carry cells past the sample: $f")
     assert(f.message.contains("re-writing"), s"message should say a re-write heals it: $f")
   }
 
@@ -1074,9 +1103,12 @@ class WorkbookLintSpec extends FunSuite:
     "unseeded autoNoTable data table" -> autoNoTableParts(unseededDataTableSheetXml),
     "partly seeded autoNoTable data table" -> autoNoTableParts(partlySeededDataTableSheetXml),
     "torn autoNoTable data table" -> autoNoTableParts(tornInteriorSheetXml),
-    // GH-456: <f> text observation must agree between the DOM and SAX scanners
+    // GH-456: <f> text observation must agree between the DOM and SAX scanners, including the
+    // aggregated per-part shape (sample order + total count)
     "leading-equals formula" ->
       (baseParts + ("xl/worksheets/sheet1.xml" -> leadingEqualsSheetXml)),
+    "many leading-equals formulas" ->
+      (baseParts + ("xl/worksheets/sheet1.xml" -> manyLeadingEqualsSheetXml)),
     "clean formula text" -> (baseParts + ("xl/worksheets/sheet1.xml" -> cleanFormulaSheetXml)),
     // GH-458: Microsoft xlExternalLinkPath variants resolve clean in both modes
     "ms xlPathMissing external" ->

--- a/xl/test/src/xlprelude/ScriptingPreludeTest.scala
+++ b/xl/test/src/xlprelude/ScriptingPreludeTest.scala
@@ -178,16 +178,21 @@ class ScriptingPreludeTest extends FunSuite:
 
   test("fx formulas serialize without the display form's leading '=' in <f> (GH-456)"):
     val wb = Workbook(Sheet("S").put(ref"A1", 2).put(ref"B1", fx"=A1*2"))
-    val path = java.nio.file.Files.createTempDirectory("xl-prelude-fx").resolve("fx.xlsx")
-    Excel.write(wb, path.toString)
-    val zip = new java.util.zip.ZipFile(path.toFile)
+    val dir = java.nio.file.Files.createTempDirectory("xl-prelude-fx")
+    val path = dir.resolve("fx.xlsx")
     try
-      val entry = Option(zip.getEntry("xl/worksheets/sheet1.xml"))
-        .getOrElse(fail("sheet part missing"))
-      val xml = new String(zip.getInputStream(entry).readAllBytes(), "UTF-8")
-      assert(xml.contains("<f>A1*2</f>"), xml)
-      assert(!xml.contains("<f>="), xml)
-    finally zip.close()
+      Excel.write(wb, path.toString)
+      val zip = new java.util.zip.ZipFile(path.toFile)
+      try
+        val entry = Option(zip.getEntry("xl/worksheets/sheet1.xml"))
+          .getOrElse(fail("sheet part missing"))
+        val xml = new String(zip.getInputStream(entry).readAllBytes(), "UTF-8")
+        assert(xml.contains("<f>A1*2</f>"), xml)
+        assert(!xml.contains("<f>="), xml)
+      finally zip.close()
+    finally
+      val _ = java.nio.file.Files.deleteIfExists(path)
+      val _ = java.nio.file.Files.deleteIfExists(dir)
 
   test("writeRecalculated caches uncached formulas on disk and returns the RecalcResult (GH-360)"):
     val sheet = Sheet("Calc3")

--- a/xl/test/src/xlprelude/ScriptingPreludeTest.scala
+++ b/xl/test/src/xlprelude/ScriptingPreludeTest.scala
@@ -176,6 +176,19 @@ class ScriptingPreludeTest extends FunSuite:
       Some(3)
     )
 
+  test("fx formulas serialize without the display form's leading '=' in <f> (GH-456)"):
+    val wb = Workbook(Sheet("S").put(ref"A1", 2).put(ref"B1", fx"=A1*2"))
+    val path = java.nio.file.Files.createTempDirectory("xl-prelude-fx").resolve("fx.xlsx")
+    Excel.write(wb, path.toString)
+    val zip = new java.util.zip.ZipFile(path.toFile)
+    try
+      val entry = Option(zip.getEntry("xl/worksheets/sheet1.xml"))
+        .getOrElse(fail("sheet part missing"))
+      val xml = new String(zip.getInputStream(entry).readAllBytes(), "UTF-8")
+      assert(xml.contains("<f>A1*2</f>"), xml)
+      assert(!xml.contains("<f>="), xml)
+    finally zip.close()
+
   test("writeRecalculated caches uncached formulas on disk and returns the RecalcResult (GH-360)"):
     val sheet = Sheet("Calc3")
       .put(ref"A1", 10)


### PR DESCRIPTION
Post-0.19.0 field-QC burn-down: all seven issues surfaced by the TJC field QC on real banker books.

Closes #453
Closes #454
Closes #455
Closes #456
Closes #457
Closes #458
Closes #464

## What's in the wave

| Cluster | Issues | Fix |
|---|---|---|
| recalc-convergence | #454, #453 | `RecalcResult.converged`/`iterationsUsed` (previously computed and discarded in `iterateCycles`); data-table seeder gates on the cyclic core — narrowed per-axis Jacobi fixpoint under declared `calcPr iterate="1"` (what-if inputs stay pinned, breaking the cycle through them like Excel's substitution), skip-untouched + `CircularNotIterated` warning without it (interior stays uncached so `data-table-unseeded` lints dirty instead of shipping flat). New `seedDataTablesReport()` + explicit `IterativeCalc` overloads. `xl recalc` auto-derives iteration from the file's calcPr; `--tables` prints seed warnings. |
| printer-parens | #455 | `FormulaPrinter` printed right operands of left-associative operators at the operator's own level with a strict `>` guard → right-nested same-precedence children lost grouping (`=E13/(E12*E14)` → `=E15/E14*E16`). Right operands now print one level tighter — fixes insert/delete rows/cols, `putf --from`, `copy`, `batch`, streaming writer in one pass. Round-trip law now pinned by a recursive expression generator. Structural edits skip reprinting on sheets that neither are the target nor reference it (untouched sheets byte-identical at the model level). |
| jaxp-limits | #457 | Shared `XmlSecurity` factory lifts `maxGeneralEntitySizeLimit`/`totalEntitySizeLimit` on the parser itself (safe — doctype already disallowed, so expansion attacks stay structurally impossible); drifted inline factory in the CLI streaming path collapsed onto it; release workflow gains a 120k-definedNames native smoke gate. |
| ooxml-canon | #456, #458 | All `<f>` emitters strip the leading `=` (one canonical serialization for scripting + CLI paths); new `formula-leading-equals` lint surfaces legacy files. Microsoft external-link-path variants (`xlPathMissing`/`xlLibraryPath`/`xlStartupPath`/`xlAltStartupPath`) resolve as valid — no more `wrong-rel-type` false alarms on Excel-authored books. |
| cli-inplace | #464 | `runWithOutput` threads a display path — every `-i` verb (~40) now prints the real target instead of the vanished `.xl-inplace-…` temp. |

## Process

Ran as an `issue-wave` workflow: green baseline (5,118 tests) → 5 worktree-isolated TDD implementers → adversarial review per cluster (original repro re-run, new tests proven to fail without the fix, module suites re-run independently, scope check). One rework round: the recalc reviewer caught a silent-flat edge (data-table input cell *inside* the cycle was clobbered by the Jacobi overlay) — fixed, re-reviewed with pre/post-fix probes including the 2-var and self-cycle configurations. All five clusters approved.

## Verification

- Full gate on the integrated branch: `./mill __.compile` (810/810), `./mill __.test` (all modules green), `checkFormatAll` clean on 589 sources.
- End-to-end field repros against the **freshly built native binary**:
  - #457: 2.1MB single-entity workbook.xml (40k definedNames) → `xl sheets` succeeds on the native image (settles the wave's one pending-CI risk: runtime `setProperty` works in the GraalVM image).
  - #455: all four issue formulas survive `insert-rows` with grouping intact and correct values (`=E13/(E12*E14)` → `=E15/(E14*E16)`, evaluates 1); cross-sheet formula on an untouched sheet intact.
  - #454: circular book without iterate keeps the circular-error posture; with `iterate="1"` spliced → `Recalculated 2 formulas; converged in 68 iterative round(s)`, correct fixpoint values.
  - #456: legacy `<f>=B1*2</f>` file → one `formula-leading-equals` finding; rewrite through xl heals to `<f>B1*2</f>`, lints clean.
  - #458: xlPathMissing external link → `lint` clean, exit 0.
  - #464: `xl -f book.xlsx -i recalc` prints `Saved: book.xlsx`.

## Follow-ups to file (wave gap notes)

- Gauss–Seidel ordering within declared cycles (faster convergence than Jacobi) — #454's "consider".
- calcPr bridge in CLI `batch` (still plain `recalculate()`).
- DependencyGraph-based cross-sheet cache invalidation after structural edits (transitive staleness on non-participating sheets — the old behavior was only "safe" by nuking every cache, which was exactly #455's byte-instability).
- `^` associativity: xl parses right-associative, Excel is left-associative (pre-existing, untouched by this wave).
- Compact function-argument separator for rewrite reprints (`IF(A1, 1, 0)` vs Excel's bare commas — cosmetic xlsx-diff noise).
- Error-path `-i` messages may still name the deleted temp (cosmetic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)