### PR TITLE
feat(cats-effect): make the streaming writer's spill directory injectable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ excel.read(path).flatMap(wb => excel.write(wb, outPath))
 
 ```bash
 ./mill __.compile          # Compile all
-./mill __.test             # Run all tests (5,452)
+./mill __.test             # Run all tests (5,454)
 ./mill xl-core.test        # Test specific module
 ./mill __.reformat         # Format (Scalafmt 3.10.1)
 ./mill __.checkFormat      # CI check
@@ -396,12 +396,12 @@ Styles deduplicated by `CellStyle.canonicalKey`. Build style index before emitti
 
 **Framework**: MUnit + ScalaCheck | **Generators**: `xl-core/test/src/com/tjclp/xl/Generators.scala`
 
-**5,452 tests** by module: xl-evaluator (2100), xl-core (1283), xl-ooxml (1047), xl-cli (727), xl-cats-effect (146), xl-agent (122), xl prelude probes (27). See `docs/reference/testing-guide.md` for suite structure and patterns.
+**5,454 tests** by module: xl-evaluator (2100), xl-core (1283), xl-ooxml (1047), xl-cli (727), xl-cats-effect (148), xl-agent (122), xl prelude probes (27). See `docs/reference/testing-guide.md` for suite structure and patterns.
 
 ## Documentation
 
 - **Roadmap**: `docs/plan/roadmap.md` (single source of truth for work scheduling)
-- **Status**: `docs/STATUS.md` (current capabilities, 5,452 tests)
+- **Status**: `docs/STATUS.md` (current capabilities, 5,454 tests)
 - **Design**: `docs/design/*.md` (architecture, purity charter, domain model)
 - **Reference**: `docs/reference/*.md` (examples, scaffolds, performance guide)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ excel.read(path).flatMap(wb => excel.write(wb, outPath))
 
 ```bash
 ./mill __.compile          # Compile all
-./mill __.test             # Run all tests (5,451)
+./mill __.test             # Run all tests (5,452)
 ./mill xl-core.test        # Test specific module
 ./mill __.reformat         # Format (Scalafmt 3.10.1)
 ./mill __.checkFormat      # CI check
@@ -396,12 +396,12 @@ Styles deduplicated by `CellStyle.canonicalKey`. Build style index before emitti
 
 **Framework**: MUnit + ScalaCheck | **Generators**: `xl-core/test/src/com/tjclp/xl/Generators.scala`
 
-**5,451 tests** by module: xl-evaluator (2100), xl-core (1283), xl-ooxml (1047), xl-cli (727), xl-cats-effect (145), xl-agent (122), xl prelude probes (27). See `docs/reference/testing-guide.md` for suite structure and patterns.
+**5,452 tests** by module: xl-evaluator (2100), xl-core (1283), xl-ooxml (1047), xl-cli (727), xl-cats-effect (146), xl-agent (122), xl prelude probes (27). See `docs/reference/testing-guide.md` for suite structure and patterns.
 
 ## Documentation
 
 - **Roadmap**: `docs/plan/roadmap.md` (single source of truth for work scheduling)
-- **Status**: `docs/STATUS.md` (current capabilities, 5,451 tests)
+- **Status**: `docs/STATUS.md` (current capabilities, 5,452 tests)
 - **Design**: `docs/design/*.md` (architecture, purity charter, domain model)
 - **Reference**: `docs/reference/*.md` (examples, scaffolds, performance guide)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ excel.read(path).flatMap(wb => excel.write(wb, outPath))
 
 ```bash
 ./mill __.compile          # Compile all
-./mill __.test             # Run all tests (5,454)
+./mill __.test             # Run all tests (5,455)
 ./mill xl-core.test        # Test specific module
 ./mill __.reformat         # Format (Scalafmt 3.10.1)
 ./mill __.checkFormat      # CI check
@@ -396,12 +396,12 @@ Styles deduplicated by `CellStyle.canonicalKey`. Build style index before emitti
 
 **Framework**: MUnit + ScalaCheck | **Generators**: `xl-core/test/src/com/tjclp/xl/Generators.scala`
 
-**5,454 tests** by module: xl-evaluator (2100), xl-core (1283), xl-ooxml (1047), xl-cli (727), xl-cats-effect (148), xl-agent (122), xl prelude probes (27). See `docs/reference/testing-guide.md` for suite structure and patterns.
+**5,455 tests** by module: xl-evaluator (2100), xl-core (1283), xl-ooxml (1047), xl-cli (727), xl-cats-effect (149), xl-agent (122), xl prelude probes (27). See `docs/reference/testing-guide.md` for suite structure and patterns.
 
 ## Documentation
 
 - **Roadmap**: `docs/plan/roadmap.md` (single source of truth for work scheduling)
-- **Status**: `docs/STATUS.md` (current capabilities, 5,454 tests)
+- **Status**: `docs/STATUS.md` (current capabilities, 5,455 tests)
 - **Design**: `docs/design/*.md` (architecture, purity charter, domain model)
 - **Reference**: `docs/reference/*.md` (examples, scaffolds, performance guide)
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -202,7 +202,7 @@
 
 ### Test Coverage
 
-**5,454 tests** (verified via `./mill __.test`, 2026-08-07):
+**5,455 tests** (verified via `./mill __.test`, 2026-08-07):
 
 | Module | Tests | Covers |
 |--------|-------|--------|
@@ -210,7 +210,7 @@
 | xl-core | 1283 | addressing laws, Patch/StylePatch monoids, codecs, optics, RichText, interpolation, render (HTML/SVG), styles DSL, charts, drawings, conditional formatting |
 | xl-ooxml | 1047 | round-trips (cells, styles, tables, comments, hyperlinks, charts, drawings, conditional formatting), compression, security (XXE, ZIP bomb), preservation |
 | xl-cli | 727 | command parsing, batch ops, view/eval/export, streaming mode |
-| xl-cats-effect | 148 | streaming I/O, O(1) memory verification, SAX/StAX write, spill-directory routing |
+| xl-cats-effect | 149 | streaming I/O, O(1) memory verification, SAX/StAX write, spill-directory routing |
 | xl-agent | 122 | benchmark engine, skill abstraction, failure-path diagnostics, release-asset resolution |
 | xl (prelude) | 27 | external-consumer probes (`xl/test/src/xlprelude/`) |
 | xl-testkit | 0 | placeholder (no sources yet) |

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -202,7 +202,7 @@
 
 ### Test Coverage
 
-**5,452 tests** (verified via `./mill __.test`, 2026-08-07):
+**5,454 tests** (verified via `./mill __.test`, 2026-08-07):
 
 | Module | Tests | Covers |
 |--------|-------|--------|
@@ -210,7 +210,7 @@
 | xl-core | 1283 | addressing laws, Patch/StylePatch monoids, codecs, optics, RichText, interpolation, render (HTML/SVG), styles DSL, charts, drawings, conditional formatting |
 | xl-ooxml | 1047 | round-trips (cells, styles, tables, comments, hyperlinks, charts, drawings, conditional formatting), compression, security (XXE, ZIP bomb), preservation |
 | xl-cli | 727 | command parsing, batch ops, view/eval/export, streaming mode |
-| xl-cats-effect | 146 | streaming I/O, O(1) memory verification, SAX/StAX write, spill-directory routing |
+| xl-cats-effect | 148 | streaming I/O, O(1) memory verification, SAX/StAX write, spill-directory routing |
 | xl-agent | 122 | benchmark engine, skill abstraction, failure-path diagnostics, release-asset resolution |
 | xl (prelude) | 27 | external-consumer probes (`xl/test/src/xlprelude/`) |
 | xl-testkit | 0 | placeholder (no sources yet) |

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -202,7 +202,7 @@
 
 ### Test Coverage
 
-**5,451 tests** (verified via `./mill __.test`, 2026-08-07):
+**5,452 tests** (verified via `./mill __.test`, 2026-08-07):
 
 | Module | Tests | Covers |
 |--------|-------|--------|
@@ -210,7 +210,7 @@
 | xl-core | 1283 | addressing laws, Patch/StylePatch monoids, codecs, optics, RichText, interpolation, render (HTML/SVG), styles DSL, charts, drawings, conditional formatting |
 | xl-ooxml | 1047 | round-trips (cells, styles, tables, comments, hyperlinks, charts, drawings, conditional formatting), compression, security (XXE, ZIP bomb), preservation |
 | xl-cli | 727 | command parsing, batch ops, view/eval/export, streaming mode |
-| xl-cats-effect | 145 | streaming I/O, O(1) memory verification, SAX/StAX write |
+| xl-cats-effect | 146 | streaming I/O, O(1) memory verification, SAX/StAX write, spill-directory routing |
 | xl-agent | 122 | benchmark engine, skill abstraction, failure-path diagnostics, release-asset resolution |
 | xl (prelude) | 27 | external-consumer probes (`xl/test/src/xlprelude/`) |
 | xl-testkit | 0 | placeholder (no sources yet) |

--- a/docs/plan/roadmap.md
+++ b/docs/plan/roadmap.md
@@ -10,7 +10,7 @@
 
 ## TL;DR
 
-**Current Status**: Production-ready with **115 formula functions** (incl. dynamic arrays SEQUENCE/SORT/UNIQUE/FILTER and OFFSET), **structural editing** (insert/delete rows & columns with formula rewriting), the **scripting prelude** (`com.tjclp.xl.scripting`), whole-workbook `recalculate`, named-range & hyperlink authoring, **typed charts + embedded pictures** (0.12.0), **conditional formatting** (0.12.1), SAX streaming (36% faster than POI), Excel tables, and full OOXML round-trip. 5,448 tests passing.
+**Current Status**: Production-ready with **115 formula functions** (incl. dynamic arrays SEQUENCE/SORT/UNIQUE/FILTER and OFFSET), **structural editing** (insert/delete rows & columns with formula rewriting), the **scripting prelude** (`com.tjclp.xl.scripting`), whole-workbook `recalculate`, named-range & hyperlink authoring, **typed charts + embedded pictures** (0.12.0), **conditional formatting** (0.12.1), SAX streaming (36% faster than POI), Excel tables, and full OOXML round-trip. 5,455 tests passing.
 
 **Current Version**: **0.19.2** "Fixpoint" (recalculation & seeding integrity, released 2026-08-06)
 

--- a/docs/reference/performance-guide.md
+++ b/docs/reference/performance-guide.md
@@ -119,10 +119,13 @@ bytes through it, so on a container with a tiny `/tmp` this is the difference be
 `No space left on device`. Single-pass `writeStream`/`writeStreamsSeq` never spill; give them an
 explicit `dimension` when you know the bounds.
 
-The scratch file holds the worksheet body in cleartext until the write ends. It is created
-`rw-------` on POSIX either way, but redirecting it makes the *directory's* permissions your
-call — and the natural targets for this setting (a shared scratch mount, a big fast volume) are
-often group- or world-traversable. Prefer a directory the process owns.
+Two things you inherit by redirecting it. The scratch file holds the worksheet body in cleartext
+until the write ends; it is created `rw-------` on POSIX either way, but the *directory's*
+permissions become your call, and the natural targets for this setting (a shared scratch mount, a
+big fast volume) are often group- or world-traversable — prefer a directory the process owns. And
+the spill is deleted by the write's own bracket, not registered with `deleteOnExit` (which leaks in
+long-lived JVMs), so a `SIGKILL` or OOM-kill mid-write strands it: in `java.io.tmpdir` the OS
+eventually sweeps it, on a persistent volume it stays until you do.
 
 ---
 

--- a/docs/reference/performance-guide.md
+++ b/docs/reference/performance-guide.md
@@ -119,6 +119,11 @@ bytes through it, so on a container with a tiny `/tmp` this is the difference be
 `No space left on device`. Single-pass `writeStream`/`writeStreamsSeq` never spill; give them an
 explicit `dimension` when you know the bounds.
 
+The scratch file holds the worksheet body in cleartext until the write ends. It is created
+`rw-------` on POSIX either way, but redirecting it makes the *directory's* permissions your
+call — and the natural targets for this setting (a shared scratch mount, a big fast volume) are
+often group- or world-traversable. Prefer a directory the process owns.
+
 ---
 
 ### Streaming Read Mode

--- a/docs/reference/performance-guide.md
+++ b/docs/reference/performance-guide.md
@@ -104,6 +104,21 @@ Stream.range(1, 1_000_001)
 - ❌ No SST (larger files if many duplicate strings).
 - ❌ Minimal styles only (no rich formatting at scale).
 
+**Where the scratch file goes**: the auto-detect variants (`writeStreamWithAutoDetect`,
+`writeStreamsSeqWithAutoDetect`) buy their up-front `<dimension>` with a two-pass write, spilling
+the worksheet body to a scratch file — one per sheet — and deleting it when the write ends, success
+or failure. It lands in `java.io.tmpdir` by default. Redirect it when that directory is small,
+read-only, or slower than the output volume:
+
+```scala
+val excel = ExcelIO.instance[IO].withSpillDir(fastVolume)  // must already exist
+```
+
+Constant-memory holds either way — the spill is disk, not heap — but a 1M-row write moves real
+bytes through it, so on a container with a tiny `/tmp` this is the difference between working and
+`No space left on device`. Single-pass `writeStream`/`writeStreamsSeq` never spill; give them an
+explicit `dimension` when you know the bounds.
+
 ---
 
 ### Streaming Read Mode

--- a/docs/reference/testing-guide.md
+++ b/docs/reference/testing-guide.md
@@ -215,14 +215,14 @@ As of 0.12.6 (per-module `./mill <module>.test`; macros are part of xl-core — 
 
 | Module | Tests |
 |--------|-------|
-| xl-evaluator | 1599 |
-| xl-core | 1104 |
-| xl-ooxml | 702 |
-| xl-cli | 448 |
-| xl-cats-effect | 111 |
-| xl-agent | 102 |
-| xl (prelude probes, `xlprelude.ScriptingPreludeTest`) | 19 |
-| **Total** | **4,085** |
+| xl-evaluator | 2100 |
+| xl-core | 1283 |
+| xl-ooxml | 1047 |
+| xl-cli | 727 |
+| xl-cats-effect | 149 |
+| xl-agent | 122 |
+| xl (prelude probes, `xlprelude.ScriptingPreludeTest`) | 27 |
+| **Total** | **5,455** |
 
 ## Test Quality Metrics
 

--- a/xl-cats-effect/src/com/tjclp/xl/io/ExcelIO.scala
+++ b/xl-cats-effect/src/com/tjclp/xl/io/ExcelIO.scala
@@ -39,6 +39,54 @@ class ExcelIO[F[_]: Async](warningHandler: XlsxReader.Warning => F[Unit])
     extends Excel[F]
     with ExcelR[F]:
 
+  /**
+   * Where the auto-detect streaming writers put their phase-1 scratch file.
+   *
+   * `None` uses the JVM's `java.io.tmpdir`. Point it elsewhere when that directory is small,
+   * read-only, or slower than the output volume — a container's tmpfs, say. Only the two-pass
+   * writers spill; the single-pass ones never touch it.
+   *
+   * A member rather than a constructor parameter so that adding the setting did not change this
+   * class's constructor signature, which consumers compiled against an earlier release link to.
+   */
+  def spillDir: Option[Path] = None
+
+  /**
+   * An interpreter identical to this one but spilling into `dir`, which must already exist.
+   *
+   * {{{
+   * val excel = ExcelIO.instance[IO].withSpillDir(fastVolume)
+   * rows.through(excel.writeStreamWithAutoDetect(out, "Data")).compile.drain
+   * }}}
+   *
+   * Instances are cheap, so this doubles as the per-call form: build one at the call site that
+   * needs a different directory and leave the rest of the program on the default.
+   */
+  def withSpillDir(dir: Path): ExcelIO[F] =
+    new ExcelIO[F](warningHandler):
+      override def spillDir: Option[Path] = Some(dir)
+
+  /**
+   * Create a scratch file for a two-pass write, honoring [[spillDir]].
+   *
+   * A missing or unwritable directory fails here rather than mid-stream, and names the setting so
+   * the cause is not mistaken for a problem with the workbook being written.
+   */
+  private def createSpillFile(prefix: String): Path =
+    try
+      spillDir match
+        case Some(dir) => JFiles.createTempFile(dir, prefix, ".xml")
+        case None => JFiles.createTempFile(prefix, ".xml")
+    catch
+      case e: java.io.IOException =>
+        val where = spillDir.fold("the default temp directory (java.io.tmpdir)")(d =>
+          s"the configured spill directory ($d)"
+        )
+        throw new java.io.IOException(
+          s"Could not create a streaming scratch file in $where: ${e.getMessage}",
+          e
+        )
+
   /** Read workbook from XLSX file */
   def read(path: Path): F[Workbook] =
     readWith(path, XlsxReader.ReaderConfig.default)
@@ -749,7 +797,7 @@ class ExcelIO[F[_]: Async](warningHandler: XlsxReader.Warning => F[Unit])
         Stream
           .bracket(
             Sync[F].delay {
-              val tempFile = JFiles.createTempFile("xl-stream-", ".xml")
+              val tempFile = createSpillFile("xl-stream-")
               val bounds = new BoundsAccumulator()
               (tempFile, bounds)
             }
@@ -1072,7 +1120,7 @@ class ExcelIO[F[_]: Async](warningHandler: XlsxReader.Warning => F[Unit])
         .bracket(
           Sync[F].delay {
             sheetsWithIndices.map { case (name, sheetIndex, _) =>
-              val tempFile = JFiles.createTempFile(s"xl-stream-$sheetIndex-", ".xml")
+              val tempFile = createSpillFile(s"xl-stream-$sheetIndex-")
               val bounds = new BoundsAccumulator()
               (name, sheetIndex, tempFile, bounds)
             }
@@ -1317,3 +1365,12 @@ object ExcelIO:
   /** Create ExcelIO with custom warning handler */
   def withWarnings[F[_]: Async](handler: XlsxReader.Warning => F[Unit]): ExcelIO[F] =
     new ExcelIO[F](handler)
+
+  /**
+   * Create ExcelIO whose streaming writers spill into `dir` instead of `java.io.tmpdir`.
+   *
+   * Shorthand for `instance[F].withSpillDir(dir)`; chain [[ExcelIO.withSpillDir]] off
+   * [[withWarnings]] to combine it with a warning handler.
+   */
+  def withSpillDir[F[_]: Async](dir: Path): ExcelIO[F] =
+    instance[F].withSpillDir(dir)

--- a/xl-cats-effect/src/com/tjclp/xl/io/ExcelIO.scala
+++ b/xl-cats-effect/src/com/tjclp/xl/io/ExcelIO.scala
@@ -61,8 +61,13 @@ class ExcelIO[F[_]: Async](warningHandler: XlsxReader.Warning => F[Unit])
    *
    * Instances are cheap, so this doubles as the per-call form: build one at the call site that
    * needs a different directory and leave the rest of the program on the default.
+   *
+   * Carries the warning handler over, but nothing else: the result is a plain `ExcelIO`, so a
+   * subclass calling this would silently lose its own overrides. Subclasses should override
+   * [[spillDir]] directly instead — hence `final`, so that trap cannot be widened by overriding
+   * this method too.
    */
-  def withSpillDir(dir: Path): ExcelIO[F] =
+  final def withSpillDir(dir: Path): ExcelIO[F] =
     new ExcelIO[F](warningHandler):
       override def spillDir: Option[Path] = Some(dir)
 
@@ -1115,14 +1120,29 @@ class ExcelIO[F[_]: Async](warningHandler: XlsxReader.Warning => F[Unit])
         (name, idx + 1, rows)
       }
 
-      // Create temp file + bounds tracker for each sheet
+      // Create temp file + bounds tracker for each sheet.
+      //
+      // Acquire is all-or-nothing: bracket's release never runs for a failed acquire, so a spill
+      // that cannot be created partway through — a full or quota-bound volume, a directory the
+      // process may traverse but not write — would strand the sheets already spilled. Unwind them
+      // here before rethrowing. Only reachable once the directory is the caller's choice; a broken
+      // java.io.tmpdir fails on the first sheet, with nothing yet to clean up.
       Stream
         .bracket(
           Sync[F].delay {
-            sheetsWithIndices.map { case (name, sheetIndex, _) =>
-              val tempFile = createSpillFile(s"xl-stream-$sheetIndex-")
-              val bounds = new BoundsAccumulator()
-              (name, sheetIndex, tempFile, bounds)
+            sheetsWithIndices.foldLeft(Seq.empty[(String, Int, Path, BoundsAccumulator)]) {
+              case (acquired, (name, sheetIndex, _)) =>
+                try
+                  acquired :+ ((
+                    name,
+                    sheetIndex,
+                    createSpillFile(s"xl-stream-$sheetIndex-"),
+                    new BoundsAccumulator()
+                  ))
+                catch
+                  case e: Throwable =>
+                    acquired.foreach { case (_, _, tempFile, _) => JFiles.deleteIfExists(tempFile) }
+                    throw e
             }
           }
         ) { resources =>

--- a/xl-cats-effect/src/com/tjclp/xl/io/ExcelIO.scala
+++ b/xl-cats-effect/src/com/tjclp/xl/io/ExcelIO.scala
@@ -48,6 +48,8 @@ class ExcelIO[F[_]: Async](warningHandler: XlsxReader.Warning => F[Unit])
    *
    * A member rather than a constructor parameter so that adding the setting did not change this
    * class's constructor signature, which consumers compiled against an earlier release link to.
+   * Consulted exactly once per spilled sheet, so an override that varies between reads decides one
+   * sheet at a time rather than being sampled twice for the same file.
    */
   def spillDir: Option[Path] = None
 
@@ -78,13 +80,16 @@ class ExcelIO[F[_]: Async](warningHandler: XlsxReader.Warning => F[Unit])
    * the cause is not mistaken for a problem with the workbook being written.
    */
   private def createSpillFile(prefix: String): Path =
+    // Read the setting once: it is overridable, so a second read could report a directory other
+    // than the one that actually failed — exactly the confusion this message exists to prevent.
+    val target = spillDir
     try
-      spillDir match
+      target match
         case Some(dir) => JFiles.createTempFile(dir, prefix, ".xml")
         case None => JFiles.createTempFile(prefix, ".xml")
     catch
       case e: java.io.IOException =>
-        val where = spillDir.fold("the default temp directory (java.io.tmpdir)")(d =>
+        val where = target.fold("the default temp directory (java.io.tmpdir)")(d =>
           s"the configured spill directory ($d)"
         )
         throw new java.io.IOException(
@@ -1141,7 +1146,12 @@ class ExcelIO[F[_]: Async](warningHandler: XlsxReader.Warning => F[Unit])
                   ))
                 catch
                   case e: Throwable =>
-                    acquired.foreach { case (_, _, tempFile, _) => JFiles.deleteIfExists(tempFile) }
+                    // Best-effort: the pathological filesystem that failed the acquire is the one
+                    // most likely to fail these deletes too, and the cause must survive that.
+                    acquired.foreach { case (_, _, tempFile, _) =>
+                      try JFiles.deleteIfExists(tempFile)
+                      catch case d: Throwable => e.addSuppressed(d)
+                    }
                     throw e
             }
           }

--- a/xl-cats-effect/test/src/com/tjclp/xl/io/ExcelIOSpec.scala
+++ b/xl-cats-effect/test/src/com/tjclp/xl/io/ExcelIOSpec.scala
@@ -5,7 +5,8 @@ import munit.CatsEffectSuite
 
 import java.io.{ByteArrayOutputStream, FileInputStream, FileOutputStream}
 import java.nio.charset.StandardCharsets
-import java.nio.file.{Files, Path}
+import java.nio.file.attribute.PosixFilePermissions
+import java.nio.file.{FileSystems, Files, Path}
 import java.util.zip.{ZipEntry, ZipInputStream, ZipOutputStream}
 import scala.util.Using
 import com.tjclp.xl.{*, given}
@@ -36,9 +37,11 @@ class ExcelIOSpec extends CatsEffectSuite:
         .forEach(Files.delete)
   )
 
-  /** Directory to drop a fixture-adjacent copy in, falling back to the working directory. */
+  /** Directory to drop a fixture-adjacent copy in. */
   private def fixtureDirOf(source: Path): Path =
-    Option(source.getParent).getOrElse(Path.of("."))
+    Option(source.getParent).getOrElse(
+      fail(s"expected a fixture-local source so the copy is torn down with it, got: $source")
+    )
 
   /**
    * Copy `source` with one worksheet entry renamed. The copy lands beside its source — inside the
@@ -1646,7 +1649,7 @@ class ExcelIOSpec extends CatsEffectSuite:
       val rows = fs2.Stream.range(1, 11).map(i => RowData(i, Map(0 -> CellValue.Number(i))))
 
       rows
-        .through(excel.writeStreamWithAutoDetect(dir.resolve("unwritable.xlsx"), "Data"))
+        .through(excel.writeStreamWithAutoDetect(dir.resolve("missing-spill-dir.xlsx"), "Data"))
         .compile
         .drain
         .attempt
@@ -1655,6 +1658,54 @@ class ExcelIOSpec extends CatsEffectSuite:
           val message = result.left.toOption.flatMap(e => Option(e.getMessage)).getOrElse("")
           assert(
             message.contains("spill directory") && message.contains(missing.toString),
+            s"failure should name the spill directory setting, got: $message"
+          )
+        }
+  }
+
+  tempDir.test("withSpillDir: an unwritable directory fails the same way a missing one does") {
+    dir =>
+      // The read-only case the feature exists for — a container mounting its scratch volume ro —
+      // reaches createSpillFile as an AccessDeniedException rather than NoSuchFileException, so it
+      // needs its own coverage. Teardown restores write permission or the fixture cannot delete it.
+      val locked = Files.createDirectory(dir.resolve("locked"))
+      val rows = fs2.Stream.range(1, 11).map(i => RowData(i, Map(0 -> CellValue.Number(i))))
+
+      val readOnly = IO.blocking {
+        assume(
+          FileSystems.getDefault.supportedFileAttributeViews().contains("posix"),
+          "needs POSIX permissions to make a directory unwritable"
+        )
+        Files.setPosixFilePermissions(locked, PosixFilePermissions.fromString("r-x------"))
+        // root ignores the mode bits, so there would be nothing to observe.
+        assume(!Files.isWritable(locked), "running as a user that can write anyway (root?)")
+      }
+      val restore = IO
+        .blocking(
+          Files.setPosixFilePermissions(locked, PosixFilePermissions.fromString("rwx------"))
+        )
+        .void
+
+      readOnly
+        .flatMap { _ =>
+          fs2.Stream
+            .emits(rows.compile.toVector)
+            .through(
+              ExcelIO
+                .instance[IO]
+                .withSpillDir(locked)
+                .writeStreamWithAutoDetect(dir.resolve("locked-spill.xlsx"), "Data")
+            )
+            .compile
+            .drain
+            .attempt
+        }
+        .guarantee(restore)
+        .map { result =>
+          assert(result.isLeft, "an unwritable spill directory should fail the write")
+          val message = result.left.toOption.flatMap(e => Option(e.getMessage)).getOrElse("")
+          assert(
+            message.contains("spill directory") && message.contains(locked.toString),
             s"failure should name the spill directory setting, got: $message"
           )
         }

--- a/xl-cats-effect/test/src/com/tjclp/xl/io/ExcelIOSpec.scala
+++ b/xl-cats-effect/test/src/com/tjclp/xl/io/ExcelIOSpec.scala
@@ -37,9 +37,13 @@ class ExcelIOSpec extends CatsEffectSuite:
         .forEach(Files.delete)
   )
 
+  /**
+   * Copy `source` with one worksheet entry renamed. The copy lands beside its source — inside the
+   * fixture directory, which the fixture deletes — rather than in the shared temp directory, where
+   * `deleteOnExit` would strand it whenever a run ends abruptly.
+   */
   private def remapWorksheetEntry(source: Path, from: String, to: String): Path =
-    val output = Files.createTempFile("xl-stream-remap", ".xlsx")
-    output.toFile.deleteOnExit()
+    val output = Files.createTempFile(source.getParent, "remap-", ".xlsx")
     val zipIn = new ZipInputStream(new FileInputStream(source.toFile))
     val zipOut = new ZipOutputStream(new FileOutputStream(output.toFile))
     zipOut.setLevel(1)
@@ -1495,170 +1499,105 @@ class ExcelIOSpec extends CatsEffectSuite:
     }
   }
 
-  private val spillPoll: FiniteDuration = 50.millis
-
-  /** Resolved once, like the JDK's own `TempFileHelper.tmpdir` static that the writer spills to. */
-  private val spillDir: Path = Path.of(System.getProperty("java.io.tmpdir"))
-
-  /**
-   * The auto-detect writer spills its phase-1 body to `java.io.tmpdir`, which every parallel test
-   * worker JVM shares, so a raw before/after count of `xl-stream-*` entries also counts sibling
-   * suites' fixtures. The `.xml` suffix narrows that to the spill pattern — sibling *fixtures* are
-   * `.xlsx` — but does not isolate it: any suite calling this same writer (StreamingSstSpec, and
-   * the xl-cli streaming/import commands in their own module JVM) spills under the same name. So
-   * this is a discovery scan only: [[sampleSpills]] narrows it to what appeared during our own
-   * write, and [[assertSpillsCleared]] watches those exact paths rather than the directory.
-   */
-  private def spillFiles: IO[Set[Path]] = IO.blocking {
+  /** Everything currently sitting in a spill directory. */
+  private def filesIn(dir: Path): IO[Set[Path]] = IO.blocking {
     import scala.jdk.CollectionConverters.*
-    Using.resource(Files.list(spillDir)) { entries =>
-      entries
-        .iterator()
-        .asScala
-        .filter { p =>
-          val name = p.getFileName.toString
-          name.startsWith("xl-stream-") && name.endsWith(".xml")
-        }
-        .toSet
-    }
+    Using.resource(Files.list(dir))(_.iterator().asScala.toSet)
   }
 
+  /** A fresh, writer-owned spill directory under the test's fixture directory. */
+  private def spillDirUnder(dir: Path): IO[Path] =
+    IO.blocking(Files.createDirectory(dir.resolve("spill")))
+
   /**
-   * Record the spills that appeared since `before` — i.e. this write's own, since the writer
-   * creates its temp file at bracket-acquire, ahead of the first row. Sampling repeatedly keeps the
-   * record honest if the writer ever spills more than once per write.
+   * Sample a directory repeatedly while the write runs, accumulating whatever it holds.
    *
-   * A scan racing a concurrent delete must never take the write down with it: recovering to "saw
-   * nothing this time" leaves the positive control to fail loudly on the empty record instead of
-   * the test dying on a `DirectoryIteratorException` that has nothing to do with cleanup.
+   * The two-pass writers create their scratch file at bracket-acquire, ahead of the first row, so a
+   * mid-stream look always sees it. This is the positive control that keeps the "empty afterwards"
+   * assertions honest: point the writer at its own directory and "no leftovers" would also hold if
+   * it never spilled there at all, or spilled somewhere else entirely.
+   *
+   * A listing that loses a race with the writer's own cleanup must not take the write down with it
+   * — recovering to "saw nothing this time" leaves the control to fail on an empty record instead
+   * of the test dying on an unrelated `DirectoryIteratorException`.
    */
-  private def sampleSpills(before: Set[Path], into: Ref[IO, Set[Path]]): IO[Unit] =
-    spillFiles.attempt.flatMap {
-      case Right(now) => into.update(_ ++ (now -- before))
+  private def sampleDir(dir: Path, into: Ref[IO, Set[Path]]): IO[Unit] =
+    filesIn(dir).attempt.flatMap {
+      case Right(found) => into.update(_ ++ found)
       case Left(_) => IO.unit
     }
 
-  /**
-   * Assert the writer deleted the spills it created. Watching those exact paths — not the diff of a
-   * directory several worker JVMs are churning — is what keeps this honest: a foreign spill has to
-   * be in flight at one sampling instant AND outlive the budget to interfere, rather than merely
-   * overlapping the window.
-   *
-   * The bracket release is synchronous with stream termination, so the happy path settles on the
-   * first look and the budget only covers that residual case; a leak burns the whole budget and
-   * still fails. What this trades away is detection of cleanup drifting into a late async fiber —
-   * not detection of a leak. The budget is wall-clock against a monotonic deadline rather than a
-   * sleep count, so a slow filesystem cannot stretch it toward munit's timeout and degrade the
-   * failure into a bare timeout, losing the paths reported here.
-   */
-  private def assertSpillsCleared(
-    watched: Set[Path],
-    clue: String,
-    budget: FiniteDuration = 2.seconds
-  ): IO[Unit] =
-    IO.monotonic.flatMap { start =>
-      lazy val loop: IO[Unit] = IO.blocking(watched.filter(Files.exists(_))).flatMap { present =>
-        if present.isEmpty then IO.unit
-        else
-          IO.monotonic.flatMap { now =>
-            if now - start >= budget then
-              IO(
-                fail(
-                  s"$clue — still present after $budget: " +
-                    present.map(_.getFileName.toString).toSeq.sorted.mkString(", ")
-                )
-              )
-            else IO.sleep(spillPoll) *> loop
-          }
-      }
-      loop
+  private def assertEmpty(dir: Path, clue: String): IO[Unit] =
+    filesIn(dir).flatMap { leftover =>
+      IO(
+        assert(
+          leftover.isEmpty,
+          s"$clue, found: ${leftover.map(_.getFileName.toString).toSeq.sorted.mkString(", ")}"
+        )
+      )
     }
 
-  test("assertSpillsCleared names a spill that outlives its budget") {
-    // Half of the standing guard: the helper must still FAIL, and name the file, when a watched
-    // spill never clears — otherwise it could regress into a no-op that reports nothing while the
-    // writer leaks. (That the filter still finds the WRITER's spill is the other half, pinned by
-    // the positive control in both cleanup tests below.)
-    IO.blocking {
-      val p = Files.createTempFile("xl-stream-", ".xml")
-      p.toFile.deleteOnExit()
-      p
-    }.flatMap { planted =>
-      assertSpillsCleared(Set(planted), "planted spill", 200.millis).attempt
-        .map { result =>
-          assert(
-            result.left.exists(_.getMessage.contains(planted.getFileName.toString)),
-            s"helper should name the planted spill, got: $result"
-          )
-        }
-        .guarantee(IO.blocking(Files.deleteIfExists(planted)).void)
-    }
-  }
-
-  tempDir.test("writeStreamWithAutoDetect: temp files cleaned up after write") { dir =>
-    val excel = ExcelIO.instance[IO]
+  tempDir.test("withSpillDir: spill lands in the configured directory and is cleaned up") { dir =>
     val path = dir.resolve("cleanup-test.xlsx")
 
     for
-      before <- spillFiles
-      // Positive control: tie the filter to the writer rather than to itself, so moving the spill's
-      // name or location (a plausible outcome of #514) fails here instead of quietly leaving the
-      // cleanup assertion watching an empty set. Strictly it says "a spill matching the filter
-      // appeared mid-write" — a sibling JVM's in-flight spill would satisfy it too — but every
-      // producer of this pattern is this same writer, so a rename moves them all and this still
-      // bites.
-      spilled <- IO.ref(Set.empty[Path])
+      spill <- spillDirUnder(dir)
+      excel = ExcelIO.instance[IO].withSpillDir(spill)
+      seen <- IO.ref(Set.empty[Path])
       rows = fs2.Stream
         .range(1, 101)
-        .evalTap(i => IO.whenA(i % 25 == 0)(sampleSpills(before, spilled)))
+        .evalTap(i => IO.whenA(i % 25 == 0)(sampleDir(spill, seen)))
         .map(i => RowData(i, Map(0 -> CellValue.Number(i))))
       _ <- rows.through(excel.writeStreamWithAutoDetect(path, "Data")).compile.drain
-      seen <- spilled.get
-      _ <- IO(assert(seen.nonEmpty, "writer should spill a file matching the filter mid-write"))
-      _ <- assertSpillsCleared(seen, "Temp files should be cleaned up after write")
+      spilled <- seen.get
+      _ <- IO(assert(spilled.nonEmpty, "writer should spill into the configured directory"))
+      _ <- assertEmpty(spill, "spill directory should be empty after the write")
+      // Redirecting the scratch file must not change the workbook it assembles.
+      wb <- excel.read(path)
+      _ <- IO(assertEquals(wb.sheets.head(ref"A1").value, CellValue.Number(1)))
+      _ <- IO(assertEquals(wb.sheets.head(ref"A100").value, CellValue.Number(100)))
     yield ()
   }
 
-  tempDir.test("writeStreamWithAutoDetect: temp files cleaned up on error") { dir =>
-    val excel = ExcelIO.instance[IO]
+  tempDir.test("withSpillDir: spill is cleaned up when the write fails") { dir =>
     val path = dir.resolve("error-cleanup-test.xlsx")
 
     for
-      before <- spillFiles
-      spilled <- IO.ref(Set.empty[Path])
-      // Same positive control, sampled before the row-25 failure.
+      spill <- spillDirUnder(dir)
+      excel = ExcelIO.instance[IO].withSpillDir(spill)
+      seen <- IO.ref(Set.empty[Path])
       rows = fs2.Stream
         .range(1, 51)
-        .evalTap(i => IO.whenA(i % 5 == 0)(sampleSpills(before, spilled)))
+        .evalTap(i => IO.whenA(i % 5 == 0)(sampleDir(spill, seen)))
         .map { i =>
           if i == 25 then throw new RuntimeException("Simulated failure")
           RowData(i, Map(0 -> CellValue.Number(i)))
         }
       result <- rows.through(excel.writeStreamWithAutoDetect(path, "Data")).compile.drain.attempt
       _ <- IO(assert(result.isLeft, "Should have failed"))
-      seen <- spilled.get
-      _ <- IO(assert(seen.nonEmpty, "writer should spill a file matching the filter mid-write"))
-      _ <- assertSpillsCleared(seen, "Temp files should be cleaned up even on error")
+      spilled <- seen.get
+      _ <- IO(assert(spilled.nonEmpty, "writer should spill into the configured directory"))
+      _ <- assertEmpty(spill, "spill directory should be empty even after a failed write")
     yield ()
   }
 
-  tempDir.test("writeStreamsSeqWithAutoDetect: per-sheet temp files cleaned up on error") { dir =>
-    val excel = ExcelIO.instance[IO]
+  tempDir.test("withSpillDir: per-sheet spills are all cleaned up when the write fails") { dir =>
     val path = dir.resolve("multi-error-cleanup.xlsx")
 
     // The multi-sheet bracket acquires one spill per sheet up front and releases them together —
     // the shape where partial deletion hides. Failing inside the second sheet leaves the first
     // sheet's spill fully written and the second's half-written, so both must still go.
     for
-      before <- spillFiles
-      spilled <- IO.ref(Set.empty[Path])
+      spill <- spillDirUnder(dir)
+      excel = ExcelIO.instance[IO].withSpillDir(spill)
+      seen <- IO.ref(Set.empty[Path])
       sheet1 = fs2.Stream
         .range(1, 21)
-        .evalTap(i => IO.whenA(i % 5 == 0)(sampleSpills(before, spilled)))
+        .evalTap(i => IO.whenA(i % 5 == 0)(sampleDir(spill, seen)))
         .map(i => RowData(i, Map(0 -> CellValue.Number(i))))
       sheet2 = fs2.Stream
         .range(1, 21)
-        .evalTap(i => IO.whenA(i % 5 == 0)(sampleSpills(before, spilled)))
+        .evalTap(i => IO.whenA(i % 5 == 0)(sampleDir(spill, seen)))
         .map { i =>
           if i == 10 then throw new RuntimeException("Simulated failure")
           RowData(i, Map(0 -> CellValue.Number(i)))
@@ -1667,9 +1606,71 @@ class ExcelIOSpec extends CatsEffectSuite:
         .writeStreamsSeqWithAutoDetect(path, Seq("First" -> sheet1, "Second" -> sheet2))
         .attempt
       _ <- IO(assert(result.isLeft, "Should have failed"))
-      seen <- spilled.get
-      _ <- IO(assert(seen.size >= 2, s"writer should spill one file per sheet, saw: $seen"))
-      _ <- assertSpillsCleared(seen, "Per-sheet temp files should be cleaned up even on error")
+      spilled <- seen.get
+      _ <- IO(assert(spilled.size >= 2, s"writer should spill one file per sheet, saw: $spilled"))
+      _ <- assertEmpty(spill, "per-sheet spills should all be cleaned up after a failed write")
+    yield ()
+  }
+
+  tempDir.test("withSpillDir: a missing directory fails naming the setting, not the workbook") {
+    dir =>
+      val missing = dir.resolve("no-such-directory")
+      val excel = ExcelIO.instance[IO].withSpillDir(missing)
+      val rows = fs2.Stream.range(1, 11).map(i => RowData(i, Map(0 -> CellValue.Number(i))))
+
+      rows
+        .through(excel.writeStreamWithAutoDetect(dir.resolve("unwritable.xlsx"), "Data"))
+        .compile
+        .drain
+        .attempt
+        .map { result =>
+          val message = result.left.toOption.fold("")(e => s"${e.getMessage}")
+          assert(result.isLeft, "a missing spill directory should fail the write")
+          assert(
+            message.contains("spill directory") && message.contains(missing.toString),
+            s"failure should name the spill directory setting, got: $message"
+          )
+        }
+  }
+
+  tempDir.test("default spill directory is java.io.tmpdir") { dir =>
+    // Pins the default: an instance with no spill directory still uses the JVM's, as it did before
+    // the setting existed. Deliberately positive-only — parallel workers share that directory, so a
+    // foreign spill can satisfy this but can never break it. Cleanup is asserted in the isolated
+    // tests above, where it can be exact.
+    val jvmTmp = Path.of(System.getProperty("java.io.tmpdir"))
+    val excel = ExcelIO.instance[IO]
+    val path = dir.resolve("default-spill.xlsx")
+
+    def streamSpills: IO[Set[Path]] = IO.blocking {
+      import scala.jdk.CollectionConverters.*
+      Using.resource(Files.list(jvmTmp)) { entries =>
+        entries
+          .iterator()
+          .asScala
+          .filter { p =>
+            val name = p.getFileName.toString
+            name.startsWith("xl-stream-") && name.endsWith(".xml")
+          }
+          .toSet
+      }
+    }
+
+    for
+      before <- streamSpills
+      seen <- IO.ref(Set.empty[Path])
+      rows = fs2.Stream
+        .range(1, 101)
+        .evalTap(i =>
+          IO.whenA(i % 25 == 0)(streamSpills.attempt.flatMap {
+            case Right(found) => seen.update(_ ++ (found -- before))
+            case Left(_) => IO.unit
+          })
+        )
+        .map(i => RowData(i, Map(0 -> CellValue.Number(i))))
+      _ <- rows.through(excel.writeStreamWithAutoDetect(path, "Data")).compile.drain
+      spilled <- seen.get
+      _ <- IO(assert(spilled.nonEmpty, "default instance should spill into java.io.tmpdir"))
     yield ()
   }
 

--- a/xl-cats-effect/test/src/com/tjclp/xl/io/ExcelIOSpec.scala
+++ b/xl-cats-effect/test/src/com/tjclp/xl/io/ExcelIOSpec.scala
@@ -7,7 +7,6 @@ import java.io.{ByteArrayOutputStream, FileInputStream, FileOutputStream}
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Path}
 import java.util.zip.{ZipEntry, ZipInputStream, ZipOutputStream}
-import scala.concurrent.duration.*
 import scala.util.Using
 import com.tjclp.xl.{*, given}
 import com.tjclp.xl.unsafe.*
@@ -37,13 +36,17 @@ class ExcelIOSpec extends CatsEffectSuite:
         .forEach(Files.delete)
   )
 
+  /** Directory to drop a fixture-adjacent copy in, falling back to the working directory. */
+  private def fixtureDirOf(source: Path): Path =
+    Option(source.getParent).getOrElse(Path.of("."))
+
   /**
    * Copy `source` with one worksheet entry renamed. The copy lands beside its source — inside the
    * fixture directory, which the fixture deletes — rather than in the shared temp directory, where
    * `deleteOnExit` would strand it whenever a run ends abruptly.
    */
   private def remapWorksheetEntry(source: Path, from: String, to: String): Path =
-    val output = Files.createTempFile(source.getParent, "remap-", ".xlsx")
+    val output = Files.createTempFile(fixtureDirOf(source), "remap-", ".xlsx")
     val zipIn = new ZipInputStream(new FileInputStream(source.toFile))
     val zipOut = new ZipOutputStream(new FileOutputStream(output.toFile))
     zipOut.setLevel(1)
@@ -68,6 +71,30 @@ class ExcelIOSpec extends CatsEffectSuite:
         zipOut.putNextEntry(outEntry)
         zipOut.write(updatedData)
         zipOut.closeEntry()
+        zipIn.closeEntry()
+        entry = zipIn.getNextEntry
+    finally
+      zipIn.close()
+      zipOut.close()
+    output
+
+  /** Copy `source` beside itself without one zip entry, to provoke a reader warning. */
+  private def withoutZipEntry(source: Path, drop: String): Path =
+    val output = Files.createTempFile(fixtureDirOf(source), "stripped-", ".xlsx")
+    val zipIn = new ZipInputStream(new FileInputStream(source.toFile))
+    val zipOut = new ZipOutputStream(new FileOutputStream(output.toFile))
+    zipOut.setLevel(1)
+    try
+      var entry = zipIn.getNextEntry
+      while entry != null do
+        val data = readEntryBytes(zipIn)
+        if entry.getName != drop then
+          val outEntry = new ZipEntry(entry.getName)
+          outEntry.setTime(0L)
+          outEntry.setMethod(ZipEntry.DEFLATED)
+          zipOut.putNextEntry(outEntry)
+          zipOut.write(data)
+          zipOut.closeEntry()
         zipIn.closeEntry()
         entry = zipIn.getNextEntry
     finally
@@ -1624,13 +1651,59 @@ class ExcelIOSpec extends CatsEffectSuite:
         .drain
         .attempt
         .map { result =>
-          val message = result.left.toOption.fold("")(e => s"${e.getMessage}")
           assert(result.isLeft, "a missing spill directory should fail the write")
+          val message = result.left.toOption.flatMap(e => Option(e.getMessage)).getOrElse("")
           assert(
             message.contains("spill directory") && message.contains(missing.toString),
             s"failure should name the spill directory setting, got: $message"
           )
         }
+  }
+
+  tempDir.test("withSpillDir: unwinds the spills it already took when acquire fails partway") {
+    dir =>
+      // Acquire is all-or-nothing and bracket's release never runs for a failed acquire, so the
+      // sheets already spilled have to be unwound by hand. Overriding spillDir per call is the
+      // seam: the first two sheets get a real directory, the third a missing one, which is what a
+      // volume filling up mid-acquire looks like from here.
+      val good = Files.createDirectory(dir.resolve("spill"))
+      val missing = dir.resolve("gone")
+      var calls = 0
+      val excel = new ExcelIO[IO](_ => IO.unit):
+        override def spillDir: Option[Path] =
+          calls += 1
+          if calls <= 2 then Some(good) else Some(missing)
+
+      def rows = fs2.Stream.range(1, 6).map(i => RowData(i, Map(0 -> CellValue.Number(i))))
+      val sheets = Seq("A" -> rows, "B" -> rows, "C" -> rows)
+
+      for
+        result <- excel.writeStreamsSeqWithAutoDetect(dir.resolve("partial.xlsx"), sheets).attempt
+        _ <- IO(assert(result.isLeft, "a spill that cannot be created should fail the write"))
+        _ <- assertEmpty(good, "spills taken before the failure should be unwound")
+      yield ()
+  }
+
+  tempDir.test("withSpillDir: keeps the warning handler and takes the last directory set") { dir =>
+    // The reason withSpillDir rebuilds from `warningHandler` rather than from a fresh instance;
+    // nothing else would notice if that were simplified away.
+    val spill = Files.createDirectory(dir.resolve("spill"))
+    val source = dir.resolve("warns.xlsx")
+
+    for
+      seen <- IO.ref(Vector.empty[XlsxReader.Warning])
+      plain = ExcelIO.instance[IO]
+      _ <- plain.write(Workbook(Sheet("Data").put(ref"A1", CellValue.Text("x"))), source)
+      stripped <- IO.blocking(withoutZipEntry(source, "xl/styles.xml"))
+      excel = ExcelIO.withWarnings[IO](w => seen.update(_ :+ w)).withSpillDir(spill)
+      _ <- excel.read(stripped)
+      warnings <- seen.get
+      _ <- IO(assert(warnings.nonEmpty, "withSpillDir should carry the warning handler over"))
+      // Chaining replaces rather than accumulates, and the companion shorthand agrees.
+      _ <- IO(assertEquals(plain.withSpillDir(dir).withSpillDir(spill).spillDir, Some(spill)))
+      _ <- IO(assertEquals(ExcelIO.withSpillDir[IO](spill).spillDir, Some(spill)))
+      _ <- IO(assertEquals(plain.spillDir, None))
+    yield ()
   }
 
   tempDir.test("default spill directory is java.io.tmpdir") { dir =>

--- a/xl-cats-effect/test/src/com/tjclp/xl/io/streaming/StreamingFormulaCachedValueSpec.scala
+++ b/xl-cats-effect/test/src/com/tjclp/xl/io/streaming/StreamingFormulaCachedValueSpec.scala
@@ -24,7 +24,7 @@ class StreamingFormulaCachedValueSpec extends CatsEffectSuite:
   private val excel = ExcelIO.instance[IO]
 
   private def tempXlsx(label: String): Path =
-    val p = Files.createTempFile(s"xl-stream-cached-$label-", ".xlsx")
+    val p = Files.createTempFile(s"xl-fixture-cached-$label-", ".xlsx")
     p.toFile.deleteOnExit()
     p
 

--- a/xl-cats-effect/test/src/com/tjclp/xl/io/streaming/StreamingFormulaLeadingEqualsSpec.scala
+++ b/xl-cats-effect/test/src/com/tjclp/xl/io/streaming/StreamingFormulaLeadingEqualsSpec.scala
@@ -22,7 +22,7 @@ class StreamingFormulaLeadingEqualsSpec extends CatsEffectSuite:
   private val excel = ExcelIO.instance[IO]
 
   private def tempXlsx(label: String): Path =
-    val p = Files.createTempFile(s"xl-stream-leading-eq-$label-", ".xlsx")
+    val p = Files.createTempFile(s"xl-fixture-leading-eq-$label-", ".xlsx")
     p.toFile.deleteOnExit()
     p
 

--- a/xl-cats-effect/test/src/com/tjclp/xl/io/streaming/StreamingSstSpec.scala
+++ b/xl-cats-effect/test/src/com/tjclp/xl/io/streaming/StreamingSstSpec.scala
@@ -30,7 +30,7 @@ class StreamingSstSpec extends CatsEffectSuite:
   private val excel = ExcelIO.instance[IO]
 
   private def tempXlsx(label: String): Path =
-    val p = Files.createTempFile(s"xl-stream-sst-$label-", ".xlsx")
+    val p = Files.createTempFile(s"xl-fixture-sst-$label-", ".xlsx")
     p.toFile.deleteOnExit()
     p
 


### PR DESCRIPTION
Closes #514.

## Problem

The two-pass streaming writers (`writeStreamWithAutoDetect`, `writeStreamsSeqWithAutoDetect`) buy their up-front `<dimension>` by spilling the worksheet body to a scratch file — one per sheet — and that file always landed in the JVM's `java.io.tmpdir` with no way for a caller to move it.

Two consequences, one for users and one for the test suite:

- **Callers can't place the spill.** Containers routinely give `/tmp` a small tmpfs or mount it read-only, and a large write wants its scratch on the same fast volume as its output. POI solved the same problem with `TempFileCreationStrategy`.
- **The spill was unobservable in isolation.** #513 de-flaked the cleanup tests, but they could still only watch a directory several worker JVMs share, settling for up to 2s against foreign traffic.

## API

```scala
val excel = ExcelIO.instance[IO].withSpillDir(fastVolume)  // must already exist
rows.through(excel.writeStreamWithAutoDetect(out, "Data")).compile.drain
```

A missing or unwritable directory fails at acquire with a message naming the setting, so it isn't mistaken for a problem with the workbook being written.

### Three shape decisions

**`spillDir` is an overridable member, not a constructor parameter.** A parameter — even a defaulted one — changes the erased constructor from `(Function1, Async)` to `(Function1, Option, Async)`, breaking consumers compiled against an earlier release. An auxiliary constructor doesn't rescue it either: the context bound makes it `(Function1, Async, Async)`, which I confirmed with `javap` before backing it out. As shipped, the constructor is byte-identical to before and `spillDir()` is purely additive. (No MiMa in CI, so that's a manual guarantee — see follow-ups.)

**Not a `WriterConfig` field**, even though the config is already threaded to both spill sites and would have been the smaller diff. `WriterConfig` describes the document's shape — SST policy, compression, XML backend, escaping — and is also consumed by the in-memory writer, which never spills. A filesystem scratch location is the interpreter's business, not the format's.

**Per-instance rather than per-call.** Instances are cheap, so a call site that needs its own directory builds one and leaves the rest of the program on the default — one mechanism covering both.

## Two bugs found on the way

- **Partial acquire leaked.** The multi-sheet writer takes one spill per sheet inside a single bracket acquire, and bracket's release never runs for a failed acquire — so a spill that couldn't be created partway through stranded every file already taken. Pre-existing, but this PR is what makes it reachable: a broken `java.io.tmpdir` fails on sheet 1 with nothing to clean up, whereas a caller-supplied directory adds ENOSPC, quota and permission failures that land on sheet 3 of 5, in the user's own directory. Acquire now unwinds what it took, suppressing any delete failure onto the original cause rather than replacing it.
- **The failure message could name the wrong directory.** `createSpillFile` read the overridable `spillDir` twice — once to create, once to build the message. Snapshotted once, with the arity now stated in the scaladoc.

## What this buys the tests

The cleanup assertions now point the writer at a directory inside the test's own fixture, so they are exact: no name filter, no settle loop, no residual flake window. The positive control survives in sharper form — with an isolated directory, "no leftovers" would *also* hold if the writer ignored the setting, so each test proves the spill appeared there first.

One test deliberately still watches `java.io.tmpdir`, pinning that the default is unchanged. It's positive-only: a foreign spill can satisfy it, never break it.

## Verification

Each fault was injected into production code, observed, then reverted:

| injected fault | result |
|---|---|
| bracket release stubbed to a no-op | both single-sheet tests fail naming the leaked file, in 0.006s (was 2s of polling) |
| `createSpillFile` ignores its argument | 4 of 5 tests fail — the writer must actually honor the setting |
| acquire unwind removed | the partial-acquire test fails naming both orphans (`xl-stream-1-*.xml`, `xl-stream-2-*.xml`) |
| `withSpillDir` rebuilt from a fresh instance | the warning-handler test fails — pinning why it copies `warningHandler` |

Release gates, all green: `./mill __.test`, `ScalafmtModule/checkFormatAll`, `scripts/test-examples.sh`, `scripts/verify-skill-snippets.sh --local`.

## Also in this PR

The two hygiene items filed on #514: sibling fixtures move off the `xl-stream-` namespace (`xl-fixture-sst-` etc.) so the spill pattern is unambiguous, and `remapWorksheetEntry` writes into the fixture directory instead of stranding a file in the shared one when a run ends abruptly.

Docs: the performance guide gains a "where the scratch file goes" note under row-stream writes, including that redirecting the spill makes the directory's permissions the caller's business (the file itself is `rw-------` either way). Test counts to 5,455 / xl-cats-effect 149.

## Follow-ups filed

- **#516** — `XlsxWriter.writeToBytes` has the same failure with no lever (pure module, no interpreter to carry the setting).
- **#517** — a CLI `--spill-dir`. The CLI's global options thread through many `mapN` combinators and an 8-parameter `run`, so it doesn't belong here, but `xl import --stream` pushes real volume through `/tmp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)