### PR TITLE
test(cats-effect): de-flake the writer's temp-file cleanup assertions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ excel.read(path).flatMap(wb => excel.write(wb, outPath))
 
 ```bash
 ./mill __.compile          # Compile all
-./mill __.test             # Run all tests (5,448)
+./mill __.test             # Run all tests (5,450)
 ./mill xl-core.test        # Test specific module
 ./mill __.reformat         # Format (Scalafmt 3.10.1)
 ./mill __.checkFormat      # CI check
@@ -396,12 +396,12 @@ Styles deduplicated by `CellStyle.canonicalKey`. Build style index before emitti
 
 **Framework**: MUnit + ScalaCheck | **Generators**: `xl-core/test/src/com/tjclp/xl/Generators.scala`
 
-**5,448 tests** by module: xl-evaluator (1886), xl-core (1248), xl-ooxml (983), xl-cli (641), xl-cats-effect (141), xl-agent (122), xl prelude probes (26). See `docs/reference/testing-guide.md` for suite structure and patterns.
+**5,450 tests** by module: xl-evaluator (2100), xl-core (1283), xl-ooxml (1047), xl-cli (727), xl-cats-effect (144), xl-agent (122), xl prelude probes (27). See `docs/reference/testing-guide.md` for suite structure and patterns.
 
 ## Documentation
 
 - **Roadmap**: `docs/plan/roadmap.md` (single source of truth for work scheduling)
-- **Status**: `docs/STATUS.md` (current capabilities, 5,448 tests)
+- **Status**: `docs/STATUS.md` (current capabilities, 5,450 tests)
 - **Design**: `docs/design/*.md` (architecture, purity charter, domain model)
 - **Reference**: `docs/reference/*.md` (examples, scaffolds, performance guide)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ excel.read(path).flatMap(wb => excel.write(wb, outPath))
 
 ```bash
 ./mill __.compile          # Compile all
-./mill __.test             # Run all tests (5,450)
+./mill __.test             # Run all tests (5,451)
 ./mill xl-core.test        # Test specific module
 ./mill __.reformat         # Format (Scalafmt 3.10.1)
 ./mill __.checkFormat      # CI check
@@ -396,12 +396,12 @@ Styles deduplicated by `CellStyle.canonicalKey`. Build style index before emitti
 
 **Framework**: MUnit + ScalaCheck | **Generators**: `xl-core/test/src/com/tjclp/xl/Generators.scala`
 
-**5,450 tests** by module: xl-evaluator (2100), xl-core (1283), xl-ooxml (1047), xl-cli (727), xl-cats-effect (144), xl-agent (122), xl prelude probes (27). See `docs/reference/testing-guide.md` for suite structure and patterns.
+**5,451 tests** by module: xl-evaluator (2100), xl-core (1283), xl-ooxml (1047), xl-cli (727), xl-cats-effect (145), xl-agent (122), xl prelude probes (27). See `docs/reference/testing-guide.md` for suite structure and patterns.
 
 ## Documentation
 
 - **Roadmap**: `docs/plan/roadmap.md` (single source of truth for work scheduling)
-- **Status**: `docs/STATUS.md` (current capabilities, 5,450 tests)
+- **Status**: `docs/STATUS.md` (current capabilities, 5,451 tests)
 - **Design**: `docs/design/*.md` (architecture, purity charter, domain model)
 - **Reference**: `docs/reference/*.md` (examples, scaffolds, performance guide)
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -202,17 +202,17 @@
 
 ### Test Coverage
 
-**5,448 tests** (verified via `./mill __.test`, 2026-08-07):
+**5,450 tests** (verified via `./mill __.test`, 2026-08-07):
 
 | Module | Tests | Covers |
 |--------|-------|--------|
-| xl-evaluator | 1571 | parser, evaluator, 108-function library, dependency graph, cross-sheet formulas, recalculation, structural editing, Excel comparison total order, array CSE semantics |
-| xl-core | 1104 | addressing laws, Patch/StylePatch monoids, codecs, optics, RichText, interpolation, render (HTML/SVG), styles DSL, charts, drawings, conditional formatting |
-| xl-ooxml | 684 | round-trips (cells, styles, tables, comments, hyperlinks, charts, drawings, conditional formatting), compression, security (XXE, ZIP bomb), preservation |
-| xl-cli | 406 | command parsing, batch ops, view/eval/export, streaming mode |
-| xl-cats-effect | 110 | streaming I/O, O(1) memory verification, SAX/StAX write |
-| xl-agent | 102 | benchmark engine, skill abstraction, failure-path diagnostics, release-asset resolution |
-| xl (prelude) | 19 | external-consumer probes (`xl/test/src/xlprelude/`) |
+| xl-evaluator | 2100 | parser, evaluator, 108-function library, dependency graph, cross-sheet formulas, recalculation, structural editing, Excel comparison total order, array CSE semantics |
+| xl-core | 1283 | addressing laws, Patch/StylePatch monoids, codecs, optics, RichText, interpolation, render (HTML/SVG), styles DSL, charts, drawings, conditional formatting |
+| xl-ooxml | 1047 | round-trips (cells, styles, tables, comments, hyperlinks, charts, drawings, conditional formatting), compression, security (XXE, ZIP bomb), preservation |
+| xl-cli | 727 | command parsing, batch ops, view/eval/export, streaming mode |
+| xl-cats-effect | 144 | streaming I/O, O(1) memory verification, SAX/StAX write |
+| xl-agent | 122 | benchmark engine, skill abstraction, failure-path diagnostics, release-asset resolution |
+| xl (prelude) | 27 | external-consumer probes (`xl/test/src/xlprelude/`) |
 | xl-testkit | 0 | placeholder (no sources yet) |
 
 See [reference/testing-guide.md](reference/testing-guide.md) for suite structure and testing patterns.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -202,7 +202,7 @@
 
 ### Test Coverage
 
-**5,450 tests** (verified via `./mill __.test`, 2026-08-07):
+**5,451 tests** (verified via `./mill __.test`, 2026-08-07):
 
 | Module | Tests | Covers |
 |--------|-------|--------|
@@ -210,7 +210,7 @@
 | xl-core | 1283 | addressing laws, Patch/StylePatch monoids, codecs, optics, RichText, interpolation, render (HTML/SVG), styles DSL, charts, drawings, conditional formatting |
 | xl-ooxml | 1047 | round-trips (cells, styles, tables, comments, hyperlinks, charts, drawings, conditional formatting), compression, security (XXE, ZIP bomb), preservation |
 | xl-cli | 727 | command parsing, batch ops, view/eval/export, streaming mode |
-| xl-cats-effect | 144 | streaming I/O, O(1) memory verification, SAX/StAX write |
+| xl-cats-effect | 145 | streaming I/O, O(1) memory verification, SAX/StAX write |
 | xl-agent | 122 | benchmark engine, skill abstraction, failure-path diagnostics, release-asset resolution |
 | xl (prelude) | 27 | external-consumer probes (`xl/test/src/xlprelude/`) |
 | xl-testkit | 0 | placeholder (no sources yet) |

--- a/xl-cats-effect/test/src/com/tjclp/xl/io/ExcelIOSpec.scala
+++ b/xl-cats-effect/test/src/com/tjclp/xl/io/ExcelIOSpec.scala
@@ -8,6 +8,7 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Path}
 import java.util.zip.{ZipEntry, ZipInputStream, ZipOutputStream}
 import scala.concurrent.duration.*
+import scala.util.Using
 import com.tjclp.xl.{*, given}
 import com.tjclp.xl.unsafe.*
 import com.tjclp.xl.addressing.{ARef, CellRange, Column, Row}
@@ -38,6 +39,7 @@ class ExcelIOSpec extends CatsEffectSuite:
 
   private def remapWorksheetEntry(source: Path, from: String, to: String): Path =
     val output = Files.createTempFile("xl-stream-remap", ".xlsx")
+    output.toFile.deleteOnExit()
     val zipIn = new ZipInputStream(new FileInputStream(source.toFile))
     val zipOut = new ZipOutputStream(new FileOutputStream(output.toFile))
     zipOut.setLevel(1)
@@ -1493,16 +1495,19 @@ class ExcelIOSpec extends CatsEffectSuite:
     }
   }
 
+  private val spillPoll: FiniteDuration = 50.millis
+
   /**
    * The auto-detect writer spills its phase-1 body to `java.io.tmpdir`, which every parallel test
    * worker JVM shares, so a raw before/after count of `xl-stream-*` entries also counts sibling
-   * suites' fixtures. Narrow the observation to what this writer alone creates: the `.xml` spill
-   * pattern (sibling fixtures are `.xlsx`).
+   * suites' fixtures. The `.xml` suffix narrows that to the spill pattern — sibling *fixtures* are
+   * `.xlsx` — but does not isolate it: any suite calling this same writer (StreamingSstSpec, and
+   * the xl-cli streaming/import commands in their own module JVM) spills under the same name.
+   * Settling the diff in [[assertNoSpillLeak]] is what makes the observation trustworthy.
    */
-  private def spillFiles: IO[Set[Path]] = IO {
+  private def spillFiles: IO[Set[Path]] = IO.blocking {
     import scala.jdk.CollectionConverters.*
-    val entries = Files.list(Path.of(System.getProperty("java.io.tmpdir")))
-    try
+    Using.resource(Files.list(Path.of(System.getProperty("java.io.tmpdir")))) { entries =>
       entries
         .iterator()
         .asScala
@@ -1511,21 +1516,27 @@ class ExcelIOSpec extends CatsEffectSuite:
           name.startsWith("xl-stream-") && name.endsWith(".xml")
         }
         .toSet
-    finally entries.close()
+    }
   }
 
   /**
-   * Assert the writer left no spill file behind. A neighbouring worker's in-flight spill can also
-   * land in the diff, so re-observe until it clears: a foreign file is released when that write
-   * ends, whereas a genuine leak persists and still fails the assertion.
+   * Assert the writer left no spill file behind. A neighbouring worker's in-flight spill also lands
+   * in the diff, so re-observe until it clears: a foreign file is released when that write ends,
+   * whereas a leak persists for the whole budget and still fails. The bracket release is
+   * synchronous with stream termination, so this only trades away detection of cleanup drifting
+   * into a late async fiber — not detection of a leak.
    */
-  private def assertNoSpillLeak(before: Set[Path], clue: String, retries: Int = 40): IO[Unit] =
+  private def assertNoSpillLeak(
+    before: Set[Path],
+    clue: String,
+    budget: FiniteDuration = 10.seconds
+  ): IO[Unit] =
     spillFiles.flatMap { after =>
       val leaked = after -- before
       if leaked.isEmpty then IO.unit
-      else if retries <= 0 then
+      else if budget <= Duration.Zero then
         IO(fail(s"$clue: ${leaked.map(_.getFileName.toString).toSeq.sorted.mkString(", ")}"))
-      else IO.sleep(50.millis) *> assertNoSpillLeak(before, clue, retries - 1)
+      else IO.sleep(spillPoll) *> assertNoSpillLeak(before, clue, budget - spillPoll)
     }
 
   tempDir.test("writeStreamWithAutoDetect: temp files cleaned up after write") { dir =>

--- a/xl-cats-effect/test/src/com/tjclp/xl/io/ExcelIOSpec.scala
+++ b/xl-cats-effect/test/src/com/tjclp/xl/io/ExcelIOSpec.scala
@@ -1642,6 +1642,37 @@ class ExcelIOSpec extends CatsEffectSuite:
     yield ()
   }
 
+  tempDir.test("writeStreamsSeqWithAutoDetect: per-sheet temp files cleaned up on error") { dir =>
+    val excel = ExcelIO.instance[IO]
+    val path = dir.resolve("multi-error-cleanup.xlsx")
+
+    // The multi-sheet bracket acquires one spill per sheet up front and releases them together —
+    // the shape where partial deletion hides. Failing inside the second sheet leaves the first
+    // sheet's spill fully written and the second's half-written, so both must still go.
+    for
+      before <- spillFiles
+      spilled <- IO.ref(Set.empty[Path])
+      sheet1 = fs2.Stream
+        .range(1, 21)
+        .evalTap(i => IO.whenA(i % 5 == 0)(sampleSpills(before, spilled)))
+        .map(i => RowData(i, Map(0 -> CellValue.Number(i))))
+      sheet2 = fs2.Stream
+        .range(1, 21)
+        .evalTap(i => IO.whenA(i % 5 == 0)(sampleSpills(before, spilled)))
+        .map { i =>
+          if i == 10 then throw new RuntimeException("Simulated failure")
+          RowData(i, Map(0 -> CellValue.Number(i)))
+        }
+      result <- excel
+        .writeStreamsSeqWithAutoDetect(path, Seq("First" -> sheet1, "Second" -> sheet2))
+        .attempt
+      _ <- IO(assert(result.isLeft, "Should have failed"))
+      seen <- spilled.get
+      _ <- IO(assert(seen.size >= 2, s"writer should spill one file per sheet, saw: $seen"))
+      _ <- assertSpillsCleared(seen, "Per-sheet temp files should be cleaned up even on error")
+    yield ()
+  }
+
   // ========== Explicit Dimension Hint Tests ==========
 
   tempDir.test("writeStream: explicit dimension hint produces dimension element") { dir =>

--- a/xl-cats-effect/test/src/com/tjclp/xl/io/ExcelIOSpec.scala
+++ b/xl-cats-effect/test/src/com/tjclp/xl/io/ExcelIOSpec.scala
@@ -1497,6 +1497,9 @@ class ExcelIOSpec extends CatsEffectSuite:
 
   private val spillPoll: FiniteDuration = 50.millis
 
+  /** Resolved once, like the JDK's own `TempFileHelper.tmpdir` static that the writer spills to. */
+  private val spillDir: Path = Path.of(System.getProperty("java.io.tmpdir"))
+
   /**
    * The auto-detect writer spills its phase-1 body to `java.io.tmpdir`, which every parallel test
    * worker JVM shares, so a raw before/after count of `xl-stream-*` entries also counts sibling
@@ -1507,7 +1510,7 @@ class ExcelIOSpec extends CatsEffectSuite:
    */
   private def spillFiles: IO[Set[Path]] = IO.blocking {
     import scala.jdk.CollectionConverters.*
-    Using.resource(Files.list(Path.of(System.getProperty("java.io.tmpdir")))) { entries =>
+    Using.resource(Files.list(spillDir)) { entries =>
       entries
         .iterator()
         .asScala
@@ -1525,19 +1528,55 @@ class ExcelIOSpec extends CatsEffectSuite:
    * whereas a leak persists for the whole budget and still fails. The bracket release is
    * synchronous with stream termination, so this only trades away detection of cleanup drifting
    * into a late async fiber — not detection of a leak.
+   *
+   * The budget is wall-clock against a monotonic deadline, not a sleep count: each scan reads a
+   * directory that parallel workers are actively churning, so counting only the sleeps would let a
+   * slow `/tmp` push the real elapsed time toward munit's timeout and degrade the failure into a
+   * bare timeout — losing the leaked path this reports. A scan that loses a race with a concurrent
+   * delete is indistinguishable from "not settled yet", so it retries rather than erroring.
    */
   private def assertNoSpillLeak(
     before: Set[Path],
     clue: String,
     budget: FiniteDuration = 10.seconds
   ): IO[Unit] =
-    spillFiles.flatMap { after =>
-      val leaked = after -- before
-      if leaked.isEmpty then IO.unit
-      else if budget <= Duration.Zero then
-        IO(fail(s"$clue: ${leaked.map(_.getFileName.toString).toSeq.sorted.mkString(", ")}"))
-      else IO.sleep(spillPoll) *> assertNoSpillLeak(before, clue, budget - spillPoll)
+    IO.monotonic.flatMap { start =>
+      lazy val loop: IO[Unit] = spillFiles.attempt.flatMap { observed =>
+        val unsettled = observed match
+          case Right(after) =>
+            val leaked = after -- before
+            Option.when(leaked.nonEmpty)(
+              leaked.map(_.getFileName.toString).toSeq.sorted.mkString(", ")
+            )
+          case Left(err) => Some(s"spill directory could not be scanned: $err")
+
+        unsettled.fold(IO.unit) { detail =>
+          IO.monotonic.flatMap { now =>
+            if now - start >= budget then
+              IO(
+                fail(
+                  s"$clue — still present after $budget " +
+                    s"(a concurrent foreign spill can also land here): $detail"
+                )
+              )
+            else IO.sleep(spillPoll) *> loop
+          }
+        }
+      }
+      loop
     }
+
+  test("assertNoSpillLeak reports a spill that outlives its budget") {
+    // Standing guard on the helper itself: if its filter ever drifts off the writer's spill name,
+    // both cleanup tests below would pass vacuously while the writer leaks. Plant a file matching
+    // the pattern, hide it from `before`, and require the helper to report it.
+    IO.blocking(Files.createTempFile("xl-stream-", ".xml")).flatMap { planted =>
+      spillFiles
+        .flatMap(before => assertNoSpillLeak(before - planted, "planted spill", 200.millis).attempt)
+        .map(result => assert(result.isLeft, "helper should report a spill that never clears"))
+        .guarantee(IO.blocking(Files.deleteIfExists(planted)).void)
+    }
+  }
 
   tempDir.test("writeStreamWithAutoDetect: temp files cleaned up after write") { dir =>
     val excel = ExcelIO.instance[IO]

--- a/xl-cats-effect/test/src/com/tjclp/xl/io/ExcelIOSpec.scala
+++ b/xl-cats-effect/test/src/com/tjclp/xl/io/ExcelIOSpec.scala
@@ -1,6 +1,6 @@
 package com.tjclp.xl.io
 
-import cats.effect.IO
+import cats.effect.{IO, Ref}
 import munit.CatsEffectSuite
 
 import java.io.{ByteArrayOutputStream, FileInputStream, FileOutputStream}
@@ -1505,8 +1505,9 @@ class ExcelIOSpec extends CatsEffectSuite:
    * worker JVM shares, so a raw before/after count of `xl-stream-*` entries also counts sibling
    * suites' fixtures. The `.xml` suffix narrows that to the spill pattern — sibling *fixtures* are
    * `.xlsx` — but does not isolate it: any suite calling this same writer (StreamingSstSpec, and
-   * the xl-cli streaming/import commands in their own module JVM) spills under the same name.
-   * Settling the diff in [[assertNoSpillLeak]] is what makes the observation trustworthy.
+   * the xl-cli streaming/import commands in their own module JVM) spills under the same name. So
+   * this is a discovery scan only: [[sampleSpills]] narrows it to what appeared during our own
+   * write, and [[assertSpillsCleared]] watches those exact paths rather than the directory.
    */
   private def spillFiles: IO[Set[Path]] = IO.blocking {
     import scala.jdk.CollectionConverters.*
@@ -1523,57 +1524,67 @@ class ExcelIOSpec extends CatsEffectSuite:
   }
 
   /**
-   * Assert the writer left no spill file behind. A neighbouring worker's in-flight spill also lands
-   * in the diff, so re-observe until it clears: a foreign file is released when that write ends,
-   * whereas a leak persists for the whole budget and still fails. The bracket release is
-   * synchronous with stream termination, so this only trades away detection of cleanup drifting
-   * into a late async fiber — not detection of a leak.
+   * Record the spills that appeared since `before` — i.e. this write's own, since the writer
+   * creates its temp file at bracket-acquire, ahead of the first row. Sampling repeatedly keeps the
+   * record honest if the writer ever spills more than once per write.
    *
-   * The budget is wall-clock against a monotonic deadline, not a sleep count: each scan reads a
-   * directory that parallel workers are actively churning, so counting only the sleeps would let a
-   * slow `/tmp` push the real elapsed time toward munit's timeout and degrade the failure into a
-   * bare timeout — losing the leaked path this reports. A scan that loses a race with a concurrent
-   * delete is indistinguishable from "not settled yet", so it retries rather than erroring.
+   * A scan racing a concurrent delete must never take the write down with it: recovering to "saw
+   * nothing this time" leaves the positive control to fail loudly on the empty record instead of
+   * the test dying on a `DirectoryIteratorException` that has nothing to do with cleanup.
    */
-  private def assertNoSpillLeak(
-    before: Set[Path],
+  private def sampleSpills(before: Set[Path], into: Ref[IO, Set[Path]]): IO[Unit] =
+    spillFiles.attempt.flatMap {
+      case Right(now) => into.update(_ ++ (now -- before))
+      case Left(_) => IO.unit
+    }
+
+  /**
+   * Assert the writer deleted the spills it created. Watching those exact paths — not the diff of a
+   * directory several worker JVMs are churning — is what keeps this honest: a foreign spill has to
+   * be in flight at one sampling instant AND outlive the budget to interfere, rather than merely
+   * overlapping the window.
+   *
+   * The bracket release is synchronous with stream termination, so the happy path settles on the
+   * first look and the budget only covers that residual case; a leak burns the whole budget and
+   * still fails. What this trades away is detection of cleanup drifting into a late async fiber —
+   * not detection of a leak. The budget is wall-clock against a monotonic deadline rather than a
+   * sleep count, so a slow filesystem cannot stretch it toward munit's timeout and degrade the
+   * failure into a bare timeout, losing the paths reported here.
+   */
+  private def assertSpillsCleared(
+    watched: Set[Path],
     clue: String,
-    budget: FiniteDuration = 10.seconds
+    budget: FiniteDuration = 2.seconds
   ): IO[Unit] =
     IO.monotonic.flatMap { start =>
-      lazy val loop: IO[Unit] = spillFiles.attempt.flatMap { observed =>
-        val unsettled = observed match
-          case Right(after) =>
-            val leaked = after -- before
-            Option.when(leaked.nonEmpty)(
-              s"$clue — still present after $budget (a concurrent foreign spill can also land " +
-                s"here): ${leaked.map(_.getFileName.toString).toSeq.sorted.mkString(", ")}"
-            )
-          case Left(err) =>
-            Some(s"$clue — spill directory could not be scanned for $budget: $err")
-
-        unsettled.fold(IO.unit) { detail =>
+      lazy val loop: IO[Unit] = IO.blocking(watched.filter(Files.exists(_))).flatMap { present =>
+        if present.isEmpty then IO.unit
+        else
           IO.monotonic.flatMap { now =>
-            if now - start >= budget then IO(fail(detail))
+            if now - start >= budget then
+              IO(
+                fail(
+                  s"$clue — still present after $budget: " +
+                    present.map(_.getFileName.toString).toSeq.sorted.mkString(", ")
+                )
+              )
             else IO.sleep(spillPoll) *> loop
           }
-        }
       }
       loop
     }
 
-  test("assertNoSpillLeak names a spill that outlives its budget") {
-    // Half of the standing guard: the helper must still FAIL, and name the file, when something
-    // matching the pattern never clears — otherwise it could regress into a no-op that reports
-    // nothing while the writer leaks. (That the pattern still matches the WRITER is the other
-    // half, pinned by the positive control in the cleanup test below.)
+  test("assertSpillsCleared names a spill that outlives its budget") {
+    // Half of the standing guard: the helper must still FAIL, and name the file, when a watched
+    // spill never clears — otherwise it could regress into a no-op that reports nothing while the
+    // writer leaks. (That the filter still finds the WRITER's spill is the other half, pinned by
+    // the positive control in both cleanup tests below.)
     IO.blocking {
       val p = Files.createTempFile("xl-stream-", ".xml")
       p.toFile.deleteOnExit()
       p
     }.flatMap { planted =>
-      spillFiles
-        .flatMap(before => assertNoSpillLeak(before - planted, "planted spill", 200.millis).attempt)
+      assertSpillsCleared(Set(planted), "planted spill", 200.millis).attempt
         .map { result =>
           assert(
             result.left.exists(_.getMessage.contains(planted.getFileName.toString)),
@@ -1590,21 +1601,21 @@ class ExcelIOSpec extends CatsEffectSuite:
 
     for
       before <- spillFiles
-      // Positive control: pin the filter to the WRITER, not to itself. The spill is created at
-      // bracket-acquire, before the first row is pulled, so it is on disk mid-stream. Without this,
-      // moving the writer's spill name or location (a plausible outcome of #514) would leave the
-      // cleanup assertion observing nothing and passing vacuously.
+      // Positive control: tie the filter to the writer rather than to itself, so moving the spill's
+      // name or location (a plausible outcome of #514) fails here instead of quietly leaving the
+      // cleanup assertion watching an empty set. Strictly it says "a spill matching the filter
+      // appeared mid-write" — a sibling JVM's in-flight spill would satisfy it too — but every
+      // producer of this pattern is this same writer, so a rename moves them all and this still
+      // bites.
       spilled <- IO.ref(Set.empty[Path])
       rows = fs2.Stream
         .range(1, 101)
-        .evalTap(i =>
-          IO.whenA(i == 50)(spillFiles.flatMap(s => spilled.update(_ ++ (s -- before))))
-        )
+        .evalTap(i => IO.whenA(i % 25 == 0)(sampleSpills(before, spilled)))
         .map(i => RowData(i, Map(0 -> CellValue.Number(i))))
       _ <- rows.through(excel.writeStreamWithAutoDetect(path, "Data")).compile.drain
       seen <- spilled.get
       _ <- IO(assert(seen.nonEmpty, "writer should spill a file matching the filter mid-write"))
-      _ <- assertNoSpillLeak(before, "Temp files should be cleaned up after write")
+      _ <- assertSpillsCleared(seen, "Temp files should be cleaned up after write")
     yield ()
   }
 
@@ -1612,17 +1623,22 @@ class ExcelIOSpec extends CatsEffectSuite:
     val excel = ExcelIO.instance[IO]
     val path = dir.resolve("error-cleanup-test.xlsx")
 
-    // Create a stream that fails mid-way
-    val rows = fs2.Stream.range(1, 51).map { i =>
-      if i == 25 then throw new RuntimeException("Simulated failure")
-      RowData(i, Map(0 -> CellValue.Number(i)))
-    }
-
     for
       before <- spillFiles
+      spilled <- IO.ref(Set.empty[Path])
+      // Same positive control, sampled before the row-25 failure.
+      rows = fs2.Stream
+        .range(1, 51)
+        .evalTap(i => IO.whenA(i % 5 == 0)(sampleSpills(before, spilled)))
+        .map { i =>
+          if i == 25 then throw new RuntimeException("Simulated failure")
+          RowData(i, Map(0 -> CellValue.Number(i)))
+        }
       result <- rows.through(excel.writeStreamWithAutoDetect(path, "Data")).compile.drain.attempt
       _ <- IO(assert(result.isLeft, "Should have failed"))
-      _ <- assertNoSpillLeak(before, "Temp files should be cleaned up even on error")
+      seen <- spilled.get
+      _ <- IO(assert(seen.nonEmpty, "writer should spill a file matching the filter mid-write"))
+      _ <- assertSpillsCleared(seen, "Temp files should be cleaned up even on error")
     yield ()
   }
 

--- a/xl-cats-effect/test/src/com/tjclp/xl/io/ExcelIOSpec.scala
+++ b/xl-cats-effect/test/src/com/tjclp/xl/io/ExcelIOSpec.scala
@@ -7,6 +7,7 @@ import java.io.{ByteArrayOutputStream, FileInputStream, FileOutputStream}
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Path}
 import java.util.zip.{ZipEntry, ZipInputStream, ZipOutputStream}
+import scala.concurrent.duration.*
 import com.tjclp.xl.{*, given}
 import com.tjclp.xl.unsafe.*
 import com.tjclp.xl.addressing.{ARef, CellRange, Column, Row}
@@ -1492,49 +1493,58 @@ class ExcelIOSpec extends CatsEffectSuite:
     }
   }
 
+  /**
+   * The auto-detect writer spills its phase-1 body to `java.io.tmpdir`, which every parallel test
+   * worker JVM shares, so a raw before/after count of `xl-stream-*` entries also counts sibling
+   * suites' fixtures. Narrow the observation to what this writer alone creates: the `.xml` spill
+   * pattern (sibling fixtures are `.xlsx`).
+   */
+  private def spillFiles: IO[Set[Path]] = IO {
+    import scala.jdk.CollectionConverters.*
+    val entries = Files.list(Path.of(System.getProperty("java.io.tmpdir")))
+    try
+      entries
+        .iterator()
+        .asScala
+        .filter { p =>
+          val name = p.getFileName.toString
+          name.startsWith("xl-stream-") && name.endsWith(".xml")
+        }
+        .toSet
+    finally entries.close()
+  }
+
+  /**
+   * Assert the writer left no spill file behind. A neighbouring worker's in-flight spill can also
+   * land in the diff, so re-observe until it clears: a foreign file is released when that write
+   * ends, whereas a genuine leak persists and still fails the assertion.
+   */
+  private def assertNoSpillLeak(before: Set[Path], clue: String, retries: Int = 40): IO[Unit] =
+    spillFiles.flatMap { after =>
+      val leaked = after -- before
+      if leaked.isEmpty then IO.unit
+      else if retries <= 0 then
+        IO(fail(s"$clue: ${leaked.map(_.getFileName.toString).toSeq.sorted.mkString(", ")}"))
+      else IO.sleep(50.millis) *> assertNoSpillLeak(before, clue, retries - 1)
+    }
+
   tempDir.test("writeStreamWithAutoDetect: temp files cleaned up after write") { dir =>
     val excel = ExcelIO.instance[IO]
     val path = dir.resolve("cleanup-test.xlsx")
-
-    // Get temp dir before write
-    val tempDir = java.nio.file.Paths.get(System.getProperty("java.io.tmpdir"))
-
-    // Count xl-stream temp files before
-    val countTempFilesBefore = IO {
-      import scala.jdk.CollectionConverters.*
-      java.nio.file.Files
-        .list(tempDir)
-        .iterator()
-        .asScala
-        .count(p => p.getFileName.toString.startsWith("xl-stream-"))
-    }
 
     // Write some data using auto-detect (which creates temp files)
     val rows = fs2.Stream.range(1, 101).map(i => RowData(i, Map(0 -> CellValue.Number(i))))
 
     for
-      before <- countTempFilesBefore
+      before <- spillFiles
       _ <- rows.through(excel.writeStreamWithAutoDetect(path, "Data")).compile.drain
-      after <- countTempFilesBefore
-    yield
-      // Should have same number of temp files (all cleaned up)
-      assertEquals(after, before, "Temp files should be cleaned up after write")
+      _ <- assertNoSpillLeak(before, "Temp files should be cleaned up after write")
+    yield ()
   }
 
   tempDir.test("writeStreamWithAutoDetect: temp files cleaned up on error") { dir =>
     val excel = ExcelIO.instance[IO]
     val path = dir.resolve("error-cleanup-test.xlsx")
-
-    val tempDir = java.nio.file.Paths.get(System.getProperty("java.io.tmpdir"))
-
-    val countTempFilesBefore = IO {
-      import scala.jdk.CollectionConverters.*
-      java.nio.file.Files
-        .list(tempDir)
-        .iterator()
-        .asScala
-        .count(p => p.getFileName.toString.startsWith("xl-stream-"))
-    }
 
     // Create a stream that fails mid-way
     val rows = fs2.Stream.range(1, 51).map { i =>
@@ -1543,14 +1553,11 @@ class ExcelIOSpec extends CatsEffectSuite:
     }
 
     for
-      before <- countTempFilesBefore
+      before <- spillFiles
       result <- rows.through(excel.writeStreamWithAutoDetect(path, "Data")).compile.drain.attempt
-      after <- countTempFilesBefore
-    yield
-      // Should have failed
-      assert(result.isLeft, "Should have failed")
-      // But temp files should still be cleaned up
-      assertEquals(after, before, "Temp files should be cleaned up even on error")
+      _ <- IO(assert(result.isLeft, "Should have failed"))
+      _ <- assertNoSpillLeak(before, "Temp files should be cleaned up even on error")
+    yield ()
   }
 
   // ========== Explicit Dimension Hint Tests ==========

--- a/xl-cats-effect/test/src/com/tjclp/xl/io/ExcelIOSpec.scala
+++ b/xl-cats-effect/test/src/com/tjclp/xl/io/ExcelIOSpec.scala
@@ -1546,19 +1546,15 @@ class ExcelIOSpec extends CatsEffectSuite:
           case Right(after) =>
             val leaked = after -- before
             Option.when(leaked.nonEmpty)(
-              leaked.map(_.getFileName.toString).toSeq.sorted.mkString(", ")
+              s"$clue — still present after $budget (a concurrent foreign spill can also land " +
+                s"here): ${leaked.map(_.getFileName.toString).toSeq.sorted.mkString(", ")}"
             )
-          case Left(err) => Some(s"spill directory could not be scanned: $err")
+          case Left(err) =>
+            Some(s"$clue — spill directory could not be scanned for $budget: $err")
 
         unsettled.fold(IO.unit) { detail =>
           IO.monotonic.flatMap { now =>
-            if now - start >= budget then
-              IO(
-                fail(
-                  s"$clue — still present after $budget " +
-                    s"(a concurrent foreign spill can also land here): $detail"
-                )
-              )
+            if now - start >= budget then IO(fail(detail))
             else IO.sleep(spillPoll) *> loop
           }
         }
@@ -1566,14 +1562,24 @@ class ExcelIOSpec extends CatsEffectSuite:
       loop
     }
 
-  test("assertNoSpillLeak reports a spill that outlives its budget") {
-    // Standing guard on the helper itself: if its filter ever drifts off the writer's spill name,
-    // both cleanup tests below would pass vacuously while the writer leaks. Plant a file matching
-    // the pattern, hide it from `before`, and require the helper to report it.
-    IO.blocking(Files.createTempFile("xl-stream-", ".xml")).flatMap { planted =>
+  test("assertNoSpillLeak names a spill that outlives its budget") {
+    // Half of the standing guard: the helper must still FAIL, and name the file, when something
+    // matching the pattern never clears — otherwise it could regress into a no-op that reports
+    // nothing while the writer leaks. (That the pattern still matches the WRITER is the other
+    // half, pinned by the positive control in the cleanup test below.)
+    IO.blocking {
+      val p = Files.createTempFile("xl-stream-", ".xml")
+      p.toFile.deleteOnExit()
+      p
+    }.flatMap { planted =>
       spillFiles
         .flatMap(before => assertNoSpillLeak(before - planted, "planted spill", 200.millis).attempt)
-        .map(result => assert(result.isLeft, "helper should report a spill that never clears"))
+        .map { result =>
+          assert(
+            result.left.exists(_.getMessage.contains(planted.getFileName.toString)),
+            s"helper should name the planted spill, got: $result"
+          )
+        }
         .guarantee(IO.blocking(Files.deleteIfExists(planted)).void)
     }
   }
@@ -1582,12 +1588,22 @@ class ExcelIOSpec extends CatsEffectSuite:
     val excel = ExcelIO.instance[IO]
     val path = dir.resolve("cleanup-test.xlsx")
 
-    // Write some data using auto-detect (which creates temp files)
-    val rows = fs2.Stream.range(1, 101).map(i => RowData(i, Map(0 -> CellValue.Number(i))))
-
     for
       before <- spillFiles
+      // Positive control: pin the filter to the WRITER, not to itself. The spill is created at
+      // bracket-acquire, before the first row is pulled, so it is on disk mid-stream. Without this,
+      // moving the writer's spill name or location (a plausible outcome of #514) would leave the
+      // cleanup assertion observing nothing and passing vacuously.
+      spilled <- IO.ref(Set.empty[Path])
+      rows = fs2.Stream
+        .range(1, 101)
+        .evalTap(i =>
+          IO.whenA(i == 50)(spillFiles.flatMap(s => spilled.update(_ ++ (s -- before))))
+        )
+        .map(i => RowData(i, Map(0 -> CellValue.Number(i))))
       _ <- rows.through(excel.writeStreamWithAutoDetect(path, "Data")).compile.drain
+      seen <- spilled.get
+      _ <- IO(assert(seen.nonEmpty, "writer should spill a file matching the filter mid-write"))
       _ <- assertNoSpillLeak(before, "Temp files should be cleaned up after write")
     yield ()
   }


### PR DESCRIPTION
Fixes the `main` CI failure on 69ce94fe ([run 31191410314](https://github.com/TJC-LP/xl/actions/runs/31191410314/job/92908861433)). No production code changes — the writer itself is correct.

## Root cause

The two `writeStreamWithAutoDetect: temp files cleaned up ...` tests counted **every** `xl-stream-*` entry in the shared `java.io.tmpdir` before and after a write, and asserted the counts matched. Mill splits test classes across parallel worker JVMs, and sibling suites create files with that same prefix in that same directory — both fixtures and, in suites that call the same spilling writer, real spills:

| source | file |
|---|---|
| `StreamingSstSpec`, `StreamingFormulaCachedValueSpec`, `StreamingFormulaLeadingEqualsSpec` | `xl-stream-*-*.xlsx` fixtures |
| `StreamingSstSpec:175`, xl-cli `StreamingWriteCommands` / `ImportCommands` / `StreamingCsvParser` | `xl-stream-*.xml` spills, from their own module JVM |

So a neighbour's file lands in the count and the assertion fails on a workbook nobody wrote.

The log timeline is conclusive:

- `15:16:53.14` — worker `1006-1` starts `StreamingFormulaCachedValueSpec` (creates its fixtures with `deleteOnExit`, so they persist for the run)
- `15:16:53.90` — worker `1006-0`'s "cleaned up after write" sees 5 → 6
- `15:16:53.94` — "cleaned up on error" sees 10 → 11 (four more foreign files appeared in 40 ms)

The same tree was green on the PR run (31190607633).

## Fix

Stop observing the directory; observe the writer.

1. **Discover** this write's own spills by sampling the tmpdir mid-write (the bracket acquires the temp file before the first row is pulled, so it is on disk). The sample is `.attempt`-recovered — it runs inside `evalTap`, where a scan racing a concurrent delete would otherwise abort the write.
2. **Watch those exact paths** with `Files.exists`, settling against a monotonic deadline (2s). No directory scan in the loop, so foreign traffic can only interfere if it is present at one sampling instant *and* outlives the budget.

The sample doubles as a **positive control**: it asserts the writer actually spilled something matching the filter, so moving the spill's name or location fails loudly instead of leaving the cleanup assertion watching an empty set.

Also adds cleanup coverage for `writeStreamsSeqWithAutoDetect`, which acquires one spill per sheet under a single bracket — the shape where partial deletion hides — and had none.

## Verification

Each experiment was applied to production code, observed, then reverted:

| injected fault | result |
|---|---|
| bracket release stubbed to a no-op | both single-sheet tests fail, naming the leaked path (2.07s) |
| spill renamed to `xl-spilled-*.tmp` | both fail on the positive control — previously all tests stayed green |
| filter pointed at a bogus prefix | the standing guard fails; the cleanup tests pass vacuously, which is what the guard exists to catch |
| release deletes only the first sheet's spill (`resources.take(1)`) | the multi-sheet test fails naming the survivor `xl-stream-2-*.xml`; single-sheet tests stay green |

`./mill __.test` and `ScalafmtModule/checkFormatAll` green throughout.

## Note on the doc changes

This PR touches `CLAUDE.md` and `docs/STATUS.md`, and the headline moves 5,448 → 5,451 (+3) while adding 2 tests. That is a refresh, not arithmetic: both tables were stale and mutually inconsistent — CLAUDE.md's per-module figures summed to 5,047, STATUS.md's to 3,996, both headed "5,448". The new figures are read from Mill's own `out/*/test/testForked.json` results and sum exactly to their headline.

## Follow-up

#514 — make the streaming writer's spill directory injectable, which turns this assertion exact (no shared-tmpdir observation, no settle loop) and serves callers whose `/tmp` is small or read-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)