### PR TITLE
Kahn-core linear allocation + SIGTERM termination (GH-518, GH-519)

### DIFF
--- a/xl-cli/src/com/tjclp/xl/cli/Main.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/Main.scala
@@ -2,7 +2,10 @@ package com.tjclp.xl.cli
 
 import java.nio.file.Path
 
+import scala.concurrent.duration.*
+
 import cats.effect.{ExitCode, IO}
+import cats.effect.unsafe.IORuntimeConfig
 import cats.implicits.*
 import cats.syntax.parallel.*
 import com.monovore.decline.*
@@ -71,6 +74,26 @@ object Main
       header = "LLM-friendly Excel operations (stateless)",
       version = BuildInfo.version
     ):
+
+  /**
+   * GH-519: SIGTERM/SIGINT must terminate the process even mid-recalculation. The evaluator is a
+   * single non-yielding compute step, so fiber cancellation is only observed once the whole
+   * computation finishes — under the default `shutdownHookTimeout = Duration.Inf` a TERM'd `xl`
+   * kept computing at full CPU for the entire remaining recalc and then discarded the result. A
+   * finite timeout lets the JVM (and the native image, which installs exit handlers by default on
+   * GraalVM 25+) halt promptly after the cancellation attempt; the torn-`-o`-output window this
+   * leaves is identical to the pre-existing SIGKILL reality, and `-i` writes stay atomic (temp +
+   * ATOMIC_MOVE).
+   *
+   * The CPU-starvation checker is disabled outright: xl is a batch compute process, so "your
+   * compute pool is busy" is the expected steady state, and on small containers the checker drowned
+   * real diagnostics in warnings. Public (not protected) so tests can pin the config.
+   */
+  override def runtimeConfig: IORuntimeConfig =
+    super.runtimeConfig.copy(
+      shutdownHookTimeout = 2.seconds,
+      cpuStarvationCheckInitialDelay = Duration.Inf
+    )
 
   override def main: Opts[IO[ExitCode]] =
     // Workbook-level: only --file (no --sheet)

--- a/xl-cli/test/src/com/tjclp/xl/cli/MainSpec.scala
+++ b/xl-cli/test/src/com/tjclp/xl/cli/MainSpec.scala
@@ -1530,3 +1530,17 @@ class MainSpec extends CatsEffectSuite:
       "Saved (streaming): out.xlsx"
     )
   }
+
+  test("GH-519: shutdown-hook timeout is finite so SIGTERM terminates a mid-compute process") {
+    // The evaluator is a single non-yielding compute step; fiber cancellation is only observed
+    // when it completes. With the cats-effect default (Duration.Inf) a TERM'd xl computed the
+    // entire remaining recalc at full CPU and then discarded the result — timeout(1) could not
+    // bound an invocation at all. This pins the finite deadline that lets the process halt.
+    assert(
+      Main.runtimeConfig.shutdownHookTimeout.isFinite,
+      s"shutdownHookTimeout must be finite, got ${Main.runtimeConfig.shutdownHookTimeout}"
+    )
+    // Batch tool, not a server: the CPU-starvation checker is pure noise on small containers
+    // (it drowned real diagnostics in the deployed-agent sandboxes) and stays disabled.
+    assert(!Main.runtimeConfig.cpuStarvationCheckInitialDelay.isFinite)
+  }

--- a/xl-evaluator/src/com/tjclp/xl/formula/graph/DependencyGraph.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/graph/DependencyGraph.scala
@@ -834,7 +834,16 @@ object DependencyGraph:
    * in the node type (GH-346). Only nodes present in `dependencies` (formula cells) are ordered;
    * edges to non-nodes (constants, empty cells) are ignored. Left carries the nodes that could not
    * be ordered (cycle participants and everything downstream of them).
+   *
+   * GH-518: implemented with LOCAL mutable state behind the pure signature (the same posture as
+   * [[foreachSccOf]]). The immutable-List formulation allocated O(V²) cons cells — `acc :+ node`
+   * copies the accumulator once per node and `rest ++ newlyZero` copies the pending queue — which
+   * on a 50k-formula workbook was 81% of an entire recalculation's allocation. Iteration stays over
+   * the same collections in the same order, so the emitted order is unchanged: FIFO queue seeded in
+   * `allNodes` iteration order, newly-ready nodes appended in the iteration order of the filtered
+   * dependents set.
    */
+  @SuppressWarnings(Array("org.wartremover.warts.Var", "org.wartremover.warts.While"))
   private def kahnOrder[K](
     dependencies: Map[K, Set[K]],
     dependents: Map[K, Set[K]]
@@ -845,41 +854,34 @@ object DependencyGraph:
     // If no formula cells, early exit
     if allNodes.isEmpty then scala.util.Right(List.empty[K])
     else
-      // Calculate in-degree for each node (number of formula cells it depends on)
-      // Only count dependencies on other formula cells, not constants
-      val inDegree = allNodes.map { node =>
-        val deps = dependencies.getOrElse(node, Set.empty)
-        val formulaDeps = deps.filter(allNodes.contains)
-        node -> formulaDeps.size
-      }.toMap
+      // In-degree = dependencies on other formula cells only, not constants
+      val inDegree = scala.collection.mutable.HashMap.empty[K, Int]
+      allNodes.foreach { node =>
+        inDegree(node) = dependencies.getOrElse(node, Set.empty).count(allNodes.contains)
+      }
 
       // Start with nodes that have in-degree 0 (no dependencies)
-      val initialQueue = allNodes.filter(node => inDegree(node) == 0).toList
+      val queue = scala.collection.mutable.ArrayDeque.empty[K]
+      allNodes.foreach { node =>
+        if inDegree(node) == 0 then queue.append(node)
+      }
 
-      @tailrec
-      def process(
-        queue: List[K],
-        processedInDegree: Map[K, Int],
-        acc: List[K]
-      ): (List[K], Map[K, Int]) =
-        queue match
-          case Nil => (acc, processedInDegree)
-          case node :: rest =>
-            val deps = dependents.getOrElse(node, Set.empty).filter(allNodes.contains)
-            val (nextInDegree, newlyZero) = deps.foldLeft((processedInDegree, List.empty[K])) {
-              case ((degreeAcc, zeros), dep) =>
-                val newInDegree = degreeAcc(dep) - 1
-                val updatedDegree = degreeAcc.updated(dep, newInDegree)
-                val nextZeros = if newInDegree == 0 then zeros :+ dep else zeros
-                (updatedDegree, nextZeros)
-            }
-            process(rest ++ newlyZero, nextInDegree, acc :+ node)
-
-      val (result, _) = process(initialQueue, inDegree, List.empty)
+      val ordered = scala.collection.mutable.ListBuffer.empty[K]
+      while queue.nonEmpty do
+        val node = queue.removeHead()
+        ordered += node
+        // Filtering into a Set first (rather than testing membership inline) preserves the exact
+        // emitted order of the previous formulation, which folded over this same filtered set.
+        val deps = dependents.getOrElse(node, Set.empty).filter(allNodes.contains)
+        deps.foreach { dep =>
+          val remaining = inDegree(dep) - 1
+          inDegree(dep) = remaining
+          if remaining == 0 then queue.append(dep)
+        }
 
       // If all nodes are processed, graph is acyclic
-      if result.size == allNodes.size then scala.util.Right(result)
-      else scala.util.Left(allNodes -- result.toSet)
+      if ordered.size == allNodes.size then scala.util.Right(ordered.toList)
+      else scala.util.Left(allNodes -- ordered)
 
   /**
    * Topological sort using Kahn's algorithm.

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/RecalcPerfSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/RecalcPerfSpec.scala
@@ -4,6 +4,7 @@ import com.tjclp.xl.{*, given}
 import com.tjclp.xl.addressing.{ARef, SheetName}
 import com.tjclp.xl.cells.CellValue
 import com.tjclp.xl.formula.eval.IterativeCalc
+import com.tjclp.xl.formula.graph.DependencyGraph
 import com.tjclp.xl.sheets.Sheet
 import com.tjclp.xl.workbooks.Workbook
 import munit.FunSuite
@@ -168,3 +169,34 @@ class RecalcPerfSpec extends FunSuite:
       elapsedMs < BudgetMs,
       s"iterative recalculate took ${elapsedMs}ms (budget ${BudgetMs}ms)"
     )
+
+  /**
+   * GH-518 tripwire: Kahn's core (`kahnOrder`, shared by `topologicalSort` and
+   * `qualifiedTopologicalSort`) must run in time and allocation linear in the graph, not quadratic.
+   * The pre-fix formulation appended each node to an immutable-List accumulator (`acc :+ node` — a
+   * full copy per node) and rebuilt the pending queue per node (`rest ++ newlyZero`): on this
+   * 100k-cell chain that is ~5e9 cons-cell allocations, minutes of GC against a 30s budget, while
+   * the linear version finishes in milliseconds.
+   */
+  private val ChainCells = 100000
+
+  test("GH-518: topologicalSort on a 100k-cell chain is linear, ordered, and inside the budget"):
+    val refs = (0 until ChainCells).map(i => ARef.from0(0, i)).toVector
+    val dependencies: Map[ARef, Set[ARef]] =
+      (1 until ChainCells)
+        .map(i => refs(i) -> Set(refs(i - 1)))
+        .toMap
+        .updated(refs(0), Set.empty[ARef])
+    val dependents: Map[ARef, Set[ARef]] =
+      (1 until ChainCells).map(i => refs(i - 1) -> Set(refs(i))).toMap
+    val graph = DependencyGraph(dependencies, dependents)
+    val t0 = System.nanoTime()
+    val sorted = DependencyGraph.topologicalSort(graph)
+    val elapsedMs = (System.nanoTime() - t0) / 1000000L
+    sorted match
+      case Right(order) =>
+        assertEquals(order.size, ChainCells)
+        assertEquals(order.headOption, Some(refs(0)))
+        assertEquals(order.lastOption, Some(refs(ChainCells - 1)))
+      case Left(circular) => fail(s"expected acyclic order, got: $circular")
+    assert(elapsedMs < BudgetMs, s"topologicalSort took ${elapsedMs}ms (budget ${BudgetMs}ms)")


### PR DESCRIPTION
Fixes #518 and #519 — the two defects surfaced by the 2026-08-08 finagent Camco session
(`sesn_01HdDiU7hyCyL7hqdLhCqYMs`), where one `xl put` of a Case-switch cell ran 13+ minutes at
8.2 GB RSS and could not be killed by `timeout(1)`. First of a stack; #520 (layer-parallel
evaluation) follows on top of this branch.

## 1. `fix(evaluator)`: linear-allocation Kahn core (#518)

`kahnOrder` — shared by sheet-level `topologicalSort` (every write verb's
`recalculateDependents`) and `qualifiedTopologicalSort` (whole-book `recalculate()`) — built
its result with `acc :+ node` and rebuilt its queue with `rest ++ newlyZero`: O(V²) cons-cell
allocation. JFR showed **28.1 GB of a 50k-formula recalc's 34.7 GB total allocation (81%)**
in this one loop. Rewritten with local mutable state behind the same pure signature
(`ArrayDeque` / `ListBuffer` / `mutable.HashMap` — the posture `foreachSccOf` already takes);
iteration stays over the same collections in the same order, so the emitted order is
unchanged. The GH-492 condensation Kahn (`qualifiedSccOrder`) was already linear and is
untouched.

## 2. `fix(cli)`: finite shutdown-hook timeout (#519)

SIGTERM now terminates the process ~2 s after delivery (`shutdownHookTimeout = 2.seconds`)
instead of computing the entire remaining recalc at 100% CPU and then discarding the result
(measured pre-fix: 52 s of post-TERM survival on a 200k book; 13 min in the deployed
sandbox). Same config disables the CPU-starvation checker — xl is a batch process and the
checker's warnings were drowning real diagnostics on small containers. `-i` writes stay
atomic (temp + `ATOMIC_MOVE`); torn-`-o` exposure is identical to the pre-existing SIGKILL
reality.

## Benchmarks (JVM assembly, M-series laptop, synthetic Camco-shaped books¹)

| book | heap | main @ 2c3fbcb5 | this PR | speedup |
|---|---|---|---|---|
| 50k formulas | 12 g | 8.87 s (14.4 s user) | **4.39 s** (9.6 s user) | 2.0× |
| 200k formulas | 12 g | 95.0 s (110 s user) | **20.0 s** (27 s user) | 4.8× |
| 200k formulas | 512 m | 137.9 s (**450 s user** — GC burns 3× the compute) | **17.4 s** (44 s user) | **7.9×** |

Scaling 50k→200k: baseline 4× cells → 10.7× time (super-linear); fixed 4× → 4.5× (linear).
The 512 m row is the deployed-sandbox regime (Serial-GC native image, small effective heap) —
the one where the Camco model took ~6.5 min per recalc.

SIGTERM: `kill -TERM` mid-recalc → process gone in **2.1 s**, no torn output (pre-fix: never
dies, full compute wasted).

¹ `Case` defined name feeding N `CHOOSE(Case,…)+SUM(range)` formulas chained down independent
columns — generator in the #518 report.

## Verification

- Full suite green: `./mill __.test` (5,451 tests), plus scalafmt/WartRemover pre-commit.
- New gates: `RecalcPerfSpec` "GH-518" (100k-cell chain must sort inside the standing 30 s
  budget — pre-fix that is ~5e9 allocations; order pinned head/last/size), `MainSpec` "GH-519"
  (pins finite `shutdownHookTimeout` + disabled starvation checker).
- Manual: SIGTERM timing above; JFR re-profile shows the `process$1` allocation site gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
