### PR TITLE
Wave 23b: field-hardening — criteria text operands, lookup comparator, preservation sheet-set, structural bounds + defined names, style-plane re-registration, CLI polish

### DIFF
--- a/xl-cli/src/com/tjclp/xl/cli/Main.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/Main.scala
@@ -1606,17 +1606,38 @@ EXAMPLES:
     execute(filePath, sheetNameOpt, outputOpt, backendOpt, maxSizeOpt, stream, cmd).attempt
       .map {
         case Right(output) =>
-          // In-place writes (-i) target a temp file that is atomically moved onto the
-          // input after the command succeeds; success messages must name the user-visible
-          // path, not the temp file that no longer exists by the time it is read (GH-464).
-          val rendered = (outputOpt, displayOpt) match
-            case (Some(write), Some(display)) if write != display =>
-              output.replace(write.toString, display.toString)
-            case _ => output
-          (ExitCode.Success, rendered)
+          (ExitCode.Success, renderWithTarget(output, outputOpt, displayOpt))
         case Left(err) =>
-          (ExitCode.Error, Format.errorSimple(err.getMessage))
+          (ExitCode.Error, renderErrorMessage(err, outputOpt, displayOpt))
       }
+
+  /**
+   * In-place writes (-i) target a temp file that is atomically moved onto the input after the
+   * command succeeds; user-facing messages must name the user-visible path, not the temp file that
+   * no longer exists by the time it is read (GH-464).
+   */
+  private def renderWithTarget(
+    text: String,
+    outputOpt: Option[Path],
+    displayOpt: Option[Path]
+  ): String =
+    (outputOpt, displayOpt) match
+      case (Some(write), Some(display)) if write != display =>
+        text.replace(write.toString, display.toString)
+      case _ => text
+
+  /**
+   * GH-483: failure messages get the same temp→target rewrite as successes — an exception raised
+   * mid-write (e.g. disk full) embeds the already-deleted .xl-inplace- temp path otherwise. Guards
+   * `getMessage` being null (falls back to the exception's toString).
+   */
+  private[cli] def renderErrorMessage(
+    err: Throwable,
+    outputOpt: Option[Path],
+    displayOpt: Option[Path]
+  ): String =
+    val message = Option(err.getMessage).getOrElse(err.toString)
+    Format.errorSimple(renderWithTarget(message, outputOpt, displayOpt))
 
   private def printRunResult(result: (ExitCode, String)): IO[ExitCode] =
     IO.println(result._2).as(result._1)

--- a/xl-cli/src/com/tjclp/xl/cli/commands/CellCommands.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/commands/CellCommands.scala
@@ -6,6 +6,7 @@ import cats.effect.IO
 import com.tjclp.xl.{*, given}
 import com.tjclp.xl.addressing.CellRange
 import com.tjclp.xl.cli.helpers.SheetResolver
+import com.tjclp.xl.cli.output.Format
 import com.tjclp.xl.io.ExcelIO
 import com.tjclp.xl.ooxml.writer.WriterConfig
 
@@ -27,11 +28,6 @@ object CellCommands:
     val excel = ExcelIO.instance[IO]
     if stream then excel.writeWorkbookStream(wb, outputPath, config)
     else excel.writeWith(wb, outputPath, config)
-
-  /** Build save message suffix based on write mode */
-  private def saveSuffix(outputPath: Path, stream: Boolean): String =
-    if stream then s"Saved (streaming): $outputPath"
-    else s"Saved: $outputPath"
 
   /**
    * Merge cells in range.
@@ -59,7 +55,7 @@ object CellCommands:
       updatedSheet = targetSheet.merge(range)
       updatedWb = wb.put(updatedSheet)
       _ <- writeWorkbook(updatedWb, outputPath, config, stream)
-    yield s"Merged: ${range.toA1}\n${saveSuffix(outputPath, stream)}"
+    yield s"Merged: ${range.toA1}\n${Format.saveSuffix(outputPath, stream)}"
 
   /**
    * Unmerge cells in range.
@@ -87,7 +83,7 @@ object CellCommands:
       updatedSheet = targetSheet.unmerge(range)
       updatedWb = wb.put(updatedSheet)
       _ <- writeWorkbook(updatedWb, outputPath, config, stream)
-    yield s"Unmerged: ${range.toA1}\n${saveSuffix(outputPath, stream)}"
+    yield s"Unmerged: ${range.toA1}\n${Format.saveSuffix(outputPath, stream)}"
 
   /**
    * Clear cell contents, styles, or comments from range.
@@ -152,4 +148,4 @@ object CellCommands:
         if clearComments then Some("comments") else None
       ).flatten
       clearedDesc = clearedItems.mkString(", ")
-    yield s"Cleared $clearedDesc from ${range.toA1}\n${saveSuffix(outputPath, stream)}"
+    yield s"Cleared $clearedDesc from ${range.toA1}\n${Format.saveSuffix(outputPath, stream)}"

--- a/xl-cli/src/com/tjclp/xl/cli/commands/CommentCommands.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/commands/CommentCommands.scala
@@ -7,6 +7,7 @@ import com.tjclp.xl.{Workbook, Sheet}
 import com.tjclp.xl.addressing.ARef
 import com.tjclp.xl.cells.Comment
 import com.tjclp.xl.cli.helpers.SheetResolver
+import com.tjclp.xl.cli.output.Format
 import com.tjclp.xl.io.ExcelIO
 import com.tjclp.xl.ooxml.writer.WriterConfig
 
@@ -28,11 +29,6 @@ object CommentCommands:
     val excel = ExcelIO.instance[IO]
     if stream then excel.writeWorkbookStream(wb, outputPath, config)
     else excel.writeWith(wb, outputPath, config)
-
-  /** Build save message suffix based on write mode */
-  private def saveSuffix(outputPath: Path, stream: Boolean): String =
-    if stream then s"Saved (streaming): $outputPath"
-    else s"Saved: $outputPath"
 
   /**
    * Add or update comment on a cell.
@@ -86,7 +82,7 @@ object CommentCommands:
 
       authorStr = author.map(a => s" (author: $a)").getOrElse("")
     yield s"""Added comment to ${ref.toA1}: "$text"$authorStr
-${saveSuffix(outputPath, stream)}"""
+${Format.saveSuffix(outputPath, stream)}"""
 
   /**
    * Remove comment from a cell.
@@ -134,4 +130,4 @@ ${saveSuffix(outputPath, stream)}"""
 
       status = if hadComment then "Removed comment from" else "No comment found at"
     yield s"""$status ${ref.toA1}
-${saveSuffix(outputPath, stream)}"""
+${Format.saveSuffix(outputPath, stream)}"""

--- a/xl-cli/src/com/tjclp/xl/cli/commands/ImportCommands.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/commands/ImportCommands.scala
@@ -8,6 +8,7 @@ import com.tjclp.xl.addressing.{ARef, SheetName}
 import com.tjclp.xl.cells.CellValue
 import com.tjclp.xl.cli.helpers.{CsvParser, MarkdownTableParser, StreamingCsvParser}
 import com.tjclp.xl.cli.helpers.MarkdownTableParser.ColumnAlignment
+import com.tjclp.xl.cli.output.Format
 import com.tjclp.xl.formatted.{Formatted, FormattedParsers}
 import com.tjclp.xl.io.ExcelIO
 import com.tjclp.xl.ooxml.writer.WriterConfig
@@ -37,11 +38,6 @@ object ImportCommands:
     val excel = ExcelIO.instance[IO]
     if stream then excel.writeWorkbookStream(wb, outputPath, config)
     else excel.writeWith(wb, outputPath, config)
-
-  /** Build save message suffix based on write mode */
-  private def saveSuffix(outputPath: Path, stream: Boolean): String =
-    if stream then s"Saved (streaming): $outputPath"
-    else s"Saved: $outputPath"
 
   /**
    * Import CSV data into a workbook.
@@ -162,7 +158,7 @@ object ImportCommands:
       colCount = updates.map(_._1.col).distinct.size
       cellCount = updates.size
     yield s"""Imported: ${csvPath.getFileName} → ${sheet.name} (${rowCount} rows, ${colCount} cols, ${cellCount} cells)
-${saveSuffix(outputPath, stream)}"""
+${Format.saveSuffix(outputPath, stream)}"""
 
   /**
    * Import CSV to a new sheet (created as part of the import).
@@ -213,7 +209,7 @@ ${saveSuffix(outputPath, stream)}"""
         colCount = updates.map(_._1.col).distinct.size
         cellCount = updates.size
       yield s"""Imported: ${csvPath.getFileName} → new sheet '$sheetName' (${rowCount} rows, ${colCount} cols, ${cellCount} cells)
-${saveSuffix(outputPath, stream)}"""
+${Format.saveSuffix(outputPath, stream)}"""
 
   /**
    * True streaming CSV import - O(1) memory for entire operation.
@@ -353,7 +349,7 @@ ${saveSuffix(outputPath, stream)}"""
               )
               _ <- writeWorkbook(wb.put(filled), outputPath, config, stream)
             yield importMessage(sourceName, s"new sheet '$name'", rows, table.columnCount) +
-              "\n" + saveSuffix(outputPath, stream)
+              "\n" + Format.saveSuffix(outputPath, stream)
         case None =>
           sheetOpt match
             case None =>
@@ -373,7 +369,7 @@ ${saveSuffix(outputPath, stream)}"""
                 )
                 _ <- writeWorkbook(wb.put(filled), outputPath, config, stream)
               yield importMessage(sourceName, sheet.name.value, rows, table.columnCount) +
-                "\n" + saveSuffix(outputPath, stream)
+                "\n" + Format.saveSuffix(outputPath, stream)
     yield result
 
   private def importMessage(

--- a/xl-cli/src/com/tjclp/xl/cli/commands/SheetCommands.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/commands/SheetCommands.scala
@@ -7,6 +7,7 @@ import cats.implicits.*
 import com.tjclp.xl.{*, given}
 import com.tjclp.xl.addressing.SheetName
 import com.tjclp.xl.error.XLError
+import com.tjclp.xl.cli.output.Format
 import com.tjclp.xl.io.ExcelIO
 import com.tjclp.xl.ooxml.writer.WriterConfig
 
@@ -28,11 +29,6 @@ object SheetCommands:
     val excel = ExcelIO.instance[IO]
     if stream then excel.writeWorkbookStream(wb, outputPath, config)
     else excel.writeWith(wb, outputPath, config)
-
-  /** Build save message suffix based on write mode */
-  private def saveSuffix(outputPath: Path, stream: Boolean): String =
-    if stream then s"Saved (streaming): $outputPath"
-    else s"Saved: $outputPath"
 
   /**
    * Add a new empty sheet to workbook.
@@ -100,7 +96,7 @@ object SheetCommands:
         case (Some(after), _) => s" (after '$after')"
         case (_, Some(before)) => s" (before '$before')"
         case _ => " (at end)"
-    yield s"Added sheet: $name$position\n${saveSuffix(outputPath, stream)}"
+    yield s"Added sheet: $name$position\n${Format.saveSuffix(outputPath, stream)}"
 
   /**
    * Remove sheet from workbook.
@@ -126,7 +122,7 @@ object SheetCommands:
         case e => new Exception(e.message)
       })
       _ <- writeWorkbook(updatedWb, outputPath, config, stream)
-    yield s"Removed sheet: $name\n${saveSuffix(outputPath, stream)}"
+    yield s"Removed sheet: $name\n${Format.saveSuffix(outputPath, stream)}"
 
   /**
    * Rename a sheet.
@@ -155,7 +151,7 @@ object SheetCommands:
         case e => new Exception(e.message)
       })
       _ <- writeWorkbook(updatedWb, outputPath, config, stream)
-    yield s"Renamed: $oldName → $newName\n${saveSuffix(outputPath, stream)}"
+    yield s"Renamed: $oldName → $newName\n${Format.saveSuffix(outputPath, stream)}"
 
   /**
    * Move sheet to new position.
@@ -223,7 +219,7 @@ object SheetCommands:
       updatedWb <- IO.fromEither(wb.reorder(newOrder).left.map(e => new Exception(e.message)))
       _ <- writeWorkbook(updatedWb, outputPath, config, stream)
       position = s"to position $clampedIdx"
-    yield s"Moved: $name $position\n${saveSuffix(outputPath, stream)}"
+    yield s"Moved: $name $position\n${Format.saveSuffix(outputPath, stream)}"
 
   /**
    * Copy sheet to new name.
@@ -253,7 +249,7 @@ object SheetCommands:
       copiedSheet = sourceSheet.copy(name = targetSheetName)
       updatedWb = wb.put(copiedSheet)
       _ <- writeWorkbook(updatedWb, outputPath, config, stream)
-    yield s"Copied: $sourceName → $targetName\n${saveSuffix(outputPath, stream)}"
+    yield s"Copied: $sourceName → $targetName\n${Format.saveSuffix(outputPath, stream)}"
 
   /**
    * Hide a sheet from the sheet tabs.
@@ -284,7 +280,7 @@ object SheetCommands:
       })
       _ <- writeWorkbook(updatedWb, outputPath, config, stream)
       stateDesc = if veryHide then "very hidden" else "hidden"
-    yield s"Sheet '$name' is now $stateDesc\n${saveSuffix(outputPath, stream)}"
+    yield s"Sheet '$name' is now $stateDesc\n${Format.saveSuffix(outputPath, stream)}"
 
   /** Add or replace a workbook-scoped named range, then write (GH-236). */
   def nameAdd(
@@ -297,7 +293,7 @@ object SheetCommands:
   ): IO[String] =
     val updated = wb.withDefinedName(name, refersTo)
     writeWorkbook(updated, outputPath, config, stream)
-      .as(s"Added named range '$name' -> $refersTo\n${saveSuffix(outputPath, stream)}")
+      .as(s"Added named range '$name' -> $refersTo\n${Format.saveSuffix(outputPath, stream)}")
 
   /** Remove a workbook-scoped named range, then write (GH-236). */
   def nameRemove(
@@ -312,7 +308,7 @@ object SheetCommands:
     else
       val updated = wb.removeDefinedName(name)
       writeWorkbook(updated, outputPath, config, stream)
-        .as(s"Removed named range '$name'\n${saveSuffix(outputPath, stream)}")
+        .as(s"Removed named range '$name'\n${Format.saveSuffix(outputPath, stream)}")
 
   /**
    * Show a hidden sheet (make it visible).
@@ -337,4 +333,4 @@ object SheetCommands:
         case e => new Exception(e.message)
       })
       _ <- writeWorkbook(updatedWb, outputPath, config, stream)
-    yield s"Sheet '$name' is now visible\n${saveSuffix(outputPath, stream)}"
+    yield s"Sheet '$name' is now visible\n${Format.saveSuffix(outputPath, stream)}"

--- a/xl-cli/src/com/tjclp/xl/cli/commands/StreamingWriteCommands.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/commands/StreamingWriteCommands.scala
@@ -642,7 +642,7 @@ object StreamingWriteCommands:
             val colDelta = Column.index0(targetRef.col) - startCol
             val rowDelta = Row.index0(targetRef.row) - startRow
             val shiftedExpr = FormulaShifter.shift(parsedExpr, colDelta, rowDelta)
-            val shiftedFormula = FormulaPrinter.print(shiftedExpr, includeEquals = false)
+            val shiftedFormula = FormulaPrinter.printFileForm(shiftedExpr)
             val formulaValue = CellValue.Formula(shiftedFormula, None)
             cellPatches(targetRef) = styleIdOpt match
               case Some(styleId) =>

--- a/xl-cli/src/com/tjclp/xl/cli/commands/WriteCommands.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/commands/WriteCommands.scala
@@ -64,11 +64,6 @@ object WriteCommands:
     if stream then excel.writeWorkbookStream(wb, outputPath, config)
     else excel.writeWith(wb, outputPath, config)
 
-  /** Build save message suffix based on write mode */
-  private def saveSuffix(outputPath: Path, stream: Boolean): String =
-    if stream then s"Saved (streaming): $outputPath"
-    else s"Saved: $outputPath"
-
   /**
    * Validate that the count of values/formulas matches the cell count in a range.
    *
@@ -217,7 +212,7 @@ object WriteCommands:
     val updatedSheet = putFormatted(sheet, ref, formatted)
     val updatedWb = wb.put(updatedSheet).recalculateDependents(sheet.name, Set(ref))
     writeWorkbook(updatedWb, outputPath, config, stream).map { _ =>
-      s"${Format.putSuccess(ref, formatted.value)}\n${saveSuffix(outputPath, stream)}"
+      s"${Format.putSuccess(ref, formatted.value)}\n${Format.saveSuffix(outputPath, stream)}"
     }
 
   /** Apply a detected number format without creating a redundant General style. */
@@ -264,7 +259,7 @@ object WriteCommands:
     val updatedSheet = range.cells.foldLeft(sheet)((s, ref) => putFormatted(s, ref, formatted))
     val updatedWb = wb.put(updatedSheet).recalculateDependents(sheet.name, modifiedRefs)
     writeWorkbook(updatedWb, outputPath, config, stream).map { _ =>
-      s"Filled $cellCount cells in ${range.toA1} with value ${formatted.value}\n${saveSuffix(outputPath, stream)}"
+      s"Filled $cellCount cells in ${range.toA1} with value ${formatted.value}\n${Format.saveSuffix(outputPath, stream)}"
     }
 
   /** Mode 3: Put different values to each cell (row-major order) */
@@ -292,7 +287,7 @@ object WriteCommands:
         val updatedSheet = sheet.put(updates*)
         val updatedWb = wb.put(updatedSheet).recalculateDependents(sheet.name, modifiedRefs)
         writeWorkbook(updatedWb, outputPath, config, stream).map { _ =>
-          s"Put ${values.length} values to ${range.toA1} (row-major)\n${saveSuffix(outputPath, stream)}"
+          s"Put ${values.length} values to ${range.toA1} (row-major)\n${Format.saveSuffix(outputPath, stream)}"
         }
 
   /**
@@ -379,7 +374,7 @@ object WriteCommands:
         else sheetWithFormula
       updatedWb = wb.put(finalSheet).recalculateDependents(sheet.name, Set(ref))
       _ <- writeWorkbook(updatedWb, outputPath, config, stream)
-    yield s"${Format.putSuccess(ref, CellValue.Formula(formula))}\n${saveSuffix(outputPath, stream)}"
+    yield s"${Format.putSuccess(ref, CellValue.Formula(formula))}\n${Format.saveSuffix(outputPath, stream)}"
 
   /** Mode 2: Formula dragging with anchor-aware shifting (existing behavior) */
   private def putfFormulaDragging(
@@ -405,7 +400,7 @@ object WriteCommands:
       updatedWb = wb.put(updatedSheet).recalculateDependents(sheet.name, modifiedRefs)
       _ <- writeWorkbook(updatedWb, outputPath, config, stream)
       cellCount = range.cellCount
-    yield s"Applied formula to $cellCount cells in ${range.toA1} (with anchor-aware dragging)\n${saveSuffix(outputPath, stream)}"
+    yield s"Applied formula to $cellCount cells in ${range.toA1} (with anchor-aware dragging)\n${Format.saveSuffix(outputPath, stream)}"
 
   /** Mode 3: Batch formulas (no dragging, apply as-is) */
   private def putfBatchFormulas(
@@ -443,7 +438,7 @@ object WriteCommands:
           updatedSheet = sheet.put(updates*)
           updatedWb = wb.put(updatedSheet).recalculateDependents(sheet.name, modifiedRefs)
           _ <- writeWorkbook(updatedWb, outputPath, config, stream)
-        yield s"Put ${formulas.length} formulas to ${range.toA1} (explicit, no dragging)\n${saveSuffix(outputPath, stream)}"
+        yield s"Put ${formulas.length} formulas to ${range.toA1} (explicit, no dragging)\n${Format.saveSuffix(outputPath, stream)}"
 
   /** Helper: Apply formula dragging logic (extracted from original putFormula) */
   private def putfDraggingLogic(
@@ -575,7 +570,7 @@ object WriteCommands:
         border
       )
       modeLabel = if replace then " (replace)" else " (additive)"
-    yield s"Styled: ${range.toA1}$modeLabel\nApplied: ${appliedList.mkString(", ")}\n${saveSuffix(outputPath, stream)}"
+    yield s"Styled: ${range.toA1}$modeLabel\nApplied: ${appliedList.mkString(", ")}\n${Format.saveSuffix(outputPath, stream)}"
 
   /**
    * Set row properties (height, hide/show).
@@ -609,7 +604,7 @@ object WriteCommands:
           if hide then Some("hidden=true") else None,
           if show then Some("hidden=false") else None
         ).flatten
-        s"Row $rowNum: ${changes.mkString(", ")}\n${saveSuffix(outputPath, stream)}"
+        s"Row $rowNum: ${changes.mkString(", ")}\n${Format.saveSuffix(outputPath, stream)}"
       }
     }
 
@@ -659,9 +654,9 @@ object WriteCommands:
           val updatedWb = wb.put(updatedSheet)
           writeWorkbook(updatedWb, outputPath, config, stream).map { _ =>
             results match
-              case single :: Nil => s"Column $single\n${saveSuffix(outputPath, stream)}"
+              case single :: Nil => s"Column $single\n${Format.saveSuffix(outputPath, stream)}"
               case multiple =>
-                s"Columns:\n${multiple.map("  " + _).mkString("\n")}\n${saveSuffix(outputPath, stream)}"
+                s"Columns:\n${multiple.map("  " + _).mkString("\n")}\n${Format.saveSuffix(outputPath, stream)}"
           }
     }
 
@@ -756,7 +751,7 @@ object WriteCommands:
       columnsResult match
         case Left(err) => IO.raiseError(new Exception(err))
         case Right(columns) if columns.isEmpty =>
-          IO.pure(s"No columns to auto-fit (empty sheet)\n${saveSuffix(outputPath, stream)}")
+          IO.pure(s"No columns to auto-fit (empty sheet)\n${Format.saveSuffix(outputPath, stream)}")
         case Right(columns) =>
           val (updatedSheet, widths) = columns.foldLeft((sheet, List.empty[(Column, Double)])) {
             case ((s, ws), colRef) =>
@@ -768,7 +763,7 @@ object WriteCommands:
           val updatedWb = wb.put(updatedSheet)
           writeWorkbook(updatedWb, outputPath, config, stream).map { _ =>
             val summary = widths.map { case (c, w) => f"${c.toLetter}: $w%.2f" }.mkString(", ")
-            s"Auto-fit ${columns.size} column(s): $summary\n${saveSuffix(outputPath, stream)}"
+            s"Auto-fit ${columns.size} column(s): $summary\n${Format.saveSuffix(outputPath, stream)}"
           }
     }
 
@@ -896,7 +891,7 @@ object WriteCommands:
               val ops = result.ops
               val summary = BatchParser.formatSummary(ops)
               val recalcLine = recalcOpt.fold("")(r => s"${formatRecalcSummary(r)}\n")
-              s"Applied ${ops.size} operations:\n$summary\n$recalcLine${saveSuffix(outputPath, stream)}"
+              s"Applied ${ops.size} operations:\n$summary\n$recalcLine${Format.saveSuffix(outputPath, stream)}"
             }
           }
       }
@@ -946,7 +941,7 @@ object WriteCommands:
       writeWorkbook(workbook, outputPath, config, stream).map { _ =>
         val tableNote = if seedTables then "\nSeeded data table interior caches" else ""
         val warningLines = warnings.map(w => s"\n${renderSeedWarning(w)}").mkString
-        s"${formatRecalcSummary(result)}$tableNote$warningLines\n${saveSuffix(outputPath, stream)}"
+        s"${formatRecalcSummary(result)}$tableNote$warningLines\n${Format.saveSuffix(outputPath, stream)}"
       }
     }
 
@@ -1013,7 +1008,7 @@ object WriteCommands:
       updatedWb = wb.put(updatedSheet).recalculateDependents(targetSheet.name, modifiedRefs)
       _ <- writeWorkbook(updatedWb, outputPath, config, stream)
       dirLabel = if direction == FillDirection.Right then "right" else "down"
-    yield s"Filled ${targetRange.toA1} from ${sourceRange.toA1} ($dirLabel)\n${saveSuffix(outputPath, stream)}"
+    yield s"Filled ${targetRange.toA1} from ${sourceRange.toA1} ($dirLabel)\n${Format.saveSuffix(outputPath, stream)}"
 
   /** Validate that source and target ranges are compatible for fill direction */
   private def validateFillRanges(
@@ -1234,7 +1229,7 @@ object WriteCommands:
         )
         .mkString(", ")
       headerNote = if hasHeader then " (header row preserved)" else ""
-    yield s"Sorted ${range.toA1} by $keyDesc$headerNote\n${saveSuffix(outputPath, stream)}"
+    yield s"Sorted ${range.toA1} by $keyDesc$headerNote\n${Format.saveSuffix(outputPath, stream)}"
 
   /**
    * Freeze panes at the given cell reference.
@@ -1266,7 +1261,7 @@ object WriteCommands:
       updatedSheet = sheet.freezeAt(ref)
       updatedWb = wb.put(updatedSheet)
       _ <- writeWorkbook(updatedWb, outputPath, config, stream)
-    yield s"Froze panes at ${ref.toA1} on sheet '${sheet.name.value}'\n${saveSuffix(outputPath, stream)}"
+    yield s"Froze panes at ${ref.toA1} on sheet '${sheet.name.value}'\n${Format.saveSuffix(outputPath, stream)}"
 
   /**
    * Remove freeze panes from the sheet.
@@ -1286,7 +1281,7 @@ object WriteCommands:
       updatedSheet = sheet.unfreeze
       updatedWb = wb.put(updatedSheet)
       _ <- writeWorkbook(updatedWb, outputPath, config, stream)
-    yield s"Removed freeze panes from sheet '${sheet.name.value}'\n${saveSuffix(outputPath, stream)}"
+    yield s"Removed freeze panes from sheet '${sheet.name.value}'\n${Format.saveSuffix(outputPath, stream)}"
 
   // ===== Sheet appearance & print setup (GH-358) =====
 
@@ -1306,7 +1301,7 @@ object WriteCommands:
       sheet <- SheetResolver.requireSheet(wb, sheetOpt, context)
       updatedSheet <- IO.fromEither(f(sheet).left.map(new Exception(_)))
       _ <- writeWorkbook(wb.put(updatedSheet), outputPath, config, stream)
-    yield s"${message(sheet)}\n${saveSuffix(outputPath, stream)}"
+    yield s"${message(sheet)}\n${Format.saveSuffix(outputPath, stream)}"
 
   /**
    * Set sheet view options: gridline visibility, zoom scale (10-400), tab selection. Unspecified
@@ -1387,7 +1382,7 @@ object WriteCommands:
       message = rangeOpt match
         case Some(r) => s"Set autoFilter on '${sheet.name.value}' to ${r.toA1}"
         case None => s"Removed autoFilter from sheet '${sheet.name.value}'"
-    yield s"$message\n${saveSuffix(outputPath, stream)}"
+    yield s"$message\n${Format.saveSuffix(outputPath, stream)}"
 
   /**
    * Set print page setup: orientation, scale, fit-to-width/height, and the tri-state fitToPage
@@ -1501,7 +1496,7 @@ object WriteCommands:
     yield
       val priorityNote = priority.fold("")(p => s" (priority $p)")
       s"Added conditional format on '${sheet.name.value}': ${CfRuleParser.describe(rule)} " +
-        s"over ${range.toA1}$priorityNote\n${saveSuffix(outputPath, stream)}"
+        s"over ${range.toA1}$priorityNote\n${Format.saveSuffix(outputPath, stream)}"
 
   /** List conditional-formatting rules on the sheet (read-only — no output file needed). */
   def cfList(wb: Workbook, sheetOpt: Option[Sheet]): IO[String] =
@@ -1573,7 +1568,7 @@ object WriteCommands:
       _ <- requirePositive(count, "count")
       recalced = StructuralEditor.insertRows(wb, sheet.name, at - 1, count).recalculate()
       _ <- writeWorkbook(recalced.workbook, outputPath, config, stream)
-    yield s"Inserted $count row(s) before row $at on '${sheet.name.value}'\n${formatRecalcSummary(recalced)}\n${saveSuffix(outputPath, stream)}"
+    yield s"Inserted $count row(s) before row $at on '${sheet.name.value}'\n${formatRecalcSummary(recalced)}\n${Format.saveSuffix(outputPath, stream)}"
 
   def deleteRows(
     wb: Workbook,
@@ -1590,7 +1585,7 @@ object WriteCommands:
       _ <- requirePositive(count, "count")
       recalced = StructuralEditor.deleteRows(wb, sheet.name, at - 1, count).recalculate()
       _ <- writeWorkbook(recalced.workbook, outputPath, config, stream)
-    yield s"Deleted $count row(s) from row $at on '${sheet.name.value}'\n${formatRecalcSummary(recalced)}\n${saveSuffix(outputPath, stream)}"
+    yield s"Deleted $count row(s) from row $at on '${sheet.name.value}'\n${formatRecalcSummary(recalced)}\n${Format.saveSuffix(outputPath, stream)}"
 
   def insertColumns(
     wb: Workbook,
@@ -1608,7 +1603,7 @@ object WriteCommands:
       _ <- requirePositive(n, "count")
       recalced = StructuralEditor.insertColumns(wb, sheet.name, at0, n).recalculate()
       _ <- writeWorkbook(recalced.workbook, outputPath, config, stream)
-    yield s"Inserted $n column(s) at column ${col.trim.toUpperCase} on '${sheet.name.value}'\n${formatRecalcSummary(recalced)}\n${saveSuffix(outputPath, stream)}"
+    yield s"Inserted $n column(s) at column ${col.trim.toUpperCase} on '${sheet.name.value}'\n${formatRecalcSummary(recalced)}\n${Format.saveSuffix(outputPath, stream)}"
 
   def deleteColumns(
     wb: Workbook,
@@ -1626,7 +1621,7 @@ object WriteCommands:
       _ <- requirePositive(n, "count")
       recalced = StructuralEditor.deleteColumns(wb, sheet.name, at0, n).recalculate()
       _ <- writeWorkbook(recalced.workbook, outputPath, config, stream)
-    yield s"Deleted $n column(s) from column ${col.trim.toUpperCase} on '${sheet.name.value}'\n${formatRecalcSummary(recalced)}\n${saveSuffix(outputPath, stream)}"
+    yield s"Deleted $n column(s) from column ${col.trim.toUpperCase} on '${sheet.name.value}'\n${formatRecalcSummary(recalced)}\n${Format.saveSuffix(outputPath, stream)}"
 
   /**
    * Copy a range of cells to another location with optional formula adjustment.
@@ -1693,7 +1688,7 @@ object WriteCommands:
           s" (${sourceSheet.name.value} → ${targetSheet.name.value})"
         else ""
       modeLabel = if valuesOnly then " (values only)" else " (with formula adjustment)"
-    yield s"Copied ${sourceRange.toA1} to ${targetRange.toA1}$crossSheetLabel$modeLabel\n${saveSuffix(outputPath, stream)}"
+    yield s"Copied ${sourceRange.toA1} to ${targetRange.toA1}$crossSheetLabel$modeLabel\n${Format.saveSuffix(outputPath, stream)}"
 
   /** Validate that all sort columns are within the range */
   private def validateSortColumns(range: CellRange, keys: List[SortKey]): IO[Unit] =

--- a/xl-cli/src/com/tjclp/xl/cli/commands/WriteCommands.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/commands/WriteCommands.scala
@@ -462,7 +462,7 @@ object WriteCommands:
       val colDelta = Column.index0(targetRef.col) - startCol
       val rowDelta = Row.index0(targetRef.row) - startRow
       val shiftedExpr = FormulaShifter.shift(parsedExpr, colDelta, rowDelta)
-      val shiftedFormula = FormulaPrinter.print(shiftedExpr, includeEquals = false)
+      val shiftedFormula = FormulaPrinter.printFileForm(shiftedExpr)
       val fullShiftedFormula = s"=$shiftedFormula"
       val cachedValue =
         SheetEvaluator.evaluateFormula(s)(fullShiftedFormula, workbook = Some(wb)).toOption
@@ -1166,7 +1166,7 @@ object WriteCommands:
                 sheet.put(targetRef, CellValue.Formula(formula, cachedValue))
               case Right(parsedExpr) =>
                 val shiftedExpr = FormulaShifter.shift(parsedExpr, colDelta, rowDelta)
-                val shiftedFormula = FormulaPrinter.print(shiftedExpr, includeEquals = false)
+                val shiftedFormula = FormulaPrinter.printFileForm(shiftedExpr)
                 val fullShiftedFormula = s"=$shiftedFormula"
                 val cachedValue =
                   SheetEvaluator
@@ -1912,7 +1912,7 @@ object WriteCommands:
           case Right(parsedExpr) =>
             // Shift only row references, not columns (colDelta = 0)
             val shiftedExpr = FormulaShifter.shift(parsedExpr, 0, rowDelta)
-            val shiftedFormula = FormulaPrinter.print(shiftedExpr, includeEquals = false)
+            val shiftedFormula = FormulaPrinter.printFileForm(shiftedExpr)
             // Clear cached value since it will need re-evaluation
             CellValue.Formula(shiftedFormula, None)
       case other => other

--- a/xl-cli/src/com/tjclp/xl/cli/helpers/BatchParser.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/helpers/BatchParser.scala
@@ -1353,7 +1353,7 @@ object BatchParser:
           val colDelta = Column.index0(targetRef.col) - startCol
           val rowDelta = Row.index0(targetRef.row) - startRow
           val shiftedExpr = FormulaShifter.shift(parsedExpr, colDelta, rowDelta)
-          val shiftedFormula = FormulaPrinter.print(shiftedExpr, includeEquals = false)
+          val shiftedFormula = FormulaPrinter.printFileForm(shiftedExpr)
           val cachedValue =
             SheetEvaluator.evaluateFormula(s)(s"=$shiftedFormula", workbook = Some(wb)).toOption
           applyNumFmt(

--- a/xl-cli/src/com/tjclp/xl/cli/helpers/CfRuleParser.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/helpers/CfRuleParser.scala
@@ -246,7 +246,7 @@ object CfRuleParser:
         case CfTextOp.BeginsWith => "beginsWith"
         case CfTextOp.EndsWith => "endsWith"
       s"text $name '$text'"
-    case CfRule.Preserved(_, _) => "(preserved rule)"
+    case CfRule.Preserved(_, _, _) => "(preserved rule)"
 
   private def opName(op: CfOperator): String = op match
     case CfOperator.LessThan => "lessThan"

--- a/xl-cli/src/com/tjclp/xl/cli/helpers/CopyOps.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/helpers/CopyOps.scala
@@ -150,7 +150,7 @@ object CopyOps:
         FormulaParser.parse(s"=$expr") match
           case Right(parsed) =>
             val shifted = FormulaShifter.shift(parsed, colDelta, rowDelta)
-            val shiftedExpr = FormulaPrinter.print(shifted, includeEquals = false)
+            val shiftedExpr = FormulaPrinter.printFileForm(shifted)
             (CellValue.Formula(shiftedExpr, None), Some(shiftedExpr))
           case Left(_) =>
             // Unparseable formula: preserve as-is and try to cache in phase 2.

--- a/xl-cli/src/com/tjclp/xl/cli/output/Format.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/output/Format.scala
@@ -63,6 +63,14 @@ object Format:
     s"Saved: $path ($sheetCount sheets, $cellCount cells)"
 
   /**
+   * Save-confirmation suffix appended to write-command output (GH-483: the one shared definition —
+   * was five identical private clones across the command objects).
+   */
+  def saveSuffix(outputPath: java.nio.file.Path, stream: Boolean): String =
+    if stream then s"Saved (streaming): $outputPath"
+    else s"Saved: $outputPath"
+
+  /**
    * Format an eval success message.
    */
   def evalSuccess(formula: String, result: CellValue, overrides: List[String]): String =

--- a/xl-cli/test/src/com/tjclp/xl/cli/InPlaceSpec.scala
+++ b/xl-cli/test/src/com/tjclp/xl/cli/InPlaceSpec.scala
@@ -261,3 +261,24 @@ class InPlaceSpec extends CatsEffectSuite:
       }
     }
   }
+
+  test("GH-483: error message names the target, never the deleted temp") {
+    val temp = Path.of("/data/.xl-inplace-482910.xlsx")
+    val target = Path.of("/data/book.xlsx")
+    val rendered = Main.renderErrorMessage(
+      new Exception(s"No space left on device writing $temp"),
+      Some(temp),
+      Some(target)
+    )
+    assert(rendered.contains(target.toString), s"error must name the target:\n$rendered")
+    assert(!rendered.contains(".xl-inplace-"), s"error leaks the temp path:\n$rendered")
+  }
+
+  test("GH-483: null exception message renders the exception class, not 'null'") {
+    val temp = Path.of("/data/.xl-inplace-482910.xlsx")
+    val target = Path.of("/data/book.xlsx")
+    val rendered =
+      Main.renderErrorMessage(new IllegalStateException(), Some(temp), Some(target))
+    assert(rendered.contains("IllegalStateException"), s"expected exception class in:\n$rendered")
+    assert(!rendered.contains("null"), s"error prints literal 'null':\n$rendered")
+  }

--- a/xl-cli/test/src/com/tjclp/xl/cli/MainSpec.scala
+++ b/xl-cli/test/src/com/tjclp/xl/cli/MainSpec.scala
@@ -1367,3 +1367,12 @@ class MainSpec extends CatsEffectSuite:
       else assert(result.isLeft, s"Format '$code' should fail")
     }
   }
+
+  test("GH-483: shared saveSuffix names the target path (plain and streaming)") {
+    val p = java.nio.file.Path.of("out.xlsx")
+    assertEquals(com.tjclp.xl.cli.output.Format.saveSuffix(p, stream = false), "Saved: out.xlsx")
+    assertEquals(
+      com.tjclp.xl.cli.output.Format.saveSuffix(p, stream = true),
+      "Saved (streaming): out.xlsx"
+    )
+  }

--- a/xl-cli/test/src/com/tjclp/xl/cli/StructuralCommandSpec.scala
+++ b/xl-cli/test/src/com/tjclp/xl/cli/StructuralCommandSpec.scala
@@ -275,3 +275,79 @@ class StructuralCommandSpec extends CatsEffectSuite:
       assert(r1.isLeft) // three-part range
       assert(r2.isLeft) // trailing colon (empty endpoint)
   }
+
+  // ===== GH-472: refuse inserts that would shift populated cells past the sheet edge =====
+
+  test("GH-472: insert-rows refusing an over-the-edge shift leaves the file byte-unchanged") {
+    // The exact field repro: data at rows 1048570-1048572, insert 20 rows at 5. 0.19.0 exited 0
+    // and wrote cells past row 1048576 (plus a <dimension> past the cap) — Excel refuses the file.
+    val wb = Workbook(
+      Vector(
+        Sheet("S")
+          .put(ref"A1048570", CellValue.Number(1))
+          .put(ref"B1048570", CellValue.Number(2))
+          .put(ref"A1048572", CellValue.Number(3))
+          .put(ref"B1048572", CellValue.Number(4))
+      )
+    )
+    val in = tmp("in-gh472")
+    for
+      _ <- excel.write(wb, in)
+      before <- IO(Files.readAllBytes(in).toVector)
+      read <- excel.read(in)
+      // in-place edit (out == in): a refusal must not touch the file
+      r <- WriteCommands.insertRows(read, read.sheets.headOption, 5, 20, in, config).attempt
+      after <- IO(Files.readAllBytes(in).toVector)
+    yield
+      r match
+        case Left(e) =>
+          assert(e.getMessage.contains("1048572"), e.getMessage) // offending populated row
+          assert(e.getMessage.contains("1048576"), e.getMessage) // the cap
+        case Right(msg) => fail(s"expected refusal, got success: $msg")
+      assertEquals(after, before) // file byte-identical
+  }
+
+  test("GH-472: insert-rows just under the cap still succeeds (lands exactly on 1048576)") {
+    val wb = Workbook(Vector(Sheet("S").put(ref"A1048556", CellValue.Number(42))))
+    val in = tmp("in-gh472b")
+    val out = tmp("out-gh472b")
+    for
+      _ <- excel.write(wb, in)
+      read <- excel.read(in)
+      _ <- WriteCommands.insertRows(read, read.sheets.headOption, 5, 20, out, config)
+      result <- excel.read(out)
+    yield
+      val s = result.sheets.head
+      assertEquals(s(ref"A1048576").value, CellValue.Number(42))
+      assert(!s.contains(ref"A1048556"))
+  }
+
+  test("GH-472: insert-cols refuses a shift past column XFD and leaves the file unchanged") {
+    val wb = Workbook(Vector(Sheet("S").put(ref"XFC1", CellValue.Number(1))))
+    val in = tmp("in-gh472c")
+    for
+      _ <- excel.write(wb, in)
+      before <- IO(Files.readAllBytes(in).toVector)
+      read <- excel.read(in)
+      r <- WriteCommands.insertColumns(read, read.sheets.headOption, "C", 20, in, config).attempt
+      after <- IO(Files.readAllBytes(in).toVector)
+    yield
+      r match
+        case Left(e) =>
+          assert(e.getMessage.contains("XFC"), e.getMessage)
+          assert(e.getMessage.contains("XFD"), e.getMessage)
+        case Right(msg) => fail(s"expected refusal, got success: $msg")
+      assertEquals(after, before)
+  }
+
+  test("GH-472: insert-cols just under the cap still succeeds (lands exactly on XFD)") {
+    val wb = Workbook(Vector(Sheet("S").put(ref"XFC1", CellValue.Number(7))))
+    val in = tmp("in-gh472d")
+    val out = tmp("out-gh472d")
+    for
+      _ <- excel.write(wb, in)
+      read <- excel.read(in)
+      _ <- WriteCommands.insertColumns(read, read.sheets.headOption, "C", 1, out, config)
+      result <- excel.read(out)
+    yield assertEquals(result.sheets.head(ref"XFD1").value, CellValue.Number(7))
+  }

--- a/xl-core/src/com/tjclp/xl/cf/ConditionalFormat.scala
+++ b/xl-core/src/com/tjclp/xl/cf/ConditionalFormat.scala
@@ -122,8 +122,13 @@ enum CfRule derives CanEqual:
    * containsBlanks/Errors, any rule with a child extLst, any rule whose dxf is outside the modeled
    * subset, any unknown attr/child). Reader-constructed only; canonical XML re-emitted verbatim.
    * `priority` is parsed read-only and feeds the allocator's max — never re-stamped.
+   *
+   * `dxf` carries the raw `<dxf>` payload the rule's dxfId referenced in the SOURCE styles.xml
+   * (canonical XML, None when the rule has no in-range ref). Surgical writes never consult it (the
+   * dxfs table is append-only, so the baked id stays valid); a FRESH write (source dropped)
+   * re-registers the payload into the rebuilt dxfs table and renumbers the emitted ref (GH-471).
    */
-  case Preserved(xml: String, priority: Option[Int])
+  case Preserved(xml: String, priority: Option[Int], dxf: Option[String] = None)
 
 object CfRule:
   /** Documented sentinel: "assign at append" (see `Sheet.conditionalFormat`). */
@@ -192,7 +197,7 @@ object CfRule:
     case r: DataBar => Some(r.priority)
     case r: Top10 => Some(r.priority)
     case r: Text => Some(r.priority)
-    case Preserved(_, p) => p
+    case Preserved(_, p, _) => p
 
   /** Restamp a typed rule's priority; Preserved rules are NEVER renumbered (identity). */
   def withPriority(rule: CfRule, priority: Int): CfRule = rule match

--- a/xl-core/src/com/tjclp/xl/context/ModificationTracker.scala
+++ b/xl-core/src/com/tjclp/xl/context/ModificationTracker.scala
@@ -72,6 +72,18 @@ final case class ModificationTracker(
       modifiedMetadata = true
     )
 
+  /**
+   * Record a sheet deletion that was already applied to the sheets vector by an UNTRACKED edit
+   * (GH-470: `Workbook.copy(sheets = ...)` reductions, reconciled at write time). Unlike [[delete]]
+   * nothing shifts: the indices in [[modifiedSheets]] already describe the reduced workbook, so
+   * shifting them here would detach live modification marks from their sheets. `sourceIndex` names
+   * the deleted sheet's position in the SOURCE package — it feeds the writer's source-indexed
+   * dependency checks and its deletion gates. Marks metadata modified for the same reason
+   * [[delete]] does (the workbook skeleton restructures).
+   */
+  def deleteUntracked(sourceIndex: Int): ModificationTracker =
+    copy(deletedSheets = deletedSheets + sourceIndex, modifiedMetadata = true)
+
   /** Indicate that sheet order changed. */
   def markReordered: ModificationTracker =
     if reorderedSheets then this else copy(reorderedSheets = true)

--- a/xl-core/src/com/tjclp/xl/context/SourceContext.scala
+++ b/xl-core/src/com/tjclp/xl/context/SourceContext.scala
@@ -4,7 +4,7 @@ import com.tjclp.xl.addressing.SheetName
 import com.tjclp.xl.charts.Chart
 import com.tjclp.xl.drawings.Drawing
 import com.tjclp.xl.ooxml.PartManifest
-import com.tjclp.xl.workbooks.Workbook
+import com.tjclp.xl.workbooks.{DefinedName, Workbook}
 
 import java.nio.file.{Files, Path}
 import java.security.MessageDigest
@@ -79,6 +79,11 @@ object SourceContent:
  *   through this mapping, so structural edits never alias a sheet to another sheet's part (GH-315).
  *   Empty for contexts built before the mapping existed — consumers fall back to index-based naming
  *   in that case.
+ * @param definedNamesAsRead
+ *   The `metadata.definedNames` vector exactly as the reader assembled it (GH-470, post print-name
+ *   extraction) — the baseline [[reconciledWith]] compares against to detect defined-name edits
+ *   made through a raw `Workbook.copy(metadata = ...)` instead of the tracked API. None means "no
+ *   snapshot" (contexts built outside the reader): the divergence check is skipped.
  */
 final case class SourceContext(
   content: SourceContent,
@@ -89,7 +94,8 @@ final case class SourceContext(
   drawingPathMapping: Map[SheetName, String] = Map.empty,
   drawingSnapshots: Map[SheetName, Vector[Drawing]] = Map.empty,
   chartSnapshots: Map[SheetName, Vector[ChartSnapshot]] = Map.empty,
-  sheetPathMapping: Map[SheetName, String] = Map.empty
+  sheetPathMapping: Map[SheetName, String] = Map.empty,
+  definedNamesAsRead: Option[Vector[DefinedName]] = None
 ) derives CanEqual:
 
   /** True when no workbook modifications have been recorded. */
@@ -112,6 +118,61 @@ final case class SourceContext(
       chartSnapshots = chartSnapshots - name,
       sheetPathMapping = sheetPathMapping - name
     )
+
+  /**
+   * Mark a sheet removal that was applied OUTSIDE the tracked edit API (GH-470): the sheet is
+   * already gone from `Workbook.sheets`, so unlike [[markSheetDeleted]] no live-index shifting may
+   * touch the modified-sheet marks — they are in the already-reduced index space. `sourceIndex` is
+   * the sheet's best-effort position in the SOURCE package. The identity-keyed mappings drop
+   * exactly like a tracked delete, so the writer's surviving-sheet resolution and orphan pruning
+   * (GH-417) treat the sheet as removed.
+   */
+  def markUntrackedSheetRemoval(sourceIndex: Int, name: SheetName): SourceContext =
+    copy(
+      modificationTracker = modificationTracker.deleteUntracked(sourceIndex),
+      commentPathMapping = commentPathMapping - name,
+      drawingPathMapping = drawingPathMapping - name,
+      drawingSnapshots = drawingSnapshots - name,
+      chartSnapshots = chartSnapshots - name,
+      sheetPathMapping = sheetPathMapping - name
+    )
+
+  /**
+   * Reconcile untracked structural divergence between the workbook MODEL and this context (GH-470).
+   * Raw `Workbook.copy(sheets = ...)` / `copy(metadata = ...)` edits bypass the tracked API,
+   * leaving a clean-looking tracker over a structurally different workbook — a preservation write
+   * would then re-emit the SOURCE structure, silently shipping sheets or defined names the caller
+   * believes were removed (a confidentiality hazard) and dropping sheets the caller appended. The
+   * writer calls this before choosing a write strategy:
+   *
+   *   - a source sheet (identity-keyed `sheetPathMapping` entry) with no surviving model sheet is
+   *     marked deleted exactly like `Workbook.remove` marks it — tracker deletion plus mapping
+   *     drops — so surviving sheets regenerate against their own source parts and the removed
+   *     sheet's part/rel/media closure is pruned (GH-417);
+   *   - a model sheet with no source identity (untracked addition) marks metadata modified, so the
+   *     workbook skeleton regenerates from the model instead of a verbatim copy dropping the sheet;
+   *   - a defined-name set diverging from [[definedNamesAsRead]] marks metadata modified, so
+   *     workbook.xml re-derives from the model.
+   *
+   * Returns `this` unchanged when nothing diverges — a genuinely clean workbook keeps the verbatim
+   * fast path. Contexts without an identity mapping (pre-GH-315) skip the sheet-set checks.
+   */
+  def reconciledWith(workbook: Workbook): SourceContext =
+    val liveNames = workbook.sheets.map(_.name).toSet
+    val ghosts = sheetPathMapping.keySet.diff(liveNames).toVector.sortBy(_.value)
+    val withRemovals = ghosts.zipWithIndex.foldLeft(this) { case (ctx, (ghost, ordinal)) =>
+      val sourceIndex = ctx.sheetPathMapping
+        .get(ghost)
+        .flatMap(SourceContext.worksheetPartNumber)
+        .getOrElse(workbook.sheets.size + ordinal)
+      ctx.markUntrackedSheetRemoval(sourceIndex, ghost)
+    }
+    val untrackedAddition =
+      sheetPathMapping.nonEmpty && workbook.sheets.exists(s => !sheetPathMapping.contains(s.name))
+    val definedNamesDiverged =
+      definedNamesAsRead.exists(_ != workbook.metadata.definedNames)
+    if untrackedAddition || definedNamesDiverged then withRemovals.markMetadataModified
+    else withRemovals
 
   /**
    * Re-key the identity-keyed source mappings after a tracked rename (GH-315): identity follows the
@@ -140,6 +201,18 @@ final case class SourceContext(
     copy(modificationTracker = modificationTracker.markMetadata)
 
 object SourceContext:
+
+  private val WorksheetPartNumber = raw"xl/worksheets/sheet(\d+)\.xml".r
+
+  /**
+   * Zero-based source sheet index implied by the conventional worksheet part name (GH-470:
+   * `xl/worksheets/sheet3.xml` → 2). None for foreign packages with unconventional part names — the
+   * caller falls back to a synthetic non-colliding index.
+   */
+  private[context] def worksheetPartNumber(path: String): Option[Int] = path match
+    case WorksheetPartNumber(n) => n.toIntOption.map(_ - 1).filter(_ >= 0)
+    case _ => None
+
   /**
    * Construct a context for a workbook that originated from a file.
    *

--- a/xl-core/src/com/tjclp/xl/sheets/Sheet.scala
+++ b/xl-core/src/com/tjclp/xl/sheets/Sheet.scala
@@ -167,6 +167,37 @@ final case class Sheet(
     if count <= 0 then this else shiftAxis(rowAxis = false, at, count, deleting = true)
 
   /**
+   * Highest populated 0-based index on one axis — the farthest position a structural insert would
+   * shift (GH-472). "Populated" covers every carrier of absolute positions that [[shiftAxis]]
+   * rebuilds WITHOUT clamping: cells, comments, row/column properties, drawing cell anchors, and
+   * the freeze-pane anchor/scroll target. Range-shaped structures (merges, cf/dv envelopes, print
+   * areas, tables, autoFilter) clamp at the sheet edge instead (GH-428) and can never overflow.
+   * `None` = nothing populated on the axis. Callers use this to REFUSE an insert that would push
+   * any of these past the sheet edge — Excel refuses such files outright, so writing one is never
+   * acceptable.
+   */
+  private[xl] def maxPopulatedIndex(rowAxis: Boolean): Option[Int] =
+    def axisOf(ref: ARef): Int = if rowAxis then ref.row.index0 else ref.col.index0
+    def anchorCells(anchor: DrawingAnchor): List[ARef] = anchor match
+      case DrawingAnchor.OneCell(from, _) => List(from.cell)
+      case DrawingAnchor.TwoCell(from, to, _) => List(from.cell, to.cell)
+      case _: DrawingAnchor.Absolute => Nil
+    val drawingRefs = drawings.iterator.flatMap {
+      case Drawing.Picture(anchor, _, _, _) => anchorCells(anchor)
+      case Drawing.ChartFrame(anchor, _, _) => anchorCells(anchor)
+      case _: Drawing.Preserved => Nil
+    }
+    val freezeRefs = freezePane.iterator.flatMap {
+      case FreezePane.At(topLeftCell, scrolledTo) => topLeftCell :: scrolledTo.toList
+      case FreezePane.Remove => Nil
+    }
+    val propIndices =
+      if rowAxis then rowProperties.keysIterator.map(_.index0)
+      else columnProperties.keysIterator.map(_.index0)
+    ((cells.keysIterator ++ comments.keysIterator ++ drawingRefs ++ freezeRefs).map(axisOf)
+      ++ propIndices).maxOption
+
+  /**
    * Shared structural-shift engine for one axis (row or column).
    *
    * Maps a 0-based index on the active axis: insert shifts indices `>= at` by `+count`; delete

--- a/xl-core/test/src/com/tjclp/xl/SourceContextSpec.scala
+++ b/xl-core/test/src/com/tjclp/xl/SourceContextSpec.scala
@@ -5,6 +5,8 @@ import java.nio.file.Files
 import com.tjclp.xl.addressing.SheetName
 import com.tjclp.xl.context.{SourceContext, SourceFingerprint}
 import com.tjclp.xl.ooxml.PartManifest
+import com.tjclp.xl.sheets.Sheet
+import com.tjclp.xl.workbooks.{DefinedName, Workbook}
 import munit.FunSuite
 
 class SourceContextSpec extends FunSuite:
@@ -66,6 +68,84 @@ class SourceContextSpec extends FunSuite:
     assertEquals(deleted.drawingPathMapping, Map.empty[SheetName, String])
     assertEquals(deleted.drawingSnapshots.keySet, Set.empty[SheetName])
     assertEquals(deleted.sheetPathMapping, Map(name("B") -> "xl/worksheets/sheet2.xml"))
+  }
+
+  test("GH-470: reconciledWith marks an untracked sheet-set reduction like a delete") {
+    val ctx = SourceContext
+      .fromFile(
+        tempPath,
+        PartManifest.empty,
+        SourceFingerprint.fromPath(tempPath),
+        commentPathMapping = Map(name("B") -> "xl/comments1.xml"),
+        sheetPathMapping =
+          Map(name("A") -> "xl/worksheets/sheet1.xml", name("B") -> "xl/worksheets/sheet2.xml")
+      )
+    // "B" dropped via Workbook.copy(sheets = ...) — no tracked delete ever ran
+    val reduced = Workbook(Vector(Sheet(name("A"))))
+    val reconciled = ctx.reconciledWith(reduced)
+
+    assert(!reconciled.isClean, "an untracked reduction must dirty the context")
+    assertEquals(reconciled.modificationTracker.deletedSheets, Set(1))
+    assert(reconciled.modificationTracker.modifiedMetadata)
+    assertEquals(reconciled.sheetPathMapping, Map(name("A") -> "xl/worksheets/sheet1.xml"))
+    assertEquals(reconciled.commentPathMapping, Map.empty[SheetName, String])
+  }
+
+  test("GH-470: reconciledWith does NOT shift live modified-sheet marks") {
+    val ctx = SourceContext
+      .fromFile(
+        tempPath,
+        PartManifest.empty,
+        SourceFingerprint.fromPath(tempPath),
+        sheetPathMapping =
+          Map(name("A") -> "xl/worksheets/sheet1.xml", name("B") -> "xl/worksheets/sheet2.xml")
+      )
+      .markSheetModified(0) // live index 0 = "B" AFTER the untracked drop of "A"
+    val reduced = Workbook(Vector(Sheet(name("B"))))
+    val reconciled = ctx.reconciledWith(reduced)
+
+    assertEquals(reconciled.modificationTracker.deletedSheets, Set(0))
+    assertEquals(
+      reconciled.modificationTracker.modifiedSheets,
+      Set(0),
+      "the surviving sheet's modification mark must not be shifted or dropped"
+    )
+  }
+
+  test("GH-470: reconciledWith marks untracked additions and defined-name drift as metadata") {
+    val ctx = SourceContext
+      .fromFile(
+        tempPath,
+        PartManifest.empty,
+        SourceFingerprint.fromPath(tempPath),
+        sheetPathMapping = Map(name("A") -> "xl/worksheets/sheet1.xml")
+      )
+    val appended = Workbook(Vector(Sheet(name("A")), Sheet(name("New"))))
+    assert(ctx.reconciledWith(appended).modificationTracker.modifiedMetadata)
+    assertEquals(ctx.reconciledWith(appended).modificationTracker.deletedSheets, Set.empty[Int])
+
+    val snapshot =
+      ctx.copy(definedNamesAsRead = Some(Vector(DefinedName(name = "SECRET", formula = "A!$A$1"))))
+    val redacted = Workbook(Vector(Sheet(name("A"))))
+    assert(
+      snapshot.reconciledWith(redacted).modificationTracker.modifiedMetadata,
+      "dropping a defined name via copy(metadata = ...) must dirty the context"
+    )
+  }
+
+  test("GH-470: reconciledWith is identity when nothing diverges") {
+    val ctx = SourceContext
+      .fromFile(
+        tempPath,
+        PartManifest.empty,
+        SourceFingerprint.fromPath(tempPath),
+        sheetPathMapping = Map(name("A") -> "xl/worksheets/sheet1.xml")
+      )
+    val untouched = Workbook(Vector(Sheet(name("A"))))
+    assert(
+      ctx.reconciledWith(untouched) eq ctx,
+      "a clean workbook must keep the verbatim fast path"
+    )
   }
 
   test("GH-315: markSheetRenamed re-keys identity mappings (identity follows the sheet)") {

--- a/xl-core/test/src/com/tjclp/xl/StructuralEditSpec.scala
+++ b/xl-core/test/src/com/tjclp/xl/StructuralEditSpec.scala
@@ -1,7 +1,7 @@
 package com.tjclp.xl
 
 import com.tjclp.xl.{*, given}
-import com.tjclp.xl.addressing.CellRange
+import com.tjclp.xl.addressing.{CellRange, Row}
 import com.tjclp.xl.cells.CellValue
 import com.tjclp.xl.sheets.FreezePane
 import munit.ScalaCheckSuite
@@ -244,4 +244,30 @@ class StructuralEditSpec extends ScalaCheckSuite:
           ps.repeatRows.contains((ns + 1, ne + 1))
         }
     }
+  }
+
+  // ===== GH-472: maxPopulatedIndex — the insert-refusal query =====
+
+  test("GH-472: maxPopulatedIndex sees cells on both axes") {
+    val s = Sheet("S").put("B3" -> 1, "D2" -> 2)
+    assertEquals(s.maxPopulatedIndex(rowAxis = true), Some(2)) // row 3 (0-based 2)
+    assertEquals(s.maxPopulatedIndex(rowAxis = false), Some(3)) // col D (0-based 3)
+    assertEquals(Sheet("Empty").maxPopulatedIndex(rowAxis = true), None)
+  }
+
+  test("GH-472: maxPopulatedIndex sees comments, row properties, and the freeze anchor") {
+    import com.tjclp.xl.cells.Comment
+    import com.tjclp.xl.sheets.RowProperties
+    val withComment = Sheet("S").comment(ref"A9", Comment.plainText("note"))
+    assertEquals(withComment.maxPopulatedIndex(rowAxis = true), Some(8))
+    val withProps =
+      Sheet("S").copy(rowProperties = Map(Row.from0(41) -> RowProperties(height = Some(30.0))))
+    assertEquals(withProps.maxPopulatedIndex(rowAxis = true), Some(41))
+    val withFreeze = Sheet("S").copy(freezePane = Some(FreezePane.At(ref"B3")))
+    assertEquals(withFreeze.maxPopulatedIndex(rowAxis = true), Some(2))
+  }
+
+  test("GH-472: maxPopulatedIndex ignores merged ranges (those clamp per GH-428)") {
+    val s = Sheet("S").copy(mergedRanges = Set(CellRange(ref"A1", ref"A1048576")))
+    assertEquals(s.maxPopulatedIndex(rowAxis = true), None)
   }

--- a/xl-evaluator/src/com/tjclp/xl/formula/eval/CriteriaMatcher.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/eval/CriteriaMatcher.scala
@@ -20,15 +20,17 @@ import scala.util.matching.Regex
  *   - **Exact**: `"Apple"` or `42` → Cells equal to value
  *   - **Wildcard**: `"A*"`, `"*pple"`, `"A?ple"` → Pattern matching (* = any chars, ? = single
  *     char)
- *   - **Greater**: `">100"`, `">=50"` → Numeric comparison
- *   - **Less**: `"<10"`, `"<=5"` → Numeric comparison
- *   - **Not Equal**: `"<>0"` → Numeric inequality
+ *   - **Greater**: `">100"`, `">=50"` → Numeric comparison; `">m"` → Text comparison
+ *   - **Less**: `"<10"`, `"<=5"` → Numeric comparison; `"<m"` → Text comparison
+ *   - **Not Equal**: `"<>0"` → Numeric inequality; `"<>x"` → Text inequality; bare `"<>"` →
+ *     non-blank; `"<>A*"` → negated wildcard
  *
  * Laws:
  *   1. Exact match: `matches(Text("Apple"), Exact(ExprValue.Text("Apple"))) == true`
  *   2. Wildcard: `matches(Text("Apple"), Wildcard("A*")) == true`
  *   3. Case-insensitive text: `matches(Text("APPLE"), Exact(ExprValue.Text("apple"))) == true`
  *   4. Numeric comparison: `matches(Number(150), Compare(Gt, 100)) == true`
+ *   5. Text comparison: `matches(Text("x"), CompareText(Gt, "m")) == true`
  */
 object CriteriaMatcher:
 
@@ -41,8 +43,19 @@ object CriteriaMatcher:
   /** Numeric comparison */
   case class Compare(op: CompareOp, value: BigDecimal) extends Criterion
 
+  /**
+   * Case-insensitive text comparison (GH-466).
+   *
+   * Produced when the operand after `<>`/`>=`/`<=`/`>`/`<` is not numeric, e.g. `"<>x"` or `">m"`.
+   * Bare `"<>"` parses to `CompareText(Neq, "")` — Excel's non-blank idiom.
+   */
+  case class CompareText(op: CompareOp, value: String) extends Criterion
+
   /** Wildcard pattern (* = any chars, ? = single char) */
   case class Wildcard(pattern: String) extends Criterion
+
+  /** Negated wildcard pattern, from `<>` followed by a pattern with unescaped wildcards */
+  case class NotWildcard(pattern: String) extends Criterion
 
   /** Comparison operators for numeric criteria */
   enum CompareOp derives CanEqual:
@@ -93,30 +106,36 @@ object CriteriaMatcher:
   private def parseString(s: String): Criterion =
     s match
       // Not equal: <>
+      // GH-466: non-numeric operands are text inequality (bare "<>" = non-blank);
+      // wildcard operands negate the pattern (Excel "<>A*" = not-like "A*").
       case _ if s.startsWith("<>") =>
-        parseNumeric(s.drop(2)) match
+        val operand = s.drop(2)
+        parseNumeric(operand) match
           case Some(n) => Compare(CompareOp.Neq, n)
-          case None => Exact(ExprValue.Text(s)) // Couldn't parse number, treat as literal
+          case None if hasUnescapedWildcard(operand) => NotWildcard(operand)
+          case None if hasEscapeSequence(operand) =>
+            CompareText(CompareOp.Neq, unescapePattern(operand))
+          case None => CompareText(CompareOp.Neq, operand)
       // Greater than or equal: >=
       case _ if s.startsWith(">=") =>
         parseNumeric(s.drop(2)) match
           case Some(n) => Compare(CompareOp.Gte, n)
-          case None => Exact(ExprValue.Text(s))
+          case None => CompareText(CompareOp.Gte, s.drop(2)) // GH-466: text ordering
       // Less than or equal: <=
       case _ if s.startsWith("<=") =>
         parseNumeric(s.drop(2)) match
           case Some(n) => Compare(CompareOp.Lte, n)
-          case None => Exact(ExprValue.Text(s))
+          case None => CompareText(CompareOp.Lte, s.drop(2)) // GH-466: text ordering
       // Greater than: >
       case _ if s.startsWith(">") =>
         parseNumeric(s.drop(1)) match
           case Some(n) => Compare(CompareOp.Gt, n)
-          case None => Exact(ExprValue.Text(s))
+          case None => CompareText(CompareOp.Gt, s.drop(1)) // GH-466: text ordering
       // Less than: <
       case _ if s.startsWith("<") =>
         parseNumeric(s.drop(1)) match
           case Some(n) => Compare(CompareOp.Lt, n)
-          case None => Exact(ExprValue.Text(s))
+          case None => CompareText(CompareOp.Lt, s.drop(1)) // GH-466: text ordering
       // Equal: =
       case _ if s.startsWith("=") =>
         parseNumeric(s.drop(1)) match
@@ -219,7 +238,9 @@ object CriteriaMatcher:
     criterion match
       case Exact(expected) => matchesExact(cellValue, expected)
       case Compare(op, threshold) => matchesCompare(cellValue, op, threshold)
+      case CompareText(op, operand) => matchesCompareText(cellValue, op, operand)
       case Wildcard(pattern) => matchesWildcard(cellValue, pattern)
+      case NotWildcard(pattern) => matchesNotWildcard(cellValue, pattern)
 
   /**
    * Exact matching with type coercion.
@@ -308,6 +329,68 @@ object CriteriaMatcher:
           case CompareOp.Lte => value <= threshold
           case CompareOp.Neq => value != threshold
       case None => false
+
+  /**
+   * Text comparison matching (GH-466), for criteria like "<>x" and ">m".
+   *
+   * Excel semantics:
+   *   - `<>text` is a negated exact match with the same coercion rules as [[Exact]], so numbers,
+   *     booleans and blank cells all match `"<>x"` (they are not equal to "x"). Bare `"<>"`
+   *     (operand "") therefore matches exactly the non-blank cells.
+   *   - Ordering operators (`>`, `>=`, `<`, `<=`) compare text case-insensitively and only apply to
+   *     text values: numbers, booleans and blanks never satisfy a text ordering criterion (Excel
+   *     criteria comparisons are type-segregated).
+   *   - Error cells and uncached formulas never match.
+   */
+  private def matchesCompareText(
+    cellValue: CellValue,
+    op: CompareOp,
+    operand: String
+  ): Boolean =
+    cellValue match
+      case CellValue.Error(_) => false
+      case CellValue.Formula(_, Some(cached), _) => matchesCompareText(cached, op, operand)
+      case CellValue.Formula(_, None, _) => false
+      case other =>
+        op match
+          case CompareOp.Neq => !matchesExact(other, ExprValue.Text(operand))
+          case CompareOp.Gt | CompareOp.Gte | CompareOp.Lt | CompareOp.Lte =>
+            extractOrderableText(other) match
+              case Some(text) =>
+                val cmp = text.compareToIgnoreCase(operand)
+                op match
+                  case CompareOp.Gt => cmp > 0
+                  case CompareOp.Gte => cmp >= 0
+                  case CompareOp.Lt => cmp < 0
+                  case CompareOp.Lte => cmp <= 0
+                  case CompareOp.Neq => cmp != 0 // Unreachable: Neq handled above
+              case None => false
+
+  /**
+   * Extract text for ordering comparisons (GH-466).
+   *
+   * Deliberately narrower than [[extractText]]: only genuine text participates in text ordering,
+   * matching Excel (a number never satisfies `">m"`).
+   */
+  private def extractOrderableText(cellValue: CellValue): Option[String] =
+    cellValue match
+      case CellValue.Text(s) => Some(s)
+      case CellValue.RichText(rt) => Some(rt.toPlainText)
+      case CellValue.Formula(_, Some(cached), _) => extractOrderableText(cached)
+      case _ => None
+
+  /**
+   * Negated wildcard matching (GH-466), for criteria like "<>A*".
+   *
+   * Matches cells that do NOT match the pattern (blanks included, consistent with `<>text`); error
+   * cells and uncached formulas never match.
+   */
+  private def matchesNotWildcard(cellValue: CellValue, pattern: String): Boolean =
+    cellValue match
+      case CellValue.Error(_) => false
+      case CellValue.Formula(_, Some(cached), _) => matchesNotWildcard(cached, pattern)
+      case CellValue.Formula(_, None, _) => false
+      case other => !matchesWildcard(other, pattern)
 
   /**
    * Extract numeric value from cell, with type coercion.

--- a/xl-evaluator/src/com/tjclp/xl/formula/eval/StructuralEditor.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/eval/StructuralEditor.scala
@@ -179,7 +179,7 @@ object StructuralEditor:
                     // survives: a shortened range can produce a different aggregate, and moving a
                     // cell changes position-sensitive formulas such as ROW(). Leave the expression
                     // evaluatable and uncached so the next recalculation cannot expose stale data.
-                    val newStr = FormulaPrinter.print(shiftedExpr, includeEquals = false)
+                    val newStr = FormulaPrinter.printFileForm(shiftedExpr)
                     val newKind = shiftedArrayKind(kind, shiftLocal, isRow, at, delta)
                     (ref, cell.copy(value = CellValue.Formula(newStr, None, newKind)))
                   case None =>
@@ -322,7 +322,7 @@ object StructuralEditor:
           formula
         case Right(expr) =>
           FormulaShifter.shiftStructural(expr, shiftLocal, editedSheet, isRow, at, delta) match
-            case Some(shifted) => FormulaPrinter.print(shifted, includeEquals = false)
+            case Some(shifted) => FormulaPrinter.printFileForm(shifted)
             case None => "#REF!"
         case Left(_) => formula
 

--- a/xl-evaluator/src/com/tjclp/xl/formula/eval/StructuralEditor.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/eval/StructuralEditor.scala
@@ -93,12 +93,27 @@ object StructuralEditor:
         stale = r => staleCaches.contains(QualifiedRef(s.name, r))
       )
     }
+    // GH-473: general defined names (workbook- AND sheet-scoped) are the same rewrite plane as
+    // print areas / DV / tables (GH-429): a refersTo reference targeting the edited sheet shifts
+    // with it, a fully-deleted target degrades to "#REF!", and constants / other-sheet references
+    // ride byte-identical. (Lifted print names live in typed PageSetup, not here — no double
+    // shift.)
+    val updatedNames = wb.metadata.definedNames.map { dn =>
+      dn.copy(formula = shiftDefinedNameText(dn.formula, editedName, isRow, at, delta))
+    }
+    val namesChanged = updatedNames != wb.metadata.definedNames
     // A structural edit can touch any sheet's formulas (cross-sheet refs), so mark every sheet
     // modified — otherwise the writer's clean/verbatim fast-path would copy stale bytes from the
-    // source file and silently drop the edit.
+    // source file and silently drop the edit. A defined-name rewrite lives in workbook.xml, so
+    // mark metadata modified too when one changed.
     val updatedContext =
-      wb.sourceContext.map(ctx => wb.sheets.indices.foldLeft(ctx)((c, i) => c.markSheetModified(i)))
-    wb.copy(sheets = updatedSheets, sourceContext = updatedContext)
+      wb.sourceContext.map { ctx =>
+        val marked = wb.sheets.indices.foldLeft(ctx)((c, i) => c.markSheetModified(i))
+        if namesChanged then marked.markMetadataModified else marked
+      }
+    val updatedMetadata =
+      if namesChanged then wb.metadata.copy(definedNames = updatedNames) else wb.metadata
+    wb.copy(sheets = updatedSheets, metadata = updatedMetadata, sourceContext = updatedContext)
 
   private def rewriteFormulas(
     sheet: Sheet,
@@ -325,6 +340,58 @@ object StructuralEditor:
             case Some(shifted) => FormulaPrinter.print(shifted, includeEquals = false)
             case None => "#REF!"
         case Left(_) => formula
+
+  /**
+   * GH-473: rewrite a defined name's refersTo text through the structural shift. A refersTo is bare
+   * formula text, but unlike CF/DV formulas it may be a TOP-LEVEL comma union (a multi-range name
+   * such as `Two!$A$1:$B$2,Two!$D$10`) that the formula parser rejects — split on top-level commas
+   * and shift each segment through the shared [[shiftFormulaText]]. `shiftLocal = false`: a
+   * refersTo names its sheet explicitly, so only references to the edited sheet move; constants,
+   * externals, unqualified and other-sheet references ride byte-identical (per-segment, the same
+   * non-participation gates as CF/DV).
+   */
+  private def shiftDefinedNameText(
+    formula: String,
+    editedSheet: String,
+    isRow: Boolean,
+    at: Int,
+    delta: Int
+  ): String =
+    if !mentionsSheet(formula, editedSheet) then formula
+    else
+      splitTopLevelCommas(formula)
+        .map(seg => shiftFormulaText(seg, shiftLocal = false, editedSheet, isRow, at, delta))
+        .mkString(",")
+
+  /**
+   * Split refersTo text on TOP-LEVEL commas (the multi-range union). Commas inside quoted sheet
+   * names (`'It''s, ok'!A1`), string literals (`"a,b"`) or any `()`/`{}` nesting (function
+   * arguments, array literals) do not split. Doubled quotes toggle twice — net unchanged, and no
+   * comma is consumed between the pair.
+   */
+  private def splitTopLevelCommas(s: String): Vector[String] =
+    @tailrec
+    def loop(
+      i: Int,
+      segStart: Int,
+      depth: Int,
+      inSingle: Boolean,
+      inDouble: Boolean,
+      acc: Vector[String]
+    ): Vector[String] =
+      if i >= s.length then acc :+ s.substring(segStart)
+      else
+        s.charAt(i) match
+          case '\'' if !inDouble => loop(i + 1, segStart, depth, !inSingle, inDouble, acc)
+          case '"' if !inSingle => loop(i + 1, segStart, depth, inSingle, !inDouble, acc)
+          case '(' | '{' if !inSingle && !inDouble =>
+            loop(i + 1, segStart, depth + 1, inSingle, inDouble, acc)
+          case ')' | '}' if !inSingle && !inDouble =>
+            loop(i + 1, segStart, depth - 1, inSingle, inDouble, acc)
+          case ',' if !inSingle && !inDouble && depth == 0 =>
+            loop(i + 1, i + 1, depth, inSingle, inDouble, acc :+ s.substring(segStart, i))
+          case _ => loop(i + 1, segStart, depth, inSingle, inDouble, acc)
+    loop(0, 0, 0, inSingle = false, inDouble = false, Vector.empty)
 
   /**
    * GH-136: rewrite TYPED conditional-format formula text (CellIs.formula1/formula2,

--- a/xl-evaluator/src/com/tjclp/xl/formula/eval/StructuralEditor.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/eval/StructuralEditor.scala
@@ -7,6 +7,7 @@ import com.tjclp.xl.sheets.{DataValidation, DvKind, Sheet}
 import com.tjclp.xl.addressing.{ARef, CellRange, Column, Row, SheetName}
 import com.tjclp.xl.cells.{Cell, CellError, CellValue, FormulaKind}
 import com.tjclp.xl.cf.{CfRule, Cfvo, ConditionalFormat}
+import com.tjclp.xl.error.{XLError, XLException}
 import com.tjclp.xl.formula.graph.DependencyGraph
 import com.tjclp.xl.formula.graph.DependencyGraph.QualifiedRef
 import com.tjclp.xl.formula.parser.FormulaParser
@@ -27,7 +28,11 @@ import com.tjclp.xl.formula.printer.{FormulaPrinter, FormulaShifter}
  */
 object StructuralEditor:
 
-  /** Insert `count` rows at 0-based row index `at` on `sheet`. */
+  /**
+   * Insert `count` rows at 0-based row index `at` on `sheet`. Throws a typed
+   * `XLException(XLError.OutOfBounds)` when the insert would shift any populated position past row
+   * 1048576 (GH-472) — the workbook is left untouched.
+   */
   def insertRows(wb: Workbook, sheet: SheetName, at: Int, count: Int): Workbook =
     edit(wb, sheet, isRow = true, at = at, delta = count)
 
@@ -35,7 +40,11 @@ object StructuralEditor:
   def deleteRows(wb: Workbook, sheet: SheetName, at: Int, count: Int): Workbook =
     edit(wb, sheet, isRow = true, at = at, delta = -count)
 
-  /** Insert `count` columns at 0-based column index `at` on `sheet`. */
+  /**
+   * Insert `count` columns at 0-based column index `at` on `sheet`. Throws a typed
+   * `XLException(XLError.OutOfBounds)` when the insert would shift any populated position past
+   * column XFD (GH-472) — the workbook is left untouched.
+   */
   def insertColumns(wb: Workbook, sheet: SheetName, at: Int, count: Int): Workbook =
     edit(wb, sheet, isRow = false, at = at, delta = count)
 
@@ -50,6 +59,32 @@ object StructuralEditor:
     at: Int,
     delta: Int
   ): Workbook =
+    // GH-472: REFUSE an insert that would shift any populated position (cell, comment, row/column
+    // property, drawing anchor, freeze pane) past the sheet edge. Ranges clamp (GH-428), but a
+    // data cell cannot clamp without destroying data — and 0.19.0's silent success wrote cells and
+    // a <dimension> past row 1048576, a file desktop Excel refuses outright. Throws a typed
+    // XLException(XLError.OutOfBounds); the workbook is untouched.
+    if delta > 0 then
+      wb.sheets.find(_.name == target).foreach { s =>
+        val axisMax = if isRow then Row.MaxIndex0 else Column.MaxIndex0
+        s.maxPopulatedIndex(isRow)
+          .filter(i => i >= at && i.toLong + delta > axisMax)
+          .foreach { i =>
+            def rowName(idx: Int) = s"row ${idx + 1}"
+            def colName(idx: Int) = s"column ${Column.from0(idx).toLetter}"
+            val (offending, edge) =
+              if isRow then (rowName(i), s"last ${rowName(axisMax)}")
+              else (colName(i), s"last ${colName(axisMax)}")
+            val unit = if isRow then "row(s)" else "column(s)"
+            val atName = if isRow then rowName(at) else colName(at)
+            throw XLException(
+              XLError.OutOfBounds(
+                offending,
+                s"inserting $delta $unit at $atName would shift it past the sheet's $edge"
+              )
+            )
+          }
+      }
     val editedName = target.value
     // GH-455 follow-up: the non-participation fast path below keeps formula TEXT byte-identical,
     // but a cached VALUE can be stale even when the text never names the edited sheet —

--- a/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpec.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpec.scala
@@ -36,7 +36,12 @@ final case class FunctionFlags(
 final case class ArgPrinter(
   expr: TExpr[?] => String,
   location: TExpr.RangeLocation => String,
-  cellRange: CellRange => String
+  cellRange: CellRange => String,
+  /**
+   * GH-484: the argument separator to join rendered args with — the canonical human-facing ", " by
+   * default; Excel's bare "," when printing the file form (FormulaPrinter.printFileForm).
+   */
+  separator: String = ", "
 )
 
 final case class EvalContext(
@@ -118,7 +123,7 @@ trait FunctionSpec[A]:
 
   def render(args: Args, printer: ArgPrinter): String =
     val rendered = argSpec.render(args, printer)
-    s"${name}(${rendered.mkString(", ")})"
+    s"${name}(${rendered.mkString(printer.separator)})"
 
 object FunctionSpec:
   final case class Simple[A, A0](

--- a/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpecsBase.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpecsBase.scala
@@ -264,6 +264,46 @@ trait FunctionSpecsBase:
       case TExpr.SheetRange(_, range) => Some(range.start)
       case _ => None
 
+  /**
+   * GH-467: normalize a lookup value for MATCH/XLOOKUP comparison. Cell-ref lookup values arrive as
+   * ExprValue.Cell and must be dereferenced to their underlying scalar before comparing (the
+   * literal `"k2"` and a ref to a cell holding `"k2"` must behave identically); date/datetime
+   * lookup values coerce to their Excel serial — dates ARE numbers in Excel's comparison plane
+   * (mirroring GH-449's dateTimeToExcelSerial coercion at numeric boundaries).
+   */
+  protected def normalizeLookupValue(value: ExprValue): ExprValue =
+    value match
+      case ExprValue.Cell(CellValue.Number(n)) => ExprValue.Number(n)
+      case ExprValue.Cell(CellValue.Text(s)) => ExprValue.Text(s)
+      case ExprValue.Cell(CellValue.Bool(b)) => ExprValue.Bool(b)
+      case ExprValue.Cell(CellValue.DateTime(dt)) =>
+        ExprValue.Number(BigDecimal(CellValue.dateTimeToExcelSerial(dt)))
+      case ExprValue.Cell(CellValue.Formula(_, Some(cached), _)) =>
+        normalizeLookupValue(ExprValue.Cell(cached))
+      case ExprValue.Date(d) =>
+        ExprValue.Number(BigDecimal(CellValue.dateTimeToExcelSerial(d.atStartOfDay())))
+      case ExprValue.DateTime(dt) =>
+        ExprValue.Number(BigDecimal(CellValue.dateTimeToExcelSerial(dt)))
+      case other => other
+
+  /**
+   * GH-467: exact equality for the MATCH/XLOOKUP lookup plane, over a lookup value already passed
+   * through [[normalizeLookupValue]]. Total and blank-safe: a blank cell matches nothing (a
+   * default-equal fallback here made blanks "match" every lookup value, shifting MATCH positions
+   * over ranges with holes), mismatched types match nothing, and DateTime cells compare by their
+   * Excel serial so date lookups find date columns.
+   */
+  protected def matchesLookupExact(cv: CellValue, lookup: ExprValue): Boolean =
+    (cv, lookup) match
+      case (CellValue.Number(n), ExprValue.Number(v)) => n == v
+      case (CellValue.DateTime(dt), ExprValue.Number(v)) =>
+        BigDecimal(CellValue.dateTimeToExcelSerial(dt)) == v
+      case (CellValue.Text(s), ExprValue.Text(v)) => s.equalsIgnoreCase(v)
+      case (CellValue.Bool(b), ExprValue.Bool(v)) => b == v
+      case (CellValue.Error(e1), ExprValue.Cell(CellValue.Error(e2))) => e1 == e2
+      case (CellValue.Formula(_, Some(cached), _), v) => matchesLookupExact(cached, v)
+      case _ => false
+
   /** Extract text for matching, coercing numbers and booleans to strings. */
   protected def extractTextForMatch(cv: CellValue): Option[String] =
     cv match

--- a/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpecsDateTime.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpecsDateTime.scala
@@ -281,7 +281,7 @@ trait FunctionSpecsDateTime extends FunctionSpecsBase:
               printer.expr(endDateExpr),
               printer.expr(basisExpr)
             )
-        s"YEARFRAC(${rendered.mkString(", ")})"
+        s"YEARFRAC(${rendered.mkString(printer.separator)})"
       },
       flags = FunctionFlags(returnsNumeric = true)
     ) { (args, ctx) =>

--- a/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpecsLookupIndex.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpecsLookupIndex.scala
@@ -9,16 +9,6 @@ import com.tjclp.xl.addressing.{ARef, CellRange}
 import com.tjclp.xl.cells.CellValue
 
 trait FunctionSpecsLookupIndex extends FunctionSpecsBase:
-  private def compareCellValues(cv: CellValue, value: ExprValue): Int =
-    (cv, value) match
-      case (CellValue.Number(n1), ExprValue.Number(n2)) => n1.compare(n2)
-      case (CellValue.Text(s1), ExprValue.Text(s2)) => s1.compareToIgnoreCase(s2)
-      case (CellValue.Bool(b1), ExprValue.Bool(b2)) => b1.compare(b2)
-      case (CellValue.Error(e1), ExprValue.Cell(CellValue.Error(e2))) =>
-        e1.ordinal.compareTo(e2.ordinal)
-      case (CellValue.Formula(_, Some(cached), _), other) => compareCellValues(cached, other)
-      case _ => 0
-
   private def coerceToBigDecimal(value: ExprValue): BigDecimal =
     value match
       case ExprValue.Number(n) => n
@@ -104,6 +94,9 @@ trait FunctionSpecsLookupIndex extends FunctionSpecsBase:
         (targetSheet, lookupRange) = resolved
         result <- {
           val matchTypeInt = matchType.toInt
+          // GH-467: dereference cell-ref lookup values and coerce dates to serials up front —
+          // positions below are RANGE positions (idx + 1), blanks included, never compacted.
+          val lookup = normalizeLookupValue(lookupValueEval)
           val cells: List[(Int, CellValue)] =
             lookupRange.cells.toList.zipWithIndex.map { case (ref, idx) =>
               (idx + 1, targetSheet(ref).value)
@@ -113,23 +106,21 @@ trait FunctionSpecsLookupIndex extends FunctionSpecsBase:
             case 0 =>
               cells
                 .find { case (_, cv) =>
-                  compareCellValues(cv, lookupValueEval) == 0
+                  matchesLookupExact(cv, lookup)
                 }
                 .map(_._1)
             case 1 =>
-              val numericLookup = coerceToBigDecimal(lookupValueEval)
+              val numericLookup = coerceToBigDecimal(lookup)
+              // GH-467: extractNumericValue skips blanks/text/bools (they are NOT zero) and
+              // yields serials for DateTime cells, so date columns work in approximate mode.
               val candidates = cells.flatMap { case (pos, cv) =>
-                val numericCv = coerceToNumeric(cv)
-                if numericCv <= numericLookup then Some((pos, numericCv))
-                else None
+                extractNumericValue(cv).filter(_ <= numericLookup).map(n => (pos, n))
               }
               candidates.maxByOption(_._2).map(_._1)
             case -1 =>
-              val numericLookup = coerceToBigDecimal(lookupValueEval)
+              val numericLookup = coerceToBigDecimal(lookup)
               val candidates = cells.flatMap { case (pos, cv) =>
-                val numericCv = coerceToNumeric(cv)
-                if numericCv >= numericLookup then Some((pos, numericCv))
-                else None
+                extractNumericValue(cv).filter(_ >= numericLookup).map(n => (pos, n))
               }
               candidates.minByOption(_._2).map(_._1)
             case _ =>

--- a/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpecsLookupSearch.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpecsLookupSearch.scala
@@ -24,18 +24,18 @@ trait FunctionSpecsLookupSearch extends FunctionSpecsBase:
     val lookupCells = lookupArray.cells.toVector
     val returnCells = returnArray.cells.toVector
 
+    // GH-467: dereference cell-ref lookup values and coerce dates to serials before comparing —
+    // a ref to a cell holding "k2" must match exactly like the literal "k2".
+    val lookup = normalizeLookupValue(lookupValue)
+
     // GH-55: accept binary-search modes 2 (ascending) and -2 (descending). Linear iteration in the
     // correct direction yields correct results; -2 iterates reversed like -1 (descending order).
     val indices =
       if searchMode == -1 || searchMode == -2 then lookupCells.indices.reverse
       else lookupCells.indices
 
-    val wildcardCriterionOpt = lookupValue match
+    val wildcardCriterionOpt = lookup match
       case ExprValue.Text(text) =>
-        CriteriaMatcher.parse(ExprValue.Text(text)) match
-          case c: CriteriaMatcher.Wildcard => Some(c)
-          case _ => None
-      case ExprValue.Cell(CellValue.Text(text)) =>
         CriteriaMatcher.parse(ExprValue.Text(text)) match
           case c: CriteriaMatcher.Wildcard => Some(c)
           case _ => None
@@ -45,16 +45,16 @@ trait FunctionSpecsLookupSearch extends FunctionSpecsBase:
       case 0 =>
         indices.find { idx =>
           val cellValue = lookupSheet(lookupCells(idx)).value
-          matchesExactForXLookup(cellValue, lookupValue)
+          matchesLookupExact(cellValue, lookup)
         }
       case -1 =>
-        findNextSmaller(lookupValue, lookupCells, lookupSheet, indices)
+        findNextSmaller(lookup, lookupCells, lookupSheet, indices)
       case 1 =>
-        findNextLarger(lookupValue, lookupCells, lookupSheet, indices)
+        findNextLarger(lookup, lookupCells, lookupSheet, indices)
       case 2 =>
         indices.find { idx =>
           val cellValue = lookupSheet(lookupCells(idx)).value
-          matchesExactForXLookup(cellValue, lookupValue) ||
+          matchesLookupExact(cellValue, lookup) ||
           wildcardCriterionOpt.exists(CriteriaMatcher.matches(cellValue, _))
         }
       case _ => None
@@ -65,14 +65,6 @@ trait FunctionSpecsLookupSearch extends FunctionSpecsBase:
         ifNotFoundOpt match
           case Some(expr) => evalValue(ctx, expr).map(toCellValue)
           case None => Right(CellValue.Error(CellError.NA))
-
-  private def matchesExactForXLookup(cellValue: CellValue, lookupValue: ExprValue): Boolean =
-    (cellValue, lookupValue) match
-      case (CellValue.Number(n), ExprValue.Number(v)) => n == v
-      case (CellValue.Text(s), ExprValue.Text(v)) => s.equalsIgnoreCase(v)
-      case (CellValue.Bool(b), ExprValue.Bool(v)) => b == v
-      case (CellValue.Formula(_, Some(cached), _), v) => matchesExactForXLookup(cached, v)
-      case _ => false
 
   private def findNextSmaller(
     lookupValue: ExprValue,

--- a/xl-evaluator/src/com/tjclp/xl/formula/printer/FormulaPrinter.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/printer/FormulaPrinter.scala
@@ -39,7 +39,24 @@ object FormulaPrinter:
    * }}}
    */
   def print(expr: TExpr[?], includeEquals: Boolean = true): String =
-    val formula = printExpr(expr, precedence = 0)
+    printWith(expr, includeEquals, CanonicalSeparator)
+
+  /**
+   * GH-484: print in Excel's FILE form — bare ',' argument separators, no leading '='.
+   *
+   * Every path that writes a rewritten formula back into cell text (structural edits, `putf
+   * --from`, `copy`, `batch`) must use this so reprints don't introduce ", " noise in xlsx diffs;
+   * Excel's on-disk form never spaces its separators. Human-facing output keeps the canonical
+   * spaced [[print]].
+   */
+  def printFileForm(expr: TExpr[?]): String =
+    printWith(expr, includeEquals = false, separator = ",")
+
+  /** The pre-existing canonical human-facing argument separator. */
+  private val CanonicalSeparator = ", "
+
+  private def printWith(expr: TExpr[?], includeEquals: Boolean, separator: String): String =
+    val formula = printExpr(expr, precedence = 0, separator)
     if includeEquals then s"=$formula" else formula
 
   /**
@@ -70,7 +87,7 @@ object FormulaPrinter:
    * @return
    *   Formula string (without leading '=')
    */
-  private def printExpr(expr: TExpr[?], precedence: Int): String =
+  private def printExpr(expr: TExpr[?], precedence: Int, sep: String): String =
     expr match
       // Literals
       case TExpr.Lit(value: BigDecimal) => value.toString
@@ -106,30 +123,34 @@ object FormulaPrinter:
       // prints a/(b*c), never a/b*c (which re-parses as (a/b)*c — a different value). The parser
       // has no Paren node, so the grouping the printer emits is the only grouping there is.
       case TExpr.Add(x, y) =>
-        val result = s"${printExpr(x, Precedence.AddSub)}+${printExpr(y, Precedence.AddSub + 1)}"
+        val result =
+          s"${printExpr(x, Precedence.AddSub, sep)}+${printExpr(y, Precedence.AddSub + 1, sep)}"
         parenthesizeIf(result, precedence > Precedence.AddSub)
 
       case TExpr.Sub(TExpr.Lit(n: BigDecimal), y) if n == BigDecimal(0) =>
         // Unary minus: 0-x prints as -x
-        val result = s"-${printExpr(y, Precedence.Unary)}"
+        val result = s"-${printExpr(y, Precedence.Unary, sep)}"
         parenthesizeIf(result, precedence > Precedence.Unary)
 
       case TExpr.Sub(x, y) =>
-        val result = s"${printExpr(x, Precedence.AddSub)}-${printExpr(y, Precedence.AddSub + 1)}"
+        val result =
+          s"${printExpr(x, Precedence.AddSub, sep)}-${printExpr(y, Precedence.AddSub + 1, sep)}"
         parenthesizeIf(result, precedence > Precedence.AddSub)
 
       case TExpr.Mul(x, y) =>
-        val result = s"${printExpr(x, Precedence.MulDiv)}*${printExpr(y, Precedence.MulDiv + 1)}"
+        val result =
+          s"${printExpr(x, Precedence.MulDiv, sep)}*${printExpr(y, Precedence.MulDiv + 1, sep)}"
         parenthesizeIf(result, precedence > Precedence.MulDiv)
 
       case TExpr.Div(x, y) =>
-        val result = s"${printExpr(x, Precedence.MulDiv)}/${printExpr(y, Precedence.MulDiv + 1)}"
+        val result =
+          s"${printExpr(x, Precedence.MulDiv, sep)}/${printExpr(y, Precedence.MulDiv + 1, sep)}"
         parenthesizeIf(result, precedence > Precedence.MulDiv)
 
       case TExpr.Pow(x, y) =>
         // Right-associative: allow nested powers on the right, but parenthesize ambiguous bases.
-        val base = printPowBase(x)
-        val exponent = printPowExponent(y)
+        val base = printPowBase(x, sep)
+        val exponent = printPowExponent(y, sep)
         val result = s"$base^$exponent"
         parenthesizeIf(result, precedence > Precedence.Pow)
 
@@ -138,7 +159,7 @@ object FormulaPrinter:
       // and `=+-2` replicate their source exactly (parseUnary recurses through unary chains into
       // parsePow).
       case TExpr.UnaryPlus(e) =>
-        val result = s"+${printExpr(e, Precedence.Pow)}"
+        val result = s"+${printExpr(e, Precedence.Pow, sep)}"
         parenthesizeIf(result, precedence > Precedence.Unary)
 
       // GH-355: postfix percent is preserved (never rewritten to /100). The operand prints at
@@ -146,55 +167,56 @@ object FormulaPrinter:
       // Percent(Sub(0,2)) prints (-2)%, Percent(Pow(2,3)) prints (2^3)%, while chained percents
       // stay flat (10%%). Percent itself never needs outer parens (tightest operator).
       case TExpr.Percent(e) =>
-        val result = s"${printExpr(e, Precedence.Percent)}%"
+        val result = s"${printExpr(e, Precedence.Percent, sep)}%"
         parenthesizeIf(result, precedence > Precedence.Percent)
 
       // String operators (GH-455: right operand one level tighter, see arithmetic note)
       case TExpr.Concat(x, y) =>
-        val result = s"${printExpr(x, Precedence.Concat)}&${printExpr(y, Precedence.Concat + 1)}"
+        val result =
+          s"${printExpr(x, Precedence.Concat, sep)}&${printExpr(y, Precedence.Concat + 1, sep)}"
         parenthesizeIf(result, precedence > Precedence.Concat)
 
       // Comparison operators (GH-455: right operand one level tighter, see arithmetic note)
       case TExpr.Eq(x, y) =>
         val result =
-          s"${printExpr(x, Precedence.Comparison)}=${printExpr(y, Precedence.Comparison + 1)}"
+          s"${printExpr(x, Precedence.Comparison, sep)}=${printExpr(y, Precedence.Comparison + 1, sep)}"
         parenthesizeIf(result, precedence > Precedence.Comparison)
 
       case TExpr.Neq(x, y) =>
         val result =
-          s"${printExpr(x, Precedence.Comparison)}<>${printExpr(y, Precedence.Comparison + 1)}"
+          s"${printExpr(x, Precedence.Comparison, sep)}<>${printExpr(y, Precedence.Comparison + 1, sep)}"
         parenthesizeIf(result, precedence > Precedence.Comparison)
 
       case TExpr.Lt(x, y) =>
         val result =
-          s"${printExpr(x, Precedence.Comparison)}<${printExpr(y, Precedence.Comparison + 1)}"
+          s"${printExpr(x, Precedence.Comparison, sep)}<${printExpr(y, Precedence.Comparison + 1, sep)}"
         parenthesizeIf(result, precedence > Precedence.Comparison)
 
       case TExpr.Lte(x, y) =>
         val result =
-          s"${printExpr(x, Precedence.Comparison)}<=${printExpr(y, Precedence.Comparison + 1)}"
+          s"${printExpr(x, Precedence.Comparison, sep)}<=${printExpr(y, Precedence.Comparison + 1, sep)}"
         parenthesizeIf(result, precedence > Precedence.Comparison)
 
       case TExpr.Gt(x, y) =>
         val result =
-          s"${printExpr(x, Precedence.Comparison)}>${printExpr(y, Precedence.Comparison + 1)}"
+          s"${printExpr(x, Precedence.Comparison, sep)}>${printExpr(y, Precedence.Comparison + 1, sep)}"
         parenthesizeIf(result, precedence > Precedence.Comparison)
 
       case TExpr.Gte(x, y) =>
         val result =
-          s"${printExpr(x, Precedence.Comparison)}>=${printExpr(y, Precedence.Comparison + 1)}"
+          s"${printExpr(x, Precedence.Comparison, sep)}>=${printExpr(y, Precedence.Comparison + 1, sep)}"
         parenthesizeIf(result, precedence > Precedence.Comparison)
 
       // Type conversions (print transparently - ToInt is internal)
       case TExpr.ToInt(expr) =>
-        printExpr(expr, precedence) // Print wrapped expression without conversion syntax
+        printExpr(expr, precedence, sep) // Print wrapped expression without conversion syntax
 
       // Date/Time conversions
       case TExpr.DateToSerial(expr) =>
-        printExpr(expr, precedence)
+        printExpr(expr, precedence, sep)
 
       case TExpr.DateTimeToSerial(expr) =>
-        printExpr(expr, precedence)
+        printExpr(expr, precedence, sep)
 
       // Aggregate functions
       case TExpr.Aggregate(aggregatorId, location) =>
@@ -202,18 +224,19 @@ object FormulaPrinter:
 
       case call: TExpr.Call[?] =>
         val printer = ArgPrinter(
-          expr = expr => printExpr(expr, precedence = 0),
+          expr = expr => printExpr(expr, precedence = 0, sep),
           location = formatLocation,
-          cellRange = formatRange
+          cellRange = formatRange,
+          separator = sep
         )
         call.spec.render(call.args, printer)
 
       // GH-193: LET special form — canonical LET(name, value, ..., calculation)
       case TExpr.Let(bindings, body) =>
         val parts =
-          bindings.flatMap((name, value) => List(name, printExpr(value, precedence = 0))) :+
-            printExpr(body, precedence = 0)
-        s"LET(${parts.mkString(", ")})"
+          bindings.flatMap((name, value) => List(name, printExpr(value, precedence = 0, sep))) :+
+            printExpr(body, precedence = 0, sep)
+        s"LET(${parts.mkString(sep)})"
 
       case TExpr.BindingRef(name) => name
 
@@ -231,7 +254,7 @@ object FormulaPrinter:
       // GH-306: a runtime coercion wrapper prints transparently as the wrapped expression —
       // the coercion is an evaluation concern, invisible in formula text (round-trip safe:
       // re-parsing re-derives the same wrapper from the argument position)
-      case TExpr.Coerced(inner, _) => printExpr(inner, precedence)
+      case TExpr.Coerced(inner, _) => printExpr(inner, precedence, sep)
 
   /**
    * Format ARef to A1 notation with default Relative anchor.
@@ -300,12 +323,12 @@ object FormulaPrinter:
   private def parenthesizeIf(s: String, condition: Boolean): String =
     if condition then s"($s)" else s
 
-  private def printPowBase(expr: TExpr[?]): String =
-    val rendered = printExpr(expr, Precedence.Pow)
+  private def printPowBase(expr: TExpr[?], sep: String): String =
+    val rendered = printExpr(expr, Precedence.Pow, sep)
     if needsPowBaseParens(expr) then s"($rendered)" else rendered
 
-  private def printPowExponent(expr: TExpr[?]): String =
-    printExpr(expr, Precedence.Pow)
+  private def printPowExponent(expr: TExpr[?], sep: String): String =
+    printExpr(expr, Precedence.Pow, sep)
 
   private def needsPowBaseParens(expr: TExpr[?]): Boolean =
     unwrapTransparent(expr) match

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/ConditionalFunctionsSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/ConditionalFunctionsSpec.scala
@@ -396,6 +396,67 @@ class ConditionalFunctionsSpec extends FunSuite:
     assertEval("=COUNTIFS(A1:A3, \"Yes\", B1:B3, \"Yes\")", sheet, 1)
   }
 
+  // ===== Text Comparison Criteria Tests (GH-466) =====
+
+  // Fixture from the GH-466 field-QC repro: G1:G4 = x, y, x, z; H1:H4 = 10, 20, 30, 40
+  private def gh466Sheet: Sheet =
+    sheetWith(
+      ref"G1" -> "x",
+      ref"H1" -> 10,
+      ref"G2" -> "y",
+      ref"H2" -> 20,
+      ref"G3" -> "x",
+      ref"H3" -> 30,
+      ref"G4" -> "z",
+      ref"H4" -> 40
+    )
+
+  test("SUMIFS: <>text criteria sums non-matching rows (GH-466)") {
+    assertEval("=SUMIFS(H1:H4, G1:G4, \"<>x\")", gh466Sheet, 60)
+  }
+
+  test("COUNTIFS: <>text criteria counts non-matching cells (GH-466)") {
+    assertEval("=COUNTIFS(G1:G4, \"<>x\")", gh466Sheet, 2)
+  }
+
+  test("COUNTIF: <>text with no equal values counts all (GH-466)") {
+    assertEval("=COUNTIF(G1:G4, \"<>xx\")", gh466Sheet, 4)
+  }
+
+  test("COUNTIF: <>text is case-insensitive (GH-466)") {
+    assertEval("=COUNTIF(G1:G4, \"<>X\")", gh466Sheet, 2)
+  }
+
+  test("COUNTIF: ordering operator with text operand (GH-466)") {
+    assertEval("=COUNTIF(G1:G4, \">m\")", gh466Sheet, 4)
+    assertEval("=COUNTIF(G1:G4, \"<m\")", gh466Sheet, 0)
+    assertEval("=COUNTIF(G1:G4, \">=x\")", gh466Sheet, 4)
+    assertEval("=COUNTIF(G1:G4, \">x\")", gh466Sheet, 2)
+  }
+
+  test("COUNTIF: bare <> counts non-blank cells (GH-466)") {
+    // G5 is not populated: the non-blank idiom must skip it
+    assertEval("=COUNTIF(G1:G5, \"<>\")", gh466Sheet, 4)
+  }
+
+  test("SUMIF: <>text criteria (GH-466)") {
+    assertEval("=SUMIF(G1:G4, \"<>x\", H1:H4)", gh466Sheet, 60)
+  }
+
+  test("COUNTIF: numeric <> operand unchanged by GH-466") {
+    assertEval("=COUNTIF(H1:H4, \"<>10\")", gh466Sheet, 3)
+  }
+
+  test("COUNTIF: bare equality on text unchanged by GH-466") {
+    assertEval("=COUNTIF(G1:G4, \"x\")", gh466Sheet, 2)
+    assertEval("=COUNTIF(G1:G4, \"=x\")", gh466Sheet, 2)
+  }
+
+  test("COUNTIF: <> with wildcard operand negates the pattern (GH-466)") {
+    // "<>x*" = not-like "x*": y and z match; x, x do not
+    assertEval("=COUNTIF(G1:G4, \"<>x*\")", gh466Sheet, 2)
+  }
+
   // ===== Round-trip Tests =====
 
   test("SUMIF: parse -> print -> parse roundtrip") {

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/CriteriaMatcherSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/CriteriaMatcherSpec.scala
@@ -64,9 +64,25 @@ class CriteriaMatcherSpec extends FunSuite:
     assertEquals(parseValue("<= 50"), Compare(CompareOp.Lte, BigDecimal(50)))
   }
 
-  test("parse: invalid comparison falls back to exact") {
-    assertEquals(parseValue(">abc"), exactValue(">abc"))
-    assertEquals(parseValue("<>xyz"), exactValue("<>xyz"))
+  test("parse: text operand after comparison operator (GH-466)") {
+    assertEquals(parseValue(">abc"), CompareText(CompareOp.Gt, "abc"))
+    assertEquals(parseValue(">=abc"), CompareText(CompareOp.Gte, "abc"))
+    assertEquals(parseValue("<abc"), CompareText(CompareOp.Lt, "abc"))
+    assertEquals(parseValue("<=abc"), CompareText(CompareOp.Lte, "abc"))
+    assertEquals(parseValue("<>xyz"), CompareText(CompareOp.Neq, "xyz"))
+  }
+
+  test("parse: bare <> is not-equal-to-empty, i.e. non-blank (GH-466)") {
+    assertEquals(parseValue("<>"), CompareText(CompareOp.Neq, ""))
+  }
+
+  test("parse: <> with wildcard operand negates the pattern (GH-466)") {
+    assertEquals(parseValue("<>a*"), NotWildcard("a*"))
+    assertEquals(parseValue("<>?pple"), NotWildcard("?pple"))
+  }
+
+  test("parse: <> with escaped wildcard operand is literal text (GH-466)") {
+    assertEquals(parseValue("<>test~*"), CompareText(CompareOp.Neq, "test*"))
   }
 
   test("parse: wildcard with asterisk") {
@@ -226,6 +242,61 @@ class CriteriaMatcherSpec extends FunSuite:
 
   test("matches: comparison with empty cell fails") {
     assert(!matches(CellValue.Empty, Compare(CompareOp.Gt, BigDecimal(0))))
+  }
+
+  // ===== Text Comparison Matching Tests (GH-466) =====
+
+  test("matches: <>text is case-insensitive not-equal (GH-466)") {
+    val crit = parseValue("<>x")
+    assert(!matches(CellValue.Text("x"), crit))
+    assert(!matches(CellValue.Text("X"), crit))
+    assert(matches(CellValue.Text("y"), crit))
+    // Numbers are never equal to text, so they match "<>x"
+    assert(matches(CellValue.Number(BigDecimal(5)), crit))
+    // Excel counts blank cells under "<>text" (blank is not equal to "x")
+    assert(matches(CellValue.Empty, crit))
+  }
+
+  test("matches: bare <> matches non-blank only (GH-466)") {
+    val crit = parseValue("<>")
+    assert(matches(CellValue.Text("x"), crit))
+    assert(matches(CellValue.Number(BigDecimal(0)), crit))
+    assert(matches(CellValue.Bool(false), crit))
+    assert(!matches(CellValue.Empty, crit))
+  }
+
+  test("matches: ordering operators compare text case-insensitively (GH-466)") {
+    assert(matches(CellValue.Text("x"), parseValue(">m")))
+    assert(matches(CellValue.Text("X"), parseValue(">m")))
+    assert(!matches(CellValue.Text("a"), parseValue(">m")))
+    assert(!matches(CellValue.Text("m"), parseValue(">m")))
+    assert(matches(CellValue.Text("m"), parseValue(">=m")))
+    assert(matches(CellValue.Text("M"), parseValue(">=m")))
+    assert(matches(CellValue.Text("a"), parseValue("<m")))
+    assert(!matches(CellValue.Text("x"), parseValue("<=m")))
+    assert(matches(CellValue.Text("m"), parseValue("<=m")))
+  }
+
+  test("matches: non-text values never satisfy text ordering criteria (GH-466)") {
+    val crit = parseValue(">m")
+    assert(!matches(CellValue.Number(BigDecimal(999)), crit))
+    assert(!matches(CellValue.Bool(true), crit))
+    assert(!matches(CellValue.Empty, crit))
+  }
+
+  test("matches: <> with wildcard operand is negated pattern match (GH-466)") {
+    val crit = parseValue("<>a*")
+    assert(!matches(CellValue.Text("apple"), crit))
+    assert(!matches(CellValue.Text("Apple"), crit))
+    assert(matches(CellValue.Text("banana"), crit))
+  }
+
+  test("matches: errors and uncached formulas never match text comparison (GH-466)") {
+    val crit = parseValue("<>x")
+    assert(!matches(CellValue.Error(com.tjclp.xl.cells.CellError.Value), crit))
+    assert(!matches(CellValue.Formula("=A1", None), crit))
+    assert(matches(CellValue.Formula("=A1", Some(CellValue.Text("y"))), crit))
+    assert(!matches(CellValue.Formula("=A1", Some(CellValue.Text("x"))), crit))
   }
 
   // ===== Wildcard Matching Tests =====

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/FormulaParserSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/FormulaParserSpec.scala
@@ -2010,3 +2010,34 @@ class FormulaParserSpec extends ScalaCheckSuite:
         case Left(err) => fail(s"fully parenthesized '=$source' should parse: $err")
     }
   }
+
+  test("GH-484: printFileForm emits Excel's bare-comma argument separators") {
+    FormulaParser.parse("=IF(A1,1,0)") match
+      case Right(expr) => assertEquals(FormulaPrinter.printFileForm(expr), "IF(A1,1,0)")
+      case Left(err) => fail(s"=IF(A1,1,0) should parse: $err")
+  }
+
+  test("GH-484: printFileForm joins LET bindings and nested calls with bare commas") {
+    FormulaParser.parse("=LET(x, A1, IF(x=2, 1, 0))") match
+      case Right(expr) =>
+        assertEquals(FormulaPrinter.printFileForm(expr), "LET(x,A1,IF(x=2,1,0))")
+      case Left(err) => fail(s"LET formula should parse: $err")
+  }
+
+  test("GH-484: printFileForm keeps bare commas in custom-rendered YEARFRAC") {
+    FormulaParser.parse("=YEARFRAC(A1,B1,1)") match
+      case Right(expr) => assertEquals(FormulaPrinter.printFileForm(expr), "YEARFRAC(A1,B1,1)")
+      case Left(err) => fail(s"YEARFRAC should parse: $err")
+  }
+
+  test("GH-484: printFileForm never touches commas inside string literals") {
+    FormulaParser.parse("=IF(A1,\"a, b\",0)") match
+      case Right(expr) => assertEquals(FormulaPrinter.printFileForm(expr), "IF(A1,\"a, b\",0)")
+      case Left(err) => fail(s"string-literal formula should parse: $err")
+  }
+
+  test("GH-484: default print keeps the pre-existing canonical ', ' separator") {
+    FormulaParser.parse("=IF(A1,1,0)") match
+      case Right(expr) => assertEquals(FormulaPrinter.print(expr), "=IF(A1, 1, 0)")
+      case Left(err) => fail(s"=IF(A1,1,0) should parse: $err")
+  }

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/LookupBlankDateCoercionSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/LookupBlankDateCoercionSpec.scala
@@ -1,0 +1,152 @@
+package com.tjclp.xl.formula
+
+import java.time.LocalDateTime
+
+import com.tjclp.xl.{*, given}
+import com.tjclp.xl.addressing.{ARef, SheetName}
+import com.tjclp.xl.cells.{CellError, CellValue}
+import com.tjclp.xl.sheets.Sheet
+import com.tjclp.xl.workbooks.Workbook
+import munit.FunSuite
+
+/**
+ * GH-467: MATCH/XLOOKUP lookup-plane fixes.
+ *
+ * Three sub-bugs, one comparator plane: (a) blank cells "matched" every lookup value (the old
+ * comparator returned 0 for any unhandled type pair), so MATCH over a range with blanks stopped at
+ * the first blank and every later position looked shifted; (b) date-typed lookup values (DateTime
+ * cells, DATE(...) results) hit the same fall-through and always matched position 1; (c) cell-ref
+ * lookup values arrive as ExprValue.Cell and were never dereferenced, so MATCH returned 1 and
+ * XLOOKUP returned #N/A while the equivalent literal worked.
+ */
+class LookupBlankDateCoercionSpec extends FunSuite:
+
+  private def num(i: Int): CellValue = CellValue.Number(BigDecimal(i))
+
+  private def sheetWith(cells: (ARef, CellValue)*): Sheet =
+    cells.foldLeft(new Sheet(name = SheetName.unsafe("Test"))) { case (s, (ref, value)) =>
+      s.put(ref, value)
+    }
+
+  // (a) A1:A5 = {10, _, 20, _, 30} — MATCH must index by RANGE position, blanks included
+  private val blanky = sheetWith(
+    ARef.from0(0, 0) -> num(10), // A1
+    ARef.from0(0, 2) -> num(20), // A3 (A2 blank)
+    ARef.from0(0, 4) -> num(30) // A5 (A4 blank)
+  )
+
+  test("GH-467: MATCH exact over blanks returns the range position (20 -> 3)") {
+    assertEquals(
+      blanky.evaluateFormula("=MATCH(20, A1:A5, 0)"),
+      Right(CellValue.Number(BigDecimal(3)))
+    )
+  }
+
+  test("GH-467: MATCH exact over blanks returns the range position (30 -> 5)") {
+    assertEquals(
+      blanky.evaluateFormula("=MATCH(30, A1:A5, 0)"),
+      Right(CellValue.Number(BigDecimal(5)))
+    )
+  }
+
+  test("GH-467: MATCH exact over blanks still misses cleanly (#N/A), blanks match nothing") {
+    blanky.evaluateFormula("=MATCH(25, A1:A5, 0)") match
+      case Left(error) => assert(error.toString.contains("#N/A"), s"expected #N/A, got $error")
+      case other => fail(s"Expected #N/A error, got $other")
+  }
+
+  test("GH-467: XLOOKUP exact over blanks returns the positionally aligned value") {
+    assertEquals(
+      blanky.evaluateFormula("=XLOOKUP(30, A1:A5, A1:A5)"),
+      Right(CellValue.Number(BigDecimal(30)))
+    )
+  }
+
+  // (b) date-typed lookup values: B1:B3 = 2026-02-10 / 2026-03-15 / 2026-04-20, D1 = 2026-03-15
+  private val dates = sheetWith(
+    ARef.from0(1, 0) -> CellValue.DateTime(LocalDateTime.of(2026, 2, 10, 0, 0)), // B1
+    ARef.from0(1, 1) -> CellValue.DateTime(LocalDateTime.of(2026, 3, 15, 0, 0)), // B2
+    ARef.from0(1, 2) -> CellValue.DateTime(LocalDateTime.of(2026, 4, 20, 0, 0)), // B3
+    ARef.from0(3, 0) -> CellValue.DateTime(LocalDateTime.of(2026, 3, 15, 0, 0)), // D1
+    ARef.from0(6, 0) -> num(100), // G1
+    ARef.from0(6, 1) -> num(200), // G2
+    ARef.from0(6, 2) -> num(300) // G3
+  )
+
+  test("GH-467: MATCH with a date CELL-REF lookup value finds the right position") {
+    assertEquals(
+      dates.evaluateFormula("=MATCH(D1, B1:B3, 0)"),
+      Right(CellValue.Number(BigDecimal(2)))
+    )
+  }
+
+  test("GH-467: MATCH with a DATE(...) lookup value finds the right position") {
+    assertEquals(
+      dates.evaluateFormula("=MATCH(DATE(2026,4,20), B1:B3, 0)"),
+      Right(CellValue.Number(BigDecimal(3)))
+    )
+  }
+
+  test("GH-467: XLOOKUP with a DATE(...) lookup value matches DateTime cells by serial") {
+    assertEquals(
+      dates.evaluateFormula("=XLOOKUP(DATE(2026,3,15), B1:B3, G1:G3)"),
+      Right(CellValue.Number(BigDecimal(200)))
+    )
+  }
+
+  // (c) cell-ref lookup values: E1 = "k2", F1:F3 = keys, G1:G3 = values
+  private val keyed = sheetWith(
+    ARef.from0(4, 0) -> CellValue.Text("k2"), // E1
+    ARef.from0(5, 0) -> CellValue.Text("k1"), // F1
+    ARef.from0(5, 1) -> CellValue.Text("k2"), // F2
+    ARef.from0(5, 2) -> CellValue.Text("k3"), // F3
+    ARef.from0(6, 0) -> num(100), // G1
+    ARef.from0(6, 1) -> num(200), // G2
+    ARef.from0(6, 2) -> num(300) // G3
+  )
+
+  test("GH-467: MATCH with a cell-ref lookup value matches like the literal") {
+    assertEquals(
+      keyed.evaluateFormula("=MATCH(E1, F1:F3, 0)"),
+      Right(CellValue.Number(BigDecimal(2)))
+    )
+  }
+
+  test("GH-467: XLOOKUP with a cell-ref lookup value matches like the literal") {
+    assertEquals(
+      keyed.evaluateFormula("=XLOOKUP(E1, F1:F3, G1:G3)"),
+      Right(CellValue.Number(BigDecimal(200)))
+    )
+  }
+
+  test("GH-467: XLOOKUP cell-ref lookup value across sheets (exact field repro)") {
+    val s1 = new Sheet(name = SheetName.unsafe("S1"))
+      .put(ARef.from0(4, 0), CellValue.Text("k2")) // S1!E1
+    val s2 = new Sheet(name = SheetName.unsafe("S2"))
+      .put(ARef.from0(5, 0), CellValue.Text("k1")) // S2!F1
+      .put(ARef.from0(5, 1), CellValue.Text("k2")) // S2!F2
+      .put(ARef.from0(5, 2), CellValue.Text("k3")) // S2!F3
+      .put(ARef.from0(6, 0), num(100)) // S2!G1
+      .put(ARef.from0(6, 1), num(200)) // S2!G2
+      .put(ARef.from0(6, 2), num(300)) // S2!G3
+    val wb = Workbook(s1).put(s2)
+    assertEquals(
+      wb.evaluateFormula("=XLOOKUP(E1, S2!F1:F3, S2!G1:G3)", "S1"),
+      Right(CellValue.Number(BigDecimal(200)))
+    )
+  }
+
+  test("GH-467: literal lookup values keep working (sanity)") {
+    assertEquals(
+      keyed.evaluateFormula("=MATCH(\"k2\", F1:F3, 0)"),
+      Right(CellValue.Number(BigDecimal(2)))
+    )
+    assertEquals(
+      keyed.evaluateFormula("=XLOOKUP(\"k2\", F1:F3, G1:G3)"),
+      Right(CellValue.Number(BigDecimal(200)))
+    )
+    assertEquals(
+      keyed.evaluateFormula("=XLOOKUP(\"nope\", F1:F3, G1:G3)"),
+      Right(CellValue.Error(CellError.NA))
+    )
+  }

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/StructuralBoundsSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/StructuralBoundsSpec.scala
@@ -1,0 +1,86 @@
+package com.tjclp.xl.formula
+
+import com.tjclp.xl.{*, given}
+import com.tjclp.xl.addressing.SheetName
+import com.tjclp.xl.cells.{CellValue, Comment}
+import com.tjclp.xl.error.{XLError, XLException}
+import com.tjclp.xl.sheets.Sheet
+import com.tjclp.xl.workbooks.Workbook
+import com.tjclp.xl.formula.eval.StructuralEditor
+import munit.FunSuite
+
+/**
+ * GH-472: a structural INSERT that would shift any populated position past the sheet edge (row
+ * 1048576 / column XFD) is REFUSED with a typed `XLException(XLError.OutOfBounds)` — never silently
+ * written. Ranges have clamped since GH-428; data cells, comments, row/column properties, and
+ * drawing anchors carry absolute positions and cannot clamp without destroying data, so the edit
+ * itself must be rejected (Excel refuses files with cells past the edge outright).
+ */
+class StructuralBoundsSpec extends FunSuite:
+
+  private val S = SheetName.unsafe("S")
+
+  private def sheetNamed(wb: Workbook, n: String): Sheet =
+    wb.sheets.find(_.name == SheetName.unsafe(n)).getOrElse(fail(s"missing sheet $n"))
+
+  private def outOfBounds(body: => Workbook): XLError =
+    val ex = intercept[XLException](body)
+    ex.error match
+      case e: XLError.OutOfBounds => e
+      case other => fail(s"expected XLError.OutOfBounds, got $other")
+
+  test("insertRows refuses when a populated cell would shift past row 1048576") {
+    val s = new Sheet(name = S)
+      .put(ref"A1048570", CellValue.Number(1))
+      .put(ref"B1048572", CellValue.Number(2))
+    val wb = Workbook(Vector(s))
+    val err = outOfBounds(StructuralEditor.insertRows(wb, S, at = 4, count = 20))
+    // the farthest populated row is named in the error
+    assert(err.message.contains("1048572"), err.message)
+    assert(err.message.contains("1048576"), err.message)
+  }
+
+  test("insertRows just under the cap still works (cell lands exactly on row 1048576)") {
+    val s = new Sheet(name = S).put(ref"A1048556", CellValue.Number(7))
+    val wb = StructuralEditor.insertRows(Workbook(Vector(s)), S, at = 4, count = 20)
+    val s2 = sheetNamed(wb, "S")
+    assertEquals(s2(ref"A1048576").value, CellValue.Number(7))
+    assert(!s2.contains(ref"A1048556"))
+  }
+
+  test("insertColumns refuses when a populated cell would shift past column XFD") {
+    val s = new Sheet(name = S).put(ref"XFC1", CellValue.Number(1))
+    val wb = Workbook(Vector(s))
+    val err = outOfBounds(StructuralEditor.insertColumns(wb, S, at = 2, count = 20))
+    assert(err.message.contains("XFC"), err.message)
+    assert(err.message.contains("XFD"), err.message)
+  }
+
+  test("insertColumns just under the cap still works (cell lands exactly on XFD)") {
+    val s = new Sheet(name = S).put(ref"XFC1", CellValue.Number(9))
+    val wb = StructuralEditor.insertColumns(Workbook(Vector(s)), S, at = 2, count = 1)
+    val s2 = sheetNamed(wb, "S")
+    assertEquals(s2(ref"XFD1").value, CellValue.Number(9))
+  }
+
+  test("insertRows refuses on a comment past the edge even with no cell there") {
+    val s = new Sheet(name = S)
+      .put(ref"A1", CellValue.Number(1))
+      .comment(ref"C1048572", Comment.plainText("note"))
+    val wb = Workbook(Vector(s))
+    val err = outOfBounds(StructuralEditor.insertRows(wb, S, at = 4, count = 20))
+    assert(err.message.contains("1048572"), err.message)
+  }
+
+  test("insertRows below every populated position does not refuse") {
+    val s = new Sheet(name = S).put(ref"A1048570", CellValue.Number(1))
+    // at is past the populated row: nothing shifts, nothing overflows
+    val wb = StructuralEditor.insertRows(Workbook(Vector(s)), S, at = 1048571, count = 20)
+    assertEquals(sheetNamed(wb, "S")(ref"A1048570").value, CellValue.Number(1))
+  }
+
+  test("deleteRows near the edge never refuses") {
+    val s = new Sheet(name = S).put(ref"A1048576", CellValue.Number(1))
+    val wb = StructuralEditor.deleteRows(Workbook(Vector(s)), S, at = 0, count = 5)
+    assertEquals(sheetNamed(wb, "S")(ref"A1048571").value, CellValue.Number(1))
+  }

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/StructuralDefinedNameSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/StructuralDefinedNameSpec.scala
@@ -1,0 +1,70 @@
+package com.tjclp.xl.formula
+
+import com.tjclp.xl.addressing.SheetName
+import com.tjclp.xl.formula.eval.StructuralEditor
+import com.tjclp.xl.sheets.Sheet
+import com.tjclp.xl.workbooks.{DefinedName, Workbook, WorkbookMetadata}
+import munit.FunSuite
+
+/**
+ * GH-473: structural edits rewrite general defined-name refersTo text (workbook- AND sheet-scoped)
+ * through the same shift plane as print areas / DV / tables (GH-429) — a reference targeting the
+ * edited sheet tracks the edit, a fully-deleted target degrades to "#REF!", and constants /
+ * other-sheet references ride byte-identical. A refersTo may be a top-level comma union
+ * (multi-range) the formula parser rejects; each segment shifts independently.
+ */
+class StructuralDefinedNameSpec extends FunSuite:
+
+  private val One = SheetName.unsafe("One")
+  private val Two = SheetName.unsafe("Two")
+
+  private def wbWith(names: DefinedName*): Workbook =
+    Workbook(
+      Vector(new Sheet(name = One), new Sheet(name = Two)),
+      metadata = WorkbookMetadata(definedNames = names.toVector)
+    )
+
+  private def formulas(wb: Workbook): Vector[String] =
+    wb.metadata.definedNames.map(_.formula)
+
+  test("a sheet-scoped name tracks an insert on its target sheet (the GH-473 repro)") {
+    val wb = wbWith(DefinedName("Case", "Two!$B$2", localSheetId = Some(1)))
+    val r = StructuralEditor.insertRows(wb, Two, at = 0, count = 5)
+    assertEquals(formulas(r), Vector("Two!$B$7"))
+    // scope is untouched — only the refersTo moved
+    assertEquals(r.metadata.definedNames.map(_.localSheetId), Vector(Some(1)))
+  }
+
+  test("a workbook-scoped name tracks the edit too") {
+    val wb = wbWith(DefinedName("Total", "Two!$A$1:$B$2"))
+    val r = StructuralEditor.insertRows(wb, Two, at = 0, count = 5)
+    assertEquals(formulas(r), Vector("Two!$A$6:$B$7"))
+  }
+
+  test("a name targeting an UNTOUCHED sheet rides byte-identical") {
+    val wb = wbWith(
+      DefinedName("Other", "One!$B$2"),
+      DefinedName("Rate", "0.08"),
+      DefinedName("Label", "\"two, please\"")
+    )
+    val r = StructuralEditor.insertRows(wb, Two, at = 0, count = 5)
+    assertEquals(formulas(r), Vector("One!$B$2", "0.08", "\"two, please\""))
+  }
+
+  test("deleting the rows a name points at degrades its refersTo to #REF!") {
+    val wb = wbWith(DefinedName("Case", "Two!$B$2", localSheetId = Some(1)))
+    val r = StructuralEditor.deleteRows(wb, Two, at = 1, count = 1)
+    assertEquals(formulas(r), Vector("#REF!"))
+  }
+
+  test("a multi-range refersTo shifts each top-level comma segment independently") {
+    val wb = wbWith(DefinedName("Bands", "Two!$A$1:$B$2,Two!$D$10"))
+    val r = StructuralEditor.insertRows(wb, Two, at = 0, count = 5)
+    assertEquals(formulas(r), Vector("Two!$A$6:$B$7,Two!$D$15"))
+  }
+
+  test("column edits shift names on the edited axis") {
+    val wb = wbWith(DefinedName("Case", "Two!$B$2", localSheetId = Some(1)))
+    val r = StructuralEditor.insertColumns(wb, Two, at = 0, count = 2)
+    assertEquals(formulas(r), Vector("Two!$D$2"))
+  }

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/StructuralFormulaSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/StructuralFormulaSpec.scala
@@ -225,9 +225,10 @@ class StructuralFormulaSpec extends FunSuite:
       .put(ref"G1", formulaCell("=IF(ROUND(E12-(E13+E14),0)=0,\"Yes\",\"No\")"))
     val r = StructuralEditor.insertRows(Workbook(Vector(s)), S, at = 2, count = 2)
     val s2 = sheetNamed(r, "S")
+    // GH-484: the rewrite reprints in Excel's bare-comma file form
     assertEquals(
       s2(ref"G1").value,
-      formulaCell("IF(ROUND(E14-(E15+E16), 0)=0, \"Yes\", \"No\")")
+      formulaCell("IF(ROUND(E14-(E15+E16),0)=0,\"Yes\",\"No\")")
     )
     assertEquals(
       r.evaluateFormula("=IF(ROUND(E14-(E15+E16), 0)=0, \"Yes\", \"No\")", "S"),
@@ -352,4 +353,14 @@ class StructuralFormulaSpec extends FunSuite:
       rep(ref"B2").value,
       CellValue.Formula("\"Data\"&C1", Some(CellValue.Text("Datax")))
     )
+  }
+
+  test("GH-484: structural rewrites keep Excel's bare-comma file form") {
+    val s = new Sheet(name = S)
+      .put(ref"B1", formulaCell("IF(A5=1,1,0)"))
+      .put(ref"B2", formulaCell("SUMIF(A1:A10,\">2\",C1:C10)"))
+    val r = StructuralEditor.insertRows(Workbook(Vector(s)), S, at = 2, count = 1)
+    val s2 = sheetNamed(r, "S")
+    assertEquals(s2(ref"B1").value, formulaCell("IF(A6=1,1,0)"))
+    assertEquals(s2(ref"B2").value, formulaCell("SUMIF(A1:A11,\">2\",C1:C11)"))
   }

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/XlsxReader.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/XlsxReader.scala
@@ -1492,7 +1492,9 @@ object XlsxReader:
           sheets = sheetsWithPrint,
           metadata = metadata,
           activeSheetIndex = activeSheetIndex,
-          sourceContext = ctx
+          // GH-470: snapshot the defined names exactly as assembled so the writer can detect
+          // untracked copy(metadata = ...) edits and regenerate instead of verbatim-copying.
+          sourceContext = ctx.map(_.copy(definedNamesAsRead = Some(remainingNames)))
         )
       )
 

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/XlsxWriter.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/XlsxWriter.scala
@@ -1543,7 +1543,8 @@ object XlsxWriter:
     preservedWorksheets: Map[Int, XLResult[Option[OoxmlWorksheet]]],
     preservedDxfs: Option[Elem]
   ): CfWritePlan =
-    import com.tjclp.xl.ooxml.style.DxfTable
+    import com.tjclp.xl.cf.{CfRule, ConditionalFormat}
+    import com.tjclp.xl.ooxml.style.{DxfCodec, DxfTable}
     import com.tjclp.xl.ooxml.worksheet.CfCodec
     val sourceDxfChildren: Vector[Elem] =
       preservedDxfs.map(e => XmlUtil.getChildren(e, "dxf").toVector).getOrElse(Vector.empty)
@@ -1568,11 +1569,50 @@ object XlsxWriter:
         CfCodec.collectDxfs(sheet.conditionalFormats)
       }.flatten
     val dxfPlan = DxfTable.plan(preservedDxfs, neededDxfs)
+    // GH-471: on a FRESH write (no source styles part) the dxfs table preserved rules' dxfId
+    // refs were baked against is gone — the rebuilt table would hold only the modeled dxfs and
+    // the verbatim refs (7, 9, ...) would dangle out of range. Re-register each carried <dxf>
+    // payload (dedup by payload; reuse a typed-equal planned entry) and renumber the refs at
+    // emission. With a source present the table is append-only and original ids stay valid.
+    val preservedDxfPayloads: Vector[String] =
+      if preservedDxfs.isDefined then Vector.empty
+      else
+        decisions
+          .collect { case (_, Right(sheet)) => sheet.conditionalFormats }
+          .flatten
+          .flatMap {
+            case ConditionalFormat.Rules(_, rules, _) =>
+              rules.collect { case CfRule.Preserved(_, _, Some(payload)) => payload }
+            case _: ConditionalFormat.Preserved => Vector.empty
+          }
+          .distinct
+    val (mergedDxfs, preservedDxfIds) =
+      if preservedDxfPayloads.isEmpty then (dxfPlan.merged, Map.empty[String, Int])
+      else
+        val baseChildren: Vector[Elem] =
+          dxfPlan.merged.map(e => XmlUtil.getChildren(e, "dxf").toVector).getOrElse(Vector.empty)
+        val (ids, appended) =
+          preservedDxfPayloads.foldLeft((Map.empty[String, Int], Vector.empty[Elem])) {
+            case ((acc, app), payload) =>
+              XmlSecurity.parseSafe(payload, "preserved dxf").toOption match
+                case None => (acc, app) // non-canonical payload: leave the ref untouched
+                case Some(el) =>
+                  DxfCodec.parse(el).flatMap(dxfPlan.dxfIds.get) match
+                    case Some(idx) => (acc + (payload -> idx), app)
+                    case None => (acc + (payload -> (baseChildren.size + app.size)), app :+ el)
+          }
+        val merged =
+          if appended.isEmpty then dxfPlan.merged
+          else
+            val children = baseChildren ++ appended
+            Some(XmlUtil.elem("dxfs", "count" -> children.size.toString)(children*))
+        (merged, ids)
     val condFmt: Map[Int, Seq[Elem]] = decisions.map {
       case (idx, Left(verbatim)) => idx -> verbatim
-      case (idx, Right(sheet)) => idx -> CfCodec.toElems(sheet.conditionalFormats, dxfPlan.dxfIds)
+      case (idx, Right(sheet)) =>
+        idx -> CfCodec.toElems(sheet.conditionalFormats, dxfPlan.dxfIds, preservedDxfIds)
     }.toMap
-    CfWritePlan(condFmt, dxfPlan.merged)
+    CfWritePlan(condFmt, mergedDxfs)
 
   /**
    * Pre-pass for the data-validation slot (GH-375, the planCfWrites contract): per regenerated

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/XlsxWriter.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/XlsxWriter.scala
@@ -107,7 +107,14 @@ object XlsxWriter:
     try
       val escapeFormulas = formulaEscapingRequested(config)
       // GH-243: serialize DateTime cells with the workbook's date system before any write path.
-      val normalized = withDates1904Normalized(workbook)
+      val dated = withDates1904Normalized(workbook)
+      // GH-470: reconcile untracked structural edits (copy(sheets = ...) reductions/additions,
+      // copy(metadata = ...) defined-name drift) into the context BEFORE strategy dispatch — a
+      // clean-looking context would otherwise verbatim-copy the SOURCE structure, shipping
+      // sheets the caller removed and dropping sheets the caller appended.
+      val normalized = dated.sourceContext match
+        case Some(ctx) => dated.copy(sourceContext = Some(ctx.reconciledWith(dated)))
+        case None => dated
 
       normalized.sourceContext match
         case Some(ctx) if ctx.isClean && !escapeFormulas =>

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/style/StyleIndex.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/style/StyleIndex.scala
@@ -159,12 +159,35 @@ object StyleIndex:
       }
     }
 
+    // GH-471: a fresh write rebuilds the numFmt registry at 164+, but styles read from a source
+    // carry the SOURCE ids in CellStyle.numFmtId — and the serializers prefer the raw id over a
+    // code lookup. Re-map every cellXf numFmt reference through the rebuilt registry (keyed by
+    // format CODE): custom codes point at the rebuilt declaration; a raw id survives only when
+    // it is a genuine built-in (< NumFmt.FirstCustomId, undeclared by definition). Without this,
+    // non-contiguous source ids (194, 300, 407) ship undeclared and cells silently change
+    // display format. canonicalKey excludes numFmtId, so unifiedIndex stays valid as-is.
+    val customIdByCode: Map[String, Int] = customNumFmts.collect { case (id, NumFmt.Custom(code)) =>
+      code -> id
+    }.toMap
+    val remappedStyles = unifiedStyles.map { style =>
+      style.numFmt match
+        case NumFmt.Custom(code) =>
+          val rebuiltId = customIdByCode.get(code)
+          if style.numFmtId == rebuiltId then style else style.copy(numFmtId = rebuiltId)
+        case fmt =>
+          // A raw id in the custom range with a built-in semantic type (only constructible via
+          // withNumFmtId) would dangle in the rebuilt table — fall back to the built-in id.
+          if style.numFmtId.exists(_ >= NumFmt.FirstCustomId) then
+            style.copy(numFmtId = NumFmt.builtInId(fmt))
+          else style
+    }
+
     val styleIndex = StyleIndex(
       uniqueFonts,
       uniqueFills,
       uniqueBorders,
       customNumFmts,
-      unifiedStyles,
+      remappedStyles,
       unifiedIndex
     )
 

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/CfCodec.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/worksheet/CfCodec.scala
@@ -146,7 +146,21 @@ object CfCodec:
           parsed <- parseFamily(rule, typeToken, attrs, children, priority, ranges, dxfs)
         yield parsed
     }
-    typed.getOrElse(CfRule.Preserved(preservedXml(rule, blockScope), parsedPriority))
+    typed.getOrElse(
+      CfRule.Preserved(preservedXml(rule, blockScope), parsedPriority, preservedDxf(rule, dxfs))
+    )
+
+  /**
+   * The raw `<dxf>` an unmodeled rule's dxfId references, captured scope-self-contained (GH-471) so
+   * a fresh write can re-register it after the source dxfs table is gone. None when the rule has no
+   * dxfId or the ref is out of range (a dangling source ref cannot be resurrected).
+   */
+  private def preservedDxf(rule: Elem, dxfs: Vector[Elem]): Option[String] =
+    rule
+      .attribute("dxfId")
+      .flatMap(_.text.toIntOption)
+      .flatMap(dxfs.lift)
+      .map(d => XmlUtil.compact(rebindUsedNamespaces(d, includeDefault = true)))
 
   private def parseStopIfTrue(attrs: Map[String, String]): Option[Boolean] =
     attrs.get("stopIfTrue") match
@@ -344,8 +358,16 @@ object CfCodec:
    * `priority <= 0` (direct construction bypassing `Sheet.conditionalFormat`) is assigned
    * `max+1, +2, ...` in document order, saturating at `Int.MaxValue` (never a schema-invalid
    * negative); explicit and Preserved priorities are NEVER renumbered.
+   *
+   * `preservedDxfIds` (GH-471, fresh writes only) maps a Preserved rule's carried `<dxf>` payload
+   * to its index in the REBUILT dxfs table; a hit renumbers the re-emitted rule's dxfId attribute.
+   * Surgical writes pass the default empty map — preserved payloads stay verbatim.
    */
-  def toElems(cfs: Vector[ConditionalFormat], dxfIds: Map[Dxf, Int]): Seq[Elem] =
+  def toElems(
+    cfs: Vector[ConditionalFormat],
+    dxfIds: Map[Dxf, Int],
+    preservedDxfIds: Map[String, Int] = Map.empty
+  ): Seq[Elem] =
     val maxExisting = Sheet.maxCfPriority(cfs)
     val (stamped, _) = cfs.foldLeft((Vector.empty[ConditionalFormat], maxExisting)) {
       case ((acc, cur), ConditionalFormat.Rules(ranges, rules, pivot)) =>
@@ -361,7 +383,7 @@ object CfCodec:
     }
     stamped.flatMap {
       case ConditionalFormat.Rules(ranges, rules, pivot) if ranges.nonEmpty && rules.nonEmpty =>
-        val ruleElems = rules.flatMap(ruleToElem(_, ranges, dxfIds))
+        val ruleElems = rules.flatMap(ruleToElem(_, ranges, dxfIds, preservedDxfIds))
         Option.when(ruleElems.nonEmpty) {
           val attrs =
             (if pivot then Seq("pivot" -> "1") else Seq.empty) :+
@@ -384,7 +406,8 @@ object CfCodec:
   private def ruleToElem(
     rule: CfRule,
     ranges: Vector[CellRange],
-    dxfIds: Map[Dxf, Int]
+    dxfIds: Map[Dxf, Int],
+    preservedDxfIds: Map[String, Int]
   ): Option[Elem] =
     def dxfAttr(dxf: Option[Dxf]): Seq[(String, String)] =
       dxf.flatMap(dxfIds.get).map(id => "dxfId" -> id.toString).toList
@@ -435,7 +458,15 @@ object CfCodec:
           elemOrdered("cfRule", attrs*)(formulaElem(formula))
         }
 
-      case CfRule.Preserved(xml, _) => parsePreserved(xml)
+      // GH-471: on a fresh write the carried dxf payload has been re-registered into the
+      // rebuilt table — renumber the verbatim payload's dxfId to the new index. Surgical
+      // writes pass an empty map, so the payload rides through untouched.
+      case CfRule.Preserved(xml, _, dxfPayload) =>
+        parsePreserved(xml).map { e =>
+          dxfPayload.flatMap(preservedDxfIds.get) match
+            case Some(id) => e % new UnprefixedAttribute("dxfId", id.toString, Null)
+            case None => e
+        }
 
   private def cfvoToXml(cfvo: Cfvo): Elem = cfvo match
     case Cfvo.Min => elemOrdered("cfvo", "type" -> "min")()

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/CfPreservationSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/CfPreservationSpec.scala
@@ -151,7 +151,7 @@ class CfPreservationSpec extends FunSuite:
             )
           case ConditionalFormat.Rules(_, rules, _) =>
             rules.foreach {
-              case CfRule.Preserved(xml, _) =>
+              case CfRule.Preserved(xml, _, _) =>
                 assert(
                   XmlSecurity.parseSafe(xml, s"$name rule Preserved").isRight,
                   s"$name: rule-level Preserved payload is not self-contained XML:\n$xml"

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/FreshWriteStylePlaneSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/FreshWriteStylePlaneSpec.scala
@@ -1,0 +1,294 @@
+package com.tjclp.xl.ooxml
+
+import java.io.ByteArrayOutputStream
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path}
+import java.util.zip.{ZipEntry, ZipFile, ZipOutputStream}
+
+import munit.FunSuite
+import com.tjclp.xl.api.*
+import com.tjclp.xl.cf.{CfRule, ConditionalFormat}
+import com.tjclp.xl.macros.ref
+import com.tjclp.xl.styles.numfmt.NumFmt
+
+/**
+ * GH-471: fresh write after read (`copy(sourceContext = None)`) must re-register the style plane.
+ *
+ *   - (a) numFmt cross-wire: the source declares custom formats at non-contiguous ids (194, 300,
+ *     407); the fresh write renumbers `<numFmts>` to 164+ so every `<xf>` numFmtId must be
+ *     re-mapped through the rebuilt registry (keyed by format CODE) — keeping the SOURCE ids
+ *     silently changes cell display formats.
+ *   - (b) dxfs under-registration: `CfRule.Preserved` payloads carry source dxfId refs (7, 9) but
+ *     the fresh write emits only the modeled dxfs — the referenced `<dxf>` payloads must be carried
+ *     into the rebuilt table and the refs renumbered, or the shipped file has out-of-range dxfIds.
+ */
+// Test code uses .get/.head for brevity in assertions
+@SuppressWarnings(Array("org.wartremover.warts.OptionPartial", "org.wartremover.warts.IterableOps"))
+class FreshWriteStylePlaneSpec extends FunSuite:
+
+  private val nsMain = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+
+  private val contentTypesXml =
+    """<?xml version="1.0" encoding="UTF-8"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+  <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+  <Override PartName="/xl/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"/>
+</Types>"""
+
+  private val rootRelationshipsXml =
+    """<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>"""
+
+  private val workbookRelationshipsXml =
+    """<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+  <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/>
+</Relationships>"""
+
+  private val workbookXml =
+    s"""<?xml version="1.0" encoding="UTF-8"?>
+<workbook xmlns="$nsMain"
+          xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <sheets>
+    <sheet name="Sheet1" sheetId="1" r:id="rId1"/>
+  </sheets>
+</workbook>"""
+
+  private def buildXlsx(stylesXml: String, worksheetXml: String): Array[Byte] =
+    val parts = Vector(
+      "[Content_Types].xml" -> contentTypesXml,
+      "_rels/.rels" -> rootRelationshipsXml,
+      "xl/workbook.xml" -> workbookXml,
+      "xl/_rels/workbook.xml.rels" -> workbookRelationshipsXml,
+      "xl/styles.xml" -> stylesXml,
+      "xl/worksheets/sheet1.xml" -> worksheetXml
+    )
+    val baos = new ByteArrayOutputStream()
+    val zipOut = new ZipOutputStream(baos)
+    parts.foreach { case (name, text) =>
+      zipOut.putNextEntry(new ZipEntry(name))
+      zipOut.write(text.getBytes(StandardCharsets.UTF_8))
+      zipOut.closeEntry()
+    }
+    zipOut.close()
+    baos.toByteArray
+
+  private def readBytes(bytes: Array[Byte]): Workbook =
+    XlsxReader
+      .readFromBytes(bytes)
+      .fold(err => fail(s"fixture failed to read: ${err.message}"), identity)
+
+  private def writeFresh(wb: Workbook, label: String): Path =
+    val out = Files.createTempFile(s"xl-gh471-$label-", ".xlsx")
+    out.toFile.deleteOnExit()
+    XlsxWriter
+      .write(wb.copy(sourceContext = None), out)
+      .fold(err => fail(s"fresh write failed: ${err.message}"), _ => ())
+    out
+
+  private def entryText(path: Path, name: String): String =
+    val zip = new ZipFile(path.toFile)
+    try
+      Option(zip.getEntry(name)) match
+        case Some(e) =>
+          new String(zip.getInputStream(e).readAllBytes(), StandardCharsets.UTF_8)
+        case None => fail(s"zip entry $name not found in $path")
+    finally zip.close()
+
+  private def parseEntry(path: Path, name: String): scala.xml.Elem =
+    XmlSecurity.parseSafe(entryText(path, name), name).fold(e => fail(e.message), identity)
+
+  private def reread(path: Path): Workbook =
+    XlsxReader.read(path).fold(err => fail(s"re-read failed: ${err.message}"), identity)
+
+  private def styleOf(sheet: Sheet, r: com.tjclp.xl.addressing.ARef): CellStyle =
+    sheet.cells
+      .get(r)
+      .flatMap(_.styleId)
+      .flatMap(sheet.styleRegistry.get)
+      .getOrElse(fail(s"no style on ${r.toA1}"))
+
+  // ===== (a) numFmt cross-wire =====
+
+  private val fyCode = "\"FY\"0\"A\"_)"
+  private val multCode = "0.0\"x\""
+  private val bpsCode = "0.000\"y\""
+
+  private val numFmtStylesXml =
+    s"""<?xml version="1.0" encoding="UTF-8"?>
+<styleSheet xmlns="$nsMain">
+  <numFmts count="3">
+    <numFmt numFmtId="194" formatCode="&quot;FY&quot;0&quot;A&quot;_)"/>
+    <numFmt numFmtId="300" formatCode="0.0&quot;x&quot;"/>
+    <numFmt numFmtId="407" formatCode="0.000&quot;y&quot;"/>
+  </numFmts>
+  <fonts count="1"><font><sz val="11"/><name val="Calibri"/></font></fonts>
+  <fills count="2"><fill><patternFill patternType="none"/></fill><fill><patternFill patternType="gray125"/></fill></fills>
+  <borders count="1"><border/></borders>
+  <cellStyleXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0"/></cellStyleXfs>
+  <cellXfs count="5">
+    <xf numFmtId="0" fontId="0" fillId="0" borderId="0"/>
+    <xf numFmtId="194" fontId="0" fillId="0" borderId="0"/>
+    <xf numFmtId="300" fontId="0" fillId="0" borderId="0"/>
+    <xf numFmtId="407" fontId="0" fillId="0" borderId="0"/>
+    <xf numFmtId="15" fontId="0" fillId="0" borderId="0"/>
+  </cellXfs>
+  <cellStyles count="1"><cellStyle name="Normal" xfId="0" builtinId="0"/></cellStyles>
+</styleSheet>"""
+
+  private val numFmtWorksheetXml =
+    s"""<?xml version="1.0" encoding="UTF-8"?>
+<worksheet xmlns="$nsMain">
+  <sheetData>
+    <row r="1">
+      <c r="A1" s="1"><v>2026</v></c>
+      <c r="B1" s="2"><v>2.5</v></c>
+      <c r="C1" s="3"><v>0.125</v></c>
+      <c r="D1" s="4"><v>45000</v></c>
+    </row>
+  </sheetData>
+</worksheet>"""
+
+  test("fresh write re-maps cellXf numFmtIds through the rebuilt registry (GH-471a)") {
+    val wb = readBytes(buildXlsx(numFmtStylesXml, numFmtWorksheetXml))
+    val sheet = wb.sheets(0)
+    // Sanity: source ids and codes arrive intact
+    assertEquals(styleOf(sheet, ref"A1").numFmt, NumFmt.Custom(fyCode))
+    assertEquals(styleOf(sheet, ref"A1").numFmtId, Some(194))
+    assertEquals(styleOf(sheet, ref"C1").numFmtId, Some(407))
+
+    val out = writeFresh(wb, "numfmt")
+
+    // Structural invariant: every custom-range numFmtId referenced by cellXfs is DECLARED
+    val styles = parseEntry(out, "xl/styles.xml")
+    val declared: Map[Int, String] = (styles \ "numFmts" \ "numFmt").collect {
+      case e: scala.xml.Elem =>
+        e.attribute("numFmtId").get.text.toInt -> e.attribute("formatCode").get.text
+    }.toMap
+    val referenced: Vector[Int] = (styles \ "cellXfs" \ "xf").toVector
+      .flatMap(_.attribute("numFmtId"))
+      .map(_.text.toInt)
+    referenced.filter(_ >= NumFmt.FirstCustomId).foreach { id =>
+      assert(
+        declared.contains(id),
+        s"cellXf references numFmtId $id but <numFmts> declares only ${declared.keySet}"
+      )
+    }
+    // The three custom codes survive with resolvable ids
+    assertEquals(declared.values.toSet, Set(fyCode, multCode, bpsCode))
+    // The raw built-in id 15 (a d-mmm-yy Date variant) is NOT remapped away
+    assert(referenced.contains(15), s"built-in numFmtId 15 lost: $referenced")
+
+    // Behavioral proof: reopened formats resolve to the source codes
+    val sheet2 = reread(out).sheets(0)
+    assertEquals(styleOf(sheet2, ref"A1").numFmt, NumFmt.Custom(fyCode))
+    assertEquals(styleOf(sheet2, ref"B1").numFmt, NumFmt.Custom(multCode))
+    assertEquals(styleOf(sheet2, ref"C1").numFmt, NumFmt.Custom(bpsCode))
+    assertEquals(styleOf(sheet2, ref"D1").numFmt, NumFmt.Date)
+  }
+
+  // ===== (b) dxfs under-registration =====
+
+  private val dxfStylesXml =
+    s"""<?xml version="1.0" encoding="UTF-8"?>
+<styleSheet xmlns="$nsMain">
+  <fonts count="1"><font><sz val="11"/><name val="Calibri"/></font></fonts>
+  <fills count="2"><fill><patternFill patternType="none"/></fill><fill><patternFill patternType="gray125"/></fill></fills>
+  <borders count="1"><border/></borders>
+  <cellStyleXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0"/></cellStyleXfs>
+  <cellXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0"/></cellXfs>
+  <cellStyles count="1"><cellStyle name="Normal" xfId="0" builtinId="0"/></cellStyles>
+  <dxfs count="10">
+    <dxf/><dxf/><dxf/><dxf/><dxf/>
+    <dxf><font><color rgb="FFFF0000"/></font></dxf>
+    <dxf/>
+    <dxf><font><b/></font><alignment horizontal="center"/></dxf>
+    <dxf/>
+    <dxf><fill><patternFill><bgColor rgb="FF123456"/></patternFill></fill></dxf>
+  </dxfs>
+</styleSheet>"""
+
+  private val dxfWorksheetXml =
+    s"""<?xml version="1.0" encoding="UTF-8"?>
+<worksheet xmlns="$nsMain">
+  <sheetData>
+    <row r="1"><c r="A1"><v>1</v></c></row>
+    <row r="2"><c r="A2"><v>2</v></c></row>
+    <row r="3"><c r="A3"><v>3</v></c></row>
+    <row r="4"><c r="A4"><v>4</v></c></row>
+  </sheetData>
+  <conditionalFormatting sqref="A1:A4">
+    <cfRule type="expression" dxfId="5" priority="1"><formula>$$A1&gt;0</formula></cfRule>
+    <cfRule type="cellIs" dxfId="7" priority="2" operator="greaterThan"><formula>1</formula></cfRule>
+    <cfRule type="aboveAverage" dxfId="9" priority="3"/>
+  </conditionalFormatting>
+</worksheet>"""
+
+  test("fresh write re-registers preserved CF rules' dxfs and renumbers dxfId refs (GH-471b)") {
+    val wb = readBytes(buildXlsx(dxfStylesXml, dxfWorksheetXml))
+    val rules = wb
+      .sheets(0)
+      .conditionalFormats
+      .collect { case ConditionalFormat.Rules(_, rs, _) =>
+        rs
+      }
+      .flatten
+    // Sanity: the pinned typed/Preserved split — expression typed with its dxf,
+    // cellIs (untypeable dxf: alignment) and aboveAverage (unmodeled type) ride Preserved
+    assertEquals(rules.count(_.isInstanceOf[CfRule.Expression]), 1)
+    assertEquals(rules.count(_.isInstanceOf[CfRule.Preserved]), 2)
+    assert(rules.collect { case CfRule.Expression(_, dxf, _, _) => dxf }.head.isDefined)
+
+    val out = writeFresh(wb, "dxfs")
+
+    val styles = parseEntry(out, "xl/styles.xml")
+    val dxfChildren: Vector[scala.xml.Elem] =
+      (styles \ "dxfs" \ "dxf").collect { case e: scala.xml.Elem => e }.toVector
+    val declaredCount = (styles \ "dxfs").headOption
+      .flatMap(_.attribute("count"))
+      .map(_.text.toInt)
+      .getOrElse(0)
+    assertEquals(declaredCount, dxfChildren.size)
+
+    val sheetXml = parseEntry(out, "xl/worksheets/sheet1.xml")
+    val cfRules = (sheetXml \ "conditionalFormatting" \ "cfRule").collect {
+      case e: scala.xml.Elem => e
+    }.toVector
+    assertEquals(cfRules.size, 3)
+    val refs: Map[String, Int] = cfRules.flatMap { r =>
+      val tpe = r.attribute("type").map(_.text).getOrElse("")
+      r.attribute("dxfId").map(a => tpe -> a.text.toInt)
+    }.toMap
+
+    // Every shipped dxfId ref resolves into the shipped table
+    refs.foreach { case (tpe, id) =>
+      assert(
+        id >= 0 && id < dxfChildren.size,
+        s"cfRule type=$tpe references dxfId $id but <dxfs> has ${dxfChildren.size} entries"
+      )
+    }
+    // ... and points at the SOURCE dxf content it referenced
+    val cellIsDxf = dxfChildren(refs("cellIs")).toString
+    assert(cellIsDxf.contains("alignment"), s"cellIs dxf content lost: $cellIsDxf")
+    val aboveAvgDxf = dxfChildren(refs("aboveAverage")).toString
+    assert(aboveAvgDxf.contains("FF123456"), s"aboveAverage dxf content lost: $aboveAvgDxf")
+
+    // Behavioral proof: reopened, the preserved rules' dxf refs still resolve (the cellIs rule
+    // still rides Preserved — its dxf stays untypeable — but its ref is now in range) and the
+    // typed expression rule keeps its dxf
+    val rules2 = reread(out)
+      .sheets(0)
+      .conditionalFormats
+      .collect { case ConditionalFormat.Rules(_, rs, _) =>
+        rs
+      }
+      .flatten
+    assert(rules2.collect { case CfRule.Expression(_, dxf, _, _) => dxf }.head.isDefined)
+    assertEquals(rules2.count(_.isInstanceOf[CfRule.Preserved]), 2)
+  }

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/SheetSetReconcileSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/SheetSetReconcileSpec.scala
@@ -1,0 +1,222 @@
+package com.tjclp.xl.ooxml
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path}
+import java.util.zip.ZipFile
+import scala.jdk.CollectionConverters.*
+
+import munit.FunSuite
+
+import com.tjclp.xl.addressing.SheetName
+import com.tjclp.xl.api.*
+import com.tjclp.xl.cells.{Cell, CellValue}
+import com.tjclp.xl.macros.ref
+
+/**
+ * GH-470: `copy(sheets = ...)` reductions were silently IGNORED by the preservation write — a
+ * clean-looking SourceContext verbatim-copied (or surgically re-emitted) the SOURCE structure, so a
+ * "redacted" workbook built by filtering `sheets` shipped the sheet the caller believes was removed
+ * (a confidentiality hazard, not just a correctness bug). Same story for defined names dropped via
+ * `copy(metadata = ...)` and for sheets APPENDED via `copy(sheets = ...)` (silently lost).
+ *
+ * The fix dirty-tracks the sheet set and the defined-name set at write time: the writer reconciles
+ * the context against the model before strategy dispatch, routing untracked removals through the
+ * same marking `Workbook.remove` uses (tracker deletion + identity-mapping drops, so GH-417 orphan
+ * pruning engages) and forcing metadata regeneration for untracked additions / defined-name drift.
+ */
+class SheetSetReconcileSpec extends FunSuite:
+
+  private def name(s: String): SheetName = SheetName.unsafe(s)
+
+  private def write(wb: Workbook, label: String): Path =
+    val out = Files.createTempFile(s"xl-470-$label-", ".xlsx")
+    out.toFile.deleteOnExit()
+    XlsxWriter.write(wb, out).fold(err => fail(s"$label write failed: ${err.message}"), identity)
+    out
+
+  private def read(path: Path): Workbook =
+    XlsxReader.read(path).fold(err => fail(s"read failed: ${err.message}"), identity)
+
+  private def entryNames(path: Path): Set[String] =
+    val zip = new ZipFile(path.toFile)
+    try zip.entries().asScala.map(_.getName).toSet
+    finally zip.close()
+
+  private def entryText(path: Path, entry: String): String =
+    val zip = new ZipFile(path.toFile)
+    try
+      Option(zip.getEntry(entry)) match
+        case Some(e) =>
+          new String(zip.getInputStream(e).readAllBytes(), StandardCharsets.UTF_8)
+        case None => fail(s"zip entry $entry not found in $path (have ${entryNames(path)})")
+    finally zip.close()
+
+  /** Three-sheet fixture with distinct text markers, written then re-read (context present). */
+  private def threeSheetSource(label: String): Path =
+    val wb = Workbook(
+      Vector(
+        Sheet(name("One")).put(Cell(ref"A1", CellValue.Text("one-marker"))),
+        Sheet(name("Two")).put(Cell(ref"A1", CellValue.Text("two-marker"))),
+        Sheet(name("Three")).put(Cell(ref"A1", CellValue.Text("three-marker")))
+      )
+    )
+    write(wb, s"$label-src")
+
+  test("GH-470: clean context + copy(sheets = take(2)) must NOT ship the third sheet (c036)") {
+    val loaded = read(threeSheetSource("clean"))
+    assert(loaded.sourceContext.exists(_.isClean), "fixture must start clean")
+
+    val reduced = loaded.copy(sheets = loaded.sheets.take(2))
+    val out = write(reduced, "clean-reduced")
+
+    assertEquals(read(out).sheetNames.map(_.value), Vector("One", "Two"))
+    val wbXml = entryText(out, "xl/workbook.xml")
+    assert(!wbXml.contains("name=\"Three\""), s"'removed' sheet leaked into workbook.xml: $wbXml")
+    val worksheetParts =
+      entryNames(out).filter(n => n.startsWith("xl/worksheets/") && !n.contains("_rels"))
+    assertEquals(
+      worksheetParts,
+      Set("xl/worksheets/sheet1.xml", "xl/worksheets/sheet2.xml"),
+      "the removed sheet's part must not ride the preservation write"
+    )
+  }
+
+  test("GH-470: dirty (surgical) write of a copy-reduced workbook drops the sheet too") {
+    val loaded = read(threeSheetSource("dirty"))
+    val first = loaded.sheets.headOption.getOrElse(fail("no sheet"))
+    val edited = loaded.put(first.put(ref"B1", CellValue.Text("edited")))
+    val reduced = edited.copy(sheets = edited.sheets.take(2))
+
+    val out = write(reduced, "dirty-reduced")
+
+    val result = read(out)
+    assertEquals(result.sheetNames.map(_.value), Vector("One", "Two"))
+    assertEquals(
+      result.sheets.headOption.map(_(ref"B1").value),
+      Some(CellValue.Text("edited")),
+      "the tracked edit must survive reconciliation of the untracked reduction"
+    )
+    assert(!entryText(out, "xl/workbook.xml").contains("name=\"Three\""))
+  }
+
+  test("GH-470: copy-reduction writes the same package structure as remove()") {
+    val src = threeSheetSource("parity")
+
+    val viaRemove = read(src).remove(name("Three")).fold(e => fail(e.message), identity)
+    val viaCopy = read(src).copy(sheets = read(src).sheets.take(2))
+
+    val removeOut = write(viaRemove, "parity-remove")
+    val copyOut = write(viaCopy, "parity-copy")
+
+    assertEquals(entryNames(copyOut), entryNames(removeOut))
+    assertEquals(
+      entryText(copyOut, "xl/workbook.xml"),
+      entryText(removeOut, "xl/workbook.xml"),
+      "the sanctioned remove() and the reconciled copy-reduction must agree on workbook.xml"
+    )
+  }
+
+  test("GH-470: an edit to a SURVIVING sheet made after the reduction is not lost") {
+    // The untracked removal must not shift live modified-sheet marks: drop the FIRST sheet, then
+    // edit the (new) first sheet — its strings must land in the output despite the ghost of "One"
+    // reconciling at source index 0.
+    val loaded = read(threeSheetSource("shift"))
+    val reduced = loaded.copy(sheets = loaded.sheets.drop(1))
+    val second = reduced.sheets.headOption.getOrElse(fail("no sheet"))
+    val edited = reduced.put(second.put(ref"C1", CellValue.Text("fresh-string")))
+
+    val out = write(edited, "shift-out")
+
+    val result = read(out)
+    assertEquals(result.sheetNames.map(_.value), Vector("Two", "Three"))
+    assertEquals(
+      result.sheets.headOption.map(_(ref"C1").value),
+      Some(CellValue.Text("fresh-string"))
+    )
+  }
+
+  test("GH-470: defined names dropped via copy(metadata = ...) must not ship") {
+    val src = write(
+      Workbook(Sheet(name("One")).put(Cell(ref"A1", CellValue.Number(BigDecimal(1)))))
+        .withDefinedName("SECRET_RATE", "One!$A$1"),
+      "dn-src"
+    )
+    val loaded = read(src)
+    assert(
+      loaded.metadata.definedNames.exists(_.name == "SECRET_RATE"),
+      s"fixture must carry the name: ${loaded.metadata.definedNames}"
+    )
+    assert(loaded.sourceContext.exists(_.isClean), "fixture must start clean")
+
+    val redacted = loaded.copy(metadata = loaded.metadata.copy(definedNames = Vector.empty))
+    val out = write(redacted, "dn-out")
+
+    assert(
+      !entryText(out, "xl/workbook.xml").contains("SECRET_RATE"),
+      "the 'removed' defined name leaked into workbook.xml"
+    )
+    assertEquals(read(out).metadata.definedNames, Vector.empty)
+  }
+
+  test("GH-470: a sheet APPENDED via copy(sheets = ...) ships instead of silently vanishing") {
+    val loaded = read(threeSheetSource("append"))
+    val appended = loaded.copy(
+      sheets = loaded.sheets :+ Sheet(name("Appended"))
+        .put(Cell(ref"A1", CellValue.Text("appended-marker")))
+    )
+
+    val out = write(appended, "append-out")
+
+    val result = read(out)
+    assertEquals(result.sheetNames.map(_.value), Vector("One", "Two", "Three", "Appended"))
+    assertEquals(
+      result.sheets.lastOption.map(_(ref"A1").value),
+      Some(CellValue.Text("appended-marker"))
+    )
+  }
+
+  test("GH-470: untracked reduction prunes the removed sheet's chart/drawing chain (GH-417)") {
+    val charts = name("Charts")
+    val chartSheet = Sheet(charts)
+      .put(Cell(ref"A2", CellValue.Text("a")))
+      .put(Cell(ref"A3", CellValue.Text("b")))
+      .put(Cell(ref"B2", CellValue.Number(BigDecimal(3))))
+      .put(Cell(ref"B3", CellValue.Number(BigDecimal(4))))
+    val chart = Chart
+      .bar(
+        Vector(Series(DataRef(charts, ref"B2:B3"), Some(DataRef(charts, ref"A2:A3")), None)),
+        title = Some("Orphan Me")
+      )
+      .fold(e => fail(s"chart build failed: $e"), identity)
+    val wb = Workbook(
+      Vector(
+        Sheet(name("Data")).put(Cell(ref"A1", CellValue.Text("keep"))),
+        chartSheet.addChart(chart, ref"D2:K15")
+      )
+    )
+    val src = write(wb, "chart-src")
+    assert(entryNames(src).contains("xl/charts/chart1.xml"), s"fixture: ${entryNames(src)}")
+
+    val loaded = read(src)
+    val reduced = loaded.copy(sheets = loaded.sheets.filterNot(_.name == charts))
+    val out = write(reduced, "chart-out")
+
+    val names = entryNames(out)
+    assertEquals(
+      names.filter(n => n.startsWith("xl/charts/") || n.startsWith("xl/drawings/")),
+      Set.empty[String],
+      s"the chart chain must fall with its copy-removed sheet: ${names.toVector.sorted}"
+    )
+    assertEquals(read(out).sheetNames.map(_.value), Vector("Data"))
+  }
+
+  test("GH-470: a genuinely untouched workbook still takes the verbatim fast path") {
+    val src = threeSheetSource("verbatim")
+    val loaded = read(src)
+    val out = write(loaded, "verbatim-out")
+    assertEquals(
+      Files.readAllBytes(out).toVector,
+      Files.readAllBytes(src).toVector,
+      "reconciliation must return the context unchanged when nothing diverged"
+    )
+  }

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/worksheet/CfCodecSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/worksheet/CfCodecSpec.scala
@@ -231,7 +231,7 @@ class CfCodecSpec extends ScalaCheckSuite:
       """<conditionalFormatting sqref="A1:A5"><cfRule type="iconSet" priority="4"><iconSet iconSet="3Arrows"><cfvo type="percent" val="0"/><cfvo type="percent" val="33"/><cfvo type="percent" val="67"/></iconSet></cfRule></conditionalFormatting>"""
     )
     rulesOf(cf) match
-      case Vector(CfRule.Preserved(xmlStr, priority)) =>
+      case Vector(CfRule.Preserved(xmlStr, priority, _)) =>
         assertEquals(priority, Some(4))
         assert(xmlStr.contains("3Arrows"), xmlStr)
       case other => fail(s"expected Preserved iconSet, got $other")
@@ -353,7 +353,7 @@ class CfCodecSpec extends ScalaCheckSuite:
     // what WorksheetReader does before CfCodec ever sees the block
     val block = rebindUsedNamespaces(xml(raw))
     CfCodec.parseAll(Seq(block), Vector.empty) match
-      case Vector(ConditionalFormat.Rules(_, Vector(CfRule.Preserved(payload, Some(5))), _)) =>
+      case Vector(ConditionalFormat.Rules(_, Vector(CfRule.Preserved(payload, Some(5), _)), _)) =>
         assert(
           payload.contains("xmlns:x14="),
           s"x14 binding must travel with the fragment:\n$payload"


### PR DESCRIPTION
Second half of the 2026-08-04 field-QC burn-down (first half: #478). All eight issues carry probe evidence from real banker books; every fix landed red-first TDD in an isolated worktree, then integrated conflict-free. Full suite: **1028/1028**.

Closes #466
Closes #467
Closes #470
Closes #471
Closes #472
Closes #473
Closes #483
Closes #484

| Issue | Fix |
|---|---|
| #466 criteria text operands | `CriteriaMatcher` gains `CompareText` (case-insensitive ordering, type-segregated per Excel) + `NotWildcard` (`"<>A*"`); bare `"<>"` = non-blank falls out naturally; blanks match `"<>x"` per Excel. Old fallback pinned by a test — replaced. |
| #467 lookup comparator | Root cause: `compareCellValues` returned 0 for ANY unhandled pair (blanks "equalled" everything — positions only *looked* compacted). Shared `normalizeLookupValue`/`matchesLookupExact` in `FunctionSpecsBase` (deref `ExprValue.Cell`, DateTime→serial per #449); MATCH + XLOOKUP route through them; approximate modes stop coercing blanks/text to 0. |
| #470 preservation sheet-set | `SourceContext.reconciledWith(workbook)` before strategy dispatch: `copy(sheets = …)` reductions now mark deletions exactly like `wb.remove()` (mapping drop + tracker), riding the #417 orphan pruning; defined-name set reconciled too. HONOR contract — never silently re-emit. |
| #471 fresh-write style plane | `StyleIndex.fromWorkbookWithoutSource` re-maps every cellXf `numFmtId` through the rebuilt registry keyed by format CODE (built-in raw ids <164 survive); preserved CF rules' dxfs are carried and renumbered into the rebuilt `<dxfs>`. |
| #472 structural bounds | Refusal guard at the top of `StructuralEditor.edit`: any populated cell (or dimension) shifting past row 1,048,576 / col XFD → typed `XLError.OutOfBounds`, file untouched (byte-asserted). Ranges were clamped in 0.16 (#428); data cells now refuse. |
| #473 defined-name rewrite | The #429/#455 rewrite plane extends to ALL defined names via shared `shiftFormulaText` (`shiftLocal=false` — only refs sheet-qualified to the edited sheet move; constants/externals untouched; deletes → `#REF!`). |
| #483 `-i` messages | Every user-facing message names the TARGET path across the five `saveSuffix` sites. |
| #484 reprint separators | `FormulaPrinter.printFileForm` (bare `,` join, no leading `=`) threaded through all 8 rewrite sites via `ArgPrinter.separator`; human-facing pretty-printers unchanged; string-literal commas safe (join-point only). |

Notes for review picked from the fix agents: #467 flags a residual pre-existing sibling (VLOOKUP/HLOOKUP keep inline normalization lacking the DateTime-serial case — not filed yet); #466 deliberately encodes Excel's blanks-match-`<>text` semantics (numeric `"<>10"` path untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)