### PR TITLE
Range edges: memoized expansion, size-aware union, mutable reverse-edge builder (GH-522)

### DIFF
--- a/xl-evaluator/src/com/tjclp/xl/formula/eval/DependentRecalculation.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/eval/DependentRecalculation.scala
@@ -180,15 +180,11 @@ object DependentRecalculation:
         .getOrElse(s)
     }
 
-  /** Build reverse lookup from forward dependency graph */
+  /** Build reverse lookup from forward dependency graph (GH-522: shared mutable-builder core). */
   private def buildDependentsMap(
     graph: Map[QualifiedRef, Set[QualifiedRef]]
   ): Map[QualifiedRef, Set[QualifiedRef]] =
-    graph.foldLeft(Map.empty[QualifiedRef, Set[QualifiedRef]]) { case (acc, (ref, deps)) =>
-      deps.foldLeft(acc) { (acc2, dep) =>
-        acc2.updated(dep, acc2.getOrElse(dep, Set.empty) + ref)
-      }
-    }
+    DependencyGraph.reverseEdges(graph)
 
   @scala.annotation.tailrec
   private def transitiveDependentsQualified(

--- a/xl-evaluator/src/com/tjclp/xl/formula/graph/DependencyGraph.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/graph/DependencyGraph.scala
@@ -972,6 +972,8 @@ object DependencyGraph:
   def fromWorkbook(
     workbook: com.tjclp.xl.workbooks.Workbook
   ): Map[QualifiedRef, Set[QualifiedRef]] =
+    // GH-522: expand any (sheet, range) once per build — see memoizedCells
+    val cellsFor = memoizedCells(unboundedQualifiedCells)
     workbook.sheets.flatMap { sheet =>
       sheet.cells.flatMap { case (cellRef, cell) =>
         cell.value match
@@ -980,7 +982,7 @@ object DependencyGraph:
           case CellValue.Formula(expression, _, _) =>
             val deps = FormulaParser.parse(expression) match
               case scala.util.Right(expr) =>
-                extractQualifiedDependencies(expr, sheet.name, workbook = Some(workbook))
+                extractQualifiedDependencies(expr, sheet.name, cellsFor, Some(workbook))
               case scala.util.Left(_) => Set.empty[QualifiedRef]
             Some(QualifiedRef(sheet.name, cellRef) -> deps)
           case _ => None
@@ -1002,13 +1004,15 @@ object DependencyGraph:
   ): (Map[QualifiedRef, Set[QualifiedRef]], Map[QualifiedRef, Set[QualifiedRef]]) =
     val bounds: Map[SheetName, Option[CellRange]] =
       workbook.sheets.map(s => s.name -> s.usedRange).toMap
-    val cellsFor: (SheetName, CellRange) => Set[QualifiedRef] = (sheet, range) =>
+    // GH-522: expand any (sheet, range) once per build — see memoizedCells
+    val cellsFor: (SheetName, CellRange) => Set[QualifiedRef] = memoizedCells { (sheet, range) =>
       bounds.get(sheet) match
         case Some(Some(b)) =>
           range.intersect(b) match
             case Some(clipped) => clipped.cells.map(ref => QualifiedRef(sheet, ref)).toSet
             case None => Set.empty
         case _ => Set.empty // empty or missing sheet: nothing to depend on
+    }
 
     val dependencies = workbook.sheets.flatMap { sheet =>
       sheet.cells.flatMap { case (cellRef, cell) =>
@@ -1025,14 +1029,7 @@ object DependencyGraph:
       }
     }.toMap
 
-    val dependents =
-      dependencies.foldLeft(Map.empty[QualifiedRef, Set[QualifiedRef]]) { case (acc, (ref, deps)) =>
-        deps.foldLeft(acc) { (acc2, dep) =>
-          acc2.updated(dep, acc2.getOrElse(dep, Set.empty) + ref)
-        }
-      }
-
-    (dependencies, dependents)
+    (dependencies, reverseEdges(dependencies))
 
   /**
    * GH-346: every node participating in a reference cycle of the workbook-level graph — the
@@ -1187,6 +1184,52 @@ object DependencyGraph:
     (sheet, range) => range.cells.map(ref => QualifiedRef(sheet, ref)).toSet
 
   /**
+   * GH-522: expand any given (sheet, range) exactly once per graph build.
+   *
+   * A financial-model shape — many formulas each aggregating the same driver column — expanded the
+   * SAME range once per referencing formula: 9,900 × `SUM($A$1:$A$5000)` built ~50M QualifiedRefs
+   * (54 GB of a 135 GB recalc's allocation) where 5,000 suffice. The memo makes every referencing
+   * formula share one immutable Set instance; correctness is untouched because expansion is a pure
+   * function of (sheet, range) within one build (bounds are computed once up front and never change
+   * mid-build).
+   */
+  private def memoizedCells(
+    expand: (SheetName, CellRange) => Set[QualifiedRef]
+  ): (SheetName, CellRange) => Set[QualifiedRef] =
+    val cache = scala.collection.mutable.HashMap.empty[(SheetName, CellRange), Set[QualifiedRef]]
+    (sheet, range) => cache.getOrElseUpdate((sheet, range), expand(sheet, range))
+
+  /**
+   * GH-522: set union that iterates the smaller side into the larger — `Set(oneRef) ++ rangeSet`
+   * walks all 5,000 range elements today, once per operator node above a range reference. Union is
+   * commutative, and any result with more than 4 elements is a CHAMP HashSet whose iteration order
+   * is a function of its CONTENTS alone, so redirecting the merge cannot move any downstream order.
+   * When the larger side has 4 or fewer elements the left-to-right build is kept: small sets are
+   * insertion-ordered and Kahn's emitted order feeds off their iteration.
+   */
+  private def union(a: Set[QualifiedRef], b: Set[QualifiedRef]): Set[QualifiedRef] =
+    if a.size < b.size && b.size > 4 then b ++ a else a ++ b
+
+  /**
+   * GH-522: reverse-edge map built with a local mutable accumulator. The immutable foldLeft
+   * allocated a fresh outer-Map node chain per edge — 50M times on the shape above (8.5 GB). The
+   * insertion sequence is identical to the fold it replaces (same outer Map iterated in the same
+   * order, same per-key Set growth), so every per-key set — small insertion-ordered ones included —
+   * iterates exactly as before.
+   */
+  @SuppressWarnings(Array("org.wartremover.warts.Var"))
+  private[formula] def reverseEdges(
+    dependencies: Map[QualifiedRef, Set[QualifiedRef]]
+  ): Map[QualifiedRef, Set[QualifiedRef]] =
+    val acc = scala.collection.mutable.HashMap.empty[QualifiedRef, Set[QualifiedRef]]
+    dependencies.foreach { case (ref, deps) =>
+      deps.foreach { dep =>
+        acc(dep) = acc.getOrElse(dep, Set.empty) + ref
+      }
+    }
+    acc.toMap
+
+  /**
    * Extract all qualified cell references from TExpr.
    *
    * Similar to extractDependencies but returns QualifiedRef to track cross-sheet references.
@@ -1244,18 +1287,18 @@ object DependencyGraph:
         // GH-353: external-workbook refs target cells OUTSIDE the workbook — no edges ever
         case TExpr.ExternalRef(_, _, _, _) => Set.empty
         case TExpr.ExternalRange(_, _, _) => Set.empty
-        case TExpr.Add(l, r) => go(l) ++ go(r)
-        case TExpr.Sub(l, r) => go(l) ++ go(r)
-        case TExpr.Mul(l, r) => go(l) ++ go(r)
-        case TExpr.Div(l, r) => go(l) ++ go(r)
-        case TExpr.Pow(l, r) => go(l) ++ go(r)
-        case TExpr.Concat(l, r) => go(l) ++ go(r)
-        case TExpr.Eq(l, r) => go(l) ++ go(r)
-        case TExpr.Neq(l, r) => go(l) ++ go(r)
-        case TExpr.Lt(l, r) => go(l) ++ go(r)
-        case TExpr.Lte(l, r) => go(l) ++ go(r)
-        case TExpr.Gt(l, r) => go(l) ++ go(r)
-        case TExpr.Gte(l, r) => go(l) ++ go(r)
+        case TExpr.Add(l, r) => union(go(l), go(r))
+        case TExpr.Sub(l, r) => union(go(l), go(r))
+        case TExpr.Mul(l, r) => union(go(l), go(r))
+        case TExpr.Div(l, r) => union(go(l), go(r))
+        case TExpr.Pow(l, r) => union(go(l), go(r))
+        case TExpr.Concat(l, r) => union(go(l), go(r))
+        case TExpr.Eq(l, r) => union(go(l), go(r))
+        case TExpr.Neq(l, r) => union(go(l), go(r))
+        case TExpr.Lt(l, r) => union(go(l), go(r))
+        case TExpr.Lte(l, r) => union(go(l), go(r))
+        case TExpr.Gt(l, r) => union(go(l), go(r))
+        case TExpr.Gte(l, r) => union(go(l), go(r))
         // Unary operators
         case TExpr.ToInt(x) => go(x)
         case TExpr.UnaryPlus(x) => go(x)
@@ -1268,14 +1311,14 @@ object DependencyGraph:
           val values = call.spec.argSpec.toValues(call.args)
           values.foldLeft(Set.empty[QualifiedRef]) { (acc, value) =>
             value match
-              case ArgValue.Expr(expr) => acc ++ go(expr)
-              case ArgValue.Range(range) => acc ++ locCells(range)
-              case ArgValue.Cells(range) => acc ++ cellsFor(currentSheet, range)
+              case ArgValue.Expr(expr) => union(acc, go(expr))
+              case ArgValue.Range(range) => union(acc, locCells(range))
+              case ArgValue.Cells(range) => union(acc, cellsFor(currentSheet, range))
           }
 
         // GH-193: LET — union of binding-value and body dependencies; BindingRef has none
         case TExpr.Let(bindings, body) =>
-          bindings.foldLeft(go(body)) { case (acc, (_, value)) => acc ++ go(value) }
+          bindings.foldLeft(go(body)) { case (acc, (_, value)) => union(acc, go(value)) }
         case TExpr.BindingRef(_) => Set.empty
         case TExpr.CoercedBindingRef(_, _) => Set.empty
 


### PR DESCRIPTION
Fixes #522. **Stacked on #521** (base: `fix/518-519-kahn-alloc-sigterm`); #520's wave-parallel
evaluation stacks on top of this.

## The defect

The workbook-level dependency graph materializes a RANGE reference as one `QualifiedRef` edge
per covered cell, **per referencing formula**. The financial-model shape — many formulas each
aggregating the same driver column — multiplies the two: 9,900 formulas × `SUM($A$1:$A$5000)` =
~50M edge objects. JFR on one `recalc` of that book (on top of #521, so none of this is the
Kahn quadratic): **135.8 GB total allocation, of which the actual SUM math is 12.3 GB** — ~70%
is graph build/traversal churn on duplicated range edges. This is the shape of the deployed
51k-formula lender models (session `sesn_01HdDiU7hyCyL7hqdLhCqYMs`).

## Three contained fixes (no structural change)

1. **`memoizedCells`** — one graph build expands any given (sheet, range) exactly once; every
   referencing formula shares one immutable Set instance. Applied to `fromWorkbookBounded`
   (whole-book recalc + write-verb dirty cone) and `fromWorkbook` (`recalculateDependents`, the
   `-i put` path). Sound because expansion is a pure function of (sheet, range) within one
   build — bounds are computed once up front.
2. **`union`** — `extractQualifiedDependencies` merged `Set(oneRef) ++ rangeSet`, iterating the
   5,000-element side once per operator node above a range ref. Union is commutative, and any
   result above 4 elements is a CHAMP set whose iteration order is a function of its contents
   alone — so iterating the smaller side into the larger cannot move any downstream order.
   Results of ≤4 elements keep the left-to-right build (small sets are insertion-ordered, and
   Kahn's emitted order feeds off their iteration).
3. **`reverseEdges`** — the dependents fold allocated a fresh outer-Map node chain per edge, 50M
   times; replaced by a local mutable accumulator with the **identical insertion sequence** (so
   every per-key set, small insertion-ordered ones included, iterates exactly as before). Shared
   by `fromWorkbookBounded` and `DependentRecalculation.buildDependentsMap`.

## Measured (JVM assembly, M-series; "heavy book" = 9,900 formulas × SUM over a 5,000-row driver column)

| metric | #521 base | this PR | change |
|---|---|---|---|
| wall | 47.9 s | **27.9 s** | 1.7× |
| user CPU | 102.9 s (GC ≈ a full core) | **35.2 s** | 2.9× less total work |
| peak RSS | 6.0 GB | **1.7 GB** | 3.4× |

Books whose ranges are small (the 200k-formula chain book) are unchanged (~20 s), as expected —
the fix targets the range-fan-out shape specifically.

What remains on the heavy book is eval-side work (per-evaluation range reads) plus the
O(formulas × range-size) graph *traversals* (Tarjan/Kahn/cone). Range-compressed edges — a
range NODE in the graph, O(formulas + ranges) — stay the structural end-state, tracked in #522.

## Verification

Full evaluator suite green (the ordering-pinned gates — GH-491 twin exactness, GH-492
condensation determinism — are the point: every one of these changes was constrained to keep
iteration orders bit-identical). Full `__.test` run green on the stack tip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
