### PR TITLE
Wave-parallel recalculation foundation + evaluator hardening: aggregate-fold memoization, stack-safe Tarjan, dynamic-name classification (GH-520)

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -9,6 +9,7 @@
 ### What Works (Production-Ready)
 
 **New in 0.19.2 "Fixpoint"** (2026-08-06) — recalculation & seeding integrity, wave 24:
+- ✅ **Opt-in wave-parallel recalculation** (#520) — `Workbook.recalculateParallel(N)` / `xl recalc --parallel N` evaluates independent static waves concurrently, pins one clock generation, and folds results deterministically; dynamic references remain in the sequential evaluate-last bucket and iterative books retain their sequential SCC fixpoint
 - ✅ **One pass = the global fixpoint** (#492, #491) — iterative recalculation walks the SCC condensation in dependency-first order instead of splitting into preOrder / one flat Jacobi / postOrder, so no read can fall back to a stale cache and re-recalculating a correct multi-SCC circular book no longer corrupts it. `RecalcResult.cycles` / `.unconverged` / `.certified` report per-component verdicts
 - ✅ **Cycles warm-start from numeric caches** (#469) — zero-seeding no longer wipes valid caches of mutually-ISERROR-guarded pairs
 - ✅ **Data-table what-if lanes evaluate their precedent cone** (#493, #494) — acyclic grids no longer seed silently FLAT, guarded XIRR corners seed real rates, and a guard resolving to its error arm surfaces as `ErrorGuardFired` instead of banking its text arm

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -139,6 +139,13 @@ conditions, not failures, and never gate.
 xl -f model.xlsx -o out.xlsx --strict recalc    # exit 1 if any formula failed to evaluate
 ```
 
+`recalc --parallel N` evaluates statically independent formula waves on up to `N` workers, then
+folds results in the same deterministic order as ordinary `recalc`. It is an opt-in throughput
+lever, not an `N`-times-speed promise: narrow dependency chains remain sequential, and range-heavy
+books can be limited by allocation and memory bandwidth. If the workbook declares iterative
+calculation (`<calcPr iterate="1"/>`), xl keeps the sequential fixpoint path and reports that
+`--parallel` was ignored in the command summary.
+
 With `-o` the output file is written even on a strict failure (the gate only sets the exit code).
 With `-i` the temp file is discarded and the input is left byte-identical; the summary then says
 `NOT saved (--strict failure): <file> left untouched` instead of `Saved:`. `--strict` is refused

--- a/plugin/skills/xl-cli/SKILL.md
+++ b/plugin/skills/xl-cli/SKILL.md
@@ -107,6 +107,7 @@ xl -f <file> -o <out> import <csv-file> --new-sheet "Data"
 xl -f <file> -o <out> import-md <table.md> --start A1   # GFM markdown table import (0.11.3+; '-' = stdin)
 xl -f <file> -o <out> recalc                          # Refresh every formula's cached value (0.12.6+)
 xl -f <file> -o <out> recalc --tables                 # Also seed data-table interior caches (0.19.0)
+xl -f <file> -o <out> recalc --parallel 4             # Opt-in independent-wave evaluation
 ```
 
 ### Compare & Query (read-only, 0.11.3+)

--- a/xl-cli/src/com/tjclp/xl/cli/Command.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/Command.scala
@@ -113,7 +113,8 @@ enum CliCommand:
   case Batch(source: String, dryRun: Boolean = false) // "-" for stdin or file path
   // Whole-workbook recalculation: cache every formula's value (GH-352).
   // `tables` additionally seeds data-table interior caches (GH-442); default stays pinned-cache.
-  case Recalc(tables: Boolean)
+  // `parallel` evaluates independent formula regions on N threads (GH-520); None = sequential.
+  case Recalc(tables: Boolean, parallel: Option[Int])
   case Import(
     csvPath: String,
     startRef: Option[String],

--- a/xl-cli/src/com/tjclp/xl/cli/Main.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/Main.scala
@@ -1,10 +1,16 @@
 package com.tjclp.xl.cli
 
-import java.nio.file.Path
+import java.nio.file.{
+  AtomicMoveNotSupportedException,
+  FileAlreadyExistsException,
+  Files,
+  Path,
+  StandardCopyOption
+}
 
 import scala.concurrent.duration.*
 
-import cats.effect.{ExitCode, IO}
+import cats.effect.{ExitCode, IO, Resource}
 import cats.effect.unsafe.IORuntimeConfig
 import cats.implicits.*
 import cats.syntax.parallel.*
@@ -75,6 +81,13 @@ object Main
       version = BuildInfo.version
     ):
 
+  /** Rendered command result plus whether a staged output is complete and eligible to commit. */
+  private[cli] final case class CommandOutcome(
+    exitCode: ExitCode,
+    output: String,
+    outputComplete: Boolean
+  )
+
   /**
    * GH-519: SIGTERM/SIGINT must terminate the process even mid-recalculation. The evaluator is a
    * single non-yielding compute step, so fiber cancellation is only observed once the whole
@@ -82,8 +95,8 @@ object Main
    * kept computing at full CPU for the entire remaining recalc and then discarded the result. A
    * finite timeout lets the JVM (and the native image, which installs exit handlers by default on
    * GraalVM 25+) halt promptly after the cancellation attempt; the torn-`-o`-output window this
-   * leaves is identical to the pre-existing SIGKILL reality, and `-i` writes stay atomic (temp +
-   * ATOMIC_MOVE).
+   * leaves is bounded by staging every `-o`/`-i` mutation beside its destination and replacing the
+   * destination only after a complete write.
    *
    * The CPU-starvation checker is disabled outright: xl is a batch compute process, so "your
    * compute pool is busy" is the expected steady state, and on small containers the checker drowned
@@ -109,7 +122,17 @@ object Main
       (fileOpt, outputOpt.orNone, inPlaceOpt, backendOpt, maxSizeOpt, streamOpt, sheetsCmd).mapN {
         (file, outOpt, inPlace, backend, maxSize, stream, cmd) =>
           runWithOutput(outOpt, inPlace, file) { (out, display) =>
-            runResult(file, None, out, display, backend, maxSize, stream, cmd)
+            runResult(
+              file,
+              None,
+              out,
+              display,
+              backend,
+              maxSize,
+              stream,
+              cmd,
+              strictFailureDiscardsOutput = inPlace
+            )
           }
       }
 
@@ -148,7 +171,18 @@ object Main
         sheetWriteSubcmds
       ).mapN { (file, sheet, outOpt, inPlace, backend, maxSize, stream, policy, cmd) =>
         runWithOutput(outOpt, inPlace, file) { (out, display) =>
-          runResult(file, sheet, out, display, backend, maxSize, stream, cmd, policy)
+          runResult(
+            file,
+            sheet,
+            out,
+            display,
+            backend,
+            maxSize,
+            stream,
+            cmd,
+            policy,
+            strictFailureDiscardsOutput = inPlace
+          )
         }
       }
 
@@ -1684,8 +1718,8 @@ EXAMPLES:
    * verbatim (counts, failing refs, convergence verdict, plus the strict reason) — only the exit
    * code becomes 1. With `-i` that non-success code means the temp file is discarded and the input
    * is left untouched, which is the atomic reading of "this book did not pass the gate" — so the
-   * summary's `Saved:` line is rewritten to say exactly that. With `-o` the output file genuinely
-   * is written and `Saved:` stands.
+   * summary's `Saved:` line is rewritten to say exactly that. With `-o` the completed temp is still
+   * committed and `Saved:` stands.
    */
   private def runResult(
     filePath: Path,
@@ -1696,30 +1730,38 @@ EXAMPLES:
     maxSizeOpt: Option[Long],
     stream: Boolean,
     cmd: CliCommand,
-    policy: WritePolicy = WritePolicy.default
-  ): IO[(ExitCode, String)] =
+    policy: WritePolicy = WritePolicy.default,
+    strictFailureDiscardsOutput: Boolean = false
+  ): IO[CommandOutcome] =
     execute(filePath, sheetNameOpt, outputOpt, backendOpt, maxSizeOpt, stream, cmd, policy).attempt
       .map {
         case Right(output) =>
-          (ExitCode.Success, renderWithTarget(output, outputOpt, displayOpt))
+          CommandOutcome(
+            ExitCode.Success,
+            renderWithTarget(output, outputOpt, displayOpt),
+            outputComplete = true
+          )
         case Left(strict: StrictFailure) =>
-          (
+          val rendered = renderWithTarget(strict.summary, outputOpt, displayOpt)
+          CommandOutcome(
             ExitCode(1),
-            unsayTheSave(
-              renderWithTarget(strict.summary, outputOpt, displayOpt),
-              outputOpt,
-              displayOpt
-            )
+            if strictFailureDiscardsOutput then unsayTheSave(rendered, outputOpt, displayOpt)
+            else rendered,
+            outputComplete = true
           )
         case Left(err) =>
-          (ExitCode.Error, renderErrorMessage(err, outputOpt, displayOpt))
+          CommandOutcome(
+            ExitCode.Error,
+            renderErrorMessage(err, outputOpt, displayOpt),
+            outputComplete = false
+          )
       }
 
   /**
    * GH-496: an in-place run whose exit code is non-success never commits its temp file, so the
    * summary a write command already built ("...\nSaved: <path>") describes a save that did not
-   * happen. Replace that line with what is true. Only `-i` is affected: with `-o` the output file
-   * IS written before the gate runs, so its `Saved:` line stays.
+   * happen. Replace that line with what is true. Only `-i` is affected: with `-o` the completed
+   * output is committed even though the gate selects exit code 1, so its `Saved:` line stays.
    */
   private def unsayTheSave(
     text: String,
@@ -1765,8 +1807,8 @@ EXAMPLES:
     val message = Option(err.getMessage).getOrElse(err.toString)
     Format.errorSimple(renderWithTarget(message, outputOpt, displayOpt))
 
-  private def printRunResult(result: (ExitCode, String)): IO[ExitCode] =
-    IO.println(result._2).as(result._1)
+  private def printRunResult(result: CommandOutcome): IO[ExitCode] =
+    IO.println(result.output).as(result.exitCode)
 
   private def runInfo(): IO[ExitCode] =
     IO.println(formatFunctionList()).as(ExitCode.Success)
@@ -2798,11 +2840,13 @@ EXAMPLES:
    * Dispatch `run` with effective output path from --output / --in-place flags.
    *
    * The callback receives (writePath, displayPath) and returns the exit code plus rendered output
-   * without printing it. The paths differ only for `-i`, where writes go to a temp file that is
-   * moved onto the input before the successful output is printed (GH-464).
+   * without printing it. For either write mode, writes go to a sibling temp file that is moved onto
+   * the destination before successful output is printed (GH-464, GH-521). Keeping the temp on the
+   * same filesystem permits an atomic replacement on supporting providers.
    *
    * Cases:
-   *   - `-o` only: writes directly to the output path
+   *   - `-o` only: writes to a sibling temp and commits every complete output, including the file
+   *     intentionally produced by a strict-validation exit
    *   - `-i` only: writes to a sibling temp file then atomically moves onto input. If the command
    *     exits with a non-success code OR throws, the temp is deleted and the original is untouched
    *   - Neither: passes `None` through (for read-only subcommands that don't need output)
@@ -2812,36 +2856,85 @@ EXAMPLES:
     outOpt: Option[Path],
     inPlace: Boolean,
     file: Path
-  )(execute: (Option[Path], Option[Path]) => IO[(ExitCode, String)]): IO[ExitCode] =
+  )(execute: (Option[Path], Option[Path]) => IO[CommandOutcome]): IO[ExitCode] =
     (outOpt, inPlace) match
       case (Some(_), true) =>
         IO.println(
           Format.errorSimple("--in-place (-i) and --output (-o) are mutually exclusive")
         ).as(ExitCode.Error)
-      case (Some(out), false) => execute(Some(out), Some(out)).flatMap(printRunResult)
+      case (Some(out), false) =>
+        runStagedOutput(out, ".xl-output-")(outcome => outcome.outputComplete)(execute)
       case (None, false) => execute(None, None).flatMap(printRunResult)
       case (None, true) =>
-        val tmpDir = Option(file.getParent).getOrElse(java.nio.file.Paths.get("."))
-        val tmpResource = cats.effect.Resource.make(
-          IO.blocking(java.nio.file.Files.createTempFile(tmpDir, ".xl-inplace-", ".xlsx"))
-        )(tmp => IO.blocking(java.nio.file.Files.deleteIfExists(tmp)).void)
+        runStagedOutput(file, ".xl-inplace-")(outcome =>
+          outcome.outputComplete && outcome.exitCode == ExitCode.Success
+        )(execute)
 
-        tmpResource.use { tmp =>
-          execute(Some(tmp), Some(file)).flatMap {
-            case result @ (ExitCode.Success, _) =>
-              // Atomic move: same directory guarantees same filesystem on POSIX/NTFS
-              IO.blocking(
-                java.nio.file.Files.move(
-                  tmp,
-                  file,
-                  java.nio.file.StandardCopyOption.REPLACE_EXISTING
-                )
-              ) *> printRunResult(result)
-            case result =>
-              // Non-success exit: leave original file alone; Resource cleans up temp
-              printRunResult(result)
-          }
+  /**
+   * Allocate a sibling staging path and register it with the JVM before handing it to a writer.
+   *
+   * The Resource finalizer is the normal cleanup path. `deleteOnExit` is the hard-shutdown
+   * backstop: the CLI runtime deliberately stops waiting after two seconds, so a canceled writer
+   * may not get enough time to run its finalizer before the JVM exits.
+   */
+  private def stagedOutput(target: Path, prefix: String): Resource[IO, Path] =
+    val directory = Option(target.getParent).getOrElse(Path.of("."))
+    val filename = Option(target.getFileName).fold("output.tmp")(_.toString)
+    val dot = filename.lastIndexOf('.')
+    val suffix = if dot >= 0 then filename.substring(dot) else ".tmp"
+    val acquire =
+      IO.blocking(Files.createTempFile(directory, prefix, suffix)).flatMap { tmp =>
+        IO.blocking(tmp.toFile.deleteOnExit()).attempt.flatMap {
+          case Right(_) => IO.pure(tmp)
+          case Left(error) =>
+            IO.blocking(Files.deleteIfExists(tmp)).attempt *> IO.raiseError[Path](error)
         }
+      }
+    Resource.make(acquire)(tmp => IO.blocking(Files.deleteIfExists(tmp)).void)
+
+  /** Run one command against a staging path and publish only an explicitly complete output. */
+  private def runStagedOutput(
+    target: Path,
+    prefix: String
+  )(
+    shouldCommit: CommandOutcome => Boolean
+  )(
+    execute: (Option[Path], Option[Path]) => IO[CommandOutcome]
+  ): IO[ExitCode] =
+    stagedOutput(target, prefix).use { tmp =>
+      execute(Some(tmp), Some(target)).flatMap { outcome =>
+        val commit =
+          if shouldCommit(outcome) then
+            // A read-only command may accept the global -o flag but never touch its staging file.
+            // An XLSX is necessarily non-empty, so do not replace a target with the untouched file.
+            IO.blocking(Files.size(tmp) > 0L).ifM(replaceAtomically(tmp, target), IO.unit)
+          else IO.unit
+        commit *> printRunResult(outcome)
+      }
+    }
+
+  /** Replace `target` atomically when supported, with the JDK-prescribed total fallback. */
+  private[cli] def replaceAtomically(source: Path, target: Path): IO[Unit] =
+    val atomic =
+      IO.blocking(
+        Files.move(
+          source,
+          target,
+          StandardCopyOption.ATOMIC_MOVE,
+          StandardCopyOption.REPLACE_EXISTING
+        )
+      ).void
+    val fallback =
+      IO.blocking(Files.move(source, target, StandardCopyOption.REPLACE_EXISTING)).void
+    atomicMoveOrFallback(atomic, fallback)
+
+  /** Isolated for deterministic coverage of providers that reject `ATOMIC_MOVE`. */
+  private[cli] def atomicMoveOrFallback(atomic: IO[Unit], fallback: IO[Unit]): IO[Unit] =
+    atomic.handleErrorWith {
+      case _: AtomicMoveNotSupportedException => fallback
+      case _: FileAlreadyExistsException => fallback
+      case error => IO.raiseError(error)
+    }
 
   /** Require output path or raise user-friendly error, providing path to action */
   private def requireOutputAction(outputOpt: Option[Path], commandName: String)(

--- a/xl-cli/src/com/tjclp/xl/cli/Main.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/Main.scala
@@ -1208,16 +1208,25 @@ autoNoTable book needs, since Excel never recomputes tables on open.
 USAGE:
   xl -f in.xlsx -o out.xlsx recalc
   xl -f in.xlsx -i recalc
-  xl -f in.xlsx -o out.xlsx recalc --tables   # Also seed data-table interiors"""
+  xl -f in.xlsx -o out.xlsx recalc --tables       # Also seed data-table interiors
+  xl -f in.xlsx -o out.xlsx recalc --parallel 4   # Independent regions on 4 threads"""
 
   private val recalcTablesOpt: Opts[Boolean] =
     Opts
       .flag("tables", "Also seed data-table interior caches (default: pinned caches)")
       .orFalse
 
+  // GH-520: results are element-for-element identical to the sequential pass; books declaring
+  // iterative calculation ignore the flag (cyclic fixpoints are sequential) with a stderr note.
+  private val recalcParallelOpt: Opts[Option[Int]] =
+    Opts
+      .option[Int]("parallel", "Evaluate independent formula regions on N threads (GH-520)")
+      .validate("--parallel must be at least 1")(_ >= 1)
+      .orNone
+
   val recalcCmd: Opts[CliCommand] =
     Opts.subcommand("recalc", recalcHelp) {
-      recalcTablesOpt.map(CliCommand.Recalc.apply)
+      (recalcTablesOpt, recalcParallelOpt).mapN(CliCommand.Recalc.apply)
     }
 
   // --- Import command ---
@@ -2476,7 +2485,7 @@ EXAMPLES:
         WriteCommands.batch(wb, sheetOpt, source, _, _, _, policy)
       )
 
-    case CliCommand.Recalc(tables) =>
+    case CliCommand.Recalc(tables, parallel) =>
       // A recalculation asked not to recalculate is a contradiction, not a no-op: say so rather
       // than writing a file the caller will read as freshened (GH-468).
       if policy.noRecalc then
@@ -2487,7 +2496,7 @@ EXAMPLES:
         )
       else
         requireOutput("recalc", outputOpt, backendOpt, stream)(
-          WriteCommands.recalc(wb, _, _, _, tables, policy)
+          WriteCommands.recalc(wb, _, _, _, tables, policy, parallel)
         )
 
     case CliCommand.Import(csvPath, startRefOpt, delim, skipHeader, enc, newSheetOpt, noInfer) =>

--- a/xl-cli/src/com/tjclp/xl/cli/Main.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/Main.scala
@@ -2,7 +2,10 @@ package com.tjclp.xl.cli
 
 import java.nio.file.Path
 
+import scala.concurrent.duration.*
+
 import cats.effect.{ExitCode, IO}
+import cats.effect.unsafe.IORuntimeConfig
 import cats.implicits.*
 import cats.syntax.parallel.*
 import com.monovore.decline.*
@@ -71,6 +74,26 @@ object Main
       header = "LLM-friendly Excel operations (stateless)",
       version = BuildInfo.version
     ):
+
+  /**
+   * GH-519: SIGTERM/SIGINT must terminate the process even mid-recalculation. The evaluator is a
+   * single non-yielding compute step, so fiber cancellation is only observed once the whole
+   * computation finishes — under the default `shutdownHookTimeout = Duration.Inf` a TERM'd `xl`
+   * kept computing at full CPU for the entire remaining recalc and then discarded the result. A
+   * finite timeout lets the JVM (and the native image, which installs exit handlers by default on
+   * GraalVM 25+) halt promptly after the cancellation attempt; the torn-`-o`-output window this
+   * leaves is identical to the pre-existing SIGKILL reality, and `-i` writes stay atomic (temp +
+   * ATOMIC_MOVE).
+   *
+   * The CPU-starvation checker is disabled outright: xl is a batch compute process, so "your
+   * compute pool is busy" is the expected steady state, and on small containers the checker drowned
+   * real diagnostics in warnings. Public (not protected) so tests can pin the config.
+   */
+  override def runtimeConfig: IORuntimeConfig =
+    super.runtimeConfig.copy(
+      shutdownHookTimeout = 2.seconds,
+      cpuStarvationCheckInitialDelay = Duration.Inf
+    )
 
   override def main: Opts[IO[ExitCode]] =
     // Workbook-level: only --file (no --sheet)

--- a/xl-cli/src/com/tjclp/xl/cli/commands/WriteCommands.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/commands/WriteCommands.scala
@@ -1309,9 +1309,21 @@ object WriteCommands:
     config: WriterConfig,
     stream: Boolean = false,
     seedTables: Boolean = false,
-    policy: WritePolicy = WritePolicy.default
+    policy: WritePolicy = WritePolicy.default,
+    parallel: Option[Int] = None
   ): IO[String] =
-    val result = recalcHonoringCalcPr(wb)
+    // GH-520: --parallel applies to the non-iterative pass only — an iterate-declared book keeps
+    // the calcPr-honoring sequential path (cyclic fixpoints are inherently ordered), with a
+    // stderr note so the divergence from the request is never silent.
+    val iterOpt = wb.metadata.calcPr.filter(_.iterativeCalculation).map(IterativeCalc.fromCalcPr)
+    val result = (parallel, iterOpt) match
+      case (Some(n), None) => wb.recalculateParallel(n)
+      case (Some(_), Some(it)) =>
+        System.err.println(
+          "NOTE: --parallel ignored — the book declares iterative calculation (<calcPr iterate=\"1\"/>), which fixpoints sequentially"
+        )
+        wb.recalculate(Clock.system, it)
+      case (None, _) => recalcHonoringCalcPr(wb)
     val prepared: IO[(Workbook, Vector[SeedTableWarning])] =
       if !seedTables then IO.pure((result.workbook, Vector.empty))
       else

--- a/xl-cli/src/com/tjclp/xl/cli/commands/WriteCommands.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/commands/WriteCommands.scala
@@ -908,11 +908,26 @@ object WriteCommands:
    * cycles. Every CLI verb that recalculates goes through here, so an iterate-declared circular
    * book fixpoints under `batch` and the structural verbs exactly as it does under `recalc`.
    */
-  private def recalcHonoringCalcPr(wb: Workbook): RecalcResult =
-    wb.metadata.calcPr
-      .filter(_.iterativeCalculation)
-      .map(IterativeCalc.fromCalcPr)
-      .fold(wb.recalculate())(it => wb.recalculate(Clock.system, it))
+  private final case class RecalcRun(result: RecalcResult, advisory: Option[String])
+
+  private def recalcHonoringCalcPr(
+    wb: Workbook,
+    parallel: Option[Int] = None
+  ): RecalcRun =
+    wb.metadata.calcPr.filter(_.iterativeCalculation).map(IterativeCalc.fromCalcPr) match
+      case Some(iterative) =>
+        RecalcRun(
+          wb.recalculate(Clock.system, iterative),
+          parallel.map(_ =>
+            "NOTE: --parallel ignored — the book declares iterative calculation " +
+              "(<calcPr iterate=\"1\"/>), which fixpoints sequentially"
+          )
+        )
+      case None =>
+        RecalcRun(
+          parallel.fold(wb.recalculate())(wb.recalculateParallel),
+          None
+        )
 
   /**
    * Cells whose value (or formula TEXT — a structural edit rewrites references) differs between two
@@ -947,15 +962,12 @@ object WriteCommands:
     import DependencyGraph.QualifiedRef
     val seeded: Set[QualifiedRef] =
       seeds.iterator.flatMap((name, refs) => refs.iterator.map(QualifiedRef(name, _))).toSet
-    val dynamic: Set[QualifiedRef] =
-      wb.sheets.iterator.flatMap { s =>
-        DependencyGraph.dynamicCells(s).iterator.map(QualifiedRef(s.name, _))
-      }.toSet
+    val dynamic: Set[QualifiedRef] = DependencyGraph.dynamicCells(wb)
     val roots = seeded ++ dynamic
     if roots.isEmpty then Map.empty
     else
-      val (_, dependents) = DependencyGraph.fromWorkbookBounded(wb)
-      (roots ++ DependencyGraph.qualifiedTransitiveDependents(dependents, roots))
+      val dependencyIndex = DependencyGraph.fromWorkbookDependencyIndex(wb)
+      (roots ++ dependencyIndex.transitiveDependents(roots))
         .groupMap(_.sheet)(_.ref)
 
   /**
@@ -1166,7 +1178,7 @@ object WriteCommands:
    * verb that refreshes an entire book on purpose.
    */
   private def scopedRecalc(before: Workbook, edited: Workbook): (Workbook, RecalcResult) =
-    val result = recalcHonoringCalcPr(edited)
+    val result = recalcHonoringCalcPr(edited).result
     val cone = dirtyCone(edited, changedRefs(before, edited))
     (applyConeCaches(edited, result.workbook, cone), scopeToCone(result, cone))
 
@@ -1312,34 +1324,28 @@ object WriteCommands:
     policy: WritePolicy = WritePolicy.default,
     parallel: Option[Int] = None
   ): IO[String] =
-    // GH-520: --parallel applies to the non-iterative pass only — an iterate-declared book keeps
-    // the calcPr-honoring sequential path (cyclic fixpoints are inherently ordered), with a
-    // stderr note so the divergence from the request is never silent.
-    val iterOpt = wb.metadata.calcPr.filter(_.iterativeCalculation).map(IterativeCalc.fromCalcPr)
-    val result = (parallel, iterOpt) match
-      case (Some(n), None) => wb.recalculateParallel(n)
-      case (Some(_), Some(it)) =>
-        System.err.println(
-          "NOTE: --parallel ignored — the book declares iterative calculation (<calcPr iterate=\"1\"/>), which fixpoints sequentially"
-        )
-        wb.recalculate(Clock.system, it)
-      case (None, _) => recalcHonoringCalcPr(wb)
-    val prepared: IO[(Workbook, Vector[SeedTableWarning])] =
-      if !seedTables then IO.pure((result.workbook, Vector.empty))
-      else
-        IO.fromEither(
-          result.workbook
-            .seedDataTablesReport()
-            .left
-            .map(err => new Exception(err.message))
-        ).map(report => (report.workbook, report.warnings))
-    prepared.flatMap { case (workbook, warnings) =>
-      writeWorkbook(workbook, outputPath, config, stream).flatMap { _ =>
-        val tableNote = if seedTables then "\nSeeded data table interior caches" else ""
-        val warningLines = warnings.map(w => s"\n${renderSeedWarning(w)}").mkString
-        val rendered =
-          s"${formatRecalcSummary(result)}$tableNote$warningLines\n${Format.saveSuffix(outputPath, stream)}"
-        strictGate(policy, rendered, Some(result), warnings)
+    // Keep the expensive pure recalculation inside the returned IO. In particular, constructing an
+    // IO value must not print the iterative fallback advisory or start consuming CPU.
+    IO.delay(recalcHonoringCalcPr(wb, parallel)).flatMap { run =>
+      val result = run.result
+      val prepared: IO[(Workbook, Vector[SeedTableWarning])] =
+        if !seedTables then IO.pure((result.workbook, Vector.empty))
+        else
+          IO.fromEither(
+            result.workbook
+              .seedDataTablesReport()
+              .left
+              .map(err => new Exception(err.message))
+          ).map(report => (report.workbook, report.warnings))
+      prepared.flatMap { case (workbook, warnings) =>
+        writeWorkbook(workbook, outputPath, config, stream).flatMap { _ =>
+          val tableNote = if seedTables then "\nSeeded data table interior caches" else ""
+          val advisory = run.advisory.fold("")(note => s"\n$note")
+          val warningLines = warnings.map(w => s"\n${renderSeedWarning(w)}").mkString
+          val rendered =
+            s"${formatRecalcSummary(result)}$tableNote$advisory$warningLines\n${Format.saveSuffix(outputPath, stream)}"
+          strictGate(policy, rendered, Some(result), warnings)
+        }
       }
     }
 

--- a/xl-cli/test/src/com/tjclp/xl/cli/BatchRecalcSpec.scala
+++ b/xl-cli/test/src/com/tjclp/xl/cli/BatchRecalcSpec.scala
@@ -496,12 +496,27 @@ class BatchRecalcSpec extends FunSuite:
   test("GH-442: recalc --tables parses to Recalc(tables = true); bare recalc stays false") {
     val cmd = com.monovore.decline.Command("xl", "test")(Main.recalcCmd)
     cmd.parse(Seq("recalc", "--tables"), Map.empty) match
-      case Right(CliCommand.Recalc(tables)) => assert(tables, "--tables must set tables = true")
+      case Right(CliCommand.Recalc(tables, _)) => assert(tables, "--tables must set tables = true")
       case other => fail(s"expected Recalc(true), got $other")
     cmd.parse(Seq("recalc"), Map.empty) match
-      case Right(CliCommand.Recalc(tables)) =>
+      case Right(CliCommand.Recalc(tables, _)) =>
         assert(!tables, "bare recalc must keep the pinned-cache default")
       case other => fail(s"expected Recalc(false), got $other")
+  }
+
+  test("GH-520: recalc --parallel N parses; bare recalc stays sequential; 0 is refused") {
+    val cmd = com.monovore.decline.Command("xl", "test")(Main.recalcCmd)
+    cmd.parse(Seq("recalc", "--parallel", "4"), Map.empty) match
+      case Right(CliCommand.Recalc(_, parallel)) => assertEquals(parallel, Some(4))
+      case other => fail(s"expected Recalc(_, Some(4)), got $other")
+    cmd.parse(Seq("recalc"), Map.empty) match
+      case Right(CliCommand.Recalc(_, parallel)) =>
+        assertEquals(parallel, None)
+      case other => fail(s"expected Recalc(_, None), got $other")
+    assert(
+      cmd.parse(Seq("recalc", "--parallel", "0"), Map.empty).isLeft,
+      "--parallel 0 must be refused by validation"
+    )
   }
 
   // ===== GH-453/GH-454: recalc honors the file's declared calcPr; --tables on circular books =====

--- a/xl-cli/test/src/com/tjclp/xl/cli/BatchRecalcSpec.scala
+++ b/xl-cli/test/src/com/tjclp/xl/cli/BatchRecalcSpec.scala
@@ -519,6 +519,42 @@ class BatchRecalcSpec extends FunSuite:
     )
   }
 
+  test("GH-520: recalc --parallel evaluates a wide wave and writes its caches") {
+    val sheet = (1 to 32).foldLeft(Sheet("Data").put(ref"A1" -> 10)) { (s, col0) =>
+      s.put(ARef.from0(col0, 0), CellValue.Formula("=A1+1"))
+    }
+    val out = tempXlsx()
+
+    val summary = WriteCommands
+      .recalc(Workbook(sheet), out, config, parallel = Some(4))
+      .unsafeRunSync()
+
+    assert(summary.contains("Recalculated 32 formulas"), s"summary was: $summary")
+    assertCachedNumber(cachedFormulaValue(readBack(out), 1, 0), 11.0)
+    Files.deleteIfExists(out)
+  }
+
+  test("GH-520: an iterative book reports the --parallel sequential fallback in-band") {
+    val wb = Workbook(
+      Sheet("Data")
+        .put(ref"A1" -> 10)
+        .put(ref"B1", CellValue.Formula("=A1+1"))
+    ).withCalcPr(
+      com.tjclp.xl.workbooks.CalcPr(
+        iterativeCalculation = true,
+        maxIterations = Some(10),
+        maxChange = Some(BigDecimal("0.001"))
+      )
+    )
+    val out = tempXlsx()
+
+    val summary = WriteCommands.recalc(wb, out, config, parallel = Some(4)).unsafeRunSync()
+
+    assert(summary.contains("NOTE: --parallel ignored"), s"summary was: $summary")
+    assertCachedNumber(cachedFormulaValue(readBack(out), 1, 0), 11.0)
+    Files.deleteIfExists(out)
+  }
+
   // ===== GH-453/GH-454: recalc honors the file's declared calcPr; --tables on circular books =====
 
   /**

--- a/xl-cli/test/src/com/tjclp/xl/cli/InPlaceSpec.scala
+++ b/xl-cli/test/src/com/tjclp/xl/cli/InPlaceSpec.scala
@@ -16,6 +16,7 @@ import com.tjclp.xl.macros.ref
  * Tests for the `--in-place` (`-i`) flag and its atomic-write semantics.
  *
  * Verifies:
+ *   - `-o` writes are staged beside their destination before replacement
  *   - `-i` alone writes to a sibling temp file, then atomically moves onto the input
  *   - `-i` + `-o` together is an error (mutually exclusive)
  *   - A failed execution leaves the original file untouched and cleans up the temp
@@ -33,6 +34,13 @@ class InPlaceSpec extends CatsEffectSuite:
 
   private val excel = ExcelIO.instance[IO]
 
+  private def outcome(
+    code: ExitCode = ExitCode.Success,
+    output: String = "ok",
+    outputComplete: Boolean = true
+  ): Main.CommandOutcome =
+    Main.CommandOutcome(code, output, outputComplete)
+
   /** Create a temp xlsx with a single sheet containing A1="Hello", A2=42. */
   private def withTempExcelFile[A](test: Path => IO[A]): IO[A] =
     IO.blocking {
@@ -47,22 +55,144 @@ class InPlaceSpec extends CatsEffectSuite:
       excel.write(wb, tempFile) *> test(tempFile)
     }
 
-  test("runWithOutput: -o alone passes the output path through as write and display") {
-    val file = Path.of("/tmp/input.xlsx")
-    val out = Path.of("/tmp/output.xlsx")
-    var captured: Option[Path] = None
-    var capturedDisplay: Option[Path] = None
-    Main
-      .runWithOutput(Some(out), inPlace = false, file) { (received, display) =>
-        captured = received
-        capturedDisplay = display
-        IO.pure((ExitCode.Success, "ok"))
-      }
-      .map { code =>
-        assertEquals(code, ExitCode.Success)
-        assertEquals(captured, Some(out))
-        assertEquals(capturedDisplay, Some(out))
-      }
+  test("runWithOutput: -o stages beside output, then atomically replaces it") {
+    IO.blocking {
+      val directory = Files.createTempDirectory("xl-output-stage-")
+      val out = directory.resolve("output.xlsx")
+      Files.writeString(out, "original")
+      (directory, out)
+    }.bracket { case (_, out) =>
+      var captured: Option[Path] = None
+      var capturedDisplay: Option[Path] = None
+      Main
+        .runWithOutput(Some(out), inPlace = false, Path.of("/tmp/input.xlsx")) {
+          (received, display) =>
+            captured = received
+            capturedDisplay = display
+            IO.blocking(Files.writeString(received.get, "replacement")).as(outcome())
+        }
+        .flatMap { code =>
+          IO.blocking {
+            assertEquals(code, ExitCode.Success)
+            assertEquals(capturedDisplay, Some(out))
+            assert(captured.exists(_.getParent == out.getParent), s"staging path: $captured")
+            assert(captured.exists(_ != out), "-o must not write directly to the destination")
+            assert(captured.exists(p => p.getFileName.toString.startsWith(".xl-output-")))
+            assertEquals(Files.readString(out), "replacement")
+            assert(!captured.exists(Files.exists(_)), "staging file must be gone after commit")
+          }
+        }
+    } { case (directory, out) =>
+      IO.blocking {
+        Files.deleteIfExists(out)
+        Files.deleteIfExists(directory)
+      }.void
+    }
+  }
+
+  test("runWithOutput: -o preserves destination and removes partial staging output on failure") {
+    IO.blocking {
+      val directory = Files.createTempDirectory("xl-output-failure-")
+      val out = directory.resolve("output.xlsx")
+      Files.writeString(out, "original")
+      (directory, out)
+    }.bracket { case (_, out) =>
+      var staged: Option[Path] = None
+      Main
+        .runWithOutput(Some(out), inPlace = false, Path.of("input.xlsx")) { (outOpt, _) =>
+          staged = outOpt
+          IO.blocking(Files.writeString(outOpt.get, "partial")) *>
+            IO.pure(outcome(ExitCode.Error, "failed", outputComplete = false))
+        }
+        .flatMap { code =>
+          IO.blocking {
+            assertEquals(code, ExitCode.Error)
+            assertEquals(Files.readString(out), "original")
+            assert(!staged.exists(Files.exists(_)), "partial staging file must be removed")
+          }
+        }
+    } { case (directory, out) =>
+      IO.blocking {
+        Files.deleteIfExists(out)
+        Files.deleteIfExists(directory)
+      }.void
+    }
+  }
+
+  test("runWithOutput: -o commits a complete strict-failure output") {
+    IO.blocking {
+      val directory = Files.createTempDirectory("xl-output-strict-")
+      val out = directory.resolve("output.xlsx")
+      Files.writeString(out, "original")
+      (directory, out)
+    }.bracket { case (_, out) =>
+      Main
+        .runWithOutput(Some(out), inPlace = false, Path.of("input.xlsx")) { (outOpt, _) =>
+          IO.blocking(Files.writeString(outOpt.get, "complete")) *>
+            IO.pure(outcome(ExitCode(1), "strict failure", outputComplete = true))
+        }
+        .flatMap { code =>
+          IO.blocking {
+            assertEquals(code, ExitCode(1))
+            assertEquals(Files.readString(out), "complete")
+          }
+        }
+    } { case (directory, out) =>
+      IO.blocking {
+        Files.deleteIfExists(out)
+        Files.deleteIfExists(directory)
+      }.void
+    }
+  }
+
+  test("runWithOutput: a successful read-only callback does not publish an empty temp") {
+    IO.blocking {
+      val directory = Files.createTempDirectory("xl-output-read-only-")
+      val out = directory.resolve("output.xlsx")
+      Files.writeString(out, "original")
+      (directory, out)
+    }.bracket { case (_, out) =>
+      Main
+        .runWithOutput(Some(out), inPlace = false, Path.of("input.xlsx")) { (_, _) =>
+          IO.pure(outcome(output = "listed sheets"))
+        }
+        .flatMap { code =>
+          IO.blocking {
+            assertEquals(code, ExitCode.Success)
+            assertEquals(Files.readString(out), "original")
+          }
+        }
+    } { case (directory, out) =>
+      IO.blocking {
+        Files.deleteIfExists(out)
+        Files.deleteIfExists(directory)
+      }.void
+    }
+  }
+
+  test("atomic move falls back only for unsupported or provider-specific replacement") {
+    var fallbackRuns = 0
+    val unsupported = new java.nio.file.AtomicMoveNotSupportedException("from", "to", "test")
+    val existing = new java.nio.file.FileAlreadyExistsException("to")
+    val expected = new java.io.IOException("different failure")
+    for
+      _ <- Main.atomicMoveOrFallback(
+        IO.raiseError(unsupported),
+        IO(fallbackRuns += 1)
+      )
+      _ <- Main.atomicMoveOrFallback(
+        IO.raiseError(existing),
+        IO(fallbackRuns += 1)
+      )
+      other <- Main
+        .atomicMoveOrFallback(
+          IO.raiseError(expected),
+          IO(fallbackRuns += 1)
+        )
+        .attempt
+    yield
+      assertEquals(fallbackRuns, 2)
+      assertEquals(other, Left(expected))
   }
 
   test("runWithOutput: neither flag passes None through") {
@@ -73,7 +203,7 @@ class InPlaceSpec extends CatsEffectSuite:
       .runWithOutput(None, inPlace = false, file) { (received, display) =>
         captured = received
         capturedDisplay = display
-        IO.pure((ExitCode.Success, "ok"))
+        IO.pure(outcome())
       }
       .map { code =>
         assertEquals(code, ExitCode.Success)
@@ -86,7 +216,7 @@ class InPlaceSpec extends CatsEffectSuite:
     val file = Path.of("/tmp/input.xlsx")
     val out = Path.of("/tmp/output.xlsx")
     Main
-      .runWithOutput(Some(out), inPlace = true, file)((_, _) => IO.pure((ExitCode.Success, "ok")))
+      .runWithOutput(Some(out), inPlace = true, file)((_, _) => IO.pure(outcome()))
       .map { code => assertEquals(code, ExitCode.Error) }
   }
 
@@ -109,7 +239,7 @@ class InPlaceSpec extends CatsEffectSuite:
         val wb = Workbook(
           Vector(Sheet("Test").put(ref"A1", CellValue.Text("Updated")))
         )
-        excel.write(wb, out).as((ExitCode.Success, "saved"))
+        excel.write(wb, out).as(outcome(output = "saved"))
       }
 
       for
@@ -132,7 +262,7 @@ class InPlaceSpec extends CatsEffectSuite:
       val result = Main.runWithOutput(None, inPlace = true, tempFile) { (outOpt, _) =>
         writePath = outOpt
         // Simulate a failure: return Error exit code without writing anything useful
-        IO.pure((ExitCode.Error, "failed"))
+        IO.pure(outcome(ExitCode.Error, "failed", outputComplete = false))
       }
 
       for
@@ -154,7 +284,7 @@ class InPlaceSpec extends CatsEffectSuite:
       var writePath: Option[Path] = None
       val result = Main.runWithOutput(None, inPlace = true, tempFile) { (outOpt, _) =>
         writePath = outOpt
-        IO.raiseError(new RuntimeException("simulated crash"))
+        IO.raiseError[Main.CommandOutcome](new RuntimeException("simulated crash"))
       }
 
       for
@@ -199,7 +329,7 @@ class InPlaceSpec extends CatsEffectSuite:
         .runWithOutput(None, inPlace = true, destination) { (outOpt, _) =>
           val out = outOpt.get
           IO.blocking(Files.writeString(out, "replacement"))
-            .as((ExitCode.Success, s"Saved: $destination"))
+            .as(outcome(output = s"Saved: $destination"))
         }
         .attempt
       captureStdout(attempted).map { case (outcome, stdout) =>

--- a/xl-cli/test/src/com/tjclp/xl/cli/MainSpec.scala
+++ b/xl-cli/test/src/com/tjclp/xl/cli/MainSpec.scala
@@ -1530,3 +1530,17 @@ class MainSpec extends CatsEffectSuite:
       "Saved (streaming): out.xlsx"
     )
   }
+
+  test("GH-519: shutdown-hook timeout is finite so SIGTERM terminates a mid-compute process") {
+    // The evaluator is a single non-yielding compute step; fiber cancellation is only observed
+    // when it completes. With the cats-effect default (Duration.Inf) a TERM'd xl computed the
+    // entire remaining recalc at full CPU and then discarded the result — timeout(1) could not
+    // bound an invocation at all. This pins the finite deadline that lets the process halt.
+    assert(
+      Main.runtimeConfig.shutdownHookTimeout.isFinite,
+      s"shutdownHookTimeout must be finite, got ${Main.runtimeConfig.shutdownHookTimeout}"
+    )
+    // Batch tool, not a server: the CPU-starvation checker is pure noise on small containers
+    // (it drowned real diagnostics in the deployed-agent sandboxes) and stays disabled.
+    assert(!Main.runtimeConfig.cpuStarvationCheckInitialDelay.isFinite)
+  }

--- a/xl-cli/test/src/com/tjclp/xl/cli/MainSpec.scala
+++ b/xl-cli/test/src/com/tjclp/xl/cli/MainSpec.scala
@@ -1307,7 +1307,7 @@ class MainSpec extends CatsEffectSuite:
 
   test("recalc without -o reports a usage error naming the flag (GH-422)") {
     val wb = Workbook(Vector(Sheet("T")))
-    Main.executeCommand(wb, None, None, None, false, CliCommand.Recalc(false)).attempt.map {
+    Main.executeCommand(wb, None, None, None, false, CliCommand.Recalc(false, None)).attempt.map {
       case Left(err) =>
         assert(
           err.getMessage.contains("recalc requires -o"),
@@ -1508,7 +1508,7 @@ class MainSpec extends CatsEffectSuite:
         Some(java.nio.file.Paths.get("out.xlsx")),
         None,
         false,
-        CliCommand.Recalc(false),
+        CliCommand.Recalc(false, None),
         WritePolicy(noRecalc = true)
       )
       .attempt

--- a/xl-core/src/com/tjclp/xl/sheets/Sheet.scala
+++ b/xl-core/src/com/tjclp/xl/sheets/Sheet.scala
@@ -954,22 +954,38 @@ final case class Sheet(
     cells.values.filter(_.nonEmpty)
 
   /** Get used range (bounding box of all non-empty cells) */
+  @SuppressWarnings(Array("org.wartremover.warts.Var", "org.wartremover.warts.While"))
   def usedRange: Option[CellRange] =
-    val nonEmpty = nonEmptyCells
-    if nonEmpty.isEmpty then None
+    // This is a hot derived query during formula evaluation. A tuple fold allocates one tuple per
+    // cell (gigabytes across repeated range formulas); invocation-local primitives keep the
+    // immutable Sheet API while making the scan allocation-free. Keep the non-empty predicate
+    // inline too: an Iterator.filter adapter adds measurable virtual-call overhead on large sheets.
+    val cellsIterator = cells.valuesIterator
+    var found = false
+    var minCol = 0
+    var minRow = 0
+    var maxCol = 0
+    var maxRow = 0
+    while cellsIterator.hasNext do
+      val cell = cellsIterator.next()
+      if cell.nonEmpty then
+        val ref = cell.ref
+        val col = ref.col.index0
+        val row = ref.row.index0
+        if found then
+          if col < minCol then minCol = col
+          if row < minRow then minRow = row
+          if col > maxCol then maxCol = col
+          if row > maxRow then maxRow = row
+        else
+          found = true
+          minCol = col
+          minRow = row
+          maxCol = col
+          maxRow = row
+
+    if !found then None
     else
-      // Single-pass fold to compute min/max for both col and row (75% faster than 4 passes)
-      val (minCol, minRow, maxCol, maxRow) = nonEmpty
-        .map(_.ref)
-        .foldLeft((Int.MaxValue, Int.MaxValue, Int.MinValue, Int.MinValue)) {
-          case ((minC, minR, maxC, maxR), ref) =>
-            (
-              math.min(minC, ref.col.index0),
-              math.min(minR, ref.row.index0),
-              math.max(maxC, ref.col.index0),
-              math.max(maxR, ref.row.index0)
-            )
-        }
       Some(
         CellRange(
           ARef.from0(minCol, minRow),

--- a/xl-core/test/src/com/tjclp/xl/SheetUsedRangeSpec.scala
+++ b/xl-core/test/src/com/tjclp/xl/SheetUsedRangeSpec.scala
@@ -1,0 +1,22 @@
+package com.tjclp.xl
+
+import com.tjclp.xl.addressing.SheetName
+import com.tjclp.xl.cells.{Cell, CellValue}
+import com.tjclp.xl.sheets.Sheet
+import munit.FunSuite
+
+class SheetUsedRangeSpec extends FunSuite:
+
+  test("usedRange is empty when the sheet has no non-empty cells"):
+    val sheet = Sheet(SheetName.unsafe("S"))
+      .put(Cell(ref"XFD1048576", CellValue.Empty))
+
+    assertEquals(sheet.usedRange, None)
+
+  test("usedRange computes the bounding box of non-empty cells"):
+    val sheet = Sheet(SheetName.unsafe("S"))
+      .put(ref"C7", CellValue.Number(BigDecimal(1)))
+      .put(ref"A3", CellValue.Text("x"))
+      .put(ref"B5", CellValue.Bool(true))
+
+    assertEquals(sheet.usedRange, Some(CellRange(ref"A3", ref"C7")))

--- a/xl-evaluator/src/com/tjclp/xl/formula/eval/DependentRecalculation.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/eval/DependentRecalculation.scala
@@ -180,15 +180,11 @@ object DependentRecalculation:
         .getOrElse(s)
     }
 
-  /** Build reverse lookup from forward dependency graph */
+  /** Build reverse lookup from forward dependency graph (GH-522: shared mutable-builder core). */
   private def buildDependentsMap(
     graph: Map[QualifiedRef, Set[QualifiedRef]]
   ): Map[QualifiedRef, Set[QualifiedRef]] =
-    graph.foldLeft(Map.empty[QualifiedRef, Set[QualifiedRef]]) { case (acc, (ref, deps)) =>
-      deps.foldLeft(acc) { (acc2, dep) =>
-        acc2.updated(dep, acc2.getOrElse(dep, Set.empty) + ref)
-      }
-    }
+    DependencyGraph.reverseEdges(graph)
 
   @scala.annotation.tailrec
   private def transitiveDependentsQualified(

--- a/xl-evaluator/src/com/tjclp/xl/formula/eval/DependentRecalculation.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/eval/DependentRecalculation.scala
@@ -37,8 +37,8 @@ object DependentRecalculation:
      * which cells their evaluated text names, so any edit may affect them. They and their static
      * dependents recalculate last (`DependencyGraph.deferDynamic`); earlier-refreshed caches are
      * exactly what dynamic reads should observe. This is the purity-charter encoding of Excel's
-     * "volatile" marking. Caveat: INDIRECT→INDIRECT chains may need the full
-     * `Workbook.recalculate()` for guaranteed freshness (caches are refreshed, not stripped, here).
+     * "volatile" marking. The entire dynamic closure has its old caches stripped before the pass,
+     * so multi-hop INDIRECT/OFFSET chains cannot observe a previous calculation generation.
      *
      * @param modifiedRefs
      *   Set of cell references that have been modified
@@ -56,23 +56,48 @@ object DependentRecalculation:
     ): Sheet =
       if modifiedRefs.isEmpty then sheet
       else
-        val graph = DependencyGraph.fromSheet(sheet)
-        val dynamic = DependencyGraph.dynamicCells(sheet)
+        val calculationClock = WorkbookEvaluator.pinnedCalculationClock(clock)
+        val analysisWorkbook = workbook.fold(Workbook(sheet))(_.put(sheet))
+        val seeds = modifiedRefs.map(ref => QualifiedRef(sheet.name, ref))
+        val dynamic = DependencyGraph.dynamicCells(analysisWorkbook).filter(_.sheet == sheet.name)
+        val (graph, dependents) = DependencyGraph.fromWorkbookFormulaGraph(analysisWorkbook)
+        val dependencyIndex = DependencyGraph.fromWorkbookDependencyIndex(analysisWorkbook)
         val toRecalc =
-          DependencyGraph.transitiveDependents(graph, modifiedRefs ++ dynamic) ++ dynamic
+          (dependencyIndex.transitiveDependents(seeds ++ dynamic) ++ dynamic)
+            .filter(_.sheet == sheet.name)
         if toRecalc.isEmpty then sheet
         else
-          // Get topological order and filter to only affected cells
-          DependencyGraph.topologicalSort(graph) match
+          val affectedGraph = graph.filter((q, _) => toRecalc.contains(q))
+          val affectedDependents = dependents.filter((q, _) => toRecalc.contains(q))
+          val cyclic = DependencyGraph.qualifiedCyclicNodes(affectedGraph)
+          val blocked = DependencyGraph.qualifiedTransitiveDependents(affectedDependents, cyclic)
+          val skipped = (cyclic ++ blocked) & toRecalc
+          val orderGraph =
+            (affectedGraph -- skipped).view.mapValues(_ -- skipped).toMap
+          val orderDependents =
+            (affectedDependents -- skipped).view.mapValues(_ -- skipped).toMap
+          DependencyGraph.qualifiedTopologicalSort(orderGraph, orderDependents) match
+            case Left(_) => sheet
             case Right(evalOrder) =>
-              val orderedToRecalc = DependencyGraph.deferDynamic(
-                evalOrder.filter(toRecalc.contains),
-                DependencyGraph.dynamicClosure(graph, dynamic)
+              val dynamicClosure =
+                if dynamic.isEmpty then Set.empty[QualifiedRef]
+                else
+                  (dynamic ++ DependencyGraph.qualifiedTransitiveDependents(dependents, dynamic))
+                    .filter(_.sheet == sheet.name)
+                    .diff(skipped)
+              val ordered =
+                evalOrder.filterNot(dynamicClosure.contains) ++
+                  evalOrder.filter(dynamicClosure.contains)
+              val initial = SheetEvaluator.stripFormulaCaches(
+                sheet,
+                dynamicClosure.iterator.map(_.ref).toSet
               )
-              recalculateInOrder(sheet, orderedToRecalc, workbook, clock)
-            case Left(_) =>
-              // Cycle detected - skip recalculation (formulas will show error on eval)
-              sheet
+              recalculateInOrder(
+                initial,
+                ordered.map(_.ref),
+                Some(analysisWorkbook),
+                calculationClock
+              )
 
   extension (wb: Workbook)
     /**
@@ -106,47 +131,62 @@ object DependentRecalculation:
     ): Workbook =
       if modifiedRefs.isEmpty then wb
       else
+        val calculationClock = WorkbookEvaluator.pinnedCalculationClock(clock)
         val qualifiedRefs = modifiedRefs.map(ref => QualifiedRef(sheetName, ref))
         // GH-274: dynamic-reference cells (INDIRECT) on ANY sheet are always dirty — their
         // resolved targets are invisible to the static graph, so every sheet's dynamic cells
         // join the seeds (and the recalc set) unconditionally.
-        val dynamicBySheet: Map[SheetName, Set[ARef]] =
-          wb.sheets.map(s => s.name -> DependencyGraph.dynamicCells(s)).toMap
-        val dynamicQualified: Set[QualifiedRef] =
-          dynamicBySheet.toSet.flatMap { case (name, refs) =>
-            refs.map(ref => QualifiedRef(name, ref))
-          }
-        val graph = DependencyGraph.fromWorkbook(wb)
-        val dependentsMap = buildDependentsMap(graph)
-        val toRecalc =
-          transitiveDependentsQualified(dependentsMap, qualifiedRefs ++ dynamicQualified) ++
-            dynamicQualified
+        val dynamicQualified = DependencyGraph.dynamicCells(wb)
+        // Ordering needs only formula-to-formula edges; dirty discovery uses symbolic declared
+        // ranges so A:A never materializes one million cells and a just-cleared boundary ref still
+        // reaches formulas that read it.
+        val (graph, dependentsMap) = DependencyGraph.fromWorkbookFormulaGraph(wb)
+        val dependencyIndex = DependencyGraph.fromWorkbookDependencyIndex(wb)
+        val dynamicClosure =
+          if dynamicQualified.isEmpty then Set.empty[QualifiedRef]
+          else
+            dynamicQualified ++ DependencyGraph.qualifiedTransitiveDependents(
+              dependentsMap,
+              dynamicQualified
+            )
+        val modifiedDependents =
+          dependencyIndex.transitiveDependents(qualifiedRefs)
+        // Modified seeds themselves are not recalculated unless they are dynamic (the historical
+        // targeted-recalc contract); splitting the two closures avoids walking dynamic-only
+        // branches twice while retaining the closure-of-union result.
+        val toRecalc = ((modifiedDependents ++ dynamicClosure) -- qualifiedRefs) ++ dynamicQualified
 
         if toRecalc.isEmpty then wb
         else
-          // Group by sheet and recalculate each
-          toRecalc.groupBy(_.sheet).foldLeft(wb) { case (currentWb, (targetSheet, refs)) =>
-            currentWb(targetSheet).toOption
-              .map { sheet =>
-                val sheetGraph = DependencyGraph.fromSheet(sheet)
-                DependencyGraph.topologicalSort(sheetGraph) match
-                  case Right(evalOrder) =>
-                    val localRefs = refs.map(_.ref)
-                    // GH-274: same evaluate-last partition as the sheet variant
-                    val orderedToRecalc = DependencyGraph.deferDynamic(
-                      evalOrder.filter(localRefs.contains),
-                      DependencyGraph.dynamicClosure(
-                        sheetGraph,
-                        dynamicBySheet.getOrElse(sheet.name, Set.empty)
-                      )
-                    )
-                    val updatedSheet =
-                      recalculateInOrder(sheet, orderedToRecalc, Some(currentWb), clock)
-                    currentWb.put(updatedSheet)
-                  case Left(_) => currentWb
-              }
-              .getOrElse(currentWb)
-          }
+          // Sort the affected workbook nodes once. Grouping by sheet is not valid here: a
+          // downstream sheet can otherwise run before an upstream sheet and read its stale cache.
+          // Restricting only the node map keeps stable precedents out of the work while Kahn still
+          // sees every edge between affected formulas (it ignores successors absent from keySet).
+          val affectedGraph = graph.filter((q, _) => toRecalc.contains(q))
+          val affectedDependents = dependentsMap.filter((q, _) => toRecalc.contains(q))
+          val cyclic = DependencyGraph.qualifiedCyclicNodes(affectedGraph)
+          val blocked =
+            DependencyGraph.qualifiedTransitiveDependents(affectedDependents, cyclic)
+          val skipped = (cyclic ++ blocked) & toRecalc
+          val orderGraph =
+            (affectedGraph -- skipped).view.mapValues(_ -- skipped).toMap
+          val orderDependents =
+            (affectedDependents -- skipped).view.mapValues(_ -- skipped).toMap
+          DependencyGraph.qualifiedTopologicalSort(orderGraph, orderDependents) match
+            // Defensive totality: qualifiedCyclicNodes removed every cycle participant.
+            case Left(_) => wb
+            case Right(evalOrder) =>
+              // GH-274/GH-301: dynamic cells and every static dependent of one evaluate last.
+              // This is a workbook-wide stable partition, so the dependency-first order remains
+              // valid even when the dynamic chain crosses sheet boundaries.
+              val orderedMain = evalOrder.filterNot(dynamicClosure.contains)
+              val orderedDynamic = evalOrder.filter(dynamicClosure.contains)
+              recalculateQualifiedInOrder(
+                wb,
+                orderedMain ++ orderedDynamic,
+                dynamicClosure -- skipped,
+                calculationClock
+              )
 
   /** Recalculate formulas in the given order, updating cached values */
   private def recalculateInOrder(
@@ -156,44 +196,74 @@ object DependentRecalculation:
     clock: Clock
   ): Sheet =
     refs.foldLeft(sheet) { (s, ref) =>
-      s.cells
-        .get(ref)
-        .map { cell =>
-          cell.value match
-            // GH-353/GH-430: external-workbook and data-table formulas keep their Excel-written
-            // cache verbatim — re-evaluating can only fail (the external workbook is not loaded;
-            // TABLE(...) is a record, not evaluable text), and clearing the cache would destroy
-            // the sole source of truth
-            case value: CellValue.Formula if SheetEvaluator.pinnedCache(value).isDefined =>
-              s
-            case f @ CellValue.Formula(expr, _, _) =>
-              // Evaluate the formula and update cache; .copy keeps the record kind (GH-430)
-              val fullFormula = if expr.startsWith("=") then expr else s"=$expr"
-              SheetEvaluator.evaluateFormula(s)(fullFormula, clock, workbook) match
-                case Right(newValue) =>
-                  s.put(ref, f.copy(cachedValue = Some(newValue)))
-                case Left(_) =>
-                  // Evaluation error - clear cache (will show error on next eval)
-                  s.put(ref, f.copy(cachedValue = None))
-            case _ => s
-        }
-        .getOrElse(s)
+      // A sheet-qualified self-reference resolves through the workbook context rather than the
+      // direct `sheet` argument. Keep that view on the same threaded snapshot so targeted
+      // recalculation cannot expose a stale copy of the sheet currently being refreshed.
+      val currentWorkbook = workbook.map(_.put(s))
+      recalculateOne(s, ref, currentWorkbook, clock)
     }
 
-  /** Build reverse lookup from forward dependency graph (GH-522: shared mutable-builder core). */
-  private def buildDependentsMap(
-    graph: Map[QualifiedRef, Set[QualifiedRef]]
-  ): Map[QualifiedRef, Set[QualifiedRef]] =
-    DependencyGraph.reverseEdges(graph)
+  /**
+   * Recalculate workbook-qualified formulas in one global dependency-first pass.
+   *
+   * The `sheets` vector is threaded cell by cell so a cross-sheet reader sees every previously
+   * refreshed precedent. Workbook/source modification tracking is applied once per changed sheet
+   * after evaluation rather than rebuilding and marking the workbook for every formula.
+   */
+  private def recalculateQualifiedInOrder(
+    workbook: Workbook,
+    refs: List[QualifiedRef],
+    dynamicClosure: Set[QualifiedRef],
+    clock: Clock
+  ): Workbook =
+    val sheetIndex = workbook.sheets.zipWithIndex.map((s, i) => s.name -> i).toMap
+    val changed = scala.collection.mutable.BitSet.empty
+    val stripBySheet = dynamicClosure.groupMap(_.sheet)(_.ref)
+    val initialSheets = workbook.sheets.map { sheet =>
+      SheetEvaluator.stripFormulaCaches(
+        sheet,
+        stripBySheet.getOrElse(sheet.name, Set.empty)
+      )
+    }
+    val recalculatedSheets = refs.foldLeft(initialSheets) { (sheets, q) =>
+      sheetIndex.get(q.sheet) match
+        case None => sheets
+        case Some(index) =>
+          val currentWorkbook = workbook.copy(sheets = sheets)
+          val updated = recalculateOne(sheets(index), q.ref, Some(currentWorkbook), clock)
+          changed += index
+          sheets.updated(index, updated)
+    }
+    changed.foldLeft(workbook) { (current, index) =>
+      current.put(recalculatedSheets(index))
+    }
 
-  @scala.annotation.tailrec
-  private def transitiveDependentsQualified(
-    dependentsMap: Map[QualifiedRef, Set[QualifiedRef]],
-    refs: Set[QualifiedRef],
-    visited: Set[QualifiedRef] = Set.empty
-  ): Set[QualifiedRef] =
-    val toVisit = refs -- visited
-    if toVisit.isEmpty then visited -- refs
-    else
-      val directDeps = toVisit.flatMap(ref => dependentsMap.getOrElse(ref, Set.empty))
-      transitiveDependentsQualified(dependentsMap, directDeps, visited ++ toVisit)
+  /** Recalculate one formula cell, preserving pinned caches and formula record kinds. */
+  private def recalculateOne(
+    sheet: Sheet,
+    ref: ARef,
+    workbook: Option[Workbook],
+    clock: Clock
+  ): Sheet =
+    sheet.cells
+      .get(ref)
+      .map { cell =>
+        cell.value match
+          // GH-353/GH-430: external-workbook and data-table formulas keep their Excel-written
+          // cache verbatim — re-evaluating can only fail (the external workbook is not loaded;
+          // TABLE(...) is a record, not evaluable text), and clearing the cache would destroy
+          // the sole source of truth
+          case value: CellValue.Formula if SheetEvaluator.pinnedCache(value).isDefined =>
+            sheet
+          case f @ CellValue.Formula(expr, _, _) =>
+            // Evaluate the formula and update cache; .copy keeps the record kind (GH-430)
+            val fullFormula = if expr.startsWith("=") then expr else s"=$expr"
+            SheetEvaluator.evaluateFormula(sheet)(fullFormula, clock, workbook) match
+              case Right(newValue) =>
+                sheet.put(ref, f.copy(cachedValue = Some(newValue)))
+              case Left(_) =>
+                // Evaluation error - clear cache (will show error on next eval)
+                sheet.put(ref, f.copy(cachedValue = None))
+          case _ => sheet
+      }
+      .getOrElse(sheet)

--- a/xl-evaluator/src/com/tjclp/xl/formula/eval/Evaluator.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/eval/Evaluator.scala
@@ -1,5 +1,7 @@
 package com.tjclp.xl.formula.eval
 
+import java.util.concurrent.atomic.AtomicLong
+
 import com.tjclp.xl.formula.ast.{BindingCoercion, TExpr}
 import com.tjclp.xl.formula.functions.{FunctionSpec, FunctionSpecs, EvalContext}
 import com.tjclp.xl.formula.graph.DependencyGraph
@@ -13,6 +15,8 @@ import com.tjclp.xl.cells.{Cell, CellValue, FormulaKind}
 import com.tjclp.xl.workbooks.{DefinedName, Workbook}
 import com.tjclp.xl.SheetName
 import com.tjclp.xl.syntax.* // Extension methods for Sheet.get, CellRange.cells, ARef.toA1
+
+import scala.collection.concurrent.TrieMap
 import scala.math.BigDecimal
 import scala.util.boundary
 import scala.util.boundary.break
@@ -87,6 +91,19 @@ object Evaluator:
    */
   def instance(workbookPath: Option[String]): Evaluator =
     new EvaluatorImpl(workbookPath = workbookPath)
+
+  /**
+   * Internal evaluator for one workbook-recalculation generation.
+   *
+   * Public/direct evaluation deliberately has no aggregate memo: its one-shot semantics and
+   * allocation profile stay unchanged. WorkbookEvaluator alone creates this capability and shares
+   * it across the generation's sequential or parallel cell evaluations.
+   */
+  private[formula] def recalculationInstance(
+    rng: Rng,
+    aggregateMemo: AggregateMemo
+  ): Evaluator =
+    new EvaluatorImpl(rng = rng, aggregateMemo = Some(aggregateMemo))
 
   /**
    * Evaluator instance that allows array results to propagate.
@@ -345,7 +362,8 @@ object Evaluator:
     depth: Int = 0,
     rng: Rng = Rng.system,
     memo: EvalMemo = new EvalMemo,
-    workbookPath: Option[String] = None
+    workbookPath: Option[String] = None,
+    aggregateMemo: Option[AggregateMemo] = None
   ): Either[EvalError, CellValue] =
     boundary:
       // GH-161 review: Add recursion depth limit to prevent stack overflow on circular refs
@@ -377,7 +395,8 @@ object Evaluator:
             depth + 1,
             rng = rng,
             memo = Some(memo),
-            workbookPath = workbookPath
+            workbookPath = workbookPath,
+            aggregateMemo = aggregateMemo
           )
             .eval(expr, targetSheet, clock, workbook) match
             case Right(result) => Right(EvalResult.toCellValue(result))
@@ -438,6 +457,130 @@ object Evaluator:
           forSheet.update(at, computed)
           computed
 
+  /** Observable counters for focused aggregate-memo tests and profiling. */
+  private[formula] final case class AggregateMemoStats(
+    hits: Long,
+    fills: Long,
+    bypasses: Long,
+    entries: Int
+  )
+
+  /**
+   * Distinguishes the two aggregate evaluators, whose coercion contracts are not interchangeable.
+   */
+  private[formula] enum AggregateMemoMode:
+    case FunctionCall
+    case TypedNode
+
+  /**
+   * One calculation generation's memo for a single raw-range aggregate.
+   *
+   * A memo instance belongs to exactly one non-iterative workbook recalculation generation. Keys
+   * therefore use the logical sheet name rather than retaining every immutable `Sheet` snapshot:
+   * the formula graph guarantees that every formula cell in an explicit range is evaluated before
+   * its aggregate consumer, after which that range cannot change again in the one-pass generation.
+   * This is what lets same-sheet sequential consumers reuse a result even though each cache write
+   * creates a new `Sheet` object. Iterative recalculation never receives this capability. Range
+   * anchors are intentionally absent because they affect formula dragging, never values read.
+   *
+   * A per-key entry synchronizes the first eligible fold. This gives parallel waves single-flight
+   * behavior instead of allowing every cold reader to scan the same range before a TrieMap
+   * `putIfAbsent` wins. Ineligible ranges are marked once, then every reader computes outside the
+   * monitor. Results are immutable `Either[EvalError, BigDecimal]` values; errors memoize exactly
+   * like successes.
+   */
+  private[formula] final class AggregateMemo:
+    private val entries = TrieMap.empty[AggregateMemoKey, AggregateMemoEntry]
+    private val hitCount = new AtomicLong(0L)
+    private val fillCount = new AtomicLong(0L)
+    private val bypassCount = new AtomicLong(0L)
+
+    def getOrCompute(
+      targetSheet: Sheet,
+      range: CellRange,
+      aggregatorId: String,
+      mode: AggregateMemoMode
+    )(
+      compute: => Either[EvalError, BigDecimal]
+    ): Either[EvalError, BigDecimal] =
+      val key = AggregateMemoKey(targetSheet.name, range.start, range.end, aggregatorId, mode)
+      val entry = entries.getOrElseUpdate(key, new AggregateMemoEntry)
+      entry.lookupOrCompute(cacheable(targetSheet, range))(compute) match
+        case AggregateMemoLookup.Hit(value) =>
+          hitCount.incrementAndGet()
+          value
+        case AggregateMemoLookup.Filled(value) =>
+          fillCount.incrementAndGet()
+          value
+        case AggregateMemoLookup.Bypass =>
+          bypassCount.incrementAndGet()
+          compute
+
+    def stats: AggregateMemoStats =
+      AggregateMemoStats(
+        hits = hitCount.get(),
+        fills = fillCount.get(),
+        bypasses = bypassCount.get(),
+        entries = entries.size
+      )
+
+    private def cacheable(targetSheet: Sheet, range: CellRange): Boolean =
+      def isUncachedFormula(value: CellValue): Boolean = value match
+        case CellValue.Formula(_, None, _) => true
+        case _ => false
+
+      val containsUncachedFormula =
+        if range.cellCount <= targetSheet.cells.size.toLong then
+          range.cells.exists(ref =>
+            targetSheet.cells.get(ref).exists(c => isUncachedFormula(c.value))
+          )
+        else
+          targetSheet.cells.iterator.exists { case (ref, cell) =>
+            range.contains(ref) && isUncachedFormula(cell.value)
+          }
+      !containsUncachedFormula
+
+  /** Generation-local logical key; anchors and transient immutable Sheet identities are absent. */
+  private final case class AggregateMemoKey(
+    targetSheet: SheetName,
+    start: ARef,
+    end: ARef,
+    aggregatorId: String,
+    mode: AggregateMemoMode
+  )
+
+  private enum AggregateMemoState:
+    case Unchecked
+    case Uncacheable
+    case Cached(value: Either[EvalError, BigDecimal])
+
+  private enum AggregateMemoLookup:
+    case Hit(value: Either[EvalError, BigDecimal])
+    case Filled(value: Either[EvalError, BigDecimal])
+    case Bypass
+
+  @SuppressWarnings(Array("org.wartremover.warts.Var"))
+  private final class AggregateMemoEntry:
+    private var state: AggregateMemoState = AggregateMemoState.Unchecked
+
+    def lookupOrCompute(
+      cacheable: => Boolean
+    )(
+      compute: => Either[EvalError, BigDecimal]
+    ): AggregateMemoLookup = synchronized {
+      state match
+        case AggregateMemoState.Cached(value) => AggregateMemoLookup.Hit(value)
+        case AggregateMemoState.Uncacheable => AggregateMemoLookup.Bypass
+        case AggregateMemoState.Unchecked =>
+          if cacheable then
+            val value = compute
+            state = AggregateMemoState.Cached(value)
+            AggregateMemoLookup.Filled(value)
+          else
+            state = AggregateMemoState.Uncacheable
+            AggregateMemoLookup.Bypass
+    }
+
 /**
  * GH-344: the single typed-result → CellValue table, shared by the cross-sheet recursion
  * (Evaluator.evalCrossSheetFormula) and the public evaluation boundary (SheetEvaluator) so a value
@@ -485,7 +628,8 @@ private class EvaluatorImpl(
   bindings: Map[String, Any] = Map.empty,
   rng: Rng = Rng.system,
   resolvingNames: Set[String] = Set.empty,
-  workbookPath: Option[String] = None
+  workbookPath: Option[String] = None,
+  aggregateMemo: Option[Evaluator.AggregateMemo] = None
 ) extends Evaluator:
   /** Current recursion depth for cross-sheet formula evaluation. */
   protected def currentDepth: Int = 0
@@ -496,6 +640,9 @@ private class EvaluatorImpl(
    * derived evaluator of the pass via EvaluatorWithDepth).
    */
   protected def memoOpt: Option[Evaluator.EvalMemo] = None
+
+  /** One workbook recalculation generation's raw-range aggregate memo, absent for public eval. */
+  protected def aggregateMemoOpt: Option[Evaluator.AggregateMemo] = aggregateMemo
   // Suppress asInstanceOf warning for GADT type handling (required for type parameter erasure)
   @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
   def eval[A](
@@ -571,7 +718,8 @@ private class EvaluatorImpl(
                           currentDepth,
                           rng,
                           memo,
-                          workbookPath
+                          workbookPath,
+                          aggregateMemoOpt
                         )
                       }
                       .flatMap(evaluatedValue =>
@@ -639,7 +787,8 @@ private class EvaluatorImpl(
                     currentDepth,
                     rng,
                     memo,
-                    workbookPath
+                    workbookPath,
+                    aggregateMemoOpt
                   )
               }
               .flatMap(evaluatedValue => decodeOrCarried(at, Cell(at, evaluatedValue), decode))
@@ -764,7 +913,18 @@ private class EvaluatorImpl(
             // GH-411: the ambient name-cycle guard rides along so a name's refersTo cannot
             // re-enter itself through a range slot
             Evaluator.resolveRangeLocation(location, sheet, workbook, resolvingNames).flatMap {
-              case (targetSheet, range) => evalAggregateNode(agg, range, targetSheet)
+              case (targetSheet, range) =>
+                aggregateMemoOpt match
+                  case Some(memo) =>
+                    memo.getOrCompute(
+                      targetSheet,
+                      range,
+                      agg.name,
+                      Evaluator.AggregateMemoMode.TypedNode
+                    ) {
+                      evalAggregateNode(agg, range, targetSheet)
+                    }
+                  case None => evalAggregateNode(agg, range, targetSheet)
             }
 
       case call: TExpr.Call[?] =>
@@ -800,7 +960,8 @@ private class EvaluatorImpl(
             rng,
             Some(callMemo),
             resolvingNames, // GH-384: the name-cycle guard survives array-argument evaluation
-            workbookPath
+            workbookPath,
+            aggregateMemoOpt
           )
             .eval(expr, sheet, clock, workbook, currentCell)
 
@@ -815,7 +976,8 @@ private class EvaluatorImpl(
           bindings,
           rng,
           Some(callMemo),
-          workbookPath
+          workbookPath,
+          aggregateMemoOpt
         )
         call.spec.eval(call.args, ctx)
 
@@ -905,7 +1067,8 @@ private class EvaluatorImpl(
               rng,
               memoOpt,
               resolvingNames,
-              workbookPath
+              workbookPath,
+              aggregateMemoOpt
             )
               .eval(resolved.asInstanceOf[TExpr[Any]], sheet, clock, workbook, currentCell) match
               case Right(value) => Right(env + (name -> unwrapBindingValue(value)))
@@ -948,7 +1111,8 @@ private class EvaluatorImpl(
             rng,
             memoOpt,
             resolvingNames,
-            workbookPath
+            workbookPath,
+            aggregateMemoOpt
           )
             .eval(resolvedBody.asInstanceOf[TExpr[Any]], sheet, clock, workbook, currentCell)
     }
@@ -1048,7 +1212,8 @@ private class EvaluatorImpl(
                         rng,
                         memoOpt,
                         resolvingNames + key,
-                        workbookPath
+                        workbookPath,
+                        aggregateMemoOpt
                       )
                         .eval(
                           resolved.asInstanceOf[TExpr[Any]],
@@ -1459,7 +1624,15 @@ private class EvaluatorWithDepth(
   rng: Rng = Rng.system,
   memo: Option[Evaluator.EvalMemo] = None,
   resolvingNames: Set[String] = Set.empty,
-  workbookPath: Option[String] = None
-) extends EvaluatorImpl(allowArrayResults, bindings, rng, resolvingNames, workbookPath):
+  workbookPath: Option[String] = None,
+  aggregateMemo: Option[Evaluator.AggregateMemo] = None
+) extends EvaluatorImpl(
+      allowArrayResults,
+      bindings,
+      rng,
+      resolvingNames,
+      workbookPath,
+      aggregateMemo
+    ):
   override protected def currentDepth: Int = depth
   override protected def memoOpt: Option[Evaluator.EvalMemo] = memo

--- a/xl-evaluator/src/com/tjclp/xl/formula/eval/SheetEvaluator.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/eval/SheetEvaluator.scala
@@ -131,17 +131,7 @@ object SheetEvaluator:
       clock: Clock = Clock.system,
       workbook: Option[Workbook] = None
     ): XLResult[CellValue] =
-      val cell = sheet(ref)
-      cell.value match
-        case value @ CellValue.Formula(expr, _, _) =>
-          pinnedCache(value) match
-            // GH-353/GH-430: pinned-cache semantics — the Excel-written cache IS the value
-            case Some(cached) => scala.util.Right(cached)
-            case None =>
-              // Pass the current cell ref for ROW()/COLUMN() without arguments
-              evaluateFormula(expr, clock, workbook, Some(ref))
-        case other =>
-          scala.util.Right(other)
+      evaluateCellWithEvaluator(sheet, ref, Evaluator.instance, clock, workbook)
 
     /** Evaluate a formula cell with an explicit randomness source (GH-115). */
     @annotation.targetName("evaluateCellWithRng")
@@ -156,15 +146,7 @@ object SheetEvaluator:
       rng: Rng,
       workbook: Option[Workbook]
     ): XLResult[CellValue] =
-      sheet(ref).value match
-        case value @ CellValue.Formula(expr, _, _) =>
-          pinnedCache(value) match
-            // GH-353/GH-430: pinned-cache semantics — the Excel-written cache IS the value
-            case Some(cached) => scala.util.Right(cached)
-            case None =>
-              evaluateFormulaWith(sheet, expr, Evaluator.instance(rng), clock, workbook, Some(ref))
-        case other =>
-          scala.util.Right(other)
+      evaluateCellWithEvaluator(sheet, ref, Evaluator.instance(rng), clock, workbook)
 
     /**
      * Evaluate all formula cells in sheet with dependency checking.
@@ -289,7 +271,7 @@ object SheetEvaluator:
         // cell — dynamic targets are invisible to the static walk, so correctness requires
         // the whole sheet computed in order (correctness over narrowness; results still
         // report only the requested range).
-        val dynamic = DependencyGraph.dynamicCells(sheet)
+        val dynamic = dynamicCellsFor(sheet, workbook)
         val allFormulaCells = graph.dependencies.keySet
         val targetCells =
           if dynamic.isEmpty then rangeFormulaCells ++ (transitiveDeps & allFormulaCells)
@@ -321,7 +303,8 @@ object SheetEvaluator:
                   scala.util.Right((initial, Map.empty))
                 ) {
                   case (scala.util.Right((tempSheet, results)), ref) =>
-                    tempSheet.evaluateCell(ref, clock, workbook) match
+                    val currentWorkbook = workbook.map(_.put(tempSheet))
+                    tempSheet.evaluateCell(ref, clock, currentWorkbook) match
                       case scala.util.Right(value) =>
                         val nextResults =
                           if rangeFormulaCells.contains(ref) then results + (ref -> value)
@@ -414,6 +397,30 @@ object SheetEvaluator:
       putFormulaInheritingImpl(sheet, ref, formula, Some(workbook))
 
   // ========== Implementation shared by the public overloads ==========
+
+  /**
+   * Internal cell-evaluation boundary for WorkbookEvaluator.
+   *
+   * Supplying an evaluator lets one recalculation generation carry a narrowly scoped aggregate memo
+   * through every cell and parallel worker. Public overloads call the same boundary with a normal
+   * uncached evaluator, so their semantics remain unchanged.
+   */
+  private[formula] def evaluateCellWithEvaluator(
+    sheet: Sheet,
+    ref: ARef,
+    evaluator: => Evaluator,
+    clock: Clock,
+    workbook: Option[Workbook]
+  ): XLResult[CellValue] =
+    sheet(ref).value match
+      case value @ CellValue.Formula(expr, _, _) =>
+        pinnedCache(value) match
+          // GH-353/GH-430: pinned-cache semantics — the Excel-written cache IS the value
+          case Some(cached) => scala.util.Right(cached)
+          case None =>
+            // Pass the current cell ref for ROW()/COLUMN() without arguments
+            evaluateFormulaWith(sheet, expr, evaluator, clock, workbook, Some(ref))
+      case other => scala.util.Right(other)
 
   private def evaluateArrayFormulaImpl(
     sheet: Sheet,
@@ -547,16 +554,17 @@ object SheetEvaluator:
             // computed values. A dynamic depth-cap error fails the call, consistent with
             // this method's fail-fast cycle behavior.
             val (ordered, initial) =
-              deferDynamicWithStrip(sheet, graph, evalOrder, DependencyGraph.dynamicCells(sheet))
+              deferDynamicWithStrip(sheet, graph, evalOrder, dynamicCellsFor(sheet, workbook))
             // Evaluate in dependency order, threading the partially evaluated sheet so
             // dependent formulas see previously computed values. Fail-fast on first error.
             val evalResult = ordered.foldLeft[XLResult[(Sheet, Map[ARef, CellValue])]](
               scala.util.Right((initial, Map.empty))
             ) {
               case (scala.util.Right((tempSheet, results)), ref) =>
+                val currentWorkbook = workbook.map(_.put(tempSheet))
                 val evaluated = rngOpt match
-                  case Some(rng) => tempSheet.evaluateCell(ref, clock, rng, workbook)
-                  case None => tempSheet.evaluateCell(ref, clock, workbook)
+                  case Some(rng) => tempSheet.evaluateCell(ref, clock, rng, currentWorkbook)
+                  case None => tempSheet.evaluateCell(ref, clock, currentWorkbook)
                 evaluated match
                   case scala.util.Right(value) =>
                     scala.util.Right((tempSheet.put(ref, value), results + (ref -> value)))
@@ -634,6 +642,18 @@ object SheetEvaluator:
           s.put(r, f.copy(cachedValue = None))
         case _ => s
     }
+
+  /** Resolve name-hidden dynamic references when the caller supplied workbook metadata. */
+  private def dynamicCellsFor(sheet: Sheet, workbook: Option[Workbook]): Set[ARef] =
+    workbook match
+      case None => DependencyGraph.dynamicCells(sheet)
+      case Some(wb) =>
+        DependencyGraph
+          .dynamicCells(wb.put(sheet))
+          .iterator
+          .filter(_.sheet == sheet.name)
+          .map(_.ref)
+          .toSet
 
   /**
    * GH-274: defer dynamic (INDIRECT-bearing) cells and their static dependents to the end of a

--- a/xl-evaluator/src/com/tjclp/xl/formula/eval/StructuralEditor.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/eval/StructuralEditor.scala
@@ -287,7 +287,7 @@ object StructuralEditor:
     // reads it can have changed. Cells whose own text the shift rewrote are handled separately (a
     // rewritten reference always drops its cache below); this set is about the ones that do not.
     lazy val staleCaches: Set[QualifiedRef] =
-      val (_, dependents) = DependencyGraph.fromWorkbookBounded(wb)
+      val dependencyIndex = DependencyGraph.fromWorkbookDependencyIndex(wb)
       val axisIndex0: ARef => Int = r => if isRow then r.row.index0 else r.col.index0
       // The narrowing is gated too, not just the cache-carrying decision below: `staleCaches` also
       // feeds `keepNonParticipant`, which runs on EVERY path. A cross-sheet reader that reaches the
@@ -296,17 +296,26 @@ object StructuralEditor:
       // DEFAULT recalculating path then never refreshes (it drops out of `changedRefs`, so the
       // dirty cone misses it), silently resurfacing a poisoned <v> from a verb that promises to
       // recalculate. Off the flag, seeds stay the whole edited sheet, byte-for-byte as before.
-      val seeds = dependents.keySet.filter(q =>
+      val pointSeeds = dependencyIndex.pointDependents.keySet.filter(q =>
         q.sheet == target && (!preserveUntouchedCaches || axisIndex0(q.ref) >= at)
       )
+      // Symbolic ranges have no materialized cell keys. A structural edit affects a declared range
+      // when its edited axis reaches the cut; add its readers directly, then close transitively.
+      val rangeReaders = dependencyIndex.rangeDependents
+        .getOrElse(target, Vector.empty)
+        .iterator
+        .filter { entry =>
+          !preserveUntouchedCaches ||
+          (if isRow then entry.range.rowEnd.index0 >= at else entry.range.colEnd.index0 >= at)
+        }
+        .flatMap(_.dependents)
+        .toSet
       // A dynamic reference can reach the edited sheet without contributing a static graph edge.
       // Conservatively invalidate every dynamic cell and its static dependent closure: the edit
       // may have changed what its unchanged reference text resolves to.
-      val dynamic = wb.sheets.iterator.flatMap { s =>
-        DependencyGraph.dynamicCells(s).iterator.map(r => QualifiedRef(s.name, r))
-      }.toSet
-      seeds ++ dynamic ++
-        DependencyGraph.qualifiedTransitiveDependents(dependents, seeds ++ dynamic)
+      val dynamic = DependencyGraph.dynamicCells(wb)
+      val roots = pointSeeds ++ rangeReaders ++ dynamic
+      roots ++ dependencyIndex.transitiveDependents(roots)
     val updatedSheets = wb.sheets.map { s =>
       // 1. Pure cell/merge/property shift — only on the edited sheet. Its own typed charts
       //    (anchors + same-sheet data refs) are handled INSIDE the shift (GH-222).

--- a/xl-evaluator/src/com/tjclp/xl/formula/eval/WorkbookEvaluator.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/eval/WorkbookEvaluator.scala
@@ -1,5 +1,8 @@
 package com.tjclp.xl.formula.eval
 
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.{ExecutionException, Executors, Future, ThreadFactory, TimeUnit}
+
 import com.tjclp.xl.formula.ast.TExpr
 import com.tjclp.xl.formula.functions.{FunctionSpec, FunctionSpecs}
 import com.tjclp.xl.formula.graph.DependencyGraph
@@ -244,7 +247,26 @@ object WorkbookEvaluator:
     iterativeOpt: Option[IterativeCalc],
     parallelism: Int = 1
   ): RecalcResult =
-    val (deps, dependents) = DependencyGraph.fromWorkbookBounded(wb)
+    // One recalculate call is one volatile calculation generation. The lazy snapshot preserves
+    // the old no-volatile fast path (the supplied clock is never touched), while ensuring an
+    // arbitrary Clock is never invoked concurrently by wave workers.
+    val calculationClock = pinnedCalculationClock(clock)
+    // One narrowly scoped cache capability per non-iterative generation. The evaluator itself is
+    // immutable and AggregateMemo is thread-safe, so one instance can serve sequential cells and
+    // parallel wave workers. Iterative rounds deliberately change ranges and stay memo-free.
+    val generationEvaluator = iterativeOpt match
+      // A fixpoint intentionally revisits and changes the same ranges over multiple rounds, so a
+      // one-pass generation cache is inapplicable there.
+      case Some(_) => Evaluator.instance(rngOpt.getOrElse(Rng.system))
+      case None =>
+        Evaluator.recalculationInstance(
+          rngOpt.getOrElse(Rng.system),
+          new Evaluator.AggregateMemo
+        )
+    // Whole-book ordering needs only formula-to-formula edges. Constant cells are read during
+    // evaluation but can never participate in a cycle or constrain formula order; excluding them
+    // avoids O(formulas × range-size) graph construction and every downstream traversal.
+    val (deps, dependents) = DependencyGraph.fromWorkbookFormulaGraph(wb)
 
     def formulaText(q: QualifiedRef): String =
       wb(q.sheet).toOption.flatMap(_.cells.get(q.ref)).map(_.value) match
@@ -307,10 +329,7 @@ object WorkbookEvaluator:
         // trusting a previous generation's cache. The closure is workbook-level (GH-346): a
         // cross-sheet static dependent of a dynamic cell defers with it. Dynamic-free workbooks
         // take the identity path.
-        val dynamicAll: Set[QualifiedRef] =
-          wb.sheets.iterator.flatMap { s =>
-            DependencyGraph.dynamicCells(s).iterator.map(r => QualifiedRef(s.name, r))
-          }.toSet
+        val dynamicAll: Set[QualifiedRef] = DependencyGraph.dynamicCells(wb)
         val dynamic: Set[QualifiedRef] = dynamicAll -- removed
         val bucket =
           if dynamic.isEmpty then Set.empty[QualifiedRef]
@@ -319,7 +338,6 @@ object WorkbookEvaluator:
           if bucket.isEmpty then evalOrder else evalOrder.filterNot(bucket.contains)
         val orderedBucket =
           if bucket.isEmpty then List.empty[QualifiedRef] else evalOrder.filter(bucket.contains)
-        val ordered = orderedMain ++ orderedBucket
 
         // GH-492: the condensation walk evaluates the cyclic core too, so the deferral bucket must
         // be closed over the FULL graph — `prunedDependents` has the core deleted, and a cyclic
@@ -361,9 +379,13 @@ object WorkbookEvaluator:
             // diverging Newton loop) must degrade to this cell's per-cell error, never
             // unwind the whole recalculation.
             try
-              rngOpt match
-                case Some(rng) => tempSheet.evaluateCell(q.ref, clk, rng, Some(tempWb))
-                case None => tempSheet.evaluateCell(q.ref, clk, Some(tempWb))
+              SheetEvaluator.evaluateCellWithEvaluator(
+                tempSheet,
+                q.ref,
+                generationEvaluator,
+                clk,
+                Some(tempWb)
+              )
             catch
               case NonFatal(e) =>
                 Left(
@@ -403,6 +425,15 @@ object WorkbookEvaluator:
               case Some(result) => foldResult(state, q, result)
           }
 
+        def failPass(
+          order: IterableOnce[QualifiedRef],
+          init: PassState,
+          message: String
+        ): PassState =
+          order.iterator.foldLeft(init) { (state, q) =>
+            foldResult(state, q, Left(XLError.FormulaError(formulaText(q), message)))
+          }
+
         /**
          * GH-520: the wave-parallel equivalent of one `evalPass` over `order`.
          *
@@ -418,7 +449,7 @@ object WorkbookEvaluator:
          *
          * Waves below [[ParallelWaveCutoff]] run through the sequential fold — chain-shaped regions
          * would otherwise pay thread-handoff latency per cell. Worker results are published by
-         * `Future.get`'s happens-before edge; each chunk owns disjoint slots of the results array.
+         * `Future.get`'s happens-before edge; the atomic cursor assigns each result slot once.
          */
         @SuppressWarnings(Array("org.wartremover.warts.Var", "org.wartremover.warts.While"))
         def evalWaves(
@@ -426,52 +457,149 @@ object WorkbookEvaluator:
           init: PassState,
           clk: Clock,
           threads: Int
-        ): PassState =
+        ): (PassState, Option[String]) =
           val orderVec = order.toVector
-          if orderVec.isEmpty then init
+          if orderVec.isEmpty then (init, None)
           else
-            val inOrder = orderVec.toSet
             val depthOf = scala.collection.mutable.HashMap.empty[QualifiedRef, Int]
+            val waveBuilders =
+              scala.collection.mutable.ArrayBuffer.empty[
+                scala.collection.mutable.ArrayBuffer[QualifiedRef]
+              ]
             orderVec.foreach { q =>
               var d = 0
               prunedDeps.getOrElse(q, Set.empty).foreach { p =>
-                if inOrder.contains(p) then d = math.max(d, depthOf.getOrElse(p, 0))
+                depthOf.get(p).foreach(parentDepth => d = math.max(d, parentDepth + 1))
               }
-              depthOf(q) = d + 1
+              depthOf(q) = d
+              while waveBuilders.length <= d do
+                waveBuilders += scala.collection.mutable.ArrayBuffer.empty[QualifiedRef]
+              waveBuilders(d) += q
             }
             val waves: Vector[Vector[QualifiedRef]] =
-              orderVec.groupBy(depthOf).toVector.sortBy(_._1).map(_._2)
-            val pool = java.util.concurrent.Executors.newFixedThreadPool(threads)
-            try
-              waves.foldLeft(init) { case (state @ (sheets, _, _), wave) =>
-                if wave.length < ParallelWaveCutoff then evalPass(wave.toList, state, clk)
-                else
-                  val snapshotWb = wb.copy(sheets = sheets)
-                  val results: Array[Option[Either[XLError, CellValue]]] =
-                    Array.fill(wave.length)(None)
-                  val chunk = math.max(1, (wave.length + threads - 1) / threads)
-                  val futures = new java.util.ArrayList[java.util.concurrent.Future[?]]()
-                  var start = 0
-                  while start < wave.length do
-                    val from = start
-                    val until = math.min(wave.length, from + chunk)
+              waveBuilders.iterator.map(_.toVector).toVector
+            val widestParallelWave =
+              waves.iterator.filter(_.length >= ParallelWaveCutoff).map(_.length).maxOption
+            widestParallelWave match
+              case None => (evalPass(order, init, clk), None)
+              case Some(width) => evalParallelWaves(waves, init, clk, math.min(threads, width))
+
+        @SuppressWarnings(Array("org.wartremover.warts.Var", "org.wartremover.warts.While"))
+        def evalParallelWaves(
+          waves: Vector[Vector[QualifiedRef]],
+          init: PassState,
+          clk: Clock,
+          threads: Int
+        ): (PassState, Option[String]) =
+          val threadFactory: ThreadFactory = runnable =>
+            val thread = new Thread(
+              runnable,
+              s"xl-recalc-worker-${ParallelWorkerIds.incrementAndGet()}"
+            )
+            // Every exit path shuts the pool down. Daemon status is the final lifecycle
+            // backstop for a function implementation that ignores interruption.
+            thread.setDaemon(true)
+            thread
+          val pool = Executors.newFixedThreadPool(threads, threadFactory)
+          var hardStopped = false
+
+          def cancelOutstanding(futures: java.util.ArrayList[Future[?]]): Unit =
+            var i = 0
+            while i < futures.size() do
+              futures.get(i).cancel(true)
+              i += 1
+
+          def stopNow(
+            futures: java.util.ArrayList[Future[?]],
+            restoreInterrupt: Boolean
+          ): Unit =
+            hardStopped = true
+            cancelOutstanding(futures)
+            pool.shutdownNow()
+            var interrupted = restoreInterrupt
+            try pool.awaitTermination(ParallelShutdownWaitSeconds, TimeUnit.SECONDS)
+            catch case _: InterruptedException => interrupted = true
+            if interrupted then Thread.currentThread().interrupt()
+
+          try
+            var state = init
+            var waveIndex = 0
+            var abortReason = Option.empty[String]
+            while waveIndex < waves.length && abortReason.isEmpty do
+              val wave = waves(waveIndex)
+              if wave.length < ParallelWaveCutoff then state = evalPass(wave.toList, state, clk)
+              else
+                val (sheets, _, _) = state
+                val snapshotWb = wb.copy(sheets = sheets)
+                val results: Array[Option[Either[XLError, CellValue]]] =
+                  Array.fill(wave.length)(None)
+                // Formula costs are heterogeneous (a SUM over 5,000 cells and a scalar add can
+                // share a wave). A shared cursor gives idle workers another cell instead of
+                // pinning them behind the slowest static chunk; result slots and the fold order
+                // remain deterministic.
+                val nextIndex = AtomicInteger(0)
+                val workerCount = math.min(threads, wave.length)
+                val futures = new java.util.ArrayList[Future[?]]()
+                try
+                  var worker = 0
+                  while worker < workerCount do
                     val task: Runnable = () =>
-                      var i = from
-                      while i < until do
+                      var i = nextIndex.getAndIncrement()
+                      while i < wave.length do
                         results(i) = evalOne(sheets, snapshotWb, wave(i), clk)
-                        i += 1
+                        i = nextIndex.getAndIncrement()
                     futures.add(pool.submit(task))
-                    start = until
-                  futures.forEach { f =>
-                    f.get()
-                    ()
-                  }
-                  wave.indices.foldLeft(state) { (st, i) =>
+                    worker += 1
+
+                  var futureIndex = 0
+                  while futureIndex < futures.size() do
+                    futures.get(futureIndex).get()
+                    futureIndex += 1
+                catch
+                  case _: InterruptedException =>
+                    val reason = "Parallel recalculation interrupted"
+                    stopNow(futures, restoreInterrupt = true)
+                    abortReason = Some(reason)
+                  case execution: ExecutionException =>
+                    Option(execution.getCause) match
+                      // InterruptedException is not NonFatal in Scala because ordinary callers
+                      // must preserve their own interrupt. Here it belongs to a worker Future;
+                      // cancel the wave and report it without spuriously interrupting the caller.
+                      case Some(_: InterruptedException) | Some(NonFatal(_)) | None =>
+                        val reason = "Parallel recalculation worker failed"
+                        stopNow(futures, restoreInterrupt = false)
+                        abortReason = Some(reason)
+                      case Some(fatal) =>
+                        stopNow(futures, restoreInterrupt = false)
+                        throw fatal
+                  case NonFatal(_) =>
+                    val reason = "Parallel recalculation worker failed"
+                    stopNow(futures, restoreInterrupt = false)
+                    abortReason = Some(reason)
+
+                if abortReason.isEmpty then
+                  state = wave.indices.foldLeft(state) { (st, i) =>
                     results(i).fold(st)(foldResult(st, wave(i), _))
                   }
-              }
-            finally
+
+              if abortReason.isEmpty then waveIndex += 1
+
+            abortReason match
+              case None => (state, None)
+              case Some(reason) =>
+                val unfinished = waves.drop(waveIndex).iterator.flatten
+                (failPass(unfinished, state, reason), Some(reason))
+          finally
+            if !hardStopped then
               pool.shutdown()
+              try
+                if !pool.awaitTermination(ParallelShutdownWaitSeconds, TimeUnit.SECONDS) then
+                  pool.shutdownNow()
+                  pool.awaitTermination(ParallelShutdownWaitSeconds, TimeUnit.SECONDS)
+              catch
+                case _: InterruptedException =>
+                  pool.shutdownNow()
+                  Thread.currentThread().interrupt()
 
         /**
          * GH-492: fixpoint ONE cyclic condensation node against the threaded temp sheets, then fold
@@ -501,7 +629,16 @@ object WorkbookEvaluator:
             if iterative.seedFromCaches then warmSeed(baseSheets, members)
             else Map.empty[QualifiedRef, CellValue]
           val outcome =
-            jacobiFixpoint(wb, baseSheets, members, iterative, pinnedClock, rngOpt, seed)
+            jacobiFixpoint(
+              wb,
+              baseSheets,
+              members,
+              iterative,
+              pinnedClock,
+              rngOpt,
+              seed,
+              Some(generationEvaluator)
+            )
           val folded = members.foldLeft((baseSheets, acc0, errs0)) {
             case ((sheets, acc, errs), (q, idx, _)) =>
               outcome.results.get(q) match
@@ -546,11 +683,10 @@ object WorkbookEvaluator:
         // before anything reads it, so no read can fall back to a loaded cache and `converged`
         // certifies the workbook's GLOBAL fixpoint (see RecalcResult). The clock is pinned ONCE
         // for the whole walk: one iterative recalculation is one volatile generation, in the
-        // fixpoints AND in the acyclic bridges between them. The default path is untouched —
-        // literally the same single `evalPass(ordered, ...)` with the caller's clock.
+        // fixpoints AND in the acyclic bridges between them. Non-iterative recalculation uses the
+        // same pinned generation so sequential and parallel paths observe identical volatile time.
         val (finalState, cycleReports) = iterativeOpt match
           case Some(iterative) if cyclicCore.nonEmpty =>
-            val pinnedClock = Clock.fixed(clock.today(), clock.now())
             val components = DependencyGraph.qualifiedSccOrder(deps)
             val walk =
               if bucketIter.isEmpty then components
@@ -558,17 +694,20 @@ object WorkbookEvaluator:
                 val (eager, deferred) =
                   components.partition(c => !c.members.exists(bucketIter.contains))
                 eager ++ deferred
-            runPlan(buildPlan(walk), iterative, pinnedClock, initState)
+            runPlan(buildPlan(walk), iterative, calculationClock, initState)
           case _ =>
             // GH-520: waves parallelize only the statically ordered region; the dynamic bucket
             // keeps its sequential evaluate-last pass (its reads resolve at evaluation time).
             // A seeded Rng forces the sequential fold — its draw sequence is evaluation-order.
             val threads =
               if rngOpt.isDefined then 1 else math.min(math.max(1, parallelism), MaxParallelism)
-            val mainState =
-              if threads <= 1 then evalPass(orderedMain, initState, clock)
-              else evalWaves(orderedMain, initState, clock, threads)
-            (evalPass(orderedBucket, mainState, clock), Vector.empty[SccReport])
+            val (mainState, abortReason) =
+              if threads <= 1 then (evalPass(orderedMain, initState, calculationClock), None)
+              else evalWaves(orderedMain, initState, calculationClock, threads)
+            val completedState = abortReason match
+              case None => evalPass(orderedBucket, mainState, calculationClock)
+              case Some(reason) => failPass(orderedBucket, mainState, reason)
+            (completedState, Vector.empty[SccReport])
 
         val (_, evaluated, evalErrors) = finalState
         val cycles = cycleReports.sortBy(r =>
@@ -620,6 +759,25 @@ object WorkbookEvaluator:
   /** GH-492: the threaded state of one recalculation pass (temp sheets, values, errors). */
   private[eval] type PassState =
     (Vector[Sheet], Map[SheetName, Map[ARef, CellValue]], Vector[CellEvalError])
+
+  /**
+   * Snapshot an explicit clock at most once per recalculation generation.
+   *
+   * The shared gate serializes first access to the caller's Clock, while separate lazy fields keep
+   * the capability minimal: a TODAY-only workbook never calls `now`, and a NOW-only workbook never
+   * calls `today`. Scala publishes each lazy result safely to every wave worker. Workbooks without
+   * volatile time functions never force either snapshot.
+   */
+  private[eval] def pinnedCalculationClock(clock: Clock): Clock = new Clock:
+    private val gate = new Object
+    private lazy val generationToday = gate.synchronized(clock.today())
+    private lazy val generationNow = gate.synchronized(clock.now())
+
+    def today(): java.time.LocalDate = generationToday
+    def now(): java.time.LocalDateTime = generationNow
+
+  private val ParallelWorkerIds = AtomicInteger(0)
+  private val ParallelShutdownWaitSeconds = 5L
 
   /** GH-520: hard cap on requested parallelism — a pool wider than this only adds contention. */
   private val MaxParallelism = 64
@@ -714,7 +872,8 @@ object WorkbookEvaluator:
     iterative: IterativeCalc,
     pinnedClock: Clock,
     rngOpt: Option[Rng],
-    seedValues: Map[QualifiedRef, CellValue]
+    seedValues: Map[QualifiedRef, CellValue],
+    generationEvaluator: Option[Evaluator] = None
   ): FixpointOutcome =
     val zero: CellValue = CellValue.Number(BigDecimal(0))
     val seed: Map[QualifiedRef, CellValue] =
@@ -747,9 +906,19 @@ object WorkbookEvaluator:
           val tempSheet = overlaid(idx)
           val evaluatedCell =
             try
-              rngOpt match
-                case Some(rng) => tempSheet.evaluateCell(q.ref, pinnedClock, rng, Some(tempWb))
-                case None => tempSheet.evaluateCell(q.ref, pinnedClock, Some(tempWb))
+              generationEvaluator match
+                case Some(evaluator) =>
+                  SheetEvaluator.evaluateCellWithEvaluator(
+                    tempSheet,
+                    q.ref,
+                    evaluator,
+                    pinnedClock,
+                    Some(tempWb)
+                  )
+                case None =>
+                  rngOpt match
+                    case Some(rng) => tempSheet.evaluateCell(q.ref, pinnedClock, rng, Some(tempWb))
+                    case None => tempSheet.evaluateCell(q.ref, pinnedClock, Some(tempWb))
             catch
               case NonFatal(e) =>
                 Left(XLError.FormulaError(expr, s"Evaluation threw ${e.getClass.getName}"))

--- a/xl-evaluator/src/com/tjclp/xl/formula/eval/WorkbookEvaluator.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/eval/WorkbookEvaluator.scala
@@ -202,13 +202,47 @@ object WorkbookEvaluator:
     def recalculate(clock: Clock, rng: Rng, iterative: IterativeCalc): RecalcResult =
       recalculateImpl(wb, clock, Some(rng), Some(iterative))
 
+    /**
+     * GH-520: non-iterative recalculation with independent formula regions evaluated on
+     * `parallelism` threads.
+     *
+     * The single topological order is partitioned into longest-path depth classes ("waves") of the
+     * workbook graph: two cells in the same wave can have no path between them, so evaluating a
+     * wave's members concurrently against the pre-wave snapshot computes exactly the values the
+     * sequential pass computes, and results fold into the pass state in the sequential order — the
+     * workbook, evaluated map, and error vector are identical to `recalculate()`, element for
+     * element. Dynamic-reference cells (INDIRECT/OFFSET) and their static dependents keep their
+     * sequential evaluate-last pass (their reads resolve at evaluation time, outside the static
+     * graph), and `parallelism <= 1` is exactly `recalculate()`.
+     *
+     * Determinism caveats, by construction rather than by luck:
+     *   - No seeded-[[Rng]] variant is offered: a seeded generator draws in evaluation-order
+     *     sequence, which parallelism would reorder. RAND under this entry point uses the
+     *     thread-safe system generator ([[Rng.system]] semantics), as `recalculate()` does.
+     *   - No iterative variant is offered: cyclic components fixpoint sequentially (GH-492) and
+     *     books that need `IterativeCalc` should use the sequential overloads.
+     *   - A dependence the static graph cannot see (a defined name whose refersTo the parser
+     *     rejects — multi-area or intersection names, GH-468's blind-name class) is invisible to
+     *     wave placement exactly as it is invisible to the sequential Kahn order; both paths
+     *     evaluate such readers at an arbitrary point. Parity is guaranteed for every dependence
+     *     the graph can express.
+     */
+    def recalculateParallel(parallelism: Int): RecalcResult =
+      recalculateImpl(wb, Clock.system, None, None, parallelism)
+
+    /** GH-520: parallel non-iterative recalculation with an explicit clock. */
+    @annotation.targetName("recalculateParallelWithClock")
+    def recalculateParallel(clock: Clock, parallelism: Int): RecalcResult =
+      recalculateImpl(wb, clock, None, None, parallelism)
+
   // ========== recalculate internals ==========
 
   private def recalculateImpl(
     wb: Workbook,
     clock: Clock,
     rngOpt: Option[Rng],
-    iterativeOpt: Option[IterativeCalc]
+    iterativeOpt: Option[IterativeCalc],
+    parallelism: Int = 1
   ): RecalcResult =
     val (deps, dependents) = DependencyGraph.fromWorkbookBounded(wb)
 
@@ -281,9 +315,11 @@ object WorkbookEvaluator:
         val bucket =
           if dynamic.isEmpty then Set.empty[QualifiedRef]
           else dynamic ++ DependencyGraph.qualifiedTransitiveDependents(prunedDependents, dynamic)
-        val ordered =
-          if bucket.isEmpty then evalOrder
-          else evalOrder.filterNot(bucket.contains) ++ evalOrder.filter(bucket.contains)
+        val orderedMain =
+          if bucket.isEmpty then evalOrder else evalOrder.filterNot(bucket.contains)
+        val orderedBucket =
+          if bucket.isEmpty then List.empty[QualifiedRef] else evalOrder.filter(bucket.contains)
+        val ordered = orderedMain ++ orderedBucket
 
         // GH-492: the condensation walk evaluates the cyclic core too, so the deferral bucket must
         // be closed over the FULL graph — `prunedDependents` has the core deleted, and a cyclic
@@ -309,43 +345,133 @@ object WorkbookEvaluator:
         // values, so recursive re-derivation only arises on dynamic reads. The temp sheets live
         // in a Vector parallel to wb.sheets, updated incrementally, so per-cell cost is one
         // Workbook shell copy + one Vector update rather than re-mapping every sheet.
+        // One cell against a snapshot of the threaded sheets; None when the node names a sheet
+        // absent from the workbook. Shared verbatim by the sequential fold and the parallel waves
+        // so the two paths cannot diverge per cell.
+        def evalOne(
+          sheets: Vector[Sheet],
+          tempWb: Workbook,
+          q: QualifiedRef,
+          clk: Clock
+        ): Option[Either[XLError, CellValue]] =
+          sheetIndex.get(q.sheet).map { idx =>
+            val tempSheet = sheets(idx)
+            // GH-388 defense in depth: recalculate is documented total — a numeric blowup
+            // escaping a function implementation (e.g. BigDecimal scale overflow in a
+            // diverging Newton loop) must degrade to this cell's per-cell error, never
+            // unwind the whole recalculation.
+            try
+              rngOpt match
+                case Some(rng) => tempSheet.evaluateCell(q.ref, clk, rng, Some(tempWb))
+                case None => tempSheet.evaluateCell(q.ref, clk, Some(tempWb))
+            catch
+              case NonFatal(e) =>
+                Left(
+                  XLError.FormulaError(
+                    formulaText(q),
+                    s"Evaluation threw ${e.getClass.getName}"
+                  )
+                )
+          }
+
+        def foldResult(
+          state: PassState,
+          q: QualifiedRef,
+          result: Either[XLError, CellValue]
+        ): PassState =
+          val (sheets, acc, errs) = state
+          sheetIndex.get(q.sheet) match
+            case None => state
+            case Some(idx) =>
+              result match
+                case Right(value) =>
+                  (
+                    sheets.updated(idx, sheets(idx).put(q.ref, value)),
+                    acc.updated(q.sheet, acc.getOrElse(q.sheet, Map.empty) + (q.ref -> value)),
+                    errs
+                  )
+                case Left(error) => (sheets, acc, errs :+ CellEvalError(q.sheet, q.ref, error))
+
         def evalPass(
           order: List[QualifiedRef],
           init: PassState,
           clk: Clock
         ): PassState =
-          order.foldLeft(init) { case ((sheets, acc, errs), q) =>
-            sheetIndex.get(q.sheet) match
-              case None => (sheets, acc, errs) // node names a sheet absent from the workbook
-              case Some(idx) =>
-                val tempSheet = sheets(idx)
-                val tempWb = wb.copy(sheets = sheets)
-                // GH-388 defense in depth: recalculate is documented total — a numeric blowup
-                // escaping a function implementation (e.g. BigDecimal scale overflow in a
-                // diverging Newton loop) must degrade to this cell's per-cell error, never
-                // unwind the whole recalculation.
-                val evaluatedCell =
-                  try
-                    rngOpt match
-                      case Some(rng) => tempSheet.evaluateCell(q.ref, clk, rng, Some(tempWb))
-                      case None => tempSheet.evaluateCell(q.ref, clk, Some(tempWb))
-                  catch
-                    case NonFatal(e) =>
-                      Left(
-                        XLError.FormulaError(
-                          formulaText(q),
-                          s"Evaluation threw ${e.getClass.getName}"
-                        )
-                      )
-                evaluatedCell match
-                  case Right(value) =>
-                    (
-                      sheets.updated(idx, tempSheet.put(q.ref, value)),
-                      acc.updated(q.sheet, acc.getOrElse(q.sheet, Map.empty) + (q.ref -> value)),
-                      errs
-                    )
-                  case Left(error) => (sheets, acc, errs :+ CellEvalError(q.sheet, q.ref, error))
+          order.foldLeft(init) { case (state @ (sheets, _, _), q) =>
+            evalOne(sheets, wb.copy(sheets = sheets), q, clk) match
+              case None => state // node names a sheet absent from the workbook
+              case Some(result) => foldResult(state, q, result)
           }
+
+        /**
+         * GH-520: the wave-parallel equivalent of one `evalPass` over `order`.
+         *
+         * `order` is partitioned into longest-path depth classes over the pruned graph: if u
+         * depends on v then depth(u) > depth(v), so two cells of one wave can have no path between
+         * them and each wave member's evaluation reads only earlier-wave state. Every member of a
+         * wave therefore evaluates against the SAME pre-wave snapshot — concurrently — and computes
+         * exactly the value the sequential fold computes (an intra-wave write could only be
+         * observed through an edge the graph does not have; dynamic reads are excluded from `order`
+         * by the caller). Results fold into the pass state in the wave's sequential order, so
+         * sheets, evaluated map and error vector come out element-for-element equal to
+         * `evalPass(order, init, clk)`.
+         *
+         * Waves below [[ParallelWaveCutoff]] run through the sequential fold — chain-shaped regions
+         * would otherwise pay thread-handoff latency per cell. Worker results are published by
+         * `Future.get`'s happens-before edge; each chunk owns disjoint slots of the results array.
+         */
+        @SuppressWarnings(Array("org.wartremover.warts.Var", "org.wartremover.warts.While"))
+        def evalWaves(
+          order: List[QualifiedRef],
+          init: PassState,
+          clk: Clock,
+          threads: Int
+        ): PassState =
+          val orderVec = order.toVector
+          if orderVec.isEmpty then init
+          else
+            val inOrder = orderVec.toSet
+            val depthOf = scala.collection.mutable.HashMap.empty[QualifiedRef, Int]
+            orderVec.foreach { q =>
+              var d = 0
+              prunedDeps.getOrElse(q, Set.empty).foreach { p =>
+                if inOrder.contains(p) then d = math.max(d, depthOf.getOrElse(p, 0))
+              }
+              depthOf(q) = d + 1
+            }
+            val waves: Vector[Vector[QualifiedRef]] =
+              orderVec.groupBy(depthOf).toVector.sortBy(_._1).map(_._2)
+            val pool = java.util.concurrent.Executors.newFixedThreadPool(threads)
+            try
+              waves.foldLeft(init) { case (state @ (sheets, _, _), wave) =>
+                if wave.length < ParallelWaveCutoff then evalPass(wave.toList, state, clk)
+                else
+                  val snapshotWb = wb.copy(sheets = sheets)
+                  val results: Array[Option[Either[XLError, CellValue]]] =
+                    Array.fill(wave.length)(None)
+                  val chunk = math.max(1, (wave.length + threads - 1) / threads)
+                  val futures = new java.util.ArrayList[java.util.concurrent.Future[?]]()
+                  var start = 0
+                  while start < wave.length do
+                    val from = start
+                    val until = math.min(wave.length, from + chunk)
+                    val task: Runnable = () =>
+                      var i = from
+                      while i < until do
+                        results(i) = evalOne(sheets, snapshotWb, wave(i), clk)
+                        i += 1
+                    futures.add(pool.submit(task))
+                    start = until
+                  futures.forEach { f =>
+                    f.get()
+                    ()
+                  }
+                  wave.indices.foldLeft(state) { (st, i) =>
+                    results(i).fold(st)(foldResult(st, wave(i), _))
+                  }
+              }
+            finally
+              pool.shutdown()
 
         /**
          * GH-492: fixpoint ONE cyclic condensation node against the threaded temp sheets, then fold
@@ -433,7 +559,16 @@ object WorkbookEvaluator:
                   components.partition(c => !c.members.exists(bucketIter.contains))
                 eager ++ deferred
             runPlan(buildPlan(walk), iterative, pinnedClock, initState)
-          case _ => (evalPass(ordered, initState, clock), Vector.empty[SccReport])
+          case _ =>
+            // GH-520: waves parallelize only the statically ordered region; the dynamic bucket
+            // keeps its sequential evaluate-last pass (its reads resolve at evaluation time).
+            // A seeded Rng forces the sequential fold — its draw sequence is evaluation-order.
+            val threads =
+              if rngOpt.isDefined then 1 else math.min(math.max(1, parallelism), MaxParallelism)
+            val mainState =
+              if threads <= 1 then evalPass(orderedMain, initState, clock)
+              else evalWaves(orderedMain, initState, clock, threads)
+            (evalPass(orderedBucket, mainState, clock), Vector.empty[SccReport])
 
         val (_, evaluated, evalErrors) = finalState
         val cycles = cycleReports.sortBy(r =>
@@ -485,6 +620,16 @@ object WorkbookEvaluator:
   /** GH-492: the threaded state of one recalculation pass (temp sheets, values, errors). */
   private[eval] type PassState =
     (Vector[Sheet], Map[SheetName, Map[ARef, CellValue]], Vector[CellEvalError])
+
+  /** GH-520: hard cap on requested parallelism — a pool wider than this only adds contention. */
+  private val MaxParallelism = 64
+
+  /**
+   * GH-520: waves narrower than this evaluate through the sequential fold. A chain-shaped region
+   * produces thousands of single-cell waves; per-cell thread handoff would cost more than the
+   * evaluation itself.
+   */
+  private val ParallelWaveCutoff = 16
 
   /**
    * GH-492: one step of the condensation walk.

--- a/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpec.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpec.scala
@@ -74,7 +74,12 @@ final case class EvalContext(
    * `Evaluator.instance(workbookPath = ...)`). Read by CELL("filename"); None reproduces Excel's
    * pre-save behavior (empty string).
    */
-  workbookPath: Option[String] = None
+  workbookPath: Option[String] = None,
+  /**
+   * One WorkbookEvaluator recalculation generation's single-range aggregate memo. Public/direct
+   * evaluation leaves this absent, preserving its one-shot semantics and allocation profile.
+   */
+  aggregateMemo: Option[Evaluator.AggregateMemo] = None
 )
 
 sealed trait ArgValue

--- a/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpecsAggregate.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpecsAggregate.scala
@@ -22,6 +22,7 @@ trait FunctionSpecsAggregate extends FunctionSpecsBase:
 
   private type RowBounds = (Row, Row)
   private type ColBounds = (Column, Column)
+  private val aggregateCountUnit = BigDecimal(1)
 
   /**
    * GH-337/GH-344: the propagated failure for a carried error element consumed by an aggregate —
@@ -41,26 +42,34 @@ trait FunctionSpecsAggregate extends FunctionSpecsBase:
   private def computeBounds(
     ranges: List[(CellRange, com.tjclp.xl.sheets.Sheet)]
   ): (Option[RowBounds], Option[ColBounds]) =
-    val usedRanges = ranges.flatMap(_._2.usedRange)
-    val rowBounds =
-      if ranges.exists(_._1.isFullColumn) then
-        if usedRanges.isEmpty then None
-        else
-          val minRow =
-            usedRanges.foldLeft(Int.MaxValue)((acc, r) => Math.min(acc, r.rowStart.index0))
-          val maxRow = usedRanges.foldLeft(Int.MinValue)((acc, r) => Math.max(acc, r.rowEnd.index0))
-          Some((Row.from0(minRow), Row.from0(maxRow)))
-      else None
-    val colBounds =
-      if ranges.exists(_._1.isFullRow) then
-        if usedRanges.isEmpty then None
-        else
-          val minCol =
-            usedRanges.foldLeft(Int.MaxValue)((acc, r) => Math.min(acc, r.colStart.index0))
-          val maxCol = usedRanges.foldLeft(Int.MinValue)((acc, r) => Math.max(acc, r.colEnd.index0))
-          Some((Column.from0(minCol), Column.from0(maxCol)))
-      else None
-    (rowBounds, colBounds)
+    val hasFullColumn = ranges.exists(_._1.isFullColumn)
+    val hasFullRow = ranges.exists(_._1.isFullRow)
+    if !hasFullColumn && !hasFullRow then (None, None)
+    else
+      // Computing usedRange scans every populated cell. Bounded ranges need no shared bounds, so
+      // keep that scan entirely off their hot path.
+      val usedRanges = ranges.flatMap(_._2.usedRange)
+      val rowBounds =
+        if hasFullColumn then
+          if usedRanges.isEmpty then None
+          else
+            val minRow =
+              usedRanges.foldLeft(Int.MaxValue)((acc, r) => Math.min(acc, r.rowStart.index0))
+            val maxRow =
+              usedRanges.foldLeft(Int.MinValue)((acc, r) => Math.max(acc, r.rowEnd.index0))
+            Some((Row.from0(minRow), Row.from0(maxRow)))
+        else None
+      val colBounds =
+        if hasFullRow then
+          if usedRanges.isEmpty then None
+          else
+            val minCol =
+              usedRanges.foldLeft(Int.MaxValue)((acc, r) => Math.min(acc, r.colStart.index0))
+            val maxCol =
+              usedRanges.foldLeft(Int.MinValue)((acc, r) => Math.max(acc, r.colEnd.index0))
+            Some((Column.from0(minCol), Column.from0(maxCol)))
+        else None
+      (rowBounds, colBounds)
 
   /**
    * GH-192: Constrain full-column/row ranges to shared bounds.
@@ -148,7 +157,8 @@ trait FunctionSpecsAggregate extends FunctionSpecsBase:
             ctx.workbook,
             ctx.depth + 1,
             ctx.rng,
-            ctx.memo.getOrElse(new Evaluator.EvalMemo)
+            ctx.memo.getOrElse(new Evaluator.EvalMemo),
+            aggregateMemo = ctx.aggregateMemo
           )
       case CellValue.Formula(_, Some(cached), _) =>
         // Use cached value
@@ -190,18 +200,18 @@ trait FunctionSpecsAggregate extends FunctionSpecsBase:
     cellValue: CellValue,
     targetSheet: com.tjclp.xl.sheets.Sheet,
     ctx: EvalContext,
-    values: Vector[BigDecimal]
-  ): Either[EvalError, Vector[BigDecimal]] =
+    acc: A
+  ): Either[EvalError, A] =
     if agg.countsNonEmpty then
       // COUNTA mode: count any non-empty cell
       cellValue match
-        case CellValue.Empty => Right(values)
-        case _ => Right(values :+ BigDecimal(1))
+        case CellValue.Empty => Right(acc)
+        case _ => Right(agg.combine(acc, aggregateCountUnit))
     else if agg.countsEmpty then
       // COUNTBLANK mode: count only empty cells
       cellValue match
-        case CellValue.Empty => Right(values :+ BigDecimal(1))
-        case _ => Right(values)
+        case CellValue.Empty => Right(agg.combine(acc, aggregateCountUnit))
+        case _ => Right(acc)
     else
       // Standard numeric mode: resolve the effective value, police carried errors
       // per the aggregator's policy (GH-344 item 6), then extract-or-skip
@@ -213,9 +223,34 @@ trait FunctionSpecsAggregate extends FunctionSpecsBase:
         agg.propagatesErrors
       )
         .map {
-          case Some(n) => values :+ n
-          case None => values
+          case Some(n) => agg.combine(acc, n)
+          case None => acc
         }
+
+  /** Resolve a raw range and apply the full-row/full-column used-area constraint once. */
+  private def resolveConstrainedRange(
+    location: TExpr.RangeLocation,
+    ctx: EvalContext
+  ): Either[EvalError, (com.tjclp.xl.sheets.Sheet, CellRange)] =
+    Evaluator.resolveRangeLocation(location, ctx.sheet, ctx.workbook).map {
+      case (targetSheet, range) =>
+        val bounds = computeBounds(List((range, targetSheet)))
+        (targetSheet, constrainRange(range, bounds))
+    }
+
+  /** Stream one already-constrained raw range into the supplied accumulator. */
+  private def foldRawRange[A](
+    agg: Aggregator[A],
+    targetSheet: com.tjclp.xl.sheets.Sheet,
+    range: CellRange,
+    ctx: EvalContext,
+    initial: A
+  ): Either[EvalError, A] =
+    range.cells.foldLeft[Either[EvalError, A]](Right(initial)) {
+      case (Left(err), _) => Left(err)
+      case (Right(current), cellRef) =>
+        triageCellForAggregate(agg, targetSheet(cellRef).value, targetSheet, ctx, current)
+    }
 
   /** Helper to evaluate variadic aggregates with proper type handling. */
   @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
@@ -224,23 +259,14 @@ trait FunctionSpecsAggregate extends FunctionSpecsBase:
     args: List[NumericArg],
     ctx: EvalContext
   ): Either[EvalError, BigDecimal] =
-    // Collect all numeric values from both ranges and individual expressions
-    val valuesResult: Either[EvalError, Vector[BigDecimal]] =
-      args.foldLeft[Either[EvalError, Vector[BigDecimal]]](Right(Vector.empty)) {
+    // Stream values into the aggregator's own accumulator. Aggregators that need to retain their
+    // inputs (for example MEDIAN) do so in A; ordinary aggregates avoid an intermediate Vector.
+    def foldAllArgs: Either[EvalError, A] =
+      args.foldLeft[Either[EvalError, A]](Right(agg.empty)) {
         case (Left(err), _) => Left(err)
         case (Right(acc), Left(location)) =>
-          // Range argument - extract all numeric values from cells
-          Evaluator.resolveRangeLocation(location, ctx.sheet, ctx.workbook).flatMap {
-            case (targetSheet, range) =>
-              // GH-192: Constrain full-column/row ranges to used area for performance
-              val bounds = computeBounds(List((range, targetSheet)))
-              val constrainedRange = constrainRange(range, bounds)
-              // GH-192: Use iterator-based folding (no .toList) for memory efficiency
-              constrainedRange.cells.foldLeft[Either[EvalError, Vector[BigDecimal]]](Right(acc)) {
-                case (Left(err), _) => Left(err)
-                case (Right(values), cellRef) =>
-                  triageCellForAggregate(agg, targetSheet(cellRef).value, targetSheet, ctx, values)
-              }
+          resolveConstrainedRange(location, ctx).flatMap { case (targetSheet, constrainedRange) =>
+            foldRawRange(agg, targetSheet, constrainedRange, ctx, acc)
           }
         // GH-395: direct single-cell references triage per-cell like a 1×1 range. In NumericArg
         // position Ref/SheetRef can ONLY arise from direct refs (asNumericExpr rewrites
@@ -270,34 +296,34 @@ trait FunctionSpecsAggregate extends FunctionSpecsBase:
           // Left(location) branch above) keep their pre-existing skip semantics.
           ctx.evalArrayExpr(expr.asInstanceOf[TExpr[Any]]).flatMap {
             case ar: ArrayResult =>
-              ar.values.flatten.foldLeft[Either[EvalError, Vector[BigDecimal]]](Right(acc)) {
+              ar.values.iterator.flatten.foldLeft[Either[EvalError, A]](Right(acc)) {
                 case (Left(err), _) => Left(err)
-                case (Right(values), cellValue) =>
+                case (Right(current), cellValue) =>
                   if agg.countsNonEmpty then
                     cellValue match
-                      case CellValue.Empty => Right(values)
-                      case _ => Right(values :+ BigDecimal(1))
+                      case CellValue.Empty => Right(current)
+                      case _ => Right(agg.combine(current, aggregateCountUnit))
                   else if agg.countsEmpty then
                     cellValue match
-                      case CellValue.Empty => Right(values :+ BigDecimal(1))
-                      case _ => Right(values)
+                      case CellValue.Empty => Right(agg.combine(current, aggregateCountUnit))
+                      case _ => Right(current)
                   else
                     ArrayArithmetic.carriedError(cellValue) match
                       case Some(err) if agg.propagatesErrors =>
                         Left(propagatedElementError(agg.name, err))
-                      case Some(_) => Right(values) // COUNT: errors are not numbers
+                      case Some(_) => Right(current) // COUNT: errors are not numbers
                       case None =>
                         extractNumericValue(cellValue) match
-                          case Some(n) => Right(values :+ n)
-                          case None => Right(values)
+                          case Some(n) => Right(agg.combine(current, n))
+                          case None => Right(current)
               }
             case value: BigDecimal =>
               // GH-395: a numeric scalar (literal, arithmetic result) is never blank —
               // COUNTBLANK must not count it (=COUNTBLANK(5) is 0); COUNTA counts it
               Right(
-                if agg.countsNonEmpty then acc :+ BigDecimal(1)
+                if agg.countsNonEmpty then agg.combine(acc, aggregateCountUnit)
                 else if agg.countsEmpty then acc
-                else acc :+ value
+                else agg.combine(acc, value)
               )
             case other =>
               // GH-395: non-numeric scalars triage on their CellValue shape — only a genuine
@@ -307,10 +333,10 @@ trait FunctionSpecsAggregate extends FunctionSpecsBase:
               if agg.countsNonEmpty then
                 cellValue match
                   case CellValue.Empty => Right(acc)
-                  case _ => Right(acc :+ BigDecimal(1))
+                  case _ => Right(agg.combine(acc, aggregateCountUnit))
               else if agg.countsEmpty then
                 cellValue match
-                  case CellValue.Empty => Right(acc :+ BigDecimal(1))
+                  case CellValue.Empty => Right(agg.combine(acc, aggregateCountUnit))
                   case _ => Right(acc)
               else
                 ArrayArithmetic.carriedError(cellValue) match
@@ -319,16 +345,43 @@ trait FunctionSpecsAggregate extends FunctionSpecsBase:
                   case Some(_) => Right(acc)
                   case None =>
                     extractNumericValue(cellValue) match
-                      case Some(n) => Right(acc :+ n)
+                      case Some(n) => Right(agg.combine(acc, n))
                       case None => Right(acc)
           }
       }
 
-    valuesResult.flatMap { values =>
-      // Apply the aggregator to all collected values
-      val result = values.foldLeft(agg.empty)((acc, v) => agg.combine(acc, v))
-      agg.finalizeWithError(result)
-    }
+    // The common workbook-recalc hot shape is one literal raw range. Its finalized immutable
+    // result can be shared across formulas in this calculation generation when the target range
+    // contains no uncached formula cells. Mixed/scalar/array arguments keep the exact streaming
+    // fold above and are deliberately outside the cache's narrow safety proof.
+    args match
+      case List(Left(location)) =>
+        Evaluator.resolveRangeLocation(location, ctx.sheet, ctx.workbook).flatMap {
+          case (targetSheet, rawRange) =>
+            // Full-row/column aggregate semantics depend on the CURRENT sheet used bounds. Those
+            // bounds may shrink when an earlier formula evaluates to Empty even though the formula
+            // lies outside the referenced row/column, so resolve them before keying. Ordinary
+            // bounded ranges skip usedRange entirely and use their declared geometry directly.
+            val effectiveRange =
+              if rawRange.isFullColumn || rawRange.isFullRow then
+                constrainRange(rawRange, computeBounds(List((rawRange, targetSheet))))
+              else rawRange
+
+            def compute: Either[EvalError, BigDecimal] =
+              foldRawRange(agg, targetSheet, effectiveRange, ctx, agg.empty)
+                .flatMap(agg.finalizeWithError)
+
+            ctx.aggregateMemo match
+              case Some(memo) =>
+                memo.getOrCompute(
+                  targetSheet,
+                  effectiveRange,
+                  agg.name,
+                  Evaluator.AggregateMemoMode.FunctionCall
+                )(compute)
+              case None => compute
+        }
+      case _ => foldAllArgs.flatMap(agg.finalizeWithError)
 
   private def evalCriteriaValues(
     ctx: EvalContext,

--- a/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpecsArray.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/functions/FunctionSpecsArray.scala
@@ -384,7 +384,8 @@ trait FunctionSpecsArray extends FunctionSpecsBase:
                         ctx.clock,
                         ctx.workbook,
                         ctx.depth + 1,
-                        memo = ctx.memo.getOrElse(new Evaluator.EvalMemo)
+                        memo = ctx.memo.getOrElse(new Evaluator.EvalMemo),
+                        aggregateMemo = ctx.aggregateMemo
                       )
                       .map(cols :+ _)
                   case other => Right(cols :+ other)

--- a/xl-evaluator/src/com/tjclp/xl/formula/graph/DependencyGraph.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/graph/DependencyGraph.scala
@@ -834,7 +834,16 @@ object DependencyGraph:
    * in the node type (GH-346). Only nodes present in `dependencies` (formula cells) are ordered;
    * edges to non-nodes (constants, empty cells) are ignored. Left carries the nodes that could not
    * be ordered (cycle participants and everything downstream of them).
+   *
+   * GH-518: implemented with LOCAL mutable state behind the pure signature (the same posture as
+   * [[foreachSccOf]]). The immutable-List formulation allocated O(V²) cons cells — `acc :+ node`
+   * copies the accumulator once per node and `rest ++ newlyZero` copies the pending queue — which
+   * on a 50k-formula workbook was 81% of an entire recalculation's allocation. Iteration stays over
+   * the same collections in the same order, so the emitted order is unchanged: FIFO queue seeded in
+   * `allNodes` iteration order, newly-ready nodes appended in the iteration order of the filtered
+   * dependents set.
    */
+  @SuppressWarnings(Array("org.wartremover.warts.Var", "org.wartremover.warts.While"))
   private def kahnOrder[K](
     dependencies: Map[K, Set[K]],
     dependents: Map[K, Set[K]]
@@ -845,41 +854,34 @@ object DependencyGraph:
     // If no formula cells, early exit
     if allNodes.isEmpty then scala.util.Right(List.empty[K])
     else
-      // Calculate in-degree for each node (number of formula cells it depends on)
-      // Only count dependencies on other formula cells, not constants
-      val inDegree = allNodes.map { node =>
-        val deps = dependencies.getOrElse(node, Set.empty)
-        val formulaDeps = deps.filter(allNodes.contains)
-        node -> formulaDeps.size
-      }.toMap
+      // In-degree = dependencies on other formula cells only, not constants
+      val inDegree = scala.collection.mutable.HashMap.empty[K, Int]
+      allNodes.foreach { node =>
+        inDegree(node) = dependencies.getOrElse(node, Set.empty).count(allNodes.contains)
+      }
 
       // Start with nodes that have in-degree 0 (no dependencies)
-      val initialQueue = allNodes.filter(node => inDegree(node) == 0).toList
+      val queue = scala.collection.mutable.ArrayDeque.empty[K]
+      allNodes.foreach { node =>
+        if inDegree(node) == 0 then queue.append(node)
+      }
 
-      @tailrec
-      def process(
-        queue: List[K],
-        processedInDegree: Map[K, Int],
-        acc: List[K]
-      ): (List[K], Map[K, Int]) =
-        queue match
-          case Nil => (acc, processedInDegree)
-          case node :: rest =>
-            val deps = dependents.getOrElse(node, Set.empty).filter(allNodes.contains)
-            val (nextInDegree, newlyZero) = deps.foldLeft((processedInDegree, List.empty[K])) {
-              case ((degreeAcc, zeros), dep) =>
-                val newInDegree = degreeAcc(dep) - 1
-                val updatedDegree = degreeAcc.updated(dep, newInDegree)
-                val nextZeros = if newInDegree == 0 then zeros :+ dep else zeros
-                (updatedDegree, nextZeros)
-            }
-            process(rest ++ newlyZero, nextInDegree, acc :+ node)
-
-      val (result, _) = process(initialQueue, inDegree, List.empty)
+      val ordered = scala.collection.mutable.ListBuffer.empty[K]
+      while queue.nonEmpty do
+        val node = queue.removeHead()
+        ordered += node
+        // Filtering into a Set first (rather than testing membership inline) preserves the exact
+        // emitted order of the previous formulation, which folded over this same filtered set.
+        val deps = dependents.getOrElse(node, Set.empty).filter(allNodes.contains)
+        deps.foreach { dep =>
+          val remaining = inDegree(dep) - 1
+          inDegree(dep) = remaining
+          if remaining == 0 then queue.append(dep)
+        }
 
       // If all nodes are processed, graph is acyclic
-      if result.size == allNodes.size then scala.util.Right(result)
-      else scala.util.Left(allNodes -- result.toSet)
+      if ordered.size == allNodes.size then scala.util.Right(ordered.toList)
+      else scala.util.Left(allNodes -- ordered)
 
   /**
    * Topological sort using Kahn's algorithm.

--- a/xl-evaluator/src/com/tjclp/xl/formula/graph/DependencyGraph.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/graph/DependencyGraph.scala
@@ -972,6 +972,8 @@ object DependencyGraph:
   def fromWorkbook(
     workbook: com.tjclp.xl.workbooks.Workbook
   ): Map[QualifiedRef, Set[QualifiedRef]] =
+    // GH-522: expand any (sheet, range) once per build — see memoizedCells
+    val cellsFor = memoizedCells(unboundedQualifiedCells)
     workbook.sheets.flatMap { sheet =>
       sheet.cells.flatMap { case (cellRef, cell) =>
         cell.value match
@@ -980,7 +982,7 @@ object DependencyGraph:
           case CellValue.Formula(expression, _, _) =>
             val deps = FormulaParser.parse(expression) match
               case scala.util.Right(expr) =>
-                extractQualifiedDependencies(expr, sheet.name, workbook = Some(workbook))
+                extractQualifiedDependencies(expr, sheet.name, cellsFor, Some(workbook))
               case scala.util.Left(_) => Set.empty[QualifiedRef]
             Some(QualifiedRef(sheet.name, cellRef) -> deps)
           case _ => None
@@ -1002,13 +1004,15 @@ object DependencyGraph:
   ): (Map[QualifiedRef, Set[QualifiedRef]], Map[QualifiedRef, Set[QualifiedRef]]) =
     val bounds: Map[SheetName, Option[CellRange]] =
       workbook.sheets.map(s => s.name -> s.usedRange).toMap
-    val cellsFor: (SheetName, CellRange) => Set[QualifiedRef] = (sheet, range) =>
+    // GH-522: expand any (sheet, range) once per build — see memoizedCells
+    val cellsFor: (SheetName, CellRange) => Set[QualifiedRef] = memoizedCells { (sheet, range) =>
       bounds.get(sheet) match
         case Some(Some(b)) =>
           range.intersect(b) match
             case Some(clipped) => clipped.cells.map(ref => QualifiedRef(sheet, ref)).toSet
             case None => Set.empty
         case _ => Set.empty // empty or missing sheet: nothing to depend on
+    }
 
     val dependencies = workbook.sheets.flatMap { sheet =>
       sheet.cells.flatMap { case (cellRef, cell) =>
@@ -1025,14 +1029,7 @@ object DependencyGraph:
       }
     }.toMap
 
-    val dependents =
-      dependencies.foldLeft(Map.empty[QualifiedRef, Set[QualifiedRef]]) { case (acc, (ref, deps)) =>
-        deps.foldLeft(acc) { (acc2, dep) =>
-          acc2.updated(dep, acc2.getOrElse(dep, Set.empty) + ref)
-        }
-      }
-
-    (dependencies, dependents)
+    (dependencies, reverseEdges(dependencies))
 
   /**
    * GH-346: every node participating in a reference cycle of the workbook-level graph — the
@@ -1187,6 +1184,52 @@ object DependencyGraph:
     (sheet, range) => range.cells.map(ref => QualifiedRef(sheet, ref)).toSet
 
   /**
+   * GH-522: expand any given (sheet, range) exactly once per graph build.
+   *
+   * A financial-model shape — many formulas each aggregating the same driver column — expanded the
+   * SAME range once per referencing formula: 9,900 × `SUM($A$1:$A$5000)` built ~50M QualifiedRefs
+   * (54 GB of a 135 GB recalc's allocation) where 5,000 suffice. The memo makes every referencing
+   * formula share one immutable Set instance; correctness is untouched because expansion is a pure
+   * function of (sheet, range) within one build (bounds are computed once up front and never change
+   * mid-build).
+   */
+  private def memoizedCells(
+    expand: (SheetName, CellRange) => Set[QualifiedRef]
+  ): (SheetName, CellRange) => Set[QualifiedRef] =
+    val cache = scala.collection.mutable.HashMap.empty[(SheetName, CellRange), Set[QualifiedRef]]
+    (sheet, range) => cache.getOrElseUpdate((sheet, range), expand(sheet, range))
+
+  /**
+   * GH-522: set union that iterates the smaller side into the larger — `Set(oneRef) ++ rangeSet`
+   * walks all 5,000 range elements today, once per operator node above a range reference. Union is
+   * commutative, and any result with more than 4 elements is a CHAMP HashSet whose iteration order
+   * is a function of its CONTENTS alone, so redirecting the merge cannot move any downstream order.
+   * When the larger side has 4 or fewer elements the left-to-right build is kept: small sets are
+   * insertion-ordered and Kahn's emitted order feeds off their iteration.
+   */
+  private def union(a: Set[QualifiedRef], b: Set[QualifiedRef]): Set[QualifiedRef] =
+    if a.size < b.size && b.size > 4 then b ++ a else a ++ b
+
+  /**
+   * GH-522: reverse-edge map built with a local mutable accumulator. The immutable foldLeft
+   * allocated a fresh outer-Map node chain per edge — 50M times on the shape above (8.5 GB). The
+   * insertion sequence is identical to the fold it replaces (same outer Map iterated in the same
+   * order, same per-key Set growth), so every per-key set — small insertion-ordered ones included —
+   * iterates exactly as before.
+   */
+  @SuppressWarnings(Array("org.wartremover.warts.Var"))
+  private[formula] def reverseEdges(
+    dependencies: Map[QualifiedRef, Set[QualifiedRef]]
+  ): Map[QualifiedRef, Set[QualifiedRef]] =
+    val acc = scala.collection.mutable.HashMap.empty[QualifiedRef, Set[QualifiedRef]]
+    dependencies.foreach { case (ref, deps) =>
+      deps.foreach { dep =>
+        acc(dep) = acc.getOrElse(dep, Set.empty) + ref
+      }
+    }
+    acc.toMap
+
+  /**
    * Extract all qualified cell references from TExpr.
    *
    * Similar to extractDependencies but returns QualifiedRef to track cross-sheet references.
@@ -1244,18 +1287,18 @@ object DependencyGraph:
         // GH-353: external-workbook refs target cells OUTSIDE the workbook — no edges ever
         case TExpr.ExternalRef(_, _, _, _) => Set.empty
         case TExpr.ExternalRange(_, _, _) => Set.empty
-        case TExpr.Add(l, r) => go(l) ++ go(r)
-        case TExpr.Sub(l, r) => go(l) ++ go(r)
-        case TExpr.Mul(l, r) => go(l) ++ go(r)
-        case TExpr.Div(l, r) => go(l) ++ go(r)
-        case TExpr.Pow(l, r) => go(l) ++ go(r)
-        case TExpr.Concat(l, r) => go(l) ++ go(r)
-        case TExpr.Eq(l, r) => go(l) ++ go(r)
-        case TExpr.Neq(l, r) => go(l) ++ go(r)
-        case TExpr.Lt(l, r) => go(l) ++ go(r)
-        case TExpr.Lte(l, r) => go(l) ++ go(r)
-        case TExpr.Gt(l, r) => go(l) ++ go(r)
-        case TExpr.Gte(l, r) => go(l) ++ go(r)
+        case TExpr.Add(l, r) => union(go(l), go(r))
+        case TExpr.Sub(l, r) => union(go(l), go(r))
+        case TExpr.Mul(l, r) => union(go(l), go(r))
+        case TExpr.Div(l, r) => union(go(l), go(r))
+        case TExpr.Pow(l, r) => union(go(l), go(r))
+        case TExpr.Concat(l, r) => union(go(l), go(r))
+        case TExpr.Eq(l, r) => union(go(l), go(r))
+        case TExpr.Neq(l, r) => union(go(l), go(r))
+        case TExpr.Lt(l, r) => union(go(l), go(r))
+        case TExpr.Lte(l, r) => union(go(l), go(r))
+        case TExpr.Gt(l, r) => union(go(l), go(r))
+        case TExpr.Gte(l, r) => union(go(l), go(r))
         // Unary operators
         case TExpr.ToInt(x) => go(x)
         case TExpr.UnaryPlus(x) => go(x)
@@ -1268,14 +1311,14 @@ object DependencyGraph:
           val values = call.spec.argSpec.toValues(call.args)
           values.foldLeft(Set.empty[QualifiedRef]) { (acc, value) =>
             value match
-              case ArgValue.Expr(expr) => acc ++ go(expr)
-              case ArgValue.Range(range) => acc ++ locCells(range)
-              case ArgValue.Cells(range) => acc ++ cellsFor(currentSheet, range)
+              case ArgValue.Expr(expr) => union(acc, go(expr))
+              case ArgValue.Range(range) => union(acc, locCells(range))
+              case ArgValue.Cells(range) => union(acc, cellsFor(currentSheet, range))
           }
 
         // GH-193: LET — union of binding-value and body dependencies; BindingRef has none
         case TExpr.Let(bindings, body) =>
-          bindings.foldLeft(go(body)) { case (acc, (_, value)) => acc ++ go(value) }
+          bindings.foldLeft(go(body)) { case (acc, (_, value)) => union(acc, go(value)) }
         case TExpr.BindingRef(_) => Set.empty
         case TExpr.CoercedBindingRef(_, _) => Set.empty
 

--- a/xl-evaluator/src/com/tjclp/xl/formula/graph/DependencyGraph.scala
+++ b/xl-evaluator/src/com/tjclp/xl/formula/graph/DependencyGraph.scala
@@ -59,10 +59,13 @@ object DependencyGraph:
     cellRangeDeps: CellRange => Set[ARef]
   ): Set[ARef] =
     values.foldLeft(Set.empty[ARef]) { (acc, value) =>
-      value match
-        case ArgValue.Expr(expr) => acc ++ exprDeps(expr)
-        case ArgValue.Range(range) => acc ++ rangeDeps(range)
-        case ArgValue.Cells(range) => acc ++ cellRangeDeps(range)
+      val next = value match
+        case ArgValue.Expr(expr) => exprDeps(expr)
+        case ArgValue.Range(range) => rangeDeps(range)
+        case ArgValue.Cells(range) => cellRangeDeps(range)
+      // Preserve a memoized range Set when it is the first argument. Besides avoiding a needless
+      // rebuild, this lets every one-range aggregate in a graph share the exact cached expansion.
+      if acc.isEmpty then next else if next.isEmpty then acc else acc ++ next
     }
 
   private def boundedCells(range: CellRange, bounds: Option[CellRange]): Set[ARef] =
@@ -96,6 +99,10 @@ object DependencyGraph:
   def fromSheet(sheet: Sheet): DependencyGraph =
     // Get bounds once for all extractions - constrains full column/row ranges
     val bounds = sheet.usedRange
+    // GH-522: formulas commonly reuse the same driver range. Expand each geometric range once for
+    // the whole sheet build (anchors affect dragging, not dependency membership).
+    val rangeCache =
+      scala.collection.mutable.HashMap.empty[(ARef, ARef), Set[ARef]]
 
     val formulaCells = sheet.cells.flatMap { case (ref, cell) =>
       cell.value match
@@ -110,17 +117,24 @@ object DependencyGraph:
     // Build forward edges (dependencies) - use bounded extraction to avoid 1M+ cells
     val dependencies = formulaCells.map { case (ref, formulaStr) =>
       val deps = FormulaParser.parse(formulaStr) match
-        case scala.util.Right(expr) => extractDependenciesBounded(expr, bounds)
+        case scala.util.Right(expr) =>
+          extractDependenciesBoundedCached(expr, bounds, rangeCache)
         case scala.util.Left(_) => Set.empty[ARef] // Parse error: no dependencies
       ref -> deps
     }.toMap
 
-    // Build reverse edges (dependents)
-    val dependents = dependencies.foldLeft(Map.empty[ARef, Set[ARef]]) { case (acc, (ref, deps)) =>
-      deps.foldLeft(acc) { (acc2, dep) =>
-        acc2.updated(dep, acc2.getOrElse(dep, Set.empty) + ref)
+    // Build reverse edges with one mutable set per precedent, then freeze once. Growing an
+    // immutable Set for every edge recreates the N×range-size allocation this build avoids above.
+    val reverse = scala.collection.mutable.HashMap.empty[
+      ARef,
+      scala.collection.mutable.LinkedHashSet[ARef]
+    ]
+    dependencies.foreach { case (ref, deps) =>
+      deps.foreach { dep =>
+        reverse.getOrElseUpdate(dep, scala.collection.mutable.LinkedHashSet.empty) += ref
       }
     }
+    val dependents = reverse.iterator.map((ref, refs) => ref -> refs.toSet).toMap
 
     DependencyGraph(dependencies, dependents)
 
@@ -209,40 +223,76 @@ object DependencyGraph:
    * them. The walk recurses into Call arguments; `ArgValue.Range`/`Cells` arguments cannot contain
    * calls, and reference/literal leaves are never dynamic.
    */
-  def containsDynamicReference[A](expr: TExpr[A]): Boolean =
+  @nowarn("msg=Unreachable case")
+  private def containsDynamicReferenceResolved[A](
+    expr: TExpr[A],
+    resolveName: (String, Option[SheetName]) => Boolean
+  ): Boolean =
     expr match
       case call: TExpr.Call[?] =>
         call.spec.flags.dynamicDeps || call.spec.argSpec
           .toValues(call.args)
           .exists {
-            case ArgValue.Expr(e) => containsDynamicReference(e)
+            case ArgValue.Expr(e) => containsDynamicReferenceResolved(e, resolveName)
+            case ArgValue.Range(TExpr.RangeLocation.Name(name, scope)) =>
+              resolveName(name, scope)
             case ArgValue.Range(_) => false
             case ArgValue.Cells(_) => false
           }
-      case TExpr.Add(l, r) => containsDynamicReference(l) || containsDynamicReference(r)
-      case TExpr.Sub(l, r) => containsDynamicReference(l) || containsDynamicReference(r)
-      case TExpr.Mul(l, r) => containsDynamicReference(l) || containsDynamicReference(r)
-      case TExpr.Div(l, r) => containsDynamicReference(l) || containsDynamicReference(r)
-      case TExpr.Pow(l, r) => containsDynamicReference(l) || containsDynamicReference(r)
-      case TExpr.Concat(l, r) => containsDynamicReference(l) || containsDynamicReference(r)
-      case TExpr.Eq(l, r) => containsDynamicReference(l) || containsDynamicReference(r)
-      case TExpr.Neq(l, r) => containsDynamicReference(l) || containsDynamicReference(r)
-      case TExpr.Lt(l, r) => containsDynamicReference(l) || containsDynamicReference(r)
-      case TExpr.Lte(l, r) => containsDynamicReference(l) || containsDynamicReference(r)
-      case TExpr.Gt(l, r) => containsDynamicReference(l) || containsDynamicReference(r)
-      case TExpr.Gte(l, r) => containsDynamicReference(l) || containsDynamicReference(r)
-      case TExpr.ToInt(e) => containsDynamicReference(e)
-      case TExpr.UnaryPlus(e) => containsDynamicReference(e)
-      case TExpr.Percent(e) => containsDynamicReference(e)
-      case TExpr.DateToSerial(e) => containsDynamicReference(e)
-      case TExpr.DateTimeToSerial(e) => containsDynamicReference(e)
+      case TExpr.Add(l, r) =>
+        containsDynamicReferenceResolved(l, resolveName) ||
+        containsDynamicReferenceResolved(r, resolveName)
+      case TExpr.Sub(l, r) =>
+        containsDynamicReferenceResolved(l, resolveName) ||
+        containsDynamicReferenceResolved(r, resolveName)
+      case TExpr.Mul(l, r) =>
+        containsDynamicReferenceResolved(l, resolveName) ||
+        containsDynamicReferenceResolved(r, resolveName)
+      case TExpr.Div(l, r) =>
+        containsDynamicReferenceResolved(l, resolveName) ||
+        containsDynamicReferenceResolved(r, resolveName)
+      case TExpr.Pow(l, r) =>
+        containsDynamicReferenceResolved(l, resolveName) ||
+        containsDynamicReferenceResolved(r, resolveName)
+      case TExpr.Concat(l, r) =>
+        containsDynamicReferenceResolved(l, resolveName) ||
+        containsDynamicReferenceResolved(r, resolveName)
+      case TExpr.Eq(l, r) =>
+        containsDynamicReferenceResolved(l, resolveName) ||
+        containsDynamicReferenceResolved(r, resolveName)
+      case TExpr.Neq(l, r) =>
+        containsDynamicReferenceResolved(l, resolveName) ||
+        containsDynamicReferenceResolved(r, resolveName)
+      case TExpr.Lt(l, r) =>
+        containsDynamicReferenceResolved(l, resolveName) ||
+        containsDynamicReferenceResolved(r, resolveName)
+      case TExpr.Lte(l, r) =>
+        containsDynamicReferenceResolved(l, resolveName) ||
+        containsDynamicReferenceResolved(r, resolveName)
+      case TExpr.Gt(l, r) =>
+        containsDynamicReferenceResolved(l, resolveName) ||
+        containsDynamicReferenceResolved(r, resolveName)
+      case TExpr.Gte(l, r) =>
+        containsDynamicReferenceResolved(l, resolveName) ||
+        containsDynamicReferenceResolved(r, resolveName)
+      case TExpr.ToInt(e) => containsDynamicReferenceResolved(e, resolveName)
+      case TExpr.UnaryPlus(e) => containsDynamicReferenceResolved(e, resolveName)
+      case TExpr.Percent(e) => containsDynamicReferenceResolved(e, resolveName)
+      case TExpr.DateToSerial(e) => containsDynamicReferenceResolved(e, resolveName)
+      case TExpr.DateTimeToSerial(e) => containsDynamicReferenceResolved(e, resolveName)
       // GH-306: runtime coercion wrapper — a coerced INDIRECT/OFFSET is still dynamic
-      case TExpr.Coerced(inner, _) => containsDynamicReference(inner)
+      case TExpr.Coerced(inner, _) => containsDynamicReferenceResolved(inner, resolveName)
       // GH-193: LET — binding values and the body may carry dynamic calls
       case TExpr.Let(bindings, body) =>
-        bindings.exists((_, value) => containsDynamicReference(value)) ||
-        containsDynamicReference(body)
+        bindings.exists((_, value) => containsDynamicReferenceResolved(value, resolveName)) ||
+        containsDynamicReferenceResolved(body, resolveName)
+      case TExpr.NameRef(name) => resolveName(name, None)
+      case TExpr.SheetNameRef(sheet, name) => resolveName(name, Some(sheet))
+      case TExpr.Aggregate(_, TExpr.RangeLocation.Name(name, scope)) => resolveName(name, scope)
       case _ => false
+
+  def containsDynamicReference[A](expr: TExpr[A]): Boolean =
+    containsDynamicReferenceResolved(expr, (_, _) => false)
 
   /**
    * GH-274: Find all formula cells in the sheet bearing dynamic references (INDIRECT et al).
@@ -258,11 +308,100 @@ object DependencyGraph:
       sheet.cells.iterator.flatMap { case (ref, cell) =>
         cell.value match
           case CellValue.Formula(expression, _, _)
-              if names.exists(n => expression.toUpperCase.contains(n)) =>
+              if names.exists(n => expression.toUpperCase(java.util.Locale.ROOT).contains(n)) =>
             FormulaParser.parse(expression) match
               case scala.util.Right(expr) if containsDynamicReference(expr) => Some(ref)
               case _ => None
           case _ => None
+      }.toSet
+
+  /**
+   * GH-520: workbook-aware dynamic classification, including parseable defined-name chains.
+   *
+   * A name is resolved with the same case-insensitive, sheet-scoped-shadowing rules as evaluation.
+   * The lookup sheet and the formula's ambient sheet both belong to the memo key: for
+   * `Other!GlobalName`, lookup occurs as seen from `Other`, while an unqualified name inside a
+   * workbook-scoped definition still resolves from the original formula's sheet. Name cycles stop
+   * cleanly, matching dependency extraction's total posture.
+   *
+   * Ordinary names do not make their users dynamic. Definitions are parsed and memoized first; only
+   * names whose parseable chains actually reach a dynamic function join the cheap substring
+   * pre-filter used for cell formulas. This matters for financial models with tens of thousands of
+   * formulas referring to a static scenario name such as `Case`.
+   */
+  @SuppressWarnings(Array("org.wartremover.warts.Var"))
+  def dynamicCells(workbook: Workbook): Set[QualifiedRef] =
+    type NameKey = (SheetName, SheetName, String)
+
+    val dynamicFunctions = FunctionRegistry.dynamicFunctionNames
+    val memo = scala.collection.mutable.HashMap.empty[NameKey, Boolean]
+
+    def expressionIsDynamic(
+      expr: TExpr[?],
+      currentSheet: SheetName,
+      visiting: Set[NameKey]
+    ): Boolean =
+      containsDynamicReferenceResolved(
+        expr,
+        (name, scope) =>
+          nameIsDynamic(
+            name,
+            lookupFrom = scope.getOrElse(currentSheet),
+            fallbackSheet = currentSheet,
+            visiting = visiting
+          )
+      )
+
+    def nameIsDynamic(
+      name: String,
+      lookupFrom: SheetName,
+      fallbackSheet: SheetName,
+      visiting: Set[NameKey]
+    ): Boolean =
+      val key = (lookupFrom, fallbackSheet, name.toUpperCase(java.util.Locale.ROOT))
+      memo.get(key) match
+        case Some(dynamic) => dynamic
+        case None if visiting.contains(key) => false
+        case None =>
+          val dynamic =
+            (for
+              definedName <- Evaluator.lookupDefinedName(workbook, lookupFrom, name)
+              target <- FormulaParser.parse(definedName.formula).toOption
+            yield
+              val definingSheet =
+                Evaluator
+                  .definedNameScope(workbook, definedName)
+                  .map(_.name)
+                  .getOrElse(fallbackSheet)
+              expressionIsDynamic(target, definingSheet, visiting + key)
+            ).getOrElse(false)
+          memo(key) = dynamic
+          dynamic
+
+    val definedNameIds = workbook.metadata.definedNames.iterator.map(_.name).toSet
+    val dynamicNameTokens = workbook.sheets.iterator.flatMap { sheet =>
+      definedNameIds.iterator.collect {
+        case name if nameIsDynamic(name, sheet.name, sheet.name, Set.empty) =>
+          name.toUpperCase(java.util.Locale.ROOT)
+      }
+    }.toSet
+    val candidateTokens = dynamicFunctions ++ dynamicNameTokens
+
+    if candidateTokens.isEmpty then Set.empty
+    else
+      workbook.sheets.iterator.flatMap { sheet =>
+        sheet.cells.iterator.flatMap { case (ref, cell) =>
+          cell.value match
+            case CellValue.Formula(expression, _, _)
+                if candidateTokens.exists(
+                  expression.toUpperCase(java.util.Locale.ROOT).contains
+                ) =>
+              FormulaParser.parse(expression) match
+                case scala.util.Right(expr) if expressionIsDynamic(expr, sheet.name, Set.empty) =>
+                  Some(QualifiedRef(sheet.name, ref))
+                case _ => None
+            case _ => None
+        }
       }.toSet
 
   /**
@@ -501,13 +640,34 @@ object DependencyGraph:
    * @return
    *   Set of all cell references used in the expression, bounded by the given range
    */
-  @nowarn("msg=Unreachable case")
   def extractDependenciesBounded[A](expr: TExpr[A], bounds: Option[CellRange]): Set[ARef] =
+    extractDependenciesBoundedCached(
+      expr,
+      bounds,
+      scala.collection.mutable.HashMap.empty[(ARef, ARef), Set[ARef]]
+    )
+
+  @nowarn("msg=Unreachable case")
+  private def extractDependenciesBoundedCached[A](
+    expr: TExpr[A],
+    bounds: Option[CellRange],
+    rangeCache: scala.collection.mutable.HashMap[(ARef, ARef), Set[ARef]]
+  ): Set[ARef] =
     // Helper to bound a CellRange
     def boundRange(range: CellRange): Set[ARef] =
-      bounds match
-        case Some(b) => range.intersect(b).map(_.cells.toSet).getOrElse(Set.empty)
-        case None => range.cells.toSet
+      rangeCache.getOrElseUpdate(
+        (range.start, range.end),
+        bounds match
+          case Some(b) => range.intersect(b).map(_.cells.toSet).getOrElse(Set.empty)
+          case None => range.cells.toSet
+      )
+
+    def recurse[B](child: TExpr[B]): Set[ARef] =
+      extractDependenciesBoundedCached(child, bounds, rangeCache)
+
+    def localCells(location: TExpr.RangeLocation): Set[ARef] = location match
+      case TExpr.RangeLocation.Local(range) => boundRange(range)
+      case _ => Set.empty
 
     expr match
       // Single cell reference
@@ -527,46 +687,46 @@ object DependencyGraph:
 
       // Recursive cases (binary operators)
       case TExpr.Add(l, r) =>
-        extractDependenciesBounded(l, bounds) ++ extractDependenciesBounded(r, bounds)
+        recurse(l) ++ recurse(r)
       case TExpr.Sub(l, r) =>
-        extractDependenciesBounded(l, bounds) ++ extractDependenciesBounded(r, bounds)
+        recurse(l) ++ recurse(r)
       case TExpr.Mul(l, r) =>
-        extractDependenciesBounded(l, bounds) ++ extractDependenciesBounded(r, bounds)
+        recurse(l) ++ recurse(r)
       case TExpr.Div(l, r) =>
-        extractDependenciesBounded(l, bounds) ++ extractDependenciesBounded(r, bounds)
+        recurse(l) ++ recurse(r)
       case TExpr.Pow(l, r) =>
-        extractDependenciesBounded(l, bounds) ++ extractDependenciesBounded(r, bounds)
+        recurse(l) ++ recurse(r)
       case TExpr.Concat(l, r) =>
-        extractDependenciesBounded(l, bounds) ++ extractDependenciesBounded(r, bounds)
+        recurse(l) ++ recurse(r)
       case TExpr.Eq(l, r) =>
-        extractDependenciesBounded(l, bounds) ++ extractDependenciesBounded(r, bounds)
+        recurse(l) ++ recurse(r)
       case TExpr.Neq(l, r) =>
-        extractDependenciesBounded(l, bounds) ++ extractDependenciesBounded(r, bounds)
+        recurse(l) ++ recurse(r)
       case TExpr.Lt(l, r) =>
-        extractDependenciesBounded(l, bounds) ++ extractDependenciesBounded(r, bounds)
+        recurse(l) ++ recurse(r)
       case TExpr.Lte(l, r) =>
-        extractDependenciesBounded(l, bounds) ++ extractDependenciesBounded(r, bounds)
+        recurse(l) ++ recurse(r)
       case TExpr.Gt(l, r) =>
-        extractDependenciesBounded(l, bounds) ++ extractDependenciesBounded(r, bounds)
+        recurse(l) ++ recurse(r)
       case TExpr.Gte(l, r) =>
-        extractDependenciesBounded(l, bounds) ++ extractDependenciesBounded(r, bounds)
-      case TExpr.ToInt(expr) => extractDependenciesBounded(expr, bounds)
-      case TExpr.UnaryPlus(expr) => extractDependenciesBounded(expr, bounds)
-      case TExpr.Percent(expr) => extractDependenciesBounded(expr, bounds)
-      case TExpr.Aggregate(_, location) => location.localCellsBounded(bounds)
+        recurse(l) ++ recurse(r)
+      case TExpr.ToInt(expr) => recurse(expr)
+      case TExpr.UnaryPlus(expr) => recurse(expr)
+      case TExpr.Percent(expr) => recurse(expr)
+      case TExpr.Aggregate(_, location) => localCells(location)
 
       case call: TExpr.Call[?] =>
         depsFromArgValues(
           call.spec.argSpec.toValues(call.args),
-          expr => extractDependenciesBounded(expr, bounds),
-          loc => loc.localCellsBounded(bounds),
-          range => boundedCells(range, bounds)
+          recurse,
+          localCells,
+          boundRange
         )
 
       // GH-193: LET — union of binding-value and body dependencies; BindingRef has none
       case TExpr.Let(bindings, body) =>
-        bindings.foldLeft(extractDependenciesBounded(body, bounds)) { case (acc, (_, value)) =>
-          acc ++ extractDependenciesBounded(value, bounds)
+        bindings.foldLeft(recurse(body)) { case (acc, (_, value)) =>
+          acc ++ recurse(value)
         }
       case TExpr.BindingRef(_) => Set.empty
       case TExpr.CoercedBindingRef(_, _) => Set.empty
@@ -579,12 +739,12 @@ object DependencyGraph:
       case TExpr.SheetNameRef(_, _) => Set.empty
 
       // GH-306: runtime coercion wrapper — transparent for analysis
-      case TExpr.Coerced(inner, _) => extractDependenciesBounded(inner, bounds)
+      case TExpr.Coerced(inner, _) => recurse(inner)
 
       // Literals and nullary functions (no dependencies)
       case TExpr.Lit(_) => Set.empty
-      case TExpr.DateToSerial(dateExpr) => extractDependenciesBounded(dateExpr, bounds)
-      case TExpr.DateTimeToSerial(dtExpr) => extractDependenciesBounded(dtExpr, bounds)
+      case TExpr.DateToSerial(dateExpr) => recurse(dateExpr)
+      case TExpr.DateTimeToSerial(dtExpr) => recurse(dtExpr)
 
   /**
    * Get cells this cell depends on (precedents).
@@ -698,81 +858,169 @@ object DependencyGraph:
    * Reverse-reachability core shared by the sheet-level and workbook-level (qualified) variants —
    * generic in the node type (GH-346). Excludes the starting refs from the result.
    */
+  @SuppressWarnings(Array("org.wartremover.warts.While"))
   private def transitiveDependentsOf[K](
     dependents: Map[K, Set[K]],
     originalRefs: Set[K]
   ): Set[K] =
-    @scala.annotation.tailrec
-    def impl(frontier: Set[K], visited: Set[K]): Set[K] =
-      val toVisit = frontier -- visited
-      if toVisit.isEmpty then visited -- originalRefs // Exclude starting refs
-      else
-        val directDeps = toVisit.flatMap(ref => dependents.getOrElse(ref, Set.empty))
-        impl(directDeps, visited ++ toVisit)
-    impl(originalRefs, Set.empty)
+    // A persistent-Set frontier looks elegant but is catastrophically expensive on deep graphs:
+    // every round rebuilds `frontier -- visited` and `visited ++ frontier`. A 100k linear cone can
+    // therefore perform billions of hash probes. Keep mutation invocation-local and freeze once.
+    val visited = scala.collection.mutable.HashSet.empty[K]
+    val pending = scala.collection.mutable.ArrayDeque.empty[K]
+    originalRefs.foreach { ref =>
+      visited += ref
+      pending.append(ref)
+    }
+    while pending.nonEmpty do
+      val ref = pending.removeHead()
+      dependents.getOrElse(ref, Set.empty).foreach { dependent =>
+        if visited.add(dependent) then pending.append(dependent)
+      }
+    visited --= originalRefs
+    visited.toSet
 
   /**
-   * Iterative Tarjan SCC engine shared by `detectCycles`, `cyclicNodes`, and their qualified
-   * (workbook-level) counterparts — generic in the node type (GH-346).
+   * Iterative Tarjan SCC engine shared by `cyclicNodes` and its qualified (workbook-level)
+   * counterparts — generic in the node type (GH-346).
    *
    * Uses an explicit work stack instead of recursion: `recalculate` promises totality, and a deep
    * linear dependency chain (e.g. 100k sequential formulas) must not throw StackOverflowError.
    * Invokes `onScc` for every completed component in Tarjan pop order (deepest member first,
    * component root last).
    */
-  @SuppressWarnings(Array("org.wartremover.warts.Var"))
+  @SuppressWarnings(Array("org.wartremover.warts.Var", "org.wartremover.warts.While"))
   private def foreachSccOf[K](dependencies: Map[K, Set[K]])(onScc: List[K] => Unit): Unit =
-    var index = 0
-    var indices = Map.empty[K, Int]
-    var lowLinks = Map.empty[K, Int]
-    var stack = List.empty[K]
-    var onStack = Set.empty[K]
-    // DFS frames: (node, successors not yet examined)
-    var frames = List.empty[(K, List[K])]
+    final class Frame(val node: K, val successors: Iterator[K])
+
+    var nextIndex = 0
+    val indices = scala.collection.mutable.HashMap.empty[K, Int]
+    val lowLinks = scala.collection.mutable.HashMap.empty[K, Int]
+    val stack = scala.collection.mutable.ArrayBuffer.empty[K]
+    val onStack = scala.collection.mutable.HashSet.empty[K]
+    val frames = scala.collection.mutable.ArrayBuffer.empty[Frame]
+    indices.sizeHint(dependencies.size)
+    lowLinks.sizeHint(dependencies.size)
+    stack.sizeHint(dependencies.size)
+    onStack.sizeHint(dependencies.size)
+    frames.sizeHint(dependencies.size)
 
     def push(v: K): Unit =
-      indices = indices.updated(v, index)
-      lowLinks = lowLinks.updated(v, index)
-      index += 1
-      stack = v :: stack
-      onStack = onStack + v
-      frames = (v, dependencies.getOrElse(v, Set.empty).toList) :: frames
+      indices(v) = nextIndex
+      lowLinks(v) = nextIndex
+      nextIndex += 1
+      stack += v
+      onStack += v
+      frames += new Frame(v, dependencies.getOrElse(v, Set.empty).iterator)
 
     dependencies.keySet.foreach { root =>
       if !indices.contains(root) then
         push(root)
         while frames.nonEmpty do
-          frames match
-            case (v, w :: rest) :: tail =>
-              frames = (v, rest) :: tail
-              if !indices.contains(w) then push(w)
-              else if onStack.contains(w) then
-                lowLinks = lowLinks.updated(v, math.min(lowLinks(v), indices(w)))
-            case (v, Nil) :: tail =>
-              frames = tail
-              if lowLinks(v) == indices(v) then
-                val (sccTail, remaining) = stack.span(_ != v)
-                stack = remaining.drop(1)
-                val scc = sccTail :+ v
-                onStack = onStack -- scc
-                onScc(scc)
-              frames match
-                case (p, _) :: _ =>
-                  lowLinks = lowLinks.updated(p, math.min(lowLinks(p), lowLinks(v)))
-                case Nil => ()
-            case Nil => () // unreachable: guarded by frames.nonEmpty
+          val frame = frames(frames.length - 1)
+          if frame.successors.hasNext then
+            val successor = frame.successors.next()
+            if !indices.contains(successor) then push(successor)
+            else if onStack.contains(successor) then
+              lowLinks(frame.node) = math.min(lowLinks(frame.node), indices(successor))
+          else
+            frames.remove(frames.length - 1)
+            val node = frame.node
+            if lowLinks(node) == indices(node) then
+              val members = List.newBuilder[K]
+              var complete = false
+              while !complete do
+                val member = stack.remove(stack.length - 1)
+                onStack -= member
+                members += member
+                complete = member == node
+              onScc(members.result())
+            if frames.nonEmpty then
+              val parent = frames(frames.length - 1).node
+              lowLinks(parent) = math.min(lowLinks(parent), lowLinks(node))
     }
 
   private def foreachScc(graph: DependencyGraph)(onScc: List[ARef] => Unit): Unit =
     foreachSccOf(graph.dependencies)(onScc)
 
   /**
-   * Detect circular references using Tarjan's strongly connected components algorithm.
+   * Return the first actual directed cycle encountered inside `nodes`.
+   *
+   * SCC membership alone is insufficient for diagnostics: Tarjan pop order is not necessarily an
+   * edge path when a component branches. Likewise, following one successor from a Kahn remainder
+   * can begin downstream of a cycle, so blindly appending the first visited node may invent a
+   * closing edge. This explicit-stack DFS records the active path and closes a cycle only on a back
+   * edge to an active ancestor. Every adjacent pair in the result is therefore an edge in
+   * `dependencies`, the first and last nodes are equal, and no interior node is repeated.
+   *
+   * Roots and successors are ordered by `key`, making the diagnostic a function of the graph's
+   * value rather than Map/Set construction order. All mutation is invocation-local and the returned
+   * path is immutable.
+   */
+  @SuppressWarnings(Array("org.wartremover.warts.Var", "org.wartremover.warts.While"))
+  private def firstCycleOf[K, O: Ordering](
+    dependencies: Map[K, Set[K]],
+    nodes: Set[K],
+    key: K => O
+  ): Option[List[K]] =
+    // State: absent = unseen, 1 = active (gray), 2 = complete (black).
+    val states = scala.collection.mutable.HashMap.empty[K, Int]
+    val activePath = scala.collection.mutable.ArrayBuffer.empty[K]
+    val activeIndices = scala.collection.mutable.HashMap.empty[K, Int]
+    states.sizeHint(nodes.size)
+    activePath.sizeHint(nodes.size)
+    activeIndices.sizeHint(nodes.size)
+    var frames = List.empty[(K, List[K])]
+    var found = Option.empty[List[K]]
+
+    def push(node: K): Unit =
+      states(node) = 1
+      activeIndices(node) = activePath.size
+      activePath += node
+      val successors =
+        dependencies
+          .getOrElse(node, Set.empty)
+          .iterator
+          .filter(nodes.contains)
+          .toList
+          .sortBy(key)
+      frames = (node, successors) :: frames
+
+    val roots = nodes.toList.sortBy(key).iterator
+    while roots.hasNext && found.isEmpty do
+      val root = roots.next()
+      if !states.contains(root) then
+        push(root)
+        while frames.nonEmpty && found.isEmpty do
+          frames match
+            case (node, successor :: rest) :: tail =>
+              frames = (node, rest) :: tail
+              states.get(successor) match
+                case None => push(successor)
+                case Some(1) =>
+                  activeIndices.get(successor) match
+                    case Some(start) =>
+                      found = Some(activePath.iterator.drop(start).toList :+ successor)
+                    case None => () // impossible for an active node; remain total if state corrupts
+                case Some(_) => ()
+            case (node, Nil) :: tail =>
+              frames = tail
+              states(node) = 2
+              activeIndices -= node
+              if activePath.nonEmpty then activePath.remove(activePath.size - 1)
+            case Nil => () // unreachable: guarded by frames.nonEmpty
+
+    found
+
+  /**
+   * Detect circular references using an explicit-stack depth-first search.
    *
    * A circular reference occurs when a cell's formula depends (directly or transitively) on its own
    * value. For example: A1="=B1", B1="=C1", C1="=A1" forms a cycle.
    *
-   * Runs in O(V + E) with an explicit work stack (stack-safe on deep dependency chains).
+   * The explicit DFS is O(V + E), stops at the first back edge, and is stack-safe on deep
+   * dependency chains. Canonical diagnostic ordering adds sorting proportional to the visited roots
+   * and successor sets.
    *
    * @param graph
    *   The dependency graph to analyze
@@ -788,21 +1036,12 @@ object DependencyGraph:
    * detectCycles(graph) // Left(EvalError.CircularRef(List(A1, B1, A1)))
    * }}}
    */
-  @SuppressWarnings(Array("org.wartremover.warts.Var"))
   def detectCycles(graph: DependencyGraph): Either[EvalError.CircularRef, Unit] =
-    var found = Option.empty[List[ARef]]
-    foreachScc(graph) { scc =>
-      if found.isEmpty then
-        scc match
-          case single :: Nil =>
-            if graph.dependencies.get(single).exists(_.contains(single)) then
-              found = Some(List(single, single)) // Self-loop: v -> v
-          case multi =>
-            val cycleNodes = multi.reverse
-            found =
-              Some(cycleNodes :+ cycleNodes.headOption.getOrElse(multi.last)) // close the cycle
-    }
-    found match
+    firstCycleOf(
+      graph.dependencies,
+      graph.dependencies.keySet,
+      (ref: ARef) => (ref.row.index0, ref.col.index0)
+    ) match
       case Some(cycle) => scala.util.Left(EvalError.CircularRef(cycle))
       case None => scala.util.Right(())
 
@@ -813,7 +1052,7 @@ object DependencyGraph:
    * of cells inside strongly connected components of size > 1, plus self-loops. Used by
    * `Workbook.recalculate` to isolate cyclic cells while still evaluating the acyclic remainder.
    *
-   * Stack-safe: shares the iterative Tarjan engine with `detectCycles`.
+   * Stack-safe: uses the iterative Tarjan engine shared with the qualified workbook-level path.
    *
    * @return
    *   The set of cycle participants (empty when the graph is acyclic)
@@ -841,9 +1080,11 @@ object DependencyGraph:
    * on a 50k-formula workbook was 81% of an entire recalculation's allocation. Iteration stays over
    * the same collections in the same order, so the emitted order is unchanged: FIFO queue seeded in
    * `allNodes` iteration order, newly-ready nodes appended in the iteration order of the filtered
-   * dependents set.
+   * dependents set. The FIFO discipline is additionally load-bearing for parallel recalculation: it
+   * keeps longest-path depth classes contiguous, so folding completed waves preserves the exact
+   * sequential error order. A replacement queue must retain that level-monotone property.
    */
-  @SuppressWarnings(Array("org.wartremover.warts.Var", "org.wartremover.warts.While"))
+  @SuppressWarnings(Array("org.wartremover.warts.While"))
   private def kahnOrder[K](
     dependencies: Map[K, Set[K]],
     dependents: Map[K, Set[K]]
@@ -855,13 +1096,16 @@ object DependencyGraph:
     if allNodes.isEmpty then scala.util.Right(List.empty[K])
     else
       // In-degree = dependencies on other formula cells only, not constants
-      val inDegree = scala.collection.mutable.HashMap.empty[K, Int]
+      val inDegree = new scala.collection.mutable.HashMap[K, Int](
+        allNodes.size * 2,
+        scala.collection.mutable.HashMap.defaultLoadFactor
+      )
       allNodes.foreach { node =>
         inDegree(node) = dependencies.getOrElse(node, Set.empty).count(allNodes.contains)
       }
 
       // Start with nodes that have in-degree 0 (no dependencies)
-      val queue = scala.collection.mutable.ArrayDeque.empty[K]
+      val queue = new scala.collection.mutable.ArrayDeque[K](allNodes.size)
       allNodes.foreach { node =>
         if inDegree(node) == 0 then queue.append(node)
       }
@@ -870,13 +1114,14 @@ object DependencyGraph:
       while queue.nonEmpty do
         val node = queue.removeHead()
         ordered += node
-        // Filtering into a Set first (rather than testing membership inline) preserves the exact
-        // emitted order of the previous formulation, which folded over this same filtered set.
-        val deps = dependents.getOrElse(node, Set.empty).filter(allNodes.contains)
-        deps.foreach { dep =>
-          val remaining = inDegree(dep) - 1
-          inDegree(dep) = remaining
-          if remaining == 0 then queue.append(dep)
+        // Test membership inline: materializing `filter(allNodes.contains)` allocated one throwaway
+        // Set per processed formula. Iteration stays over the original Set in the same order; only
+        // successors absent from the node set are skipped.
+        dependents.getOrElse(node, Set.empty).foreach { dep =>
+          if allNodes.contains(dep) then
+            val remaining = inDegree(dep) - 1
+            inDegree(dep) = remaining
+            if remaining == 0 then queue.append(dep)
         }
 
       // If all nodes are processed, graph is acyclic
@@ -911,24 +1156,15 @@ object DependencyGraph:
     kahnOrder(graph.dependencies, graph.dependents) match
       case scala.util.Right(order) => scala.util.Right(order)
       case scala.util.Left(remainingNodes) =>
-        // Cycle detected: find one cycle for error reporting
-        val cycle = remainingNodes.headOption match
-          case Some(start) =>
-            // Follow dependencies to reconstruct cycle
-            def findCycle(current: ARef, visited: Set[ARef]): List[ARef] =
-              if visited.contains(current) then
-                // Found cycle
-                List(current)
-              else
-                graph.dependencies.getOrElse(current, Set.empty).headOption match
-                  case Some(next) if remainingNodes.contains(next) =>
-                    current :: findCycle(next, visited + current)
-                  case _ => List(current)
-
-            val cyclePath = findCycle(start, Set.empty)
-            cyclePath.headOption.map(first => cyclePath :+ first).getOrElse(List.empty)
-          case None => List.empty
-
+        // Kahn's remainder can include nodes merely downstream of a cycle. Reconstruct only from a
+        // real back edge, so the diagnostic never invents an edge from the cycle to that tail.
+        val cycle =
+          firstCycleOf(
+            graph.dependencies,
+            remainingNodes,
+            (ref: ARef) => (ref.row.index0, ref.col.index0)
+          )
+            .getOrElse(List.empty)
         scala.util.Left(EvalError.CircularRef(cycle))
 
   // ===== Cross-Sheet Dependency Tracking =====
@@ -1030,6 +1266,170 @@ object DependencyGraph:
     }.toMap
 
     (dependencies, reverseEdges(dependencies))
+
+  /**
+   * Build the formula-to-formula graph needed by whole-workbook recalculation.
+   *
+   * The public dependency graph records every referenced cell because impact analysis must answer
+   * "which formulas read this edited constant?" Whole-book topological evaluation asks a much
+   * narrower question: "which FORMULAS must run before this formula?" Materializing constant cells
+   * in that graph is pure waste. On a common financial-model shape — 9,900 formulas sharing
+   * `SUM($A$1:$A$5000)` over a constant driver column — the value-preserving graph has no range
+   * edges at all, while [[fromWorkbookBounded]] retains and repeatedly traverses 49.5 million.
+   *
+   * Range lookup scans only the target sheet's formula refs and is memoized by range. Single-cell
+   * references are filtered against the same formula-node set after name resolution. Consequently
+   * this graph is exactly `fromWorkbookBounded` with every non-formula successor removed, without
+   * first allocating those successors. Formula evaluation itself is unchanged and still reads the
+   * complete ranges from the workbook snapshot.
+   *
+   * This representation is intentionally internal: dirty-cone callers still need the public graph
+   * (or, ultimately, a symbolic point/range index) to discover formulas affected by edited values.
+   */
+  private[formula] def fromWorkbookFormulaGraph(
+    workbook: com.tjclp.xl.workbooks.Workbook
+  ): (Map[QualifiedRef, Set[QualifiedRef]], Map[QualifiedRef, Set[QualifiedRef]]) =
+    val formulas: Vector[(QualifiedRef, String)] = workbook.sheets.flatMap { sheet =>
+      sheet.cells.flatMap { case (cellRef, cell) =>
+        cell.value match
+          case CellValue.Formula(_, _, _: FormulaKind.DataTable) => None
+          case CellValue.Formula(expression, _, _) =>
+            Some(QualifiedRef(sheet.name, cellRef) -> expression)
+          case _ => None
+      }
+    }
+    val formulaNodes = formulas.iterator.map(_._1).toSet
+    val refsBySheet: Map[SheetName, Vector[ARef]] =
+      formulas.groupMap(_._1.sheet)(_._1.ref)
+    val cellsFor: (SheetName, CellRange) => Set[QualifiedRef] = memoizedCells { (sheet, range) =>
+      refsBySheet
+        .getOrElse(sheet, Vector.empty)
+        .iterator
+        .filter(range.contains)
+        .map(ref => QualifiedRef(sheet, ref))
+        .toSet
+    }
+
+    val dependencies = formulas.iterator.map { case (ref, expression) =>
+      val deps = FormulaParser.parse(expression) match
+        case scala.util.Right(expr) =>
+          extractQualifiedDependencies(expr, ref.sheet, cellsFor, Some(workbook))
+            .filter(formulaNodes.contains)
+        case scala.util.Left(_) => Set.empty[QualifiedRef]
+      ref -> deps
+    }.toMap
+
+    (dependencies, reverseEdges(dependencies))
+
+  /** One declared range and the formulas that read it. */
+  private[xl] final case class QualifiedRangeDependents(
+    range: CellRange,
+    dependents: Set[QualifiedRef]
+  )
+
+  /**
+   * Symbolic reverse-dependency index for targeted recalculation.
+   *
+   * Point references retain the usual `cell -> formulas` map. Range references remain canonical
+   * rectangles rather than expanding to one map entry per covered cell. This changes the common
+   * N-formulas-by-M-range shape from O(N × M) retained memberships to O(N + unique ranges), and a
+   * full-column reference never allocates one million `QualifiedRef`s merely to discover whether an
+   * edited point lies inside it.
+   */
+  private[xl] final case class QualifiedDependencyIndex(
+    pointDependents: Map[QualifiedRef, Set[QualifiedRef]],
+    rangeDependents: Map[SheetName, Vector[QualifiedRangeDependents]]
+  ):
+    /**
+     * Every formula directly or transitively affected by `originalRefs`, excluding the seeds.
+     *
+     * Local mutation makes a deep chain linear. Range containment is checked against declared
+     * coordinates, not `usedRange`, so clearing the last occupied cell in a range cannot erase the
+     * dependency before invalidation runs.
+     */
+    @SuppressWarnings(Array("org.wartremover.warts.While"))
+    def transitiveDependents(originalRefs: Set[QualifiedRef]): Set[QualifiedRef] =
+      val visited = scala.collection.mutable.HashSet.empty[QualifiedRef]
+      val pending = scala.collection.mutable.ArrayDeque.empty[QualifiedRef]
+
+      def enqueue(ref: QualifiedRef): Unit =
+        if visited.add(ref) then pending.append(ref)
+
+      originalRefs.foreach(enqueue)
+      while pending.nonEmpty do
+        val ref = pending.removeHead()
+        pointDependents.getOrElse(ref, Set.empty).foreach(enqueue)
+        rangeDependents.getOrElse(ref.sheet, Vector.empty).foreach { entry =>
+          if entry.range.contains(ref.ref) then entry.dependents.foreach(enqueue)
+        }
+
+      visited --= originalRefs
+      visited.toSet
+
+  /**
+   * Build a symbolic reverse-dependency index without materializing range cells.
+   *
+   * The existing qualified extractor already centralizes every AST shape and defined-name rule.
+   * Supplying a range callback that records canonical rectangles and returns an empty set separates
+   * point dependencies from range dependencies without duplicating that traversal. All mutation is
+   * build-local; only immutable maps, vectors, ranges, and sets escape.
+   */
+  private[xl] def fromWorkbookDependencyIndex(
+    workbook: com.tjclp.xl.workbooks.Workbook
+  ): QualifiedDependencyIndex =
+    val pointBuilders = scala.collection.mutable.HashMap.empty[
+      QualifiedRef,
+      scala.collection.mutable.HashSet[QualifiedRef]
+    ]
+    val rangeBuilders = scala.collection.mutable.HashMap.empty[
+      (SheetName, ARef, ARef),
+      scala.collection.mutable.HashSet[QualifiedRef]
+    ]
+
+    workbook.sheets.foreach { sheet =>
+      sheet.cells.foreach { case (cellRef, cell) =>
+        cell.value match
+          case CellValue.Formula(_, _, _: FormulaKind.DataTable) => ()
+          case CellValue.Formula(expression, _, _) =>
+            FormulaParser.parse(expression) match
+              case scala.util.Left(_) => ()
+              case scala.util.Right(expr) =>
+                val dependent = QualifiedRef(sheet.name, cellRef)
+                val ranges = scala.collection.mutable.HashSet.empty[(SheetName, ARef, ARef)]
+                val recordRange: (SheetName, CellRange) => Set[QualifiedRef] =
+                  (targetSheet, range) =>
+                    ranges += ((targetSheet, range.start, range.end))
+                    Set.empty
+                val points = extractQualifiedDependencies(
+                  expr,
+                  sheet.name,
+                  recordRange,
+                  Some(workbook)
+                )
+                points.foreach { point =>
+                  pointBuilders.getOrElseUpdate(
+                    point,
+                    scala.collection.mutable.HashSet.empty
+                  ) += dependent
+                }
+                ranges.foreach { key =>
+                  rangeBuilders.getOrElseUpdate(
+                    key,
+                    scala.collection.mutable.HashSet.empty
+                  ) += dependent
+                }
+          case _ => ()
+      }
+    }
+
+    val points = pointBuilders.iterator.map((ref, refs) => ref -> refs.toSet).toMap
+    val ranges = rangeBuilders.iterator
+      .map { case ((sheet, start, end), refs) =>
+        sheet -> QualifiedRangeDependents(CellRange(start, end), refs.toSet)
+      }
+      .toVector
+      .groupMap(_._1)(_._2)
+    QualifiedDependencyIndex(points, ranges)
 
   /**
    * GH-346: every node participating in a reference cycle of the workbook-level graph — the
@@ -1191,43 +1591,53 @@ object DependencyGraph:
    * (54 GB of a 135 GB recalc's allocation) where 5,000 suffice. The memo makes every referencing
    * formula share one immutable Set instance; correctness is untouched because expansion is a pure
    * function of (sheet, range) within one build (bounds are computed once up front and never change
-   * mid-build).
+   * mid-build). The captured mutable map is intentionally build-local and unsynchronized: callers
+   * must invoke the returned closure only from the single graph-building thread.
    */
   private def memoizedCells(
     expand: (SheetName, CellRange) => Set[QualifiedRef]
   ): (SheetName, CellRange) => Set[QualifiedRef] =
-    val cache = scala.collection.mutable.HashMap.empty[(SheetName, CellRange), Set[QualifiedRef]]
-    (sheet, range) => cache.getOrElseUpdate((sheet, range), expand(sheet, range))
+    // Anchors affect formula dragging, never the cells a dependency range denotes. Keying by the
+    // normalized endpoints lets `$A$1:$A$5000`, `A1:A5000`, and mixed-anchor spellings share the
+    // same expansion within one graph build.
+    val cache =
+      scala.collection.mutable.HashMap.empty[(SheetName, ARef, ARef), Set[QualifiedRef]]
+    (sheet, range) => cache.getOrElseUpdate((sheet, range.start, range.end), expand(sheet, range))
 
   /**
    * GH-522: set union that iterates the smaller side into the larger — `Set(oneRef) ++ rangeSet`
    * walks all 5,000 range elements today, once per operator node above a range reference. Union is
    * commutative, and any result with more than 4 elements is a CHAMP HashSet whose iteration order
-   * is a function of its CONTENTS alone, so redirecting the merge cannot move any downstream order.
-   * When the larger side has 4 or fewer elements the left-to-right build is kept: small sets are
-   * insertion-ordered and Kahn's emitted order feeds off their iteration.
+   * is a function of its contents (apart from full hash-collision nodes, whose insertion sequence
+   * is unchanged here), so redirecting the merge cannot move downstream order. When the larger side
+   * has 4 or fewer elements the left-to-right build is kept: small sets are insertion-ordered and
+   * Kahn's emitted order feeds off their iteration.
    */
   private def union(a: Set[QualifiedRef], b: Set[QualifiedRef]): Set[QualifiedRef] =
     if a.size < b.size && b.size > 4 then b ++ a else a ++ b
 
   /**
    * GH-522: reverse-edge map built with a local mutable accumulator. The immutable foldLeft
-   * allocated a fresh outer-Map node chain per edge — 50M times on the shape above (8.5 GB). The
-   * insertion sequence is identical to the fold it replaces (same outer Map iterated in the same
-   * order, same per-key Set growth), so every per-key set — small insertion-ordered ones included —
-   * iterates exactly as before.
+   * allocated a fresh outer-Map node chain per edge — 50M times on the shape above (8.5 GB). The A
+   * mutable insertion-ordered set per precedent also avoids building one intermediate immutable Set
+   * per edge. Each set receives refs in the identical sequence as the fold it replaces, then
+   * freezes through the ordinary immutable Set builder, so its observable iteration order is
+   * unchanged. The outer map's iteration order is deliberately not a contract; every consumer
+   * performs keyed lookup or set membership.
    */
-  @SuppressWarnings(Array("org.wartremover.warts.Var"))
   private[formula] def reverseEdges(
     dependencies: Map[QualifiedRef, Set[QualifiedRef]]
   ): Map[QualifiedRef, Set[QualifiedRef]] =
-    val acc = scala.collection.mutable.HashMap.empty[QualifiedRef, Set[QualifiedRef]]
+    val acc = scala.collection.mutable.HashMap.empty[
+      QualifiedRef,
+      scala.collection.mutable.LinkedHashSet[QualifiedRef]
+    ]
     dependencies.foreach { case (ref, deps) =>
       deps.foreach { dep =>
-        acc(dep) = acc.getOrElse(dep, Set.empty) + ref
+        acc.getOrElseUpdate(dep, scala.collection.mutable.LinkedHashSet.empty) += ref
       }
     }
-    acc.toMap
+    acc.iterator.map((ref, refs) => ref -> refs.toSet).toMap
 
   /**
    * Extract all qualified cell references from TExpr.
@@ -1381,7 +1791,7 @@ object DependencyGraph:
     go(expr)
 
   /**
-   * Detect circular references across sheets using Tarjan's SCC algorithm.
+   * Detect circular references across sheets using an explicit-stack depth-first search.
    *
    * Similar to detectCycles but works with QualifiedRef to detect cycles that span multiple sheets.
    * A cross-sheet cycle occurs when cells across different sheets form a circular dependency (e.g.,
@@ -1400,77 +1810,14 @@ object DependencyGraph:
    *   case Right(_) => println("No cycles")
    * }}}
    */
-  @SuppressWarnings(
-    Array(
-      "org.wartremover.warts.Var",
-      "org.wartremover.warts.IterableOps",
-      "org.wartremover.warts.Return",
-      "org.wartremover.warts.IsInstanceOf",
-      "org.wartremover.warts.AsInstanceOf"
-    )
-  )
   def detectCrossSheetCycles(
     graph: Map[QualifiedRef, Set[QualifiedRef]]
   ): Either[EvalError.CircularRef, Unit] =
-    // Tarjan's SCC algorithm adapted for QualifiedRef
-    var index = 0
-    var stack = List.empty[QualifiedRef]
-    var indices = Map.empty[QualifiedRef, Int]
-    var lowLinks = Map.empty[QualifiedRef, Int]
-    var onStack = Set.empty[QualifiedRef]
-
-    def strongConnect(v: QualifiedRef): Option[List[ARef]] =
-      indices = indices.updated(v, index)
-      lowLinks = lowLinks.updated(v, index)
-      index += 1
-      stack = v :: stack
-      onStack = onStack + v
-
-      val successors = graph.getOrElse(v, Set.empty)
-      val cycleFound = successors.foldLeft(Option.empty[List[ARef]]) { (acc, w) =>
-        acc match
-          case Some(cycle) => Some(cycle)
-          case None =>
-            if !indices.contains(w) then
-              strongConnect(w) match
-                case Some(cycle) => Some(cycle)
-                case None =>
-                  lowLinks = lowLinks.updated(v, math.min(lowLinks(v), lowLinks(w)))
-                  None
-            else if onStack.contains(w) then
-              lowLinks = lowLinks.updated(v, math.min(lowLinks(v), indices(w)))
-              // Found cycle - reconstruct from stack
-              val cycleNodes = (stack.takeWhile(_ != w) :+ w).reverse
-              // Convert to List[ARef] with sheet prefix for error message
-              Some(cycleNodes.map(_.ref) :+ cycleNodes.head.ref)
-            else None
-      }
-
-      cycleFound match
-        case Some(cycle) => Some(cycle)
-        case None =>
-          if lowLinks(v) == indices(v) then
-            val (scc, remaining) = stack.span(_ != v)
-            stack = remaining.tail
-            onStack = onStack -- (scc :+ v)
-
-            if scc.nonEmpty then
-              // Multiple nodes in SCC = cycle
-              val cycleNodes = (scc :+ v).reverse
-              Some(cycleNodes.map(_.ref) :+ cycleNodes.head.ref)
-            else if graph.get(v).exists(_.contains(v)) then Some(List(v.ref, v.ref)) // Self-loop
-            else None
-          else None
-
-    val allNodes = graph.keySet
-    val cycleFound = allNodes.foldLeft(Option.empty[List[ARef]]) { (acc, node) =>
-      acc match
-        case Some(cycle) => Some(cycle)
-        case None =>
-          if !indices.contains(node) then strongConnect(node)
-          else None
-    }
-
-    cycleFound match
-      case Some(cycle) => scala.util.Left(EvalError.CircularRef(cycle))
+    firstCycleOf(
+      graph,
+      graph.keySet,
+      (q: QualifiedRef) => (q.sheet.value, q.ref.row.index0, q.ref.col.index0)
+    ) match
+      // CircularRef predates QualifiedRef and therefore retains its sheetless public payload.
+      case Some(cycle) => scala.util.Left(EvalError.CircularRef(cycle.map(_.ref)))
       case None => scala.util.Right(())

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/AggregateMemoSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/AggregateMemoSpec.scala
@@ -1,0 +1,261 @@
+package com.tjclp.xl.formula
+
+import java.util.concurrent.{Callable, Executors, TimeUnit}
+
+import com.tjclp.xl.{*, given}
+import com.tjclp.xl.addressing.{ARef, SheetName}
+import com.tjclp.xl.cells.CellValue
+import com.tjclp.xl.error.XLError
+import com.tjclp.xl.formula.ast.TExpr
+import com.tjclp.xl.formula.eval.{EvalError, Evaluator, RecalcResult, SheetEvaluator}
+import com.tjclp.xl.formula.parser.FormulaParser
+import com.tjclp.xl.sheets.Sheet
+import com.tjclp.xl.workbooks.Workbook
+import munit.FunSuite
+
+import scala.jdk.CollectionConverters.*
+
+/** Calculation-generation cache laws for the common one-raw-range aggregate shape. */
+class AggregateMemoSpec extends FunSuite:
+
+  private val dataName = SheetName.unsafe("Data")
+  private val inputsName = SheetName.unsafe("Inputs")
+  private val outputName = SheetName.unsafe("Output")
+
+  private def num(value: Int): CellValue = CellValue.Number(BigDecimal(value))
+  private def formula(expr: String, cached: Option[CellValue] = None): CellValue =
+    CellValue.Formula(expr, cached)
+
+  private def evaluate(
+    sheet: Sheet,
+    ref: ARef,
+    workbook: Workbook,
+    evaluator: com.tjclp.xl.formula.eval.Evaluator
+  ): Either[com.tjclp.xl.error.XLError, CellValue] =
+    SheetEvaluator.evaluateCellWithEvaluator(
+      sheet,
+      ref,
+      evaluator,
+      Clock.system,
+      Some(workbook)
+    )
+
+  private def assertSameResult(sequential: RecalcResult, parallel: RecalcResult): Unit =
+    assertEquals(parallel.errors, sequential.errors)
+    assertEquals(parallel.evaluated, sequential.evaluated)
+    assertEquals(parallel.workbook, sequential.workbook)
+    assertEquals(parallel.converged, sequential.converged)
+    assertEquals(parallel.cycles, sequential.cycles)
+
+  test("aggregate memo ignores anchors but distinguishes aggregator identity"):
+    val data = Sheet(dataName)
+      .put(ARef.from0(0, 0), num(1))
+      .put(ARef.from0(0, 1), num(2))
+      .put(ARef.from0(0, 2), num(3))
+    val sumAnchored = ARef.from0(0, 0)
+    val sumRelative = ARef.from0(1, 0)
+    val average = ARef.from0(2, 0)
+    val output = Sheet(outputName)
+      .put(sumAnchored, formula("=SUM(Data!$A$1:$A$3)"))
+      .put(sumRelative, formula("=SUM(Data!A1:A3)"))
+      .put(average, formula("=AVERAGE(Data!A1:A3)"))
+    val workbook = Workbook(data, output)
+    val memo = new Evaluator.AggregateMemo
+    val evaluator = Evaluator.recalculationInstance(Rng.system, memo)
+
+    assertEquals(evaluate(output, sumAnchored, workbook, evaluator), Right(num(6)))
+    assertEquals(evaluate(output, sumRelative, workbook, evaluator), Right(num(6)))
+    assertEquals(evaluate(output, average, workbook, evaluator), Right(num(2)))
+    assertEquals(
+      memo.stats,
+      Evaluator.AggregateMemoStats(hits = 1, fills = 2, bypasses = 0, entries = 2)
+    )
+
+  test("function-call and typed-node coercion modes cannot contaminate one another"):
+    val sheet = Sheet(dataName).put(ref"A1", CellValue.Bool(true))
+    val call = FormulaParser.parse("=SUM(A1:A1)") match
+      case Right(expr) => expr
+      case Left(error) => fail(s"failed to parse aggregate call: $error")
+    val node = TExpr.Aggregate(
+      "SUM",
+      TExpr.RangeLocation.Local(CellRange(ref"A1", ref"A1"))
+    )
+
+    def evaluate(expr: TExpr[?], evaluator: Evaluator): Either[EvalError, String] =
+      evaluator.eval(expr, sheet, Clock.system).map(_.toString)
+
+    def run(
+      first: TExpr[?],
+      second: TExpr[?]
+    ): (Either[EvalError, String], Either[EvalError, String]) =
+      val memo = new Evaluator.AggregateMemo
+      val evaluator = Evaluator.recalculationInstance(Rng.system, memo)
+      val results = (evaluate(first, evaluator), evaluate(second, evaluator))
+      assertEquals(memo.stats.fills, 2L)
+      assertEquals(memo.stats.entries, 2)
+      results
+
+    assertEquals(run(call, node), (Right("0"), Right("1")))
+    assertEquals(run(node, call), (Right("1"), Right("0")))
+
+  test("same-generation snapshots reuse when writes leave the aggregated range unchanged"):
+    val data = Sheet(dataName)
+      .put(ARef.from0(0, 0), num(1))
+      .put(ARef.from0(0, 1), num(2))
+    val laterSnapshot = data.put(ARef.from0(1, 0), num(99))
+    assert(!(laterSnapshot eq data))
+
+    val outputRef = ARef.from0(0, 0)
+    val output = Sheet(outputName).put(outputRef, formula("=SUM(Data!A1:A2)"))
+    val memo = new Evaluator.AggregateMemo
+    val evaluator = Evaluator.recalculationInstance(Rng.system, memo)
+
+    assertEquals(evaluate(output, outputRef, Workbook(data, output), evaluator), Right(num(3)))
+    assertEquals(
+      evaluate(output, outputRef, Workbook(laterSnapshot, output), evaluator),
+      Right(num(3))
+    )
+    assertEquals(
+      memo.stats,
+      Evaluator.AggregateMemoStats(hits = 1, fills = 1, bypasses = 0, entries = 1)
+    )
+
+  test("same-sheet sequential cache writes retain one shared aggregate entry"):
+    val rows = 500
+    val readers = 32
+    val readerRefs = (1 to readers).map(col => ARef.from0(col, 0)).toVector
+    val data = (1 to rows).foldLeft(Sheet(dataName)) { (sheet, row) =>
+      sheet.put(ARef.from0(0, row - 1), num(1))
+    }
+    val initial = readerRefs.foldLeft(data) { (sheet, ref) =>
+      sheet.put(ref, formula(s"=SUM(A1:A$rows)"))
+    }
+    val memo = new Evaluator.AggregateMemo
+    val evaluator = Evaluator.recalculationInstance(Rng.system, memo)
+
+    val (_, values) = readerRefs.foldLeft((initial, Vector.empty[CellValue])) {
+      case ((sheet, acc), ref) =>
+        evaluate(sheet, ref, Workbook(sheet), evaluator) match
+          case Right(value) => (sheet.put(ref, value), acc :+ value)
+          case Left(error) => fail(s"aggregate evaluation failed: $error")
+    }
+
+    assertEquals(values, Vector.fill(readers)(num(rows)))
+    assertEquals(
+      memo.stats,
+      Evaluator.AggregateMemoStats(
+        hits = readers - 1,
+        fills = 1,
+        bypasses = 0,
+        entries = 1
+      )
+    )
+
+  test("full-column cache keys follow changing effective used bounds"):
+    val empty = Sheet(SheetName.unsafe("Empty"))
+    val data = Sheet(dataName).put(
+      ref"Z1000",
+      formula("=IFERROR(COUNTBLANK(A:A)/0,Empty!A1)")
+    )
+    val output = Sheet(outputName).put(
+      ref"A1",
+      formula("=COUNTBLANK(Data!A:A)+0*Data!Z1000")
+    )
+
+    val result = Workbook(data, empty, output).recalculate()
+
+    assert(result.isClean, result.errors.map(_.render).mkString("; "))
+    assertEquals(result.evaluated(outputName)(ref"A1"), num(0))
+
+  test("uncached formula ranges bypass; cached formula ranges may reuse"):
+    val inputRef = ARef.from0(0, 0)
+    val outputRef = ARef.from0(0, 0)
+    val inputs1 = Sheet(inputsName).put(inputRef, num(1))
+    val inputs2 = Sheet(inputsName).put(inputRef, num(2))
+    val output = Sheet(outputName).put(outputRef, formula("=SUM(Data!A1:A1)"))
+
+    // The same Data Sheet identity computes against two different workbook snapshots. Caching its
+    // uncached formula would return the first workbook's value for the second workbook.
+    val uncachedData = Sheet(dataName).put(inputRef, formula("=Inputs!A1"))
+    val uncachedMemo = new Evaluator.AggregateMemo
+    val uncachedEvaluator = Evaluator.recalculationInstance(Rng.system, uncachedMemo)
+    assertEquals(
+      evaluate(output, outputRef, Workbook(inputs1, uncachedData, output), uncachedEvaluator),
+      Right(num(1))
+    )
+    assertEquals(
+      evaluate(output, outputRef, Workbook(inputs2, uncachedData, output), uncachedEvaluator),
+      Right(num(2))
+    )
+    assertEquals(
+      uncachedMemo.stats,
+      Evaluator.AggregateMemoStats(hits = 0, fills = 0, bypasses = 2, entries = 1)
+    )
+
+    // A cached formula's effective value is immutable within its Sheet snapshot and is safe.
+    val cachedData = Sheet(dataName).put(inputRef, formula("=Inputs!A1", Some(num(7))))
+    val cachedMemo = new Evaluator.AggregateMemo
+    val cachedEvaluator = Evaluator.recalculationInstance(Rng.system, cachedMemo)
+    assertEquals(
+      evaluate(output, outputRef, Workbook(inputs1, cachedData, output), cachedEvaluator),
+      Right(num(7))
+    )
+    assertEquals(
+      evaluate(output, outputRef, Workbook(inputs2, cachedData, output), cachedEvaluator),
+      Right(num(7))
+    )
+    assertEquals(
+      cachedMemo.stats,
+      Evaluator.AggregateMemoStats(hits = 1, fills = 1, bypasses = 0, entries = 1)
+    )
+
+  test("shared-range aggregate wave is sequential/parallel equivalent"):
+    val rows = 500
+    val readers = 32
+    val data = (1 to rows).foldLeft(Sheet(dataName)) { (sheet, row) =>
+      sheet.put(ARef.from0(0, row - 1), num(row))
+    }
+    val output = (0 until readers).foldLeft(Sheet(outputName)) { (sheet, col) =>
+      val range = if col % 2 == 0 then "$A$1:$A$500" else "A1:A500"
+      sheet.put(ARef.from0(col, 0), formula(s"=SUM(Data!$range)"))
+    }
+    val workbook = Workbook(data, output)
+    val sequential = workbook.recalculate()
+    val parallel = workbook.recalculateParallel(8)
+
+    assertSameResult(sequential, parallel)
+    val expected = num(rows * (rows + 1) / 2)
+    assertEquals(parallel.evaluated(outputName).values.toSet, Set(expected))
+
+  test("parallel readers single-flight one eligible range fold"):
+    val rows = 5000
+    val readers = 32
+    val data = (1 to rows).foldLeft(Sheet(dataName)) { (sheet, row) =>
+      sheet.put(ARef.from0(0, row - 1), num(1))
+    }
+    val outputRef = ARef.from0(0, 0)
+    val output = Sheet(outputName).put(outputRef, formula(s"=SUM(Data!A1:A$rows)"))
+    val workbook = Workbook(data, output)
+    val memo = new Evaluator.AggregateMemo
+    val evaluator = Evaluator.recalculationInstance(Rng.system, memo)
+    val pool = Executors.newFixedThreadPool(8)
+    val tasks = new java.util.ArrayList[Callable[Either[XLError, CellValue]]]()
+    (0 until readers).foreach { _ =>
+      tasks.add(() => evaluate(output, outputRef, workbook, evaluator))
+    }
+
+    try
+      val results = pool.invokeAll(tasks).asScala.map(_.get()).toVector
+      assertEquals(results, Vector.fill(readers)(Right(num(rows))))
+      assertEquals(
+        memo.stats,
+        Evaluator.AggregateMemoStats(
+          hits = readers - 1,
+          fills = 1,
+          bypasses = 0,
+          entries = 1
+        )
+      )
+    finally
+      pool.shutdownNow()
+      pool.awaitTermination(5, TimeUnit.SECONDS)

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/CrossSheetFormulaSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/CrossSheetFormulaSpec.scala
@@ -508,6 +508,42 @@ class CrossSheetFormulaSpec extends ScalaCheckSuite:
     }
   }
 
+  test("evaluateWithDependencyCheck threads the refreshed sheet through self-qualified reads") {
+    val stale = CellValue.Number(BigDecimal(999))
+    val sheet = sheetWith(
+      "Main",
+      ref"A1" -> CellValue.Formula("=1+1", Some(stale)),
+      // The local A1 edge fixes the evaluation order; the qualified read must then see that same
+      // refreshed snapshot rather than Main from the caller's original workbook.
+      ref"B1" -> CellValue.Formula("=A1+Main!A1")
+    )
+    val result = sheet.evaluateWithDependencyCheck(workbook = Some(workbookWith(sheet)))
+
+    assertEquals(result.map(_(ref"B1")), Right(CellValue.Number(BigDecimal(4))))
+  }
+
+  test("evaluateWithDependencyCheck defers INDIRECT hidden behind a defined name") {
+    val candidates = Vector(ref"A1", ref"B1")
+    val probe = candidates.foldLeft(sheetWith("Main")) { (sheet, at) =>
+      sheet.put(at, CellValue.Formula("=1+1"))
+    }
+    val (reader, target) =
+      DependencyGraph.topologicalSort(DependencyGraph.fromSheet(probe)) match
+        case Right(first :: second :: _) => (first, second)
+        case other => fail(s"expected two acyclic formula nodes, got $other")
+    val stale = CellValue.Number(BigDecimal(999))
+    val sheet = sheetWith(
+      "Main",
+      reader -> CellValue.Formula("=DynamicName", Some(stale)),
+      target -> CellValue.Formula("=1+1", Some(stale))
+    )
+    val wb = workbookWith(sheet).withDefinedName("DynamicName", s"INDIRECT(\"${target.toA1}\")")
+
+    val result = sheet.evaluateWithDependencyCheck(workbook = Some(wb))
+
+    assertEquals(result.map(_(reader)), Right(CellValue.Number(BigDecimal(2))))
+  }
+
   // ===== Cross-Sheet Cycle Detection Tests =====
 
   test("DependencyGraph.fromWorkbook: extracts cross-sheet dependencies") {

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/DependencyGraphSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/DependencyGraphSpec.scala
@@ -28,6 +28,28 @@ class DependencyGraphSpec extends ScalaCheckSuite:
   private def parseRef(ref: String): ARef =
     ARef.parse(ref).fold(err => fail(err), identity)
 
+  private def assertActualCycle(
+    dependencies: Map[ARef, Set[ARef]],
+    cycle: List[ARef]
+  ): Unit =
+    val first = cycle.headOption.getOrElse(fail("expected a non-empty cycle"))
+    val last = cycle.lastOption.getOrElse(fail("expected a non-empty cycle"))
+    assertEquals(last, first, "cycle must close at its first node")
+    val interior = cycle.dropRight(1)
+    assertEquals(
+      interior.distinct.size,
+      interior.size,
+      s"cycle of size ${cycle.size} must not repeat an interior node"
+    )
+    cycle.sliding(2).foreach {
+      case from :: to :: Nil =>
+        assert(
+          dependencies.getOrElse(from, Set.empty).contains(to),
+          s"reported non-edge ${from.toA1} -> ${to.toA1} in cycle of size ${cycle.size}"
+        )
+      case _ => ()
+    }
+
   // ===== Dependency Extraction Tests (10 tests) =====
 
   test("extractDependencies: Lit has no dependencies") {
@@ -363,6 +385,41 @@ class DependencyGraphSpec extends ScalaCheckSuite:
       case _ => fail("Expected CircularRef error")
   }
 
+  test("detectCycles: a branching SCC reports an actual directed cycle, not Tarjan pop order") {
+    // All three nodes share one SCC, but B1 -> C1 and C1 -> B1 do not exist. Treating the SCC's
+    // pop order as a path can therefore report A1 -> B1 -> C1 -> A1 with an invented middle edge.
+    val dependencies = Map(
+      ref"A1" -> Set(ref"B1", ref"C1"),
+      ref"B1" -> Set(ref"A1"),
+      ref"C1" -> Set(ref"A1")
+    )
+    val graph = DependencyGraph(
+      dependencies,
+      Map(
+        ref"A1" -> Set(ref"B1", ref"C1"),
+        ref"B1" -> Set(ref"A1"),
+        ref"C1" -> Set(ref"A1")
+      )
+    )
+
+    val cycle = DependencyGraph.detectCycles(graph) match
+      case Left(EvalError.CircularRef(path)) => path
+      case other => fail(s"expected a circular reference, got $other")
+    assertActualCycle(dependencies, cycle)
+
+    // Small immutable maps/sets retain construction order. Rebuilding the same graph in reverse
+    // must not change a user-visible diagnostic.
+    val rebuilt = List(
+      ref"C1" -> Set(ref"A1"),
+      ref"B1" -> Set(ref"A1"),
+      ref"A1" -> List(ref"C1", ref"B1").toSet
+    ).toMap
+    val rebuiltCycle = DependencyGraph.detectCycles(DependencyGraph(rebuilt, Map.empty)) match
+      case Left(EvalError.CircularRef(path)) => path
+      case other => fail(s"expected a circular reference, got $other")
+    assertEquals(rebuiltCycle, cycle)
+  }
+
   test("detectCycles: cycle through range (A1 -> SUM(B1:B3) where B2 -> A1)") {
     val sheet = sheetWith(
       ref"A1" -> CellValue.Formula("=SUM(B1:B3)"),
@@ -464,6 +521,26 @@ class DependencyGraphSpec extends ScalaCheckSuite:
     assert(result.isLeft)
   }
 
+  test("topologicalSort: excludes a downstream Kahn remainder tail from the reported cycle") {
+    // A1 is blocked by B1 <-> C1 but is not itself cyclic. The former single-successor walk could
+    // start at A1, revisit B1, then append A1 and invent the closing edge B1 -> A1.
+    val dependencies = Map(
+      ref"A1" -> Set(ref"B1"),
+      ref"B1" -> Set(ref"C1"),
+      ref"C1" -> Set(ref"B1")
+    )
+    val graph = DependencyGraph(
+      dependencies,
+      Map(ref"B1" -> Set(ref"A1", ref"C1"), ref"C1" -> Set(ref"B1"))
+    )
+
+    DependencyGraph.topologicalSort(graph) match
+      case Left(EvalError.CircularRef(cycle)) =>
+        assertActualCycle(dependencies, cycle)
+        assert(!cycle.contains(ref"A1"), s"downstream tail leaked into cycle: $cycle")
+      case other => fail(s"expected a circular reference, got $other")
+  }
+
   test("topologicalSort: self-loop produces Left(CircularRef)") {
     val sheet = sheetWith(ref"A1" -> CellValue.Formula("=A1"))
     val graph = DependencyGraph.fromSheet(sheet)
@@ -528,6 +605,38 @@ class DependencyGraphSpec extends ScalaCheckSuite:
       case _ => fail("Expected successful topological sort")
   }
 
+  test("topologicalSort: 100k-node cycle reporting is stack-safe and returns one closed ring") {
+    val n = 100000
+    val dependencies = (0 until n).iterator.map { i =>
+      ARef.from0(0, i) -> Set(ARef.from0(0, (i + 1) % n))
+    }.toMap
+    // Every node has in-degree one, so Kahn needs no reverse edges to establish the cyclic
+    // remainder. Keeping this fixture direct isolates path reconstruction from graph construction.
+    val graph = DependencyGraph(dependencies, Map.empty)
+
+    DependencyGraph.topologicalSort(graph) match
+      case Left(EvalError.CircularRef(cycle)) =>
+        assertEquals(cycle.size, n + 1)
+        assertActualCycle(dependencies, cycle)
+      case other => fail(s"expected a circular reference, got $other")
+  }
+
+  test("detectCrossSheetCycles: a 20k-node cycle is stack-safe") {
+    val n = 20000
+    val sheet = SheetName.unsafe("Deep")
+    val graph = (0 until n).iterator.map { i =>
+      val node = DependencyGraph.QualifiedRef(sheet, ARef.from0(0, i))
+      val next = DependencyGraph.QualifiedRef(sheet, ARef.from0(0, (i + 1) % n))
+      node -> Set(next)
+    }.toMap
+
+    DependencyGraph.detectCrossSheetCycles(graph) match
+      case Left(EvalError.CircularRef(cycle)) =>
+        assertEquals(cycle.size, n + 1)
+        assertEquals(cycle.headOption, cycle.lastOption)
+      case other => fail(s"expected a circular reference, got $other")
+  }
+
   test("topologicalSort: range dependencies maintain order") {
     val sheet = sheetWith(
       ref"A1" -> CellValue.Number(BigDecimal(1)),
@@ -546,6 +655,95 @@ class DependencyGraphSpec extends ScalaCheckSuite:
         // B1 must come before C1
         assert(b1Idx < c1Idx)
       case _ => fail("Expected successful topological sort")
+  }
+
+  property("GH-518: optimized Kahn preserves the immutable FIFO order exactly") {
+    val dagGen = for
+      size <- Gen.choose(0, 30)
+      rawEdges <- Gen.listOf(Gen.zip(Gen.choose(0, 29), Gen.choose(0, 29)))
+      outsiderFlags <- Gen.listOfN(size, Gen.oneOf(true, false))
+    yield
+      val nodes = Vector.tabulate(size)(row0 => ARef.from0(0, row0))
+      val dependencies = nodes.zipWithIndex.map { case (node, index) =>
+        val deps = rawEdges.iterator.collect {
+          case (from, to) if from == index && to < index => nodes(to)
+        }.toSet
+        node -> deps
+      }.toMap
+      val reverse = dependencies.foldLeft(Map.empty[ARef, Set[ARef]]) {
+        case (acc, (dependent, precedents)) =>
+          precedents.foldLeft(acc) { (seen, precedent) =>
+            seen.updated(precedent, seen.getOrElse(precedent, Set.empty) + dependent)
+          }
+      }
+      val outsiders = outsiderFlags.zip(nodes).collect { case (true, node) => node }.toSet
+      val outsider = ARef.from0(1, 100)
+      val dependents = outsiders.foldLeft(reverse) { (acc, node) =>
+        acc.updated(node, acc.getOrElse(node, Set.empty) + outsider)
+      }
+      DependencyGraph(dependencies, dependents)
+
+    forAll(dagGen) { graph =>
+      val allNodes = graph.dependencies.keySet
+      val initialDegree = allNodes.iterator.map { node =>
+        node -> graph.dependencies.getOrElse(node, Set.empty).count(allNodes.contains)
+      }.toMap
+      val initialQueue = allNodes.iterator.filter(initialDegree(_) == 0).toList
+
+      @annotation.tailrec
+      def reference(
+        queue: List[ARef],
+        degree: Map[ARef, Int],
+        ordered: List[ARef]
+      ): List[ARef] =
+        queue match
+          case Nil => ordered
+          case node :: rest =>
+            val successors = graph.dependents.getOrElse(node, Set.empty).filter(allNodes.contains)
+            val (nextDegree, newlyReady) =
+              successors.foldLeft((degree, List.empty[ARef])) {
+                case ((current, ready), successor) =>
+                  val remaining = current(successor) - 1
+                  (
+                    current.updated(successor, remaining),
+                    if remaining == 0 then ready :+ successor else ready
+                  )
+              }
+            reference(rest ++ newlyReady, nextDegree, ordered :+ node)
+
+      assertEquals(
+        DependencyGraph.topologicalSort(graph),
+        Right(reference(initialQueue, initialDegree, List.empty))
+      )
+    }
+  }
+
+  property("GH-522: mutable reverse-edge construction equals the immutable reference") {
+    val graphGen = for
+      size <- Gen.choose(0, 30)
+      rawEdges <- Gen.listOf(Gen.zip(Gen.choose(0, 29), Gen.choose(0, 29)))
+    yield
+      val sheet = SheetName.unsafe("S")
+      val nodes =
+        Vector.tabulate(size)(row0 => DependencyGraph.QualifiedRef(sheet, ARef.from0(0, row0)))
+      nodes.zipWithIndex.map { case (node, index) =>
+        val deps = rawEdges.iterator.collect {
+          case (from, to) if from == index && to < size => nodes(to)
+        }.toSet
+        node -> deps
+      }.toMap
+
+    forAll(graphGen) { dependencies =>
+      val expected = dependencies.foldLeft(
+        Map.empty[DependencyGraph.QualifiedRef, Set[DependencyGraph.QualifiedRef]]
+      ) { case (acc, (dependent, precedents)) =>
+        precedents.foldLeft(acc) { (seen, precedent) =>
+          seen.updated(precedent, seen.getOrElse(precedent, Set.empty) + dependent)
+        }
+      }
+
+      assertEquals(DependencyGraph.reverseEdges(dependencies), expected)
+    }
   }
 
   // ===== Query Tests (4 tests) =====

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/DependentRecalculationSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/DependentRecalculationSpec.scala
@@ -1,5 +1,8 @@
 package com.tjclp.xl.formula
 
+import java.time.{LocalDate, LocalDateTime}
+import java.util.concurrent.atomic.AtomicInteger
+
 import com.tjclp.xl.*
 import com.tjclp.xl.addressing.{ARef, SheetName}
 import com.tjclp.xl.cells.CellValue
@@ -195,6 +198,24 @@ class DependentRecalculationSpec extends FunSuite:
     assertEquals(result.cells, sheet.cells)
   }
 
+  test(
+    "recalculateDependents: a cleared used-range boundary still invalidates full-column readers"
+  ) {
+    val sheet = sheetWith(
+      ref"A100" -> CellValue.Number(BigDecimal(5)),
+      ref"B1" -> CellValue.Formula("=SUM(A:A)", Some(CellValue.Number(BigDecimal(5))))
+    )
+
+    val recalculated = sheet
+      .put(ref"A100", CellValue.Empty)
+      .recalculateDependents(Set(ref"A100"))
+
+    assertEquals(
+      recalculated(ref"B1").value,
+      CellValue.Formula("=SUM(A:A)", Some(CellValue.Number(BigDecimal(0))))
+    )
+  }
+
   // ===== Workbook Cross-Sheet Tests (3 tests) =====
 
   test("workbook recalculateDependents: updates dependent on same sheet") {
@@ -237,6 +258,57 @@ class DependentRecalculationSpec extends FunSuite:
         case CellValue.Formula(_, Some(CellValue.Number(n)), _) => Some(n)
         case _ => None)
     assertEquals(a1Value, Some(BigDecimal(100)))
+  }
+
+  test("workbook recalculateDependents: follows a global cross-sheet topological order") {
+    // Deliberately stale caches on a three-sheet chain. Evaluating by grouped sheet hash order
+    // can refresh E before A, leaving E at 3 even after A becomes 11.
+    val input = new Sheet(name = SheetName.unsafe("I"))
+      .put(ref"A1", CellValue.Number(BigDecimal(1)))
+    val middle = new Sheet(name = SheetName.unsafe("A"))
+      .put(ref"A1", CellValue.Formula("=I!A1+1", Some(CellValue.Number(BigDecimal(2)))))
+    val output = new Sheet(name = SheetName.unsafe("E"))
+      .put(ref"A1", CellValue.Formula("=A!A1+1", Some(CellValue.Number(BigDecimal(3)))))
+    val wb = Workbook(input, middle, output)
+
+    val updated = wb
+      .put(input.put(ref"A1", CellValue.Number(BigDecimal(10))))
+      .recalculateDependents(input.name, Set(ref"A1"))
+
+    assertEquals(
+      updated(middle.name).toOption.map(_(ref"A1").value),
+      Some(CellValue.Formula("=I!A1+1", Some(CellValue.Number(BigDecimal(11)))))
+    )
+    assertEquals(
+      updated(output.name).toOption.map(_(ref"A1").value),
+      Some(CellValue.Formula("=A!A1+1", Some(CellValue.Number(BigDecimal(12)))))
+    )
+  }
+
+  test("workbook recalculateDependents isolates an affected cycle and refreshes healthy branches") {
+    val input = Sheet(SheetName.unsafe("I"))
+      .put(ref"A1", CellValue.Number(BigDecimal(1)))
+    val healthy = Sheet(SheetName.unsafe("H")).put(
+      ref"A1",
+      CellValue.Formula("=I!A1+1", Some(CellValue.Number(BigDecimal(2))))
+    )
+    val cyclic = Sheet(SheetName.unsafe("C"))
+      .put(
+        ref"A1",
+        CellValue.Formula("=B1+I!A1", Some(CellValue.Number(BigDecimal(100))))
+      )
+      .put(ref"B1", CellValue.Formula("=A1+1", Some(CellValue.Number(BigDecimal(101)))))
+    val wb = Workbook(input, healthy, cyclic)
+
+    val updated = wb
+      .put(input.put(ref"A1", CellValue.Number(BigDecimal(10))))
+      .recalculateDependents(input.name, Set(ref"A1"))
+
+    assertEquals(
+      updated(healthy.name).toOption.map(_(ref"A1").value),
+      Some(CellValue.Formula("=I!A1+1", Some(CellValue.Number(BigDecimal(11)))))
+    )
+    assertEquals(updated(cyclic.name).toOption, Some(cyclic))
   }
 
   test("workbook recalculateDependents: empty refs returns unchanged") {
@@ -313,6 +385,97 @@ class DependentRecalculationSpec extends FunSuite:
       out,
       Some(CellValue.Formula("=INDIRECT(\"S1!A1\")", Some(CellValue.Number(BigDecimal(9)))))
     )
+  }
+
+  test("GH-274: workbook dynamic closure remains ordered across sheets") {
+    val input = (new Sheet(name = SheetName.unsafe("I")))
+      .put(ref"A1", CellValue.Number(BigDecimal(5)))
+    val dynamic = (new Sheet(name = SheetName.unsafe("A"))).put(
+      ref"A1",
+      CellValue.Formula("=INDIRECT(\"I!A1\")", Some(CellValue.Number(BigDecimal(5))))
+    )
+    val downstream = (new Sheet(name = SheetName.unsafe("E"))).put(
+      ref"A1",
+      CellValue.Formula("=A!A1+1", Some(CellValue.Number(BigDecimal(6))))
+    )
+
+    val updated = Workbook(input, dynamic, downstream)
+      .put(input.put(ref"A1", CellValue.Number(BigDecimal(9))))
+      .recalculateDependents(input.name, Set(ref"A1"))
+
+    assertEquals(
+      updated(dynamic.name).toOption.map(_(ref"A1").value),
+      Some(CellValue.Formula("=INDIRECT(\"I!A1\")", Some(CellValue.Number(BigDecimal(9)))))
+    )
+    assertEquals(
+      updated(downstream.name).toOption.map(_(ref"A1").value),
+      Some(CellValue.Formula("=A!A1+1", Some(CellValue.Number(BigDecimal(10)))))
+    )
+  }
+
+  test("GH-274: targeted recalc does not expose stale caches between dynamic readers") {
+    val candidates = Vector(ref"A1", ref"B1")
+    val probe = candidates.foldLeft(emptySheet) { (sheet, at) =>
+      sheet.put(at, CellValue.Formula("=INDIRECT(\"D1\")"))
+    }
+    val order = DependencyGraph.topologicalSort(DependencyGraph.fromSheet(probe)).toOption.get
+    val first = order.head
+    val second = order(1)
+    val firstExpr = s"=INDIRECT(\"${second.toA1}\")"
+    val secondExpr = "=INDIRECT(\"D1\")"
+    val stale = CellValue.Number(BigDecimal(999))
+    val sheet = sheetWith(
+      ref"D1" -> CellValue.Number(BigDecimal(5)),
+      first -> CellValue.Formula(firstExpr, Some(stale)),
+      second -> CellValue.Formula(secondExpr, Some(stale))
+    )
+
+    val recalculated = sheet
+      .put(ref"D1", CellValue.Number(BigDecimal(9)))
+      .recalculateDependents(Set(ref"D1"))
+
+    assertEquals(
+      recalculated(first).value,
+      CellValue.Formula(firstExpr, Some(CellValue.Number(BigDecimal(9))))
+    )
+    assertEquals(
+      recalculated(second).value,
+      CellValue.Formula(secondExpr, Some(CellValue.Number(BigDecimal(9))))
+    )
+  }
+
+  test("targeted recalc pins one volatile clock generation across every dependent") {
+    final class CountingClock extends Clock:
+      val todayCalls = AtomicInteger(0)
+      val nowCalls = AtomicInteger(0)
+
+      def today(): LocalDate =
+        todayCalls.incrementAndGet()
+        LocalDate.of(2026, 8, 8)
+
+      def now(): LocalDateTime =
+        nowCalls.incrementAndGet()
+        LocalDateTime.of(2026, 8, 8, 12, 30)
+
+    val clock = new CountingClock
+    val sheet = sheetWith(
+      ref"A1" -> CellValue.Number(BigDecimal(1)),
+      ref"B1" -> CellValue.Formula("=IF(A1>0,NOW(),NOW())"),
+      ref"C1" -> CellValue.Formula("=IF(A1>0,NOW(),NOW())")
+    )
+
+    val recalculated = sheet
+      .put(ref"A1", CellValue.Number(BigDecimal(2)))
+      .recalculateDependents(Set(ref"A1"), clock = clock)
+
+    assert(recalculated(ref"B1").value match
+      case CellValue.Formula(_, Some(_), _) => true
+      case _ => false)
+    assert(recalculated(ref"C1").value match
+      case CellValue.Formula(_, Some(_), _) => true
+      case _ => false)
+    assertEquals(clock.todayCalls.get(), 0)
+    assertEquals(clock.nowCalls.get(), 1)
   }
 
   // ===== GH-301: OFFSET cells are always-dirty in targeted recalculation (INDIRECT parity) =====

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/FormulaGraphPerfSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/FormulaGraphPerfSpec.scala
@@ -1,0 +1,114 @@
+package com.tjclp.xl.formula
+
+import com.tjclp.xl.{*, given}
+import com.tjclp.xl.addressing.{ARef, SheetName}
+import com.tjclp.xl.cells.CellValue
+import com.tjclp.xl.formula.graph.DependencyGraph
+import com.tjclp.xl.sheets.Sheet
+import com.tjclp.xl.workbooks.Workbook
+import munit.FunSuite
+
+/** Regression gates for the formula-only graph used by whole-workbook recalculation. */
+class FormulaGraphPerfSpec extends FunSuite:
+
+  private def number(n: Int): CellValue = CellValue.Number(BigDecimal(n))
+  private def formula(text: String): CellValue = CellValue.Formula(text, None)
+
+  test("formula-only graph equals the bounded graph restricted to formula nodes"):
+    val data = Sheet(SheetName.unsafe("Data"))
+      .put(ref"A1", number(1))
+      .put(ref"A2", number(2))
+      .put(ref"A3", formula("=A1+A2"))
+      .put(ref"B3", formula("=SUM(A1:A3)"))
+    val summary = Sheet(SheetName.unsafe("Summary"))
+      .put(ref"A1", formula("=SUM(Data!A:A)+Data!B3"))
+    val wb = Workbook(data, summary)
+
+    val (bounded, _) = DependencyGraph.fromWorkbookBounded(wb)
+    val formulaNodes = bounded.keySet
+    val expected = bounded.view.mapValues(_ & formulaNodes).toMap
+    val (actual, actualReverse) = DependencyGraph.fromWorkbookFormulaGraph(wb)
+
+    assertEquals(actual, expected)
+    assertEquals(actualReverse, DependencyGraph.reverseEdges(expected))
+
+  test("constant driver ranges contribute no topology edges"):
+    val driverRows = 5000
+    val formulaCount = 1000
+    val data = (1 to driverRows).foldLeft(Sheet(SheetName.unsafe("Data"))) { (sheet, row) =>
+      sheet.put(ARef.from0(0, row - 1), number(row))
+    }
+    val model = (1 to formulaCount).foldLeft(Sheet(SheetName.unsafe("Model"))) { (sheet, row) =>
+      sheet.put(ARef.from0(1, row - 1), formula("=SUM(Data!A:A)"))
+    }
+    val wb = Workbook(data, model)
+
+    val started = System.nanoTime()
+    val (dependencies, dependents) = DependencyGraph.fromWorkbookFormulaGraph(wb)
+    val elapsedMs = (System.nanoTime() - started) / 1000000L
+
+    assertEquals(dependencies.size, formulaCount)
+    assert(dependencies.valuesIterator.forall(_.isEmpty))
+    assertEquals(dependents, Map.empty)
+    assert(
+      elapsedMs < 5000L,
+      s"formula-only graph took ${elapsedMs}ms for $formulaCount shared driver ranges"
+    )
+
+  test("formula cells inside ranges remain topology precedents"):
+    val sheet = Sheet(SheetName.unsafe("S"))
+      .put(ref"A1", number(1))
+      .put(ref"A2", formula("=A1+1"))
+      .put(ref"A3", formula("=SUM(A1:A2)"))
+    val (dependencies, _) = DependencyGraph.fromWorkbookFormulaGraph(Workbook(sheet))
+    val qA2 = DependencyGraph.QualifiedRef(sheet.name, ref"A2")
+    val qA3 = DependencyGraph.QualifiedRef(sheet.name, ref"A3")
+
+    assertEquals(dependencies(qA2), Set.empty)
+    assertEquals(dependencies(qA3), Set(qA2))
+
+  test("sheet graph reuses one expansion across anchor spellings of the same range"):
+    val sheet = (1 to 1000)
+      .foldLeft(Sheet(SheetName.unsafe("S"))) { (current, row) =>
+        current.put(ARef.from0(0, row - 1), number(row))
+      }
+      .put(ref"B1", formula("=SUM(A1:A1000)"))
+      .put(ref"B2", formula("=SUM($A$1:$A$1000)"))
+
+    val graph = DependencyGraph.fromSheet(sheet)
+    val relative = graph.dependencies(ref"B1")
+    val anchored = graph.dependencies(ref"B2")
+
+    assertEquals(relative.size, 1000)
+    assert(anchored eq relative, "anchor-only spelling differences must hit the same range cache")
+
+  test("symbolic range index survives clearing the old used-range boundary"):
+    val sheetName = SheetName.unsafe("S")
+    val sum = DependencyGraph.QualifiedRef(sheetName, ref"B1")
+    val cleared = DependencyGraph.QualifiedRef(sheetName, ref"A100")
+    // This is the POST-edit sheet: A100 has disappeared, so usedRange no longer intersects A:A.
+    val sheet = Sheet(sheetName)
+      .put(ref"B1", CellValue.Formula("=SUM(A:A)", Some(number(5))))
+    val index = DependencyGraph.fromWorkbookDependencyIndex(Workbook(sheet))
+
+    assertEquals(index.transitiveDependents(Set(cleared)), Set(sum))
+
+  test("symbolic index stores a shared range once instead of per covered cell"):
+    val formulaCount = 1000
+    val dataName = SheetName.unsafe("Data")
+    val modelName = SheetName.unsafe("Model")
+    val data = Sheet(dataName).put(ref"A1", number(1)).put(ref"A1000", number(1000))
+    val model = (1 to formulaCount).foldLeft(Sheet(modelName)) { (sheet, row) =>
+      sheet.put(ARef.from0(1, row - 1), formula("=SUM(Data!A1:A1000)"))
+    }
+
+    val index = DependencyGraph.fromWorkbookDependencyIndex(Workbook(data, model))
+    val entries = index.rangeDependents.getOrElse(dataName, Vector.empty)
+
+    assertEquals(entries.size, 1)
+    assertEquals(entries(0).range, CellRange(ref"A1", ref"A1000"))
+    assertEquals(entries(0).dependents.size, formulaCount)
+    assertEquals(
+      index.transitiveDependents(Set(DependencyGraph.QualifiedRef(dataName, ref"A500"))).size,
+      formulaCount
+    )

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/ParallelRecalcSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/ParallelRecalcSpec.scala
@@ -1,12 +1,23 @@
 package com.tjclp.xl.formula
 
+import java.time.{LocalDate, LocalDateTime}
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
+import java.util.concurrent.locks.LockSupport
+import java.util.concurrent.{ConcurrentLinkedQueue, CountDownLatch, TimeUnit}
+
 import com.tjclp.xl.{*, given}
 import com.tjclp.xl.addressing.{ARef, SheetName}
 import com.tjclp.xl.cells.CellValue
 import com.tjclp.xl.formula.eval.RecalcResult
+import com.tjclp.xl.formula.graph.DependencyGraph
+import com.tjclp.xl.formula.graph.DependencyGraph.QualifiedRef
 import com.tjclp.xl.sheets.Sheet
-import com.tjclp.xl.workbooks.Workbook
-import munit.FunSuite
+import com.tjclp.xl.workbooks.{DefinedName, Workbook}
+import munit.ScalaCheckSuite
+import org.scalacheck.Gen
+import org.scalacheck.Prop.*
+
+import scala.jdk.CollectionConverters.*
 
 /**
  * GH-520: `recalculateParallel(n)` must be observationally IDENTICAL to `recalculate()` — same
@@ -18,7 +29,7 @@ import munit.FunSuite
  * (error ORDER is part of the contract), cycles (circular + blocked reporting precedes the pass),
  * and dynamic INDIRECT cells (excluded from waves, sequential evaluate-last).
  */
-class ParallelRecalcSpec extends FunSuite:
+class ParallelRecalcSpec extends ScalaCheckSuite:
 
   private def num(d: Double): CellValue = CellValue.Number(BigDecimal(d))
   private def formula(expr: String): CellValue = CellValue.Formula(expr, None)
@@ -28,6 +39,7 @@ class ParallelRecalcSpec extends FunSuite:
     assertEquals(parallel.evaluated, sequential.evaluated)
     assertEquals(parallel.workbook, sequential.workbook)
     assertEquals(parallel.converged, sequential.converged)
+    assertEquals(parallel.iterationsUsed, sequential.iterationsUsed)
     assertEquals(parallel.cycles, sequential.cycles)
 
   /**
@@ -118,7 +130,211 @@ class ParallelRecalcSpec extends FunSuite:
       assertSameResult(first, wb.recalculateParallel(8))
     }
 
+  property("GH-520: random wide acyclic books preserve the full RecalcResult law"):
+    val width = 20
+    val cases = for
+      constants <- Gen.listOfN(width, Gen.choose(-100, 100))
+      factors <- Gen.listOfN(width, Gen.choose(-5, 5))
+      offsets <- Gen.listOfN(width, Gen.choose(-20, 20))
+      leftLinks <- Gen.listOfN(width, Gen.choose(0, width - 1))
+      rightLinks <- Gen.listOfN(width, Gen.choose(0, width - 1))
+    yield (constants, factors, offsets, leftLinks, rightLinks)
+
+    forAll(cases) { case (constants, factors, offsets, leftLinks, rightLinks) =>
+      val base = constants.zipWithIndex.foldLeft(Sheet(SheetName.unsafe("Generated"))) {
+        case (sheet, (value, col)) => sheet.put(ARef.from0(col, 0), num(value.toDouble))
+      }
+      val firstLayer = (0 until width).foldLeft(base) { (sheet, col) =>
+        val input = ARef.from0(col, 0).toA1
+        sheet.put(
+          ARef.from0(col, 1),
+          formula(s"=$input*${factors(col)}+${offsets(col)}")
+        )
+      }
+      val secondLayer = (0 until width).foldLeft(firstLayer) { (sheet, col) =>
+        val left = ARef.from0(leftLinks(col), 1).toA1
+        val right = ARef.from0(rightLinks(col), 1).toA1
+        sheet.put(ARef.from0(col, 2), formula(s"=$left+$right"))
+      }
+      val wb = Workbook(secondLayer)
+
+      assertSameResult(wb.recalculate(), wb.recalculateParallel(8))
+    }
+
   test("GH-520: parallelism 1 and an absurd width both degrade safely"):
     val wb = wideGrid
     assertSameResult(wb.recalculate(), wb.recalculateParallel(1))
     assertSameResult(wb.recalculate(), wb.recalculateParallel(10000))
+
+  test("GH-520: multi-hop defined name hiding INDIRECT stays out of parallel waves"):
+    val sheetName = SheetName.unsafe("Dyn")
+    val target = ARef.from0(0, 0)
+    val reader = ARef.from0(19, 0)
+    val staticNameReader = ARef.from0(20, 0)
+    val staleTarget = CellValue.Formula("=1+1", Some(num(999)))
+    val base = Sheet(sheetName).put(target, staleTarget)
+    val sheet = (1 until 19)
+      .foldLeft(base) { (s, col) =>
+        s.put(ARef.from0(col, 0), formula(s"=${col + 1}+1"))
+      }
+      .put(reader, formula("=OuterDyn"))
+      .put(staticNameReader, formula("=Case"))
+    val wb = Workbook(sheet)
+      .withDefinedName("InnerDyn", "INDIRECT(\"A1\")")
+      .withDefinedName("OuterDyn", "InnerDyn")
+      .withDefinedName("Case", "42")
+
+    assertEquals(
+      DependencyGraph.dynamicCells(wb),
+      Set(QualifiedRef(sheetName, reader)),
+      "only the name chain that reaches INDIRECT is dynamic; ordinary Case stays parallel-safe"
+    )
+
+    val sequential = wb.recalculate()
+    val parallel = wb.recalculateParallel(8)
+    assertSameResult(sequential, parallel)
+    assertEquals(parallel.evaluated(sheetName)(reader), num(2))
+
+  test("GH-520: dynamic-name analysis honors multi-hop sheet-scoped shadowing"):
+    val calcName = SheetName.unsafe("Calc")
+    val otherName = SheetName.unsafe("Other")
+    val reader = ARef.from0(19, 0)
+    val calc = Sheet(calcName)
+      .put(ARef.from0(0, 0), num(7))
+      .put(reader, formula("=Outer"))
+    val other = Sheet(otherName)
+      .put(ARef.from0(0, 0), num(9))
+      .put(reader, formula("=Outer"))
+    val base = Workbook(calc, other)
+      .withDefinedName("Driver", "41")
+      .withDefinedName("Outer", "Driver")
+    val wb = base.copy(
+      metadata = base.metadata.copy(
+        definedNames = base.metadata.definedNames :+
+          DefinedName("Driver", "OFFSET(A1, 0, 0)", localSheetId = Some(0))
+      )
+    )
+
+    assertEquals(
+      DependencyGraph.dynamicCells(wb),
+      Set(QualifiedRef(calcName, reader)),
+      "Calc's local Driver shadows the static workbook Driver only on Calc"
+    )
+
+    val result = wb.recalculateParallel(8)
+    assert(result.isClean, result.errors.map(_.render).mkString("; "))
+    assertEquals(result.evaluated(calcName)(reader), num(7))
+    assertEquals(result.evaluated(otherName)(reader), num(41))
+
+  test("GH-520: one pinned Clock generation is shared safely by every wave worker"):
+    final class GuardClock extends Clock:
+      val todayCalls = AtomicInteger(0)
+      val nowCalls = AtomicInteger(0)
+      val overlap = AtomicBoolean(false)
+      private val active = AtomicBoolean(false)
+
+      private def guarded[A](value: A): A =
+        if !active.compareAndSet(false, true) then overlap.set(true)
+        try
+          LockSupport.parkNanos(2_000_000L)
+          value
+        finally active.set(false)
+
+      def today(): LocalDate =
+        todayCalls.incrementAndGet()
+        guarded(LocalDate.of(2026, 8, 7))
+
+      def now(): LocalDateTime =
+        nowCalls.incrementAndGet()
+        guarded(LocalDateTime.of(2026, 8, 7, 12, 30))
+
+    val sheet = (0 until 20).foldLeft(Sheet(SheetName.unsafe("Clock"))) { (s, col) =>
+      val expr = if col % 2 == 0 then "=TODAY()" else "=NOW()"
+      s.put(ARef.from0(col, 0), formula(expr))
+    }
+    val wb = Workbook(sheet)
+    val sequentialClock = new GuardClock
+    val parallelClock = new GuardClock
+    val sequential = wb.recalculate(sequentialClock)
+    val parallel = wb.recalculateParallel(parallelClock, 8)
+
+    assertSameResult(sequential, parallel)
+    assertEquals(sequentialClock.todayCalls.get(), 1)
+    assertEquals(sequentialClock.nowCalls.get(), 1)
+    assertEquals(parallelClock.todayCalls.get(), 1)
+    assertEquals(parallelClock.nowCalls.get(), 1)
+    assert(!parallelClock.overlap.get(), "the caller's Clock must never be invoked concurrently")
+
+  test("GH-520: pinned Clock forces only the volatile capability formulas request"):
+    val clock = new Clock:
+      def today(): LocalDate = throw new IllegalStateException("TODAY was not requested")
+      def now(): LocalDateTime = LocalDateTime.of(2026, 8, 8, 12, 30)
+    val sheet = (0 until 20).foldLeft(Sheet(SheetName.unsafe("NowOnly"))) { (s, col) =>
+      s.put(ARef.from0(col, 0), formula("=NOW()"))
+    }
+
+    val result = Workbook(sheet).recalculateParallel(clock, 8)
+
+    assert(result.isClean, result.errors.map(_.render).mkString("; "))
+
+  test("GH-520: caller interruption cancels workers, restores interrupt, and stays total"):
+    val started = CountDownLatch(1)
+    val release = CountDownLatch(1)
+    val finished = CountDownLatch(1)
+    val interruptedAtReturn = AtomicBoolean(false)
+    val results = new ConcurrentLinkedQueue[RecalcResult]()
+    val clock = new Clock:
+      def today(): LocalDate = LocalDate.of(2026, 8, 7)
+
+      def now(): LocalDateTime =
+        started.countDown()
+        try
+          release.await()
+          LocalDateTime.of(2026, 8, 7, 12, 30)
+        finally finished.countDown()
+
+    val sheet = (0 until 20).foldLeft(Sheet(SheetName.unsafe("Interrupt"))) { (s, col) =>
+      s.put(ARef.from0(col, 0), formula("=NOW()"))
+    }
+    val wb = Workbook(sheet)
+    val caller = new Thread(
+      () =>
+        val result = wb.recalculateParallel(clock, 8)
+        results.add(result)
+        interruptedAtReturn.set(Thread.currentThread().isInterrupted())
+      ,
+      "parallel-recalc-interruption-test"
+    )
+
+    caller.start()
+    assert(started.await(5, TimeUnit.SECONDS), "worker never entered the blocking Clock")
+    caller.interrupt()
+    caller.join(10_000L)
+    release.countDown() // failure-path cleanup if an implementation regresses
+
+    assert(!caller.isAlive, "interrupted recalculateParallel caller must return")
+    assert(finished.await(5, TimeUnit.SECONDS), "the canceled Clock worker must terminate")
+    assert(interruptedAtReturn.get(), "recalculateParallel must restore the caller interrupt")
+    val result = Option(results.poll()).getOrElse(fail("interrupted recalc returned no result"))
+    assertEquals(result.errors.size, 20)
+    assert(result.errors.forall(_.error.message.contains("interrupted")))
+    val liveWorkers = Thread.getAllStackTraces.keySet().asScala.filter { thread =>
+      thread.isAlive && thread.getName.startsWith("xl-recalc-worker-")
+    }
+    assertEquals(liveWorkers.toVector, Vector.empty)
+
+  test("GH-520: worker interruption is reported per cell and shuts down the pool"):
+    val clock = new Clock:
+      def today(): LocalDate = LocalDate.of(2026, 8, 7)
+      def now(): LocalDateTime = throw new InterruptedException("injected worker failure")
+    val sheet = (0 until 20).foldLeft(Sheet(SheetName.unsafe("WorkerFailure"))) { (s, col) =>
+      s.put(ARef.from0(col, 0), formula("=NOW()"))
+    }
+
+    val result = Workbook(sheet).recalculateParallel(clock, 8)
+    assertEquals(result.errors.size, 20)
+    assert(result.errors.forall(_.error.message.contains("worker failed")))
+    val liveWorkers = Thread.getAllStackTraces.keySet().asScala.filter { thread =>
+      thread.isAlive && thread.getName.startsWith("xl-recalc-worker-")
+    }
+    assertEquals(liveWorkers.toVector, Vector.empty)

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/ParallelRecalcSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/ParallelRecalcSpec.scala
@@ -1,0 +1,124 @@
+package com.tjclp.xl.formula
+
+import com.tjclp.xl.{*, given}
+import com.tjclp.xl.addressing.{ARef, SheetName}
+import com.tjclp.xl.cells.CellValue
+import com.tjclp.xl.formula.eval.RecalcResult
+import com.tjclp.xl.sheets.Sheet
+import com.tjclp.xl.workbooks.Workbook
+import munit.FunSuite
+
+/**
+ * GH-520: `recalculateParallel(n)` must be observationally IDENTICAL to `recalculate()` — same
+ * workbook (caches included), same evaluated map, same error vector in the same order — for every
+ * dependence the static graph can express. The wave partition guarantees it structurally (two
+ * same-depth cells have no path between them, so neither can observe the other's write); these
+ * gates pin the equality on the shapes most likely to break it: deep chains (waves below the
+ * sequential cutoff), wide independent regions (the actually-parallel path), error-bearing books
+ * (error ORDER is part of the contract), cycles (circular + blocked reporting precedes the pass),
+ * and dynamic INDIRECT cells (excluded from waves, sequential evaluate-last).
+ */
+class ParallelRecalcSpec extends FunSuite:
+
+  private def num(d: Double): CellValue = CellValue.Number(BigDecimal(d))
+  private def formula(expr: String): CellValue = CellValue.Formula(expr, None)
+
+  private def assertSameResult(sequential: RecalcResult, parallel: RecalcResult): Unit =
+    assertEquals(parallel.errors, sequential.errors)
+    assertEquals(parallel.evaluated, sequential.evaluated)
+    assertEquals(parallel.workbook, sequential.workbook)
+    assertEquals(parallel.converged, sequential.converged)
+    assertEquals(parallel.cycles, sequential.cycles)
+
+  /**
+   * 40 independent columns × 30 chained rows + a cross-sheet SUM roll-up: wide waves (40 ≥ cutoff).
+   */
+  private def wideGrid: Workbook =
+    val cols = 40
+    val rows = 30
+    val data = (0 until cols).foldLeft(Sheet(SheetName.unsafe("Data"))) { (s0, c) =>
+      (0 until rows).foldLeft(s0.put(ARef.from0(c, 0), num(100.0 + c))) { (s, r) =>
+        if r == 0 then s
+        else
+          val colName = ARef.from0(c, r).toA1.takeWhile(_.isLetter)
+          s.put(ARef.from0(c, r), formula(s"=$colName$r*1.01+SUM(Drivers!$$A$$1:$$A$$5)*0.001"))
+      }
+    }
+    val drivers = (0 until 5).foldLeft(Sheet(SheetName.unsafe("Drivers"))) { (s, i) =>
+      s.put(ARef.from0(0, i), num((i + 1) * 1.5))
+    }
+    val summary = Sheet(SheetName.unsafe("Summary"))
+      .put(ARef.from0(0, 0), formula(s"=SUM(Data!A$rows:AN$rows)"))
+    Workbook(drivers, data, summary)
+
+  test("GH-520: wide independent grid — parallel(8) equals sequential, element for element"):
+    val wb = wideGrid
+    assertSameResult(wb.recalculate(), wb.recalculateParallel(8))
+
+  test("GH-520: deep chain (waves below the cutoff) — parallel equals sequential"):
+    val n = 200
+    val chain =
+      (2 to n).foldLeft(Sheet(SheetName.unsafe("Chain")).put(ARef.from0(0, 0), num(1.0))) {
+        (s, i) => s.put(ARef.from0(0, i - 1), formula(s"=A${i - 1}*1.1+1"))
+      }
+    val wb = Workbook(chain)
+    assertSameResult(wb.recalculate(), wb.recalculateParallel(4))
+
+  test("GH-520: error-bearing book — errors, Excel errors and their ORDER are identical"):
+    val cols = 20
+    val s0 = Sheet(SheetName.unsafe("Errs"))
+    // Row 0: constants; row 1: a wide wave where every third cell divides by zero and every
+    // seventh calls an unknown function — both error planes, interleaved with healthy cells.
+    val sheet = (0 until cols).foldLeft(s0) { (s, c) =>
+      val colName = ARef.from0(c, 1).toA1.takeWhile(_.isLetter)
+      val expr =
+        if c % 3 == 0 then s"=$colName" + "1/0"
+        else if c % 7 == 0 then s"=NOSUCHFN($colName" + "1)"
+        else s"=$colName" + "1*2"
+      s.put(ARef.from0(c, 0), num(c.toDouble)).put(ARef.from0(c, 1), formula(expr))
+    }
+    val wb = Workbook(sheet)
+    val seq = wb.recalculate()
+    val par = wb.recalculateParallel(8)
+    assertSameResult(seq, par)
+    assertEquals(par.excelErrors, seq.excelErrors)
+
+  test("GH-520: cyclic core + blocked dependents — parallel equals sequential"):
+    val a1 = ARef.from0(0, 0)
+    val b1 = ARef.from0(1, 0)
+    val c1 = ARef.from0(2, 0)
+    // A1 <-> B1 cycle, C1 blocked downstream, plus a wide healthy region.
+    val base = Sheet(SheetName.unsafe("Cyc"))
+      .put(a1, formula("=B1+1"))
+      .put(b1, formula("=A1+1"))
+      .put(c1, formula("=A1*2"))
+    val sheet = (0 until 20).foldLeft(base) { (s, c) =>
+      s.put(ARef.from0(c, 2), num(c.toDouble))
+        .put(ARef.from0(c, 3), formula(s"=${ARef.from0(c, 3).toA1.takeWhile(_.isLetter)}3+1"))
+    }
+    val wb = Workbook(sheet)
+    assertSameResult(wb.recalculate(), wb.recalculateParallel(8))
+
+  test("GH-520: INDIRECT bucket stays sequential — parallel equals sequential"):
+    val base = Sheet(SheetName.unsafe("Dyn"))
+      .put(ARef.from0(0, 0), num(7.0))
+      .put(ARef.from0(1, 0), formula("=INDIRECT(\"A1\")*3"))
+      .put(ARef.from0(2, 0), formula("=B1+1")) // static dependent of a dynamic cell — bucketed
+    val sheet = (0 until 20).foldLeft(base) { (s, c) =>
+      s.put(ARef.from0(c, 2), num(c.toDouble))
+        .put(ARef.from0(c, 3), formula(s"=${ARef.from0(c, 3).toA1.takeWhile(_.isLetter)}3*2"))
+    }
+    val wb = Workbook(sheet)
+    assertSameResult(wb.recalculate(), wb.recalculateParallel(8))
+
+  test("GH-520: repeated parallel runs are deterministic"):
+    val wb = wideGrid
+    val first = wb.recalculateParallel(8)
+    (1 to 3).foreach { _ =>
+      assertSameResult(first, wb.recalculateParallel(8))
+    }
+
+  test("GH-520: parallelism 1 and an absurd width both degrade safely"):
+    val wb = wideGrid
+    assertSameResult(wb.recalculate(), wb.recalculateParallel(1))
+    assertSameResult(wb.recalculate(), wb.recalculateParallel(10000))

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/RecalcPerfSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/RecalcPerfSpec.scala
@@ -4,6 +4,7 @@ import com.tjclp.xl.{*, given}
 import com.tjclp.xl.addressing.{ARef, SheetName}
 import com.tjclp.xl.cells.CellValue
 import com.tjclp.xl.formula.eval.IterativeCalc
+import com.tjclp.xl.formula.graph.DependencyGraph
 import com.tjclp.xl.sheets.Sheet
 import com.tjclp.xl.workbooks.Workbook
 import munit.FunSuite
@@ -168,3 +169,34 @@ class RecalcPerfSpec extends FunSuite:
       elapsedMs < BudgetMs,
       s"iterative recalculate took ${elapsedMs}ms (budget ${BudgetMs}ms)"
     )
+
+  /**
+   * GH-518 tripwire: Kahn's core (`kahnOrder`, shared by `topologicalSort` and
+   * `qualifiedTopologicalSort`) must run in time and allocation linear in the graph, not quadratic.
+   * The pre-fix formulation appended each node to an immutable-List accumulator (`acc :+ node` — a
+   * full copy per node) and rebuilt the pending queue per node (`rest ++ newlyZero`): on this
+   * 100k-cell chain that is ~5e9 cons-cell allocations, minutes of GC against a 30s budget, while
+   * the linear version finishes in milliseconds.
+   */
+  private val ChainCells = 100000
+
+  test("GH-518: topologicalSort on a 100k-cell chain is linear, ordered, and inside the budget"):
+    val refs = (0 until ChainCells).map(i => ARef.from0(0, i)).toVector
+    val dependencies: Map[ARef, Set[ARef]] =
+      (1 until ChainCells)
+        .map(i => refs(i) -> Set(refs(i - 1)))
+        .toMap
+        .updated(refs(0), Set.empty[ARef])
+    val dependents: Map[ARef, Set[ARef]] =
+      (1 until ChainCells).map(i => refs(i - 1) -> Set(refs(i))).toMap
+    val graph = DependencyGraph(dependencies, dependents)
+    val t0 = System.nanoTime()
+    val sorted = DependencyGraph.topologicalSort(graph)
+    val elapsedMs = (System.nanoTime() - t0) / 1000000L
+    sorted match
+      case Right(order) =>
+        assertEquals(order.size, ChainCells)
+        assertEquals(order.headOption, Some(refs(0)))
+        assertEquals(order.lastOption, Some(refs(ChainCells - 1)))
+      case Left(circular) => fail(s"expected acyclic order, got: $circular")
+    assert(elapsedMs < BudgetMs, s"topologicalSort took ${elapsedMs}ms (budget ${BudgetMs}ms)")

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/RecalcPerfSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/RecalcPerfSpec.scala
@@ -200,3 +200,23 @@ class RecalcPerfSpec extends FunSuite:
         assertEquals(order.lastOption, Some(refs(ChainCells - 1)))
       case Left(circular) => fail(s"expected acyclic order, got: $circular")
     assert(elapsedMs < BudgetMs, s"topologicalSort took ${elapsedMs}ms (budget ${BudgetMs}ms)")
+
+  test("transitive dependent discovery is linear on a 100k-cell chain"):
+    val refs = (0 until ChainCells).map(i => ARef.from0(0, i)).toVector
+    val first = refs(0)
+    val last = refs(ChainCells - 1)
+    val dependents: Map[ARef, Set[ARef]] =
+      (1 until ChainCells).map(i => refs(i - 1) -> Set(refs(i))).toMap
+    val graph = DependencyGraph(Map.empty, dependents)
+
+    val started = System.nanoTime()
+    val reached = DependencyGraph.transitiveDependents(graph, Set(first))
+    val elapsedMs = (System.nanoTime() - started) / 1000000L
+
+    assertEquals(reached.size, ChainCells - 1)
+    assert(!reached.contains(first))
+    assert(reached.contains(last))
+    assert(
+      elapsedMs < BudgetMs,
+      s"transitiveDependents took ${elapsedMs}ms (budget ${BudgetMs}ms)"
+    )

--- a/xl-evaluator/test/src/com/tjclp/xl/formula/StatisticalFunctionsSpec.scala
+++ b/xl-evaluator/test/src/com/tjclp/xl/formula/StatisticalFunctionsSpec.scala
@@ -431,3 +431,26 @@ class StatisticalFunctionsSpec extends FunSuite:
     // Median of 1..10 = (5 + 6) / 2 = 5.5
     assertEquals(result, Right(BigDecimal(5.5)))
   }
+
+  test("variadic aggregates preserve mixed-input traversal across accumulator types") {
+    val sheet = sheetWith(
+      ref"A1" -> CellValue.Number(1),
+      ref"A2" -> CellValue.Number(2),
+      ref"B1" -> CellValue.Number(3),
+      ref"C1" -> CellValue.Number(4),
+      ref"C2" -> CellValue.Number(5)
+    )
+
+    // Exercises a raw range, direct cell, evaluated array, and scalar in one traversal.
+    val args = "A1:A2,B1,(C1:C2)*1,6"
+    assertEquals(sheet.evaluateFormula(s"=SUM($args)"), Right(CellValue.Number(BigDecimal(21))))
+    assertEquals(
+      sheet.evaluateFormula(s"=AVERAGE($args)"),
+      Right(CellValue.Number(BigDecimal("3.5")))
+    )
+    assertEquals(
+      sheet.evaluateFormula(s"=MEDIAN($args)"),
+      Right(CellValue.Number(BigDecimal("3.5")))
+    )
+    assertEquals(sheet.evaluateFormula(s"=VAR($args)"), Right(CellValue.Number(BigDecimal("3.5"))))
+  }


### PR DESCRIPTION
Closes #520. Final PR of the perf stack (#521 → #523 → this).

Two commits:

## 1. Wave-parallel non-iterative recalculation (equivalence-gated)

`recalc --parallel N` / `recalculateParallel(n)`: cells partition into longest-path depth classes (antichains — no dependency paths within a wave); each wave evaluates on a fixed thread pool, results fold back in sequential order for bit-for-bit parity. Refuses seeded-Rng and iterative modes. Seven equivalence gates in `ParallelRecalcSpec` pin parallel ≡ sequential on wide grids, deep chains, error books (including error ORDER), cyclic cores, INDIRECT buckets, and repeated runs.

## 2. Evaluator hardening + acceleration

- **Aggregate-fold memoization with single-flight**: repeated `SUM/AVERAGE/...` over the same range fold the range ONCE per calculation generation; parallel readers single-flight one eligible fold. Generation-keyed so cache writes that leave the aggregated range unchanged reuse snapshots (`AggregateMemoSpec`, 8 gates).
- **Stack-safe iterative Tarjan SCC engine** shared by cycle detection paths; cycle diagnostics now report an actual directed ring, not Tarjan pop order (100k-node cycle stack-safety pinned).
- **Workbook-aware dynamic classification**: INDIRECT/OFFSET reachability resolves through parseable defined-name chains with evaluation's own case-insensitive, sheet-scoped-shadowing rules.
- Bounded-dependency extraction caching; staged `-o`/`-i` output commits (a killed process can no longer leave a torn destination).

## Benchmarks (M-series, JVM assembly; baselines = 0.19.1 release)

| workload | 0.19.1 | after #521+#523 | this PR | total |
|---|---|---|---|---|
| 9,900 × `SUM($A$1:$A$5000)` | 47.9s / 6.0GB RSS | 27.9s / 1.7GB | **1.30s / 0.71GB** | **36.8×** |
| 200k-formula book | 95.0s | 20.0s | **13.8s** | 6.9× |
| 200k @ `-Xmx512m` | 137.9s (450s user) | 17.4s | **10.8s** | 12.8× |
| 50k-formula book | 8.87s | 4.39s | **3.14s** | 2.8× |

**Honest `--parallel` assessment:** ~1.0× on these shapes today — the aggregate memo eliminated the redundant folding that parallelism previously attacked, and the remaining cost is serial graph construction + ordered evaluation. It ships as a correctness-proven foundation that inherits every future serial-cost reduction.

Full suite: `./mill __.test` → 1028/1028 SUCCESS (including post-merge with main's lint additions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)