### PR TITLE
chore(release): Bump version to 0.19.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,12 @@ All notable changes to the XL project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.19.1] - 2026-08-04
 
-Wave 23: the post-0.19.0 field-QC burn-down — every silent-wrong-number
-and corruption bug the TJC field QC surfaced on real banker books.
+Field hardening (waves 23 + 23b): the post-0.19.0 field-QC burn-down —
+every silent-wrong-number and corruption bug the TJC field QC surfaced
+on real banker books in one day of production forensics. No features;
+additive API only where a fix demanded a signal.
 
 ### Added
 
@@ -95,6 +97,57 @@ and corruption bug the TJC field QC surfaced on real banker books.
   valid `externalBook` targets instead of `wrong-rel-type` findings,
   so "lint must exit 0" ship gates stop false-alarming on pass-through
   edits of real books.
+- **Comparison criteria with text operands silently matched nothing**
+  (#466): `CriteriaMatcher` degraded `"<>x"` / `">m"` to an exact match
+  of the whole criteria string (operator included), so
+  SUMIFS/COUNTIFS/COUNTIF cached 0 with no error. Text operands now
+  compare with Excel semantics: case-insensitive not-equal (blanks
+  match `"<>text"`, and the bare `"<>"` non-blank idiom falls out
+  naturally), case-insensitive text ordering (type-segregated — numbers
+  and booleans never satisfy `">m"`), and `"<>pattern"` negated
+  wildcards. Numeric and equality criteria unchanged.
+- **MATCH/XLOOKUP comparator fall-through matched blanks to everything**
+  (#467): the lookup comparator returned "equal" for any unhandled type
+  pair, so exact MATCH stopped at the first blank (positions looked
+  compacted), date-typed lookups matched position 1, and cell-ref
+  lookup values mis-resolved. MATCH and XLOOKUP now share total
+  `normalizeLookupValue`/`matchesLookupExact` helpers (cell-ref
+  dereference incl. cached formulas; DateTime→serial per #449;
+  case-insensitive text); approximate modes stop coercing blanks/text
+  to zero-valued candidates.
+- **`copy(sheets = …)` reductions were silently ignored under
+  preservation** (#470): the writer re-emitted the source's sheet set,
+  shipping "removed" sheets — a redaction hazard. `SourceContext` now
+  reconciles the model's sheet set (and defined names) before strategy
+  dispatch: sheets dropped via `copy` are marked deleted exactly like
+  `wb.remove()` and their parts pruned.
+- **Fresh writes desynced the style plane after a read** (#471):
+  cellXfs kept SOURCE numFmt ids while the rebuilt `<numFmts>`
+  renumbered to 164+ (cells fell back to General — or worse, collided
+  into date builtins), and preserved CF rules re-emitted dxfIds the
+  rebuilt `<dxfs>` no longer contained. Fresh writes now re-map every
+  cellXf numFmtId through the rebuilt registry keyed by format CODE and
+  carry+renumber the dxfs preserved CF rules reference.
+- **Structural edits could shift data past sheet bounds** (#472):
+  ranges were clamped at the caps in 0.16 (#428) but data cells and
+  `<dimension>` still shifted past row 1,048,576 / col XFD with exit 0
+  — desktop Excel refuses such files. `StructuralEditor.edit` now
+  refuses the edit with a typed `OutOfBounds` error and leaves the file
+  untouched.
+- **Structural edits did not rewrite general defined names** (#473):
+  print areas/DV/tables/autoFilter shifted since 0.16 (#429) but plain
+  `definedName` refs stayed put, pointing at stale cells after a row
+  insert. All defined names now ride the same rewrite plane (only refs
+  sheet-qualified to the edited sheet move; constants and external refs
+  untouched; deleted targets become `#REF!`).
+- **`-i` error paths could name the deleted temp file** (#483): every
+  user-facing message across the five `saveSuffix` sites now names the
+  target path.
+- **Structural reprints emitted `", "` argument separators** (#484):
+  rewritten formulas now serialize in Excel's file form (bare `,` at
+  join points, string literals untouched) via
+  `FormulaPrinter.printFileForm`; human-facing pretty-printers keep
+  their spacing.
 - **`-i` success messages printed the temp file** (#464): every
   in-place verb (`recalc`, `put`, `putf`, … ~40 commands) reported
   `Saved: ./.xl-inplace-….xlsx` — a path that no longer exists after

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ```scala 3 raw
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.19.0
+//> using dep com.tjclp::xl:0.19.1
 
 import com.tjclp.xl.{*, given}
 
@@ -55,13 +55,13 @@ import com.tjclp.xl.{*, given}
 
 ```scala 3 ignore
 // build.mill — single dependency for everything
-def ivyDeps = Agg(ivy"com.tjclp::xl:0.19.0")
+def ivyDeps = Agg(ivy"com.tjclp::xl:0.19.1")
 
 // Or individual modules for minimal footprint:
-// ivy"com.tjclp::xl-core:0.19.0"        — Pure domain model only
-// ivy"com.tjclp::xl-ooxml:0.19.0"       — Add OOXML read/write
-// ivy"com.tjclp::xl-cats-effect:0.19.0" — Add IO streaming
-// ivy"com.tjclp::xl-evaluator:0.19.0"   — Add formula evaluation
+// ivy"com.tjclp::xl-core:0.19.1"        — Pure domain model only
+// ivy"com.tjclp::xl-ooxml:0.19.1"       — Add OOXML read/write
+// ivy"com.tjclp::xl-cats-effect:0.19.1" — Add IO streaming
+// ivy"com.tjclp::xl-evaluator:0.19.1"   — Add formula evaluation
 ```
 
 ### Basic Usage

--- a/build.mill
+++ b/build.mill
@@ -14,7 +14,7 @@ val organization = "com.tjclp"
 /** Shared build configuration constants */
 object BuildConfig {
   /** Project version: CI sets PUBLISH_VERSION; local builds use this fallback */
-  val version: String = sys.env.getOrElse("PUBLISH_VERSION", "0.19.0")
+  val version: String = sys.env.getOrElse("PUBLISH_VERSION", "0.19.1")
 
   /** JVM options to silence Scala 3 LazyVals sun.misc.Unsafe deprecation warnings (JDK 21+) */
   val lazyValsJvmArgs: Seq[String] = Seq(

--- a/docs/QUICK-START.md
+++ b/docs/QUICK-START.md
@@ -12,19 +12,19 @@ import mill._, scalalib._
 
 object myproject extends ScalaModule {
   def scalaVersion = "3.8.3"
-  def ivyDeps = Agg(ivy"com.tjclp::xl:0.19.0")
+  def ivyDeps = Agg(ivy"com.tjclp::xl:0.19.1")
 }
 ```
 
 ### With sbt (build.sbt)
 ```scala
 scalaVersion := "3.8.3"
-libraryDependencies += "com.tjclp" %% "xl" % "0.19.0"
+libraryDependencies += "com.tjclp" %% "xl" % "0.19.1"
 ```
 
 ### With Scala CLI
 ```scala
-//> using dep com.tjclp::xl:0.19.0
+//> using dep com.tjclp::xl:0.19.1
 ```
 
 ### Individual Modules (Optional)
@@ -44,7 +44,7 @@ For scripts, skip the build setup entirely: a two-line `scala-cli` header and ON
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.19.0
+//> using dep com.tjclp::xl:0.19.1
 
 import com.tjclp.xl.scripting.{*, given}
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,12 +1,20 @@
 # XL Project Status
 
-**Last Updated**: 2026-08-03 (0.19.0)
+**Last Updated**: 2026-08-04 (0.19.1)
 
 ## Current State
 
 > **For detailed phase completion status and roadmap, see [plan/roadmap.md](plan/roadmap.md)**
 
 ### What Works (Production-Ready)
+
+**New in 0.19.1** (2026-08-04) — field hardening, waves 23 + 23b (#478/#487):
+- ✅ **Circular-book data-table seeding** (#453) — the seeder fixpoints cycle members per axis combination under the book's CalcPr instead of pinning them at loaded caches (grids no longer seed silently FLAT); `seedDataTablesReport()` + IterativeCalc overloads
+- ✅ **`RecalcResult.converged` / `iterationsUsed`** (#454) — maxIter exhaustion distinguishable from convergence; CLI recalc honors declared `calcPr iterate="1"` (#461)
+- ✅ **Reprint integrity** (#455, #484) — structural edits preserve associativity parentheses and serialize Excel's file form; scripting `<f>` leading-`=` canonicalized + `formula-leading-equals` lint (#456)
+- ✅ **Evaluator wrong-value classes dead** (#466, #467) — text-operand criteria (`"<>x"`, `">m"`, non-blank `"<>"`) evaluate with Excel semantics; MATCH/XLOOKUP comparator is total (blanks match nothing, DateTime-by-serial, cell-ref lookup values dereference)
+- ✅ **Write-integrity guards** (#470, #471, #472, #473) — `copy(sheets=…)` reductions honored under preservation; fresh-write style plane re-registered (numFmt by code, dxfs carried); structural edits refuse past-bounds shifts and rewrite general defined names
+- ✅ **Native image opens name-bloated books** (#457) — JAXP limits lifted (62k–110k definedName banker files); lint accepts `xlPathMissing` external links (#458)
 
 **New in 0.19.0** (2026-08-03):
 - ✅ **Column/row default styles** (#445) — `<col style=>` / `<row s= customFormat="1">` emit on both writer backends (StyleIndex-remapped like cell styleIds) AND parse back, so read→modify→write keeps source column styles; `Sheet.withColumnStyle`/`withRowStyle` author the sheet-wide-body-font-without-Normal mechanism

--- a/docs/plan/roadmap.md
+++ b/docs/plan/roadmap.md
@@ -12,7 +12,7 @@
 
 **Current Status**: Production-ready with **109 formula functions** (incl. dynamic arrays SEQUENCE/SORT/UNIQUE/FILTER and OFFSET), **structural editing** (insert/delete rows & columns with formula rewriting), the **scripting prelude** (`com.tjclp.xl.scripting`), whole-workbook `recalculate`, named-range & hyperlink authoring, **typed charts + embedded pictures** (0.12.0), **conditional formatting** (0.12.1), SAX streaming (36% faster than POI), Excel tables, and full OOXML round-trip. 5,047 tests passing.
 
-**Current Version**: **0.19.0 "Canon"** (released 2026-08-03)
+**Current Version**: **0.19.1** (field hardening, released 2026-08-04)
 
 ---
 

--- a/docs/reference/scripting.md
+++ b/docs/reference/scripting.md
@@ -33,7 +33,7 @@ release bump is a mechanical substitution):
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.19.0
+//> using dep com.tjclp::xl:0.19.1
 import com.tjclp.xl.scripting.{*, given}
 
 val sheet = Sheet("Demo").put(ref"A1", "Hello").put(ref"B1", 42)
@@ -51,7 +51,7 @@ read and write is pure values.
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.19.0
+//> using dep com.tjclp::xl:0.19.1
 import com.tjclp.xl.scripting.{*, given}
 
 val wb = Excel.read("input.xlsx")
@@ -130,7 +130,7 @@ intended instead of surprising the chain:
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.19.0
+//> using dep com.tjclp::xl:0.19.1
 import com.tjclp.xl.scripting.{*, given}
 
 val region = Seq("North", "East").mkString(" ")                     // runtime name
@@ -196,7 +196,7 @@ throw — they are collected per cell.
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.19.0
+//> using dep com.tjclp::xl:0.19.1
 import com.tjclp.xl.scripting.{*, given}
 
 val title = CellStyle.default.bold.size(14.0).center
@@ -330,7 +330,7 @@ them explicitly:
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.19.0
+//> using dep com.tjclp::xl:0.19.1
 import com.tjclp.xl.scripting.{*, given}
 import com.tjclp.xl.sheets.{HeaderFooter, PageMargins, PageSetup, SheetView}
 
@@ -384,7 +384,7 @@ the whole workbook:
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.19.0
+//> using dep com.tjclp::xl:0.19.1
 import com.tjclp.xl.scripting.{*, given}
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global

--- a/examples/README.md
+++ b/examples/README.md
@@ -170,7 +170,7 @@ chmod +x examples/my_example.sc
 ./examples/my_example.sc
 ```
 
-The `project.scala` file centralizes dependencies (`com.tjclp::xl:0.19.0`) for all examples.
+The `project.scala` file centralizes dependencies (`com.tjclp::xl:0.19.1`) for all examples.
 
 ## Scripting Prelude & Skill
 

--- a/examples/project.scala
+++ b/examples/project.scala
@@ -2,4 +2,4 @@
 //> using repository ivy2Local
 
 // XL aggregate - includes all modules (core, ooxml, cats-effect, evaluator)
-//> using dep com.tjclp::xl:0.19.0
+//> using dep com.tjclp::xl:0.19.1

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "xl",
   "description": "LLM-friendly Excel tooling: the xl CLI for reading, writing, styling, and analyzing spreadsheets (xl-cli skill), plus type-safe Scala scripting against the xl library via scala-cli for bulk transformations, pipelines, and formula models (xl-scripting skill).",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "author": {
     "name": "TJC L.P.",
     "url": "https://github.com/TJC-LP"

--- a/plugin/skills/xl-cli/SKILL.md
+++ b/plugin/skills/xl-cli/SKILL.md
@@ -114,7 +114,7 @@ xl -f <file> -o <out> recalc --tables                 # Also seed data-table int
 xl -f a.xlsx diff -g b.xlsx --format markdown          # Workbook diff (exit 0 identical, 1 differs)
 xl -f a.xlsx diff -g b.xlsx --format json              # Stable JSON schema for tooling
 xl -f out.xlsx lint                                    # Validate package structure before sending (exit 0 clean, 1 findings) (0.15.0+)
-                                                       # Rules: child-order, unresolved-rel-id, wrong-rel-type, missing-part, missing-content-type, ref-out-of-bounds, data-table-torn, data-table-unseeded (0.19.0), formula-leading-equals (0.20.0)
+                                                       # Rules: child-order, unresolved-rel-id, wrong-rel-type, missing-part, missing-content-type, ref-out-of-bounds, data-table-torn, data-table-unseeded (0.19.0), formula-leading-equals (0.19.1)
 xl -f <file> -s <sheet> filter --where "B > 100 AND D = TRUE" --header --format csv
 xl -f <file> -s <sheet> filter --where "Name LIKE 'Acme%'" --columns A,C:E --limit 20
 ```

--- a/plugin/skills/xl-scripting/SKILL.md
+++ b/plugin/skills/xl-scripting/SKILL.md
@@ -38,7 +38,7 @@ The canonical header for every script (this is the single source of truth — re
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.19.0
+//> using dep com.tjclp::xl:0.19.1
 
 import com.tjclp.xl.scripting.{*, given}
 
@@ -104,7 +104,7 @@ wb.update("Sales", f).unsafe                       // throws structured XLExcept
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.19.0
+//> using dep com.tjclp::xl:0.19.1
 import com.tjclp.xl.scripting.{*, given}
 
 val wb = Excel.read("input.xlsx")
@@ -236,7 +236,7 @@ Native Excel `TABLE()` two-variable data tables (0.18.0) — the house sensitivi
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.19.0
+//> using dep com.tjclp::xl:0.19.1
 import com.tjclp.xl.scripting.{*, given}
 
 val model = Sheet("Sensitivity")
@@ -282,7 +282,7 @@ Or lean on totality so there is nothing to unwrap: literal refs, `upsert`, range
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.19.0
+//> using dep com.tjclp::xl:0.19.1
 import com.tjclp.xl.scripting.{*, given}
 import java.nio.file.{Files, Paths}
 import scala.jdk.CollectionConverters.*
@@ -304,7 +304,7 @@ println(s"merged ${inputs.size} files, ${merged.sheets.size} sheets")
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.19.0
+//> using dep com.tjclp::xl:0.19.1
 import com.tjclp.xl.scripting.{*, given}
 
 val data = List(("North", 125000.50), ("South", 98000.25), ("West", 143500.00))
@@ -332,7 +332,7 @@ println(if result.isClean then "✓ report written" else result.errors.map(_.ren
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.19.0
+//> using dep com.tjclp::xl:0.19.1
 import com.tjclp.xl.scripting.{*, given}
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global

--- a/plugin/skills/xl-scripting/reference/RECIPES.md
+++ b/plugin/skills/xl-scripting/reference/RECIPES.md
@@ -10,7 +10,7 @@ Apply a 5% price increase to column C of every workbook in a directory, in place
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.19.0
+//> using dep com.tjclp::xl:0.19.1
 import com.tjclp.xl.scripting.{*, given}
 import java.nio.file.{Files, Paths}
 import scala.jdk.CollectionConverters.*
@@ -42,7 +42,7 @@ Read rows into case classes; collect per-cell validation failures into a new Iss
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.19.0
+//> using dep com.tjclp::xl:0.19.1
 import com.tjclp.xl.scripting.{*, given}
 
 final case class Order(id: Int, customer: String, amount: BigDecimal)
@@ -76,7 +76,7 @@ Three-year projection with growth formulas; fail the script if any formula error
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.19.0
+//> using dep com.tjclp::xl:0.19.1
 import com.tjclp.xl.scripting.{*, given}
 
 val header = CellStyle.default.bold.size(12.0).center
@@ -111,7 +111,7 @@ Stack the data rows of every input file under one header.
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.19.0
+//> using dep com.tjclp::xl:0.19.1
 import com.tjclp.xl.scripting.{*, given}
 import java.nio.file.{Files, Paths}
 import scala.jdk.CollectionConverters.*
@@ -147,7 +147,7 @@ println(s"combined ${files.size} files, ${combined.cells.size} cells")
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.19.0
+//> using dep com.tjclp::xl:0.19.1
 import com.tjclp.xl.scripting.{*, given}
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
@@ -176,7 +176,7 @@ println("✓ filtered (constant memory)")
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.19.0
+//> using dep com.tjclp::xl:0.19.1
 import com.tjclp.xl.scripting.{*, given}
 
 val before = Excel.read("before.xlsx")
@@ -204,7 +204,7 @@ else
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.19.0
+//> using dep com.tjclp::xl:0.19.1
 import com.tjclp.xl.scripting.{*, given}
 import java.nio.file.{Files, Paths}
 import scala.jdk.CollectionConverters.*
@@ -232,7 +232,7 @@ cell ships a cached value for `data_only` readers, pandas, and Excel-before-reca
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.19.0
+//> using dep com.tjclp::xl:0.19.1
 import com.tjclp.xl.scripting.{*, given}
 
 val reps = List(("Alice", 120000.0), ("Bob", 98000.0), ("Carol", 143500.0))
@@ -267,7 +267,7 @@ frozen header, a list-dropdown data validation, and a provenance comment — no 
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.19.0
+//> using dep com.tjclp::xl:0.19.1
 import com.tjclp.xl.scripting.{*, given}
 import com.tjclp.xl.sheets.SheetView // SheetView lives one import deeper than the prelude
 

--- a/xl-core/src/com/tjclp/xl/workbooks/WorkbookMetadata.scala
+++ b/xl-core/src/com/tjclp/xl/workbooks/WorkbookMetadata.scala
@@ -35,7 +35,7 @@ final case class WorkbookMetadata(
   modified: Option[java.time.LocalDateTime] = None,
   lastModifiedBy: Option[String] = None,
   application: Option[String] = Some("XL - Pure Scala 3.8 Excel Library"),
-  appVersion: Option[String] = Some("0.19.0"),
+  appVersion: Option[String] = Some("0.19.1"),
   theme: ThemePalette = ThemePalette.office,
   definedNames: Vector[DefinedName] = Vector.empty,
   sheetStates: Map[SheetName, Option[String]] = Map.empty,

--- a/xl/src/com/tjclp/xl/scripting.scala
+++ b/xl/src/com/tjclp/xl/scripting.scala
@@ -4,7 +4,7 @@ package com.tjclp.xl
  * Scripting prelude: everything a script needs in one import.
  *
  * {{{
- * //> using dep com.tjclp::xl:0.19.0
+ * //> using dep com.tjclp::xl:0.19.1
  * import com.tjclp.xl.scripting.{*, given}
  *
  * val wb = Excel.read("input.xlsx")


### PR DESCRIPTION
Stacked on #487 (wave 23b). Standard bump set → 0.19.1, plus:
- CHANGELOG: `[Unreleased]` → `[0.19.1] - 2026-08-04` with the wave-23b Fixed entries appended (field-hardening framing, both waves)
- `formula-leading-equals` lint help/skill text retagged `(0.20.0)` → `(0.19.1)` (shipped in #478 anticipating 0.20)
- STATUS.md "New in 0.19.1" block; roadmap current-version line

NOTE (procedure): after #487 squash-merges, this branch gets REBUILT on new main (`git diff wave..bump | git apply` + force-with-lease) before merging — the stacked history diverges otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)