### PR TITLE
lint: flag dangling external-workbook ordinals — the cross-workbook transplant corruption class (GH-525)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ always acceptable, a wrong one never is.**
 
 ### Added
 
+- **`external-ref-dangling` lint** (#525): flags formulas and defined
+  names referencing external workbook `[N]` with no N-th
+  `<externalReference>` entry — the cross-workbook sheet-transplant
+  class (ordinals index the SOURCE book's table, so an adopted sheet
+  carries danglers verbatim). Excel repairs such a file by removing
+  every offending formula plus calcChain; a field incident lost 935
+  formulas across four transplanted sheets while `xl lint` reported
+  clean. DOM/SAX finding-identical. Detection half of #526 (adoption
+  remap API).
 - **`RecalcResult.cycles` / `.unconverged` / `.certified`** (#492):
   per-cyclic-component convergence reporting. `SccReport(members,
   converged, rounds, maxDelta)` names the offenders instead of a single

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1346,6 +1346,10 @@ xl -f deliverable.xlsx lint && echo "safe to send"
   book: Excel does not recompute data tables on open, so the grid opens BLANK
 - **`formula-leading-equals`** — `<f>` text stored with the display form's leading `=`
   (non-spec; strict readers like openpyxl misread it — re-writing the file with xl heals it)
+- **`external-ref-dangling`** — a formula or defined name references external workbook `[N]`
+  with no N-th `<externalReference>` entry in workbook.xml (the cross-workbook sheet-transplant
+  class: ordinals index the SOURCE book's table) — Excel repairs the file by removing every
+  such formula plus calcChain
 
 **Exit codes** (diff-tool convention): `0` no findings · `1` findings reported · `2` error
 (unreadable file, malformed core part).

--- a/plugin/skills/xl-cli/SKILL.md
+++ b/plugin/skills/xl-cli/SKILL.md
@@ -114,7 +114,7 @@ xl -f <file> -o <out> recalc --tables                 # Also seed data-table int
 xl -f a.xlsx diff -g b.xlsx --format markdown          # Workbook diff (exit 0 identical, 1 differs)
 xl -f a.xlsx diff -g b.xlsx --format json              # Stable JSON schema for tooling
 xl -f out.xlsx lint                                    # Validate package structure before sending (exit 0 clean, 1 findings) (0.15.0+)
-                                                       # Rules: child-order, unresolved-rel-id, wrong-rel-type, missing-part, missing-content-type, ref-out-of-bounds, data-table-torn, data-table-unseeded (0.19.0), formula-leading-equals (0.19.1)
+                                                       # Rules: child-order, unresolved-rel-id, wrong-rel-type, missing-part, missing-content-type, ref-out-of-bounds, data-table-torn, data-table-unseeded (0.19.0), formula-leading-equals (0.19.1), external-ref-dangling (0.19.2)
 xl -f <file> -s <sheet> filter --where "B > 100 AND D = TRUE" --header --format csv
 xl -f <file> -s <sheet> filter --where "Name LIKE 'Acme%'" --columns A,C:E --limit 20
 ```

--- a/xl-cli/src/com/tjclp/xl/cli/Main.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/Main.scala
@@ -635,6 +635,9 @@ lenient reader accepts silently:
     BLANK — refresh them with `xl recalc --tables`)
   - formula text stored with a leading '=' inside <f> (non-spec; strict
     readers misread it — re-writing the file with xl heals it)
+  - formulas / defined names referencing external workbook [N] with no
+    N-th <externalReference> entry (the cross-workbook sheet-transplant
+    class — Excel repairs the file by removing every such formula)
 
 USAGE:
   xl lint report.xlsx
@@ -644,7 +647,7 @@ USAGE:
 FINDING CATEGORIES:
   child-order | unresolved-rel-id | wrong-rel-type | missing-part |
   missing-content-type | ref-out-of-bounds | data-table-torn |
-  data-table-unseeded | formula-leading-equals
+  data-table-unseeded | formula-leading-equals | external-ref-dangling
 
 EXIT CODES:
   0 = no findings (package structure is clean)

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/lint/WorkbookLint.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/lint/WorkbookLint.scala
@@ -58,6 +58,12 @@ enum LintCategory derives CanEqual:
    */
   case FormulaLeadingEquals
 
+  /**
+   * A formula or defined name references external workbook `[N]` with no N-th `<externalReference>`
+   * entry in workbook.xml — Excel repairs the file by removing every such formula (GH-525).
+   */
+  case ExternalRefDangling
+
   /** Stable kebab-case identifier used in CLI text and JSON output. */
   def slug: String = this match
     case LintCategory.ChildOrder => "child-order"
@@ -69,6 +75,7 @@ enum LintCategory derives CanEqual:
     case LintCategory.DataTableTorn => "data-table-torn"
     case LintCategory.DataTableUnseeded => "data-table-unseeded"
     case LintCategory.FormulaLeadingEquals => "formula-leading-equals"
+    case LintCategory.ExternalRefDangling => "external-ref-dangling"
 
 /**
  * A single structural lint finding.
@@ -110,6 +117,11 @@ final case class Finding(
  *     but strict readers (openpyxl) misread it, and re-writing the file with xl heals it.
  *     Aggregated to ONE finding per sheet part (first-5 cell sample + total count) so a legacy book
  *     where every formula offends stays bounded
+ *   - formulas and defined names referencing external workbook `[N]` beyond the workbook's
+ *     `<externalReference>` count (GH-525) — the cross-workbook sheet-transplant class: ordinals
+ *     index the SOURCE book's table, so a sheet adopted verbatim carries danglers and Excel repairs
+ *     the file by removing every such formula (plus calcChain). One finding per part per dangling
+ *     ordinal
  *
  * Lint runs on the RAW ZIP PARTS, never on the parsed domain model — a full read would
  * repair/normalize the very structure lint inspects (the reader silently falls back on unresolved
@@ -260,6 +272,7 @@ object WorkbookLint:
       "CT_Workbook"
     ) ++
       checkRelRefs(workbookPart, workbookRelRefs(wbElem), wbRels, workbookRelsPart, parts, "xl") ++
+      definedNameExternalRefFindings(wbElem) ++
       sheetResult._1 ++ externalResult._1 ++ ctFindings
 
   /**
@@ -400,6 +413,7 @@ object WorkbookLint:
     streaming: Boolean,
     autoNoTable: Boolean
   ): XLResult[(Vector[Finding], Vector[(String, String)])] =
+    val declaredExternalRefs = externalReferenceCount(wbElem)
     val targets: Vector[(String, SheetKind)] = nestedElems(wbElem, "sheets", "sheet")
       .flatMap { e =>
         for
@@ -448,6 +462,7 @@ object WorkbookLint:
                   parentDir(path)
                 ) ++
                 scan.boundsFindings ++ scan.formulaFindings ++
+                externalRefFindings(path, scan.externalRefs, declaredExternalRefs) ++
                 dataTableFindings(path, scan.dataTables, autoNoTable) ++ tableResult._1
           (
             found._1 ++ findings,
@@ -688,7 +703,9 @@ object WorkbookLint:
    * Everything the per-part checks need, produced identically by the DOM and SAX scanners: root
    * label, ordered main-namespace top-level labels (with positions among all top-level elements),
    * the captured r:id-bearing elements, the ref/sqref bounds findings, the aggregated leading-'='
-   * formula finding (GH-456), and the data-table record state accumulated over sheetData (GH-442).
+   * formula finding (GH-456), the external-workbook ordinal usage (GH-525 — findings need the
+   * workbook-level `<externalReference>` count, so the scan carries facts, not findings), and the
+   * data-table record state accumulated over sheetData (GH-442).
    */
   private final case class SheetScan(
     rootLabel: String,
@@ -696,6 +713,7 @@ object WorkbookLint:
     captures: Vector[CapturedRef],
     boundsFindings: Vector[Finding],
     formulaFindings: Vector[Finding],
+    externalRefs: ExternalRefFacts,
     dataTables: Vector[RecordFacts]
   )
 
@@ -744,18 +762,21 @@ object WorkbookLint:
       part,
       cellObs.foldLeft(LeadingEqualsFacts.empty)(_.add(_))
     )
-    SheetScan(root.label, mainChildLabelsOf(root), captures, bounds, formulaEq, dataTables)
+    val extRefs = cellObs.foldLeft(ExternalRefFacts.empty)(_.add(_))
+    SheetScan(root.label, mainChildLabelsOf(root), captures, bounds, formulaEq, extRefs, dataTables)
 
   /** One `<c>` element's data-table facts (DOM side of the parity pair). */
   private def domCellObs(cell: Elem): CellObs =
     val formula = childElems(cell, "f").headOption
+    val formulaText = formula.map(_.text)
     CellObs(
       ref = XmlUtil.getAttrOpt(cell, "r").flatMap(ARef.parse(_).toOption),
       record =
         formula.flatMap(f => dataTableKindOf(XmlUtil.getAttrOpt(f, "t"), XmlUtil.getAttrOpt(f, _))),
       hasFormula = formula.isDefined,
       hasValue = childElems(cell, "v").nonEmpty || childElems(cell, "is").nonEmpty,
-      leadingEquals = formula.exists(_.text.startsWith("="))
+      leadingEquals = formulaText.exists(_.startsWith("=")),
+      extOrdinals = formulaText.fold(Set.empty[Int])(externalOrdinals)
     )
 
   /**
@@ -792,11 +813,14 @@ object WorkbookLint:
       private val captures = Vector.newBuilder[CapturedRef]
       private val bounds = Vector.newBuilder[Finding]
       private var leadingEq: LeadingEqualsFacts = LeadingEqualsFacts.empty
+      private var extRefs: ExternalRefFacts = ExternalRefFacts.empty
       private var dataTables: Vector[RecordFacts] = Vector.empty
       private var cell: Option[CellObs] = None
-      // True while inside the current cell's FIRST <f> and no text chunk has arrived yet, so
-      // characters() inspects exactly the first character of the formula text (GH-456).
-      private var awaitingFormulaText = false
+      // Accumulates the current cell's FIRST <f> text across characters() chunks; the formula's
+      // end-element finalizes leadingEquals (GH-456) and extOrdinals (GH-525) from the full text,
+      // matching the DOM scanner's Elem.text. Bounded by Excel's formula-length limit, so the
+      // streaming mode stays O(1) in the row count.
+      private var formulaText: Option[java.lang.StringBuilder] = None
 
       def result: Option[SheetScan] =
         rootLabel.map(
@@ -806,6 +830,7 @@ object WorkbookLint:
             captures.result(),
             bounds.result(),
             formulaEqualsFindings(part, leadingEq),
+            extRefs,
             dataTables
           )
         )
@@ -836,12 +861,14 @@ object WorkbookLint:
               record = None,
               hasFormula = false,
               hasValue = false,
-              leadingEquals = false
+              leadingEquals = false,
+              extOrdinals = Set.empty
             )
           )
         else if depth == 4 && parents.headOption.contains("c") then
           // GH-456: only the cell's first <f> is observed, matching domCellObs's headOption
-          if label == "f" && cell.exists(!_.hasFormula) then awaitingFormulaText = true
+          if label == "f" && cell.exists(!_.hasFormula) then
+            formulaText = Some(new java.lang.StringBuilder)
           cell = cell.map { open =>
             if label == "f" && !open.hasFormula then
               open.copy(
@@ -863,19 +890,25 @@ object WorkbookLint:
         depth += 1
 
       override def characters(ch: Array[Char], start: Int, length: Int): Unit =
-        if awaitingFormulaText && length > 0 then
-          awaitingFormulaText = false
-          if ch(start) == '=' then cell = cell.map(_.copy(leadingEquals = true))
+        formulaText.foreach(_.append(ch, start, length))
 
       override def endElement(uri: String, localName: String, qName: String): Unit =
         val label = if localName.nonEmpty then localName else qName
         parents = parents.drop(1)
         depth -= 1
-        if label == "f" then awaitingFormulaText = false
+        if label == "f" then
+          formulaText.foreach { sb =>
+            val text = sb.toString
+            cell = cell.map(
+              _.copy(leadingEquals = text.startsWith("="), extOrdinals = externalOrdinals(text))
+            )
+          }
+          formulaText = None
         if depth == 3 && label == "c" then
           cell.foreach { obs =>
             dataTables = observeCell(dataTables, obs)
             leadingEq = leadingEq.add(obs)
+            extRefs = extRefs.add(obs)
           }
           cell = None
 
@@ -893,7 +926,8 @@ object WorkbookLint:
     record: Option[FormulaKind.DataTable],
     hasFormula: Boolean,
     hasValue: Boolean,
-    leadingEquals: Boolean
+    leadingEquals: Boolean,
+    extOrdinals: Set[Int]
   )
 
   /** Sample size for the aggregated leading-'=' finding: the first N offending cells (GH-456). */
@@ -942,6 +976,163 @@ object WorkbookLint:
             "re-writing the file with xl heals it"
         )
       )
+
+  // ===== Dangling external-workbook ordinals (GH-525) =====
+
+  /**
+   * Per-ordinal usage of external-workbook references `[N]` accumulated over ONE sheet part in
+   * document order (GH-525): for each ordinal, how many formula cells reference it and the first
+   * offending cell. Bounded by the number of DISTINCT ordinals, never the cell count, and folded
+   * identically by both scanners for parity. Findings are produced at workbook level where the
+   * `<externalReference>` count is known.
+   */
+  private final case class ExternalRefFacts(uses: Map[Int, (Long, Option[ARef])]):
+    def add(obs: CellObs): ExternalRefFacts =
+      if obs.extOrdinals.isEmpty then this
+      else
+        ExternalRefFacts(obs.extOrdinals.foldLeft(uses) { (acc, ordinal) =>
+          val (count, first) = acc.getOrElse(ordinal, (0L, None))
+          acc.updated(ordinal, (count + 1, first.orElse(obs.ref)))
+        })
+
+  private object ExternalRefFacts:
+    val empty: ExternalRefFacts = ExternalRefFacts(Map.empty)
+
+  /** The number of `<externalReference>` entries — the range formula ordinals may index. */
+  private def externalReferenceCount(wbElem: Elem): Int =
+    nestedElems(wbElem, "externalReferences", "externalReference").size
+
+  private def declaredPhrase(declared: Int): String =
+    if declared == 0 then "no <externalReference> entries"
+    else if declared == 1 then "only 1 <externalReference> entry"
+    else s"only $declared <externalReference> entries"
+
+  /**
+   * GH-525: formulas referencing external workbook `[N]` with no N-th `<externalReference>` entry —
+   * the cross-workbook sheet-transplant class (the ordinals index the SOURCE book's table). Excel
+   * repairs the file by removing every such formula plus calcChain. One finding per dangling
+   * ordinal, ordinal-ascending, carrying the formula count and first offending cell.
+   */
+  private def externalRefFindings(
+    part: String,
+    facts: ExternalRefFacts,
+    declared: Int
+  ): Vector[Finding] =
+    facts.uses.toVector
+      .filter((ordinal, _) => ordinal > declared)
+      .sortBy(_._1)
+      .map { case (ordinal, (count, first)) =>
+        Finding(
+          part,
+          LintCategory.ExternalRefDangling,
+          first.fold("<f>")(r => s"""<c r="${r.toA1}"><f>"""),
+          s"$count formula(s) reference external workbook [$ordinal] " +
+            s"(first at ${first.fold("<f>")(_.toA1)}) but workbook.xml declares " +
+            s"${declaredPhrase(declared)} — Excel repairs the file by removing every such formula"
+        )
+      }
+
+  /**
+   * GH-525 at workbook level: `<definedName>` bodies carry formula text and dangle the same way.
+   */
+  private def definedNameExternalRefFindings(wbElem: Elem): Vector[Finding] =
+    val declared = externalReferenceCount(wbElem)
+    nestedElems(wbElem, "definedNames", "definedName").flatMap { dn =>
+      val name = XmlUtil.getAttrOpt(dn, "name").getOrElse("")
+      externalOrdinals(dn.text).toVector.filter(_ > declared).sorted.map { ordinal =>
+        Finding(
+          workbookPart,
+          LintCategory.ExternalRefDangling,
+          s"""<definedName name="$name">""",
+          s"""Defined name "$name" references external workbook [$ordinal] but workbook.xml """ +
+            s"declares ${declaredPhrase(declared)} — Excel repairs the file by removing it"
+        )
+      }
+    }
+
+  /**
+   * External-workbook ordinals (>= 1) referenced by a formula's stored text (GH-525): the `[N]` of
+   * `'[3]Sheet Name'!A1`, `[5]Data!B2`, `'[5]Q1:Q4'!C3` and `[2]!ExtName`. Ordinal 0 is the
+   * self-workbook and is never returned; ordinals past Int range clamp to Int.MaxValue (still
+   * dangling). Precision rules, false-positive-averse by construction:
+   *
+   *   - double-quoted string literals are skipped (`""` escape), so `"see [3]"` never counts
+   *   - a quoted sheet name only yields an ordinal immediately after the opening apostrophe (`''`
+   *     escape) — Excel forbids `[`/`]` in sheet names, so no other bracket occurs inside
+   *   - a bracket preceded directly by an identifier character or `]` is a structured reference
+   *     (`Table1[Col]`, `Table1[[#This Row],[Col]]`, R1C1-style `R[1]C[2]`) and is skipped to its
+   *     matching close, nesting-aware — a table column literally named "3" never counts
+   *   - a non-numeric bracket in reference position (`[Book1.xlsx]Sheet1!A1` file-name form) is
+   *     skipped: lint is not a syntax validator
+   */
+  private[lint] def externalOrdinals(formula: String): Set[Int] =
+    val n = formula.length
+
+    def isIdentChar(c: Char): Boolean =
+      c.isLetterOrDigit || c == '_' || c == '.' || c == ']'
+
+    @annotation.tailrec
+    def skipString(i: Int): Int = // i is the first index after the opening '"'
+      if i >= n then n
+      else if formula(i) == '"' then
+        if i + 1 < n && formula(i + 1) == '"' then skipString(i + 2) else i + 1
+      else skipString(i + 1)
+
+    @annotation.tailrec
+    def skipQuotedName(i: Int): Int = // i is the first index after the opening '\''
+      if i >= n then n
+      else if formula(i) == '\'' then
+        if i + 1 < n && formula(i + 1) == '\'' then skipQuotedName(i + 2) else i + 1
+      else skipQuotedName(i + 1)
+
+    @annotation.tailrec
+    def skipStructured(i: Int, open: Int): Int = // i is the first index after an opening '['
+      if i >= n then n
+      else
+        formula(i) match
+          case '[' => skipStructured(i + 1, open + 1)
+          case ']' => if open == 1 then i + 1 else skipStructured(i + 1, open - 1)
+          case _ => skipStructured(i + 1, open)
+
+    // i points at '['; Some((ordinal, index after ']')) when the bracket holds only digits
+    def ordinalAt(i: Int): Option[(Int, Int)] =
+      val close = formula.indexOf(']', i + 1)
+      if close <= i + 1 then None
+      else
+        val digits = formula.substring(i + 1, close)
+        if digits.forall(c => c >= '0' && c <= '9') then
+          val ordinal =
+            digits.toLongOption.fold(Int.MaxValue)(l => math.min(l, Int.MaxValue.toLong).toInt)
+          Some((ordinal, close + 1))
+        else None
+
+    @annotation.tailrec
+    def loop(i: Int, prev: Option[Char], acc: Set[Int]): Set[Int] =
+      if i >= n then acc
+      else
+        formula(i) match
+          case '"' => loop(skipString(i + 1), Some('"'), acc)
+          case '\'' =>
+            if i + 1 < n && formula(i + 1) == '[' then
+              ordinalAt(i + 1) match
+                case Some((ordinal, after)) =>
+                  loop(
+                    skipQuotedName(after),
+                    Some('\''),
+                    if ordinal >= 1 then acc + ordinal else acc
+                  )
+                case None => loop(skipQuotedName(i + 1), Some('\''), acc)
+            else loop(skipQuotedName(i + 1), Some('\''), acc)
+          case '[' =>
+            if prev.exists(isIdentChar) then loop(skipStructured(i + 1, 1), Some(']'), acc)
+            else
+              ordinalAt(i) match
+                case Some((ordinal, after)) =>
+                  loop(after, Some(']'), if ordinal >= 1 then acc + ordinal else acc)
+                case None => loop(skipStructured(i + 1, 1), Some(']'), acc)
+          case c => loop(i + 1, Some(c), acc)
+
+    loop(0, None, Set.empty)
 
   /**
    * Accumulated facts for one data-table record, keyed by the record's own `ref`. Every field is a

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/lint/WorkbookLintSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/lint/WorkbookLintSpec.scala
@@ -1054,6 +1054,135 @@ class WorkbookLintSpec extends FunSuite:
     )
   }
 
+  // ===== GH-525: dangling external-workbook ordinals =====
+
+  /** `[1]` resolves (externalParts declares one entry); `[2]` (twice) and `[5]` dangle. */
+  private val danglingExternalRefSheetXml = worksheetWith(
+    """<sheetData>
+    <row r="1">
+      <c r="A1"><f>'[1]Extern'!A1</f><v>1</v></c>
+      <c r="B1"><f>'[2]Model Guidance (Big 3)'!AQ5</f><v>2</v></c>
+      <c r="C1"><f>[2]Extern!B1*2</f><v>4</v></c>
+    </row>
+    <row r="2"><c r="A2"><f>SUM('[5]Q1:Q4'!A1)</f><v>5</v></c></row>
+  </sheetData>"""
+  )
+
+  private val externalOkSheetXml = worksheetWith(
+    """<sheetData>
+    <row r="1"><c r="A1"><f>'[1]Extern'!A1+[1]Extern!B1</f><v>2</v></c></row>
+  </sheetData>"""
+  )
+
+  /** Bracket forms that must NEVER count: structured refs and string literals. */
+  private val bracketNoiseSheetXml = worksheetWith(
+    """<sheetData>
+    <row r="1">
+      <c r="A1"><f>SUM(Table1[3])</f><v>1</v></c>
+      <c r="B1"><f>SUM(Table1[[#This Row],[3]])</f><v>2</v></c>
+      <c r="C1" t="str"><f>"see [9] note"</f><v>see [9] note</v></c>
+    </row>
+  </sheetData>"""
+  )
+
+  private val danglingNameWorkbookXml = workbookWithExternalXml.replace(
+    "<definedName name=\"MyName\">Sheet1!$A$1</definedName>",
+    "<definedName name=\"MyName\">Sheet1!$A$1</definedName>" +
+      "<definedName name=\"ExtRate\">'[4]Src'!$A$1</definedName>"
+  )
+
+  test("GH-525: externalOrdinals reads every external-ref form and nothing else") {
+    assertEquals(WorkbookLint.externalOrdinals("'[3]GP - Customer'!$J$43"), Set(3))
+    assertEquals(WorkbookLint.externalOrdinals("[5]Data!B2+[5]Data!C2"), Set(5))
+    assertEquals(
+      WorkbookLint.externalOrdinals(
+        "INDEX('[5]Model Guidance (Big 3)'!AQ$5:AQ$15,MATCH($C78,'[5]Model Guidance (Big 3)'!$G$5:$G$15,0))"
+      ),
+      Set(5)
+    )
+    assertEquals(WorkbookLint.externalOrdinals("SUM('[2]Q1:Q4'!A1)"), Set(2))
+    assertEquals(WorkbookLint.externalOrdinals("[2]!ExtName"), Set(2))
+    assertEquals(WorkbookLint.externalOrdinals("=[1]Sheet1!A1"), Set(1))
+    assertEquals(WorkbookLint.externalOrdinals("'[12]Ext'!A1*[3]Ext!B1"), Set(12, 3))
+    // ordinal 0 is the self-workbook
+    assertEquals(WorkbookLint.externalOrdinals("[0]!ThisBookName"), Set.empty[Int])
+    // structured references — including a column literally named "3" — never count
+    assertEquals(WorkbookLint.externalOrdinals("SUM(Table1[3])"), Set.empty[Int])
+    assertEquals(
+      WorkbookLint.externalOrdinals("SUM(Table1[[#This Row],[3]])"),
+      Set.empty[Int]
+    )
+    // string literals are opaque, including escaped quotes and R1C1 text
+    assertEquals(WorkbookLint.externalOrdinals("\"see [3] note\"&A1"), Set.empty[Int])
+    assertEquals(WorkbookLint.externalOrdinals("INDIRECT(\"R[1]C[2]\",FALSE)"), Set.empty[Int])
+    assertEquals(WorkbookLint.externalOrdinals("\"a\"\"[7]\"\"b\""), Set.empty[Int])
+    // brackets inside a quoted name past position 0 cannot be an ordinal (sheet names forbid [])
+    assertEquals(WorkbookLint.externalOrdinals("'It''s [2]'!A1"), Set.empty[Int])
+    // file-name form and degenerate brackets are skipped, not findings
+    assertEquals(WorkbookLint.externalOrdinals("[Book1.xlsx]Sheet1!A1"), Set.empty[Int])
+    assertEquals(WorkbookLint.externalOrdinals("A1*[unclosed"), Set.empty[Int])
+    assertEquals(WorkbookLint.externalOrdinals("A1*[]B2"), Set.empty[Int])
+  }
+
+  test("GH-525: formulas referencing external ordinals past the declared count are flagged") {
+    val findings =
+      lintOf(externalParts + ("xl/worksheets/sheet1.xml" -> danglingExternalRefSheetXml))
+    assertEquals(
+      findings.map(_.category),
+      Vector(LintCategory.ExternalRefDangling, LintCategory.ExternalRefDangling)
+    )
+    val ord2 = findings(0)
+    val ord5 = findings(1)
+    assertEquals(ord2.part, "xl/worksheets/sheet1.xml")
+    assert(ord2.message.contains("2 formula(s) reference external workbook [2]"), ord2.toString)
+    assert(ord2.message.contains("only 1 <externalReference> entry"), ord2.toString)
+    assert(ord2.locator.contains("B1"), s"locator carries the first offending cell: $ord2")
+    assert(ord5.message.contains("1 formula(s) reference external workbook [5]"), ord5.toString)
+    assert(ord5.message.contains("first at A2"), ord5.toString)
+  }
+
+  test("GH-525: with no externalReferences block, any external ordinal dangles") {
+    val findings = lintOf(baseParts + ("xl/worksheets/sheet1.xml" -> externalOkSheetXml))
+    assertEquals(findings.map(_.category), Vector(LintCategory.ExternalRefDangling))
+    assert(
+      findings.head.message.contains("no <externalReference> entries"),
+      findings.head.toString
+    )
+    assert(findings.head.message.contains("[1]"), findings.head.toString)
+  }
+
+  test("GH-525: ordinals within the declared count are clean") {
+    assertEquals(
+      lintOf(externalParts + ("xl/worksheets/sheet1.xml" -> externalOkSheetXml)),
+      Vector.empty[Finding]
+    )
+  }
+
+  test("GH-525: structured references and string literals never count") {
+    assertEquals(
+      lintOf(externalParts + ("xl/worksheets/sheet1.xml" -> bracketNoiseSheetXml)),
+      Vector.empty[Finding]
+    )
+  }
+
+  test("GH-525: a defined name with a dangling external ordinal is flagged on workbook.xml") {
+    val findings = lintOf(externalParts + ("xl/workbook.xml" -> danglingNameWorkbookXml))
+    assertEquals(findings.map(_.category), Vector(LintCategory.ExternalRefDangling))
+    val f = findings.head
+    assertEquals(f.part, "xl/workbook.xml")
+    assert(f.locator.contains("ExtRate"), f.toString)
+    assert(f.message.contains("[4]"), f.toString)
+  }
+
+  test("GH-525: streaming mode flags dangling ordinals identically") {
+    val parts = externalParts + ("xl/worksheets/sheet1.xml" -> danglingExternalRefSheetXml)
+    assertEquals(lintStreamOf(parts), lintOf(parts))
+    assertEquals(
+      lintStreamOf(parts).map(_.category),
+      Vector(LintCategory.ExternalRefDangling, LintCategory.ExternalRefDangling)
+    )
+  }
+
   // ===== GH-413 (4): O(1) SAX scanning mode =====
 
   private def lintStreamOf(parts: Map[String, String]): Vector[Finding] =
@@ -1110,6 +1239,16 @@ class WorkbookLintSpec extends FunSuite:
     "many leading-equals formulas" ->
       (baseParts + ("xl/worksheets/sheet1.xml" -> manyLeadingEqualsSheetXml)),
     "clean formula text" -> (baseParts + ("xl/worksheets/sheet1.xml" -> cleanFormulaSheetXml)),
+    // GH-525: external-ordinal observation must agree between the DOM and SAX scanners,
+    // including the per-ordinal aggregation (counts + first-cell locators)
+    "dangling external ordinals" ->
+      (externalParts + ("xl/worksheets/sheet1.xml" -> danglingExternalRefSheetXml)),
+    "clean external ordinals" ->
+      (externalParts + ("xl/worksheets/sheet1.xml" -> externalOkSheetXml)),
+    "bracket noise formulas" ->
+      (externalParts + ("xl/worksheets/sheet1.xml" -> bracketNoiseSheetXml)),
+    "dangling defined-name ordinal" ->
+      (externalParts + ("xl/workbook.xml" -> danglingNameWorkbookXml)),
     // GH-458: Microsoft xlExternalLinkPath variants resolve clean in both modes
     "ms xlPathMissing external" ->
       (externalParts +


### PR DESCRIPTION
Fixes #525. Detection half of #526 (adoption remap API).

## The incident

A production agent transplanted four sheets between workbooks via the scripting API (`dst.copy(sheets = dst.sheets ++ srcSheets)`). Formula text carries external-workbook ordinals `[N]` that index the **source** book's `<externalReferences>` table; the destination declared 1 entry where the source had ≥5. The written file carried 935 formulas referencing `[3]`/`[4]`/`[5]`:

- `xl lint` (main, 2c3fbcb5): **clean, exit 0**
- Excel: repair dialog; strips all 935 formulas + calcChain (`Removed Records: Formula from /xl/worksheets/sheetNN.xml part`)

Exactly the lint's charter (GH-397): a corruption class Excel repairs loudly that lenient readers accept silently.

## The rule

New `external-ref-dangling` category: any `<f>` (and any `<definedName>`) whose external ordinal `[N]` exceeds the workbook's `<externalReference>` count. One finding per part per dangling ordinal — formula count + first offending cell — ordinal-ascending.

**Scanner changes (DOM/SAX parity preserved):** the SAX scanner previously peeked at only the first character of a cell's first `<f>` (GH-456). It now accumulates the full text (bounded by Excel's formula-length limit — streaming stays O(1) in rows) and derives *both* `leadingEquals` and the external ordinals from it, matching the DOM scanner's `Elem.text` exactly. Facts fold per part; findings materialize at workbook level where the declared count is known.

**Ordinal extraction is false-positive-averse by construction:**
- double-quoted string literals skipped (`""` escape) — `"see [3]"` never counts
- quoted sheet names only yield an ordinal immediately after the opening apostrophe (`''` escape); Excel forbids `[`/`]` in sheet names so no other bracket occurs inside
- a bracket directly preceded by an identifier char or `]` is a structured reference — skipped to its matching close, nesting-aware, so `Table1[3]` / `Table1[[#This Row],[3]]` (a column literally named "3") and R1C1-style text never count
- non-numeric brackets in reference position (`[Book1.xlsx]Sheet1!A1` file-name form) are skipped: lint is not a syntax validator
- ordinal 0 is the self-workbook

## Verification

- **Incident file (broken):** 6 findings — `[3]`×1, `[4]`×3, `[5]`×160 on the first transplanted sheet; `[5]`×309/231/231 on the other three — summing to **exactly the 935 formulas** Excel's repair removed (pinned by forensic diff of broken vs repaired packages)
- **Excel-repaired copy of the same file:** clean, exit 0
- 7 new spec tests (extraction precision incl. every false-positive form; flagged/clean/no-table fixtures; defined names; streaming equivalence) + 4 new SAX/DOM parity fixtures
- Full suite: `./mill __.test` → 1028/1028 SUCCESS

## Out of scope

Ordinals that *happen* to resolve in the destination silently rebind to a different external workbook — statically undetectable from one file. That half needs the #526 adoption/remap API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)