### PR TITLE
lint: flag defined names Excel repairs — fold-duplicate and definitely-illegal names (GH-528, GH-529)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,17 @@ always acceptable, a wrong one never is.**
 
 ### Added
 
+- **`defined-name-invalid` lint** (#528): flags defined names Excel
+  repairs the file over — same-scope names colliding under Excel's
+  case/width/kana-insensitive comparison (`g`/`ｇ`, `html`/`ＨＴＭＬ`,
+  `ぁ`/`あ`), names past the 255-char limit, whitespace/control chars.
+  Both 2026-08-08 field incidents carried collision fossils; Excel
+  removed the Camco ones without even logging them. Excel's full legacy
+  name-character table is deliberately not emulated (corpus shows `¤`,
+  `・`, `–` accepted while `†`, `€` are rejected — category rules would
+  false-positive). Also whitelists the suffix-less Microsoft
+  externalLinkPath rel-type variants xlStartup/xlLibrary/xlAltStartup
+  (#529) that were flagged wrong-rel-type on files Excel opens fine.
 - **`external-ref-dangling` lint** (#525): flags formulas and defined
   names referencing external workbook `[N]` with no N-th
   `<externalReference>` entry — the cross-workbook sheet-transplant

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1350,6 +1350,11 @@ xl -f deliverable.xlsx lint && echo "safe to send"
   with no N-th `<externalReference>` entry in workbook.xml (the cross-workbook sheet-transplant
   class: ordinals index the SOURCE book's table) — Excel repairs the file by removing every
   such formula plus calcChain
+- **`defined-name-invalid`** — a defined name Excel refuses: two same-scope names colliding
+  under Excel's case/width/kana-insensitive comparison (`g` vs `ｇ`, `html` vs `ＨＴＭＬ`,
+  `ぁ` vs `あ` — legacy fossil corpora carry these), a name past the 255-character limit, or
+  whitespace / control characters — Excel repairs the file by removing the named range,
+  sometimes without even logging it
 
 **Exit codes** (diff-tool convention): `0` no findings · `1` findings reported · `2` error
 (unreadable file, malformed core part).

--- a/plugin/skills/xl-cli/SKILL.md
+++ b/plugin/skills/xl-cli/SKILL.md
@@ -114,7 +114,7 @@ xl -f <file> -o <out> recalc --tables                 # Also seed data-table int
 xl -f a.xlsx diff -g b.xlsx --format markdown          # Workbook diff (exit 0 identical, 1 differs)
 xl -f a.xlsx diff -g b.xlsx --format json              # Stable JSON schema for tooling
 xl -f out.xlsx lint                                    # Validate package structure before sending (exit 0 clean, 1 findings) (0.15.0+)
-                                                       # Rules: child-order, unresolved-rel-id, wrong-rel-type, missing-part, missing-content-type, ref-out-of-bounds, data-table-torn, data-table-unseeded (0.19.0), formula-leading-equals (0.19.1), external-ref-dangling (0.19.2)
+                                                       # Rules: child-order, unresolved-rel-id, wrong-rel-type, missing-part, missing-content-type, ref-out-of-bounds, data-table-torn, data-table-unseeded (0.19.0), formula-leading-equals (0.19.1), external-ref-dangling + defined-name-invalid (0.19.2)
 xl -f <file> -s <sheet> filter --where "B > 100 AND D = TRUE" --header --format csv
 xl -f <file> -s <sheet> filter --where "Name LIKE 'Acme%'" --columns A,C:E --limit 20
 ```

--- a/xl-cli/src/com/tjclp/xl/cli/Main.scala
+++ b/xl-cli/src/com/tjclp/xl/cli/Main.scala
@@ -661,6 +661,9 @@ lenient reader accepts silently:
   - formulas / defined names referencing external workbook [N] with no
     N-th <externalReference> entry (the cross-workbook sheet-transplant
     class — Excel repairs the file by removing every such formula)
+  - defined names Excel refuses: same-scope names colliding under its
+    case/width/kana-insensitive comparison, over-long names, whitespace
+    or control characters (Excel repairs by removing the named range)
 
 USAGE:
   xl lint report.xlsx
@@ -670,7 +673,8 @@ USAGE:
 FINDING CATEGORIES:
   child-order | unresolved-rel-id | wrong-rel-type | missing-part |
   missing-content-type | ref-out-of-bounds | data-table-torn |
-  data-table-unseeded | formula-leading-equals | external-ref-dangling
+  data-table-unseeded | formula-leading-equals | external-ref-dangling |
+  defined-name-invalid
 
 EXIT CODES:
   0 = no findings (package structure is clean)

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/lint/WorkbookLint.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/lint/WorkbookLint.scala
@@ -64,6 +64,13 @@ enum LintCategory derives CanEqual:
    */
   case ExternalRefDangling
 
+  /**
+   * A defined name Excel refuses: two names in the same scope colliding under Excel's case-, width-
+   * and kana-size-insensitive comparison, or a name that is over-long or carries whitespace /
+   * control characters — Excel repairs the file by removing the named range (GH-528).
+   */
+  case DefinedNameInvalid
+
   /** Stable kebab-case identifier used in CLI text and JSON output. */
   def slug: String = this match
     case LintCategory.ChildOrder => "child-order"
@@ -76,6 +83,7 @@ enum LintCategory derives CanEqual:
     case LintCategory.DataTableUnseeded => "data-table-unseeded"
     case LintCategory.FormulaLeadingEquals => "formula-leading-equals"
     case LintCategory.ExternalRefDangling => "external-ref-dangling"
+    case LintCategory.DefinedNameInvalid => "defined-name-invalid"
 
 /**
  * A single structural lint finding.
@@ -273,6 +281,7 @@ object WorkbookLint:
     ) ++
       checkRelRefs(workbookPart, workbookRelRefs(wbElem), wbRels, workbookRelsPart, parts, "xl") ++
       definedNameExternalRefFindings(wbElem) ++
+      definedNameValidityFindings(wbElem) ++
       sheetResult._1 ++ externalResult._1 ++ ctFindings
 
   /**
@@ -512,7 +521,10 @@ object WorkbookLint:
     XmlUtil.relTypeXlPathMissing,
     XmlUtil.relTypeXlLibraryPath,
     XmlUtil.relTypeXlStartupPath,
-    XmlUtil.relTypeXlAltStartupPath
+    XmlUtil.relTypeXlAltStartupPath,
+    XmlUtil.relTypeXlStartup,
+    XmlUtil.relTypeXlLibrary,
+    XmlUtil.relTypeXlAltStartup
   )
 
   /**
@@ -1049,6 +1061,80 @@ object WorkbookLint:
         )
       }
     }
+
+  // ===== Defined-name validity (GH-528) =====
+
+  /** Small-kana -> base-kana pairs for Excel's kana-size-insensitive name comparison (GH-528). */
+  private val kanaBaseFold: Map[Char, Char] =
+    "ぁあぃいぅうぇえぉおっつゃやゅゆょよゎわゕかゖけァアィイゥウェエォオッツャヤュユョヨヮワヵカヶケ".grouped(2).map(p => p(0) -> p(1)).toMap
+
+  /**
+   * Excel's defined-name equality: case-insensitive, width-insensitive (fullwidth `ＨＴＭＬ` == `html`)
+   * and kana-size-insensitive (`ぁ` == `あ`). NFKC supplies the width folding, ROOT lowercase the
+   * case folding, and the explicit table the kana-size folding. Names equal under this fold are
+   * duplicates to Excel — the incident file's Excel-repaired copy holds exactly zero such groups
+   * (GH-528).
+   */
+  private def definedNameFold(name: String): String =
+    java.text.Normalizer
+      .normalize(name, java.text.Normalizer.Form.NFKC)
+      .toLowerCase(java.util.Locale.ROOT)
+      .map(c => kanaBaseFold.getOrElse(c, c))
+
+  /** Excel's hard cap on a defined name's length. */
+  private val maxDefinedNameLength = 255
+
+  /**
+   * GH-528: defined names Excel repairs the file over. Two checks, both false-positive-averse:
+   *
+   *   - names in the SAME scope that collide under [[definedNameFold]] — Excel removes one of each
+   *     group (the incident: `g`/`ｇ`, `html`/`ＨＴＭＬ`, `ぁ`/`あ`)
+   *   - definitely-illegal names: longer than 255 characters, or carrying whitespace / control
+   *     characters
+   *
+   * Excel's full name-character table is deliberately NOT emulated: it is legacy Windows NLS
+   * classification, not Unicode categories — the incident corpus has SURVIVING names carrying `¤`,
+   * `・` and `–` while Excel rejects `†` and `€`. A category-based rule would flag real books; the
+   * fold-duplicate rule already fails any file carrying the removal class.
+   */
+  private def definedNameValidityFindings(wbElem: Elem): Vector[Finding] =
+    val entries = nestedElems(wbElem, "definedNames", "definedName").map { dn =>
+      (XmlUtil.getAttrOpt(dn, "name").getOrElse(""), XmlUtil.getAttrOpt(dn, "localSheetId"))
+    }
+    val collisions = entries
+      .groupBy((name, scope) => (definedNameFold(name), scope))
+      .toVector
+      .collect { case ((_, scope), group) if group.sizeIs > 1 => (group.map(_._1), scope) }
+      .sortBy((names, _) => names.headOption.getOrElse(""))
+      .map { (names, scope) =>
+        val shown = names.map(n => s""""$n"""").mkString(", ")
+        val where = scope.fold("workbook scope")(id => s"sheet scope localSheetId=$id")
+        Finding(
+          workbookPart,
+          LintCategory.DefinedNameInvalid,
+          s"""<definedName name="${names.headOption.getOrElse("")}">""",
+          s"${names.size} defined names collide under Excel's case/width/kana-insensitive " +
+            s"name comparison ($shown, $where) — Excel repairs the file by removing the named range"
+        )
+      }
+    val illegal = entries.flatMap { (name, _) =>
+      val problems = Vector(
+        Option.when(name.length > maxDefinedNameLength)(
+          s"is ${name.length} characters long (Excel's limit is $maxDefinedNameLength)"
+        ),
+        Option.when(name.exists(_.isWhitespace))("contains whitespace"),
+        Option.when(name.exists(_.isControl))("contains control characters")
+      ).flatten
+      problems.map { problem =>
+        Finding(
+          workbookPart,
+          LintCategory.DefinedNameInvalid,
+          s"""<definedName name="${name.take(40)}">""",
+          s"""Defined name "${name.take(40)}" $problem — Excel repairs the file by removing it"""
+        )
+      }
+    }
+    collisions ++ illegal
 
   /**
    * External-workbook ordinals (>= 1) referenced by a formula's stored text (GH-525): the `[N]` of

--- a/xl-ooxml/src/com/tjclp/xl/ooxml/xml.scala
+++ b/xl-ooxml/src/com/tjclp/xl/ooxml/xml.scala
@@ -80,6 +80,13 @@ object XmlUtil:
     "http://schemas.microsoft.com/office/2006/relationships/xlExternalLinkPath/xlStartupPath"
   val relTypeXlAltStartupPath =
     "http://schemas.microsoft.com/office/2006/relationships/xlExternalLinkPath/xlAltStartupPath"
+  // Suffix-less variants of the same family, also found in the wild (GH-529)
+  val relTypeXlStartup =
+    "http://schemas.microsoft.com/office/2006/relationships/xlExternalLinkPath/xlStartup"
+  val relTypeXlLibrary =
+    "http://schemas.microsoft.com/office/2006/relationships/xlExternalLinkPath/xlLibrary"
+  val relTypeXlAltStartup =
+    "http://schemas.microsoft.com/office/2006/relationships/xlExternalLinkPath/xlAltStartup"
   val relTypeChartsheet =
     "http://schemas.openxmlformats.org/officeDocument/2006/relationships/chartsheet"
   val relTypeDialogsheet =

--- a/xl-ooxml/test/src/com/tjclp/xl/ooxml/lint/WorkbookLintSpec.scala
+++ b/xl-ooxml/test/src/com/tjclp/xl/ooxml/lint/WorkbookLintSpec.scala
@@ -627,6 +627,15 @@ class WorkbookLintSpec extends FunSuite:
     assertEquals(findings, Vector.empty[Finding])
   }
 
+  test("GH-529: suffix-less Microsoft variants (xlStartup, xlLibrary, xlAltStartup) are valid") {
+    for variant <- List("xlStartup", "xlLibrary", "xlAltStartup") do
+      val findings = lintOf(
+        externalParts +
+          ("xl/externalLinks/_rels/externalLink1.xml.rels" -> msVariantRelsXml(variant))
+      )
+      assertEquals(findings, Vector.empty[Finding], s"variant $variant must be accepted")
+  }
+
   test("GH-458: a genuinely wrong externalBook rel type (image) still flags WrongRelType") {
     val findings = lintOf(
       externalParts +
@@ -1183,6 +1192,70 @@ class WorkbookLintSpec extends FunSuite:
     )
   }
 
+  // ===== GH-528: defined-name validity (fold-duplicates + definitely-illegal names) =====
+
+  private def workbookWithNames(namesXml: String): String = workbookXml.replace(
+    "<definedNames><definedName name=\"MyName\">Sheet1!$A$1</definedName></definedNames>",
+    s"<definedNames>$namesXml</definedNames>"
+  )
+
+  private val foldDupWorkbookXml = workbookWithNames(
+    """<definedName name="g" hidden="1">Sheet1!$A$1</definedName>""" +
+      """<definedName name="ｇ" hidden="1">Sheet1!$A$2</definedName>"""
+  )
+
+  test("GH-528: names colliding under case/width folding in the same scope are flagged") {
+    val findings = lintOf(baseParts + ("xl/workbook.xml" -> foldDupWorkbookXml))
+    assertEquals(findings.map(_.category), Vector(LintCategory.DefinedNameInvalid))
+    val f = findings.head
+    assertEquals(f.part, "xl/workbook.xml")
+    assert(f.message.contains("\"g\""), f.toString)
+    assert(f.message.contains("\"ｇ\""), f.toString)
+    assert(f.message.contains("workbook scope"), f.toString)
+  }
+
+  test("GH-528: small vs base kana names collide (Excel's kana-size-insensitive comparison)") {
+    val wb = workbookWithNames(
+      """<definedName name="ぁ" hidden="1">Sheet1!$A$1</definedName>""" +
+        """<definedName name="あ" hidden="1">Sheet1!$A$2</definedName>"""
+    )
+    val findings = lintOf(baseParts + ("xl/workbook.xml" -> wb))
+    assertEquals(findings.map(_.category), Vector(LintCategory.DefinedNameInvalid))
+  }
+
+  test("GH-528: the same folded name on different scopes is legal shadowing, not a collision") {
+    val wb = workbookWithNames(
+      """<definedName name="Rate">Sheet1!$A$1</definedName>""" +
+        """<definedName name="RATE" localSheetId="0">Sheet1!$A$2</definedName>"""
+    )
+    assertEquals(lintOf(baseParts + ("xl/workbook.xml" -> wb)), Vector.empty[Finding])
+  }
+
+  test("GH-528: a name past Excel's 255-character limit is flagged") {
+    val long = "N" * 256
+    val wb = workbookWithNames(s"""<definedName name="$long">Sheet1!$$A$$1</definedName>""")
+    val findings = lintOf(baseParts + ("xl/workbook.xml" -> wb))
+    assertEquals(findings.map(_.category), Vector(LintCategory.DefinedNameInvalid))
+    assert(findings.head.message.contains("256"), findings.head.toString)
+  }
+
+  test("GH-528: a name carrying whitespace is flagged") {
+    val wb = workbookWithNames("""<definedName name="My Name">Sheet1!$A$1</definedName>""")
+    val findings = lintOf(baseParts + ("xl/workbook.xml" -> wb))
+    assertEquals(findings.map(_.category), Vector(LintCategory.DefinedNameInvalid))
+    assert(findings.head.message.contains("whitespace"), findings.head.toString)
+  }
+
+  test("GH-528: exact duplicates in the same scope are the degenerate fold collision") {
+    val wb = workbookWithNames(
+      """<definedName name="Twice">Sheet1!$A$1</definedName>""" +
+        """<definedName name="Twice">Sheet1!$A$2</definedName>"""
+    )
+    val findings = lintOf(baseParts + ("xl/workbook.xml" -> wb))
+    assertEquals(findings.map(_.category), Vector(LintCategory.DefinedNameInvalid))
+    assert(findings.head.message.contains("2 defined names"), findings.head.toString)
+  }
+
   // ===== GH-413 (4): O(1) SAX scanning mode =====
 
   private def lintStreamOf(parts: Map[String, String]): Vector[Finding] =
@@ -1249,6 +1322,13 @@ class WorkbookLintSpec extends FunSuite:
       (externalParts + ("xl/worksheets/sheet1.xml" -> bracketNoiseSheetXml)),
     "dangling defined-name ordinal" ->
       (externalParts + ("xl/workbook.xml" -> danglingNameWorkbookXml)),
+    // GH-528: defined-name validity is workbook-level (always DOM) but must agree in both modes
+    "fold-duplicate defined names" ->
+      (baseParts + ("xl/workbook.xml" -> foldDupWorkbookXml)),
+    // GH-529: suffix-less Microsoft externalLinkPath variants resolve clean in both modes
+    "ms xlStartup external" ->
+      (externalParts +
+        ("xl/externalLinks/_rels/externalLink1.xml.rels" -> msVariantRelsXml("xlStartup"))),
     // GH-458: Microsoft xlExternalLinkPath variants resolve clean in both modes
     "ms xlPathMissing external" ->
       (externalParts +


### PR DESCRIPTION
Fixes #528. Fixes #529. Stacked on #527 (same lint module) — retarget to `main` after #527 merges.

## The incident (second Excel-repair corruption in two days)

A deliverable assembled from a June template carrying a 25,602-name legacy fossil corpus triggered Excel's repair dialog: `Removed Records: Named range from /xl/workbook.xml part (Workbook)`. Forensics (broken vs repaired diff):

- Excel removed 9 named ranges. The decisive three collide with surviving neighbors under **Excel's case-, width- and kana-size-insensitive name comparison**: `g`/`ｇ`, `html`/`ＨＴＭＬ`, `ぁ`/`あ`. The repaired file holds exactly **zero** fold-duplicate groups — that is Excel's rule.
- The #525 incident file turns out to carry **25 more collision groups** (`HTML`/`ＨＴＭＬ` across many scopes, `f`/`ｆ`, `g`/`ｇ`) which Excel removed **without logging them** — the repair log is not a complete inventory.
- Six more removals are 186-char mixed-script garbage fossils (`†`, `€`, U+193A).

**Origin forensics — this is inherited, not written by us:** the session's own probe of the *raw input* workbook shows `html`+`HTML`+`ＨＴＭＬ` all present before any xl processing; xl's definedNames regeneration round-trips every removed record byte-identically (verified via a `name add` probe); no openpyxl saves exist in either session. These are JP-Excel-97-era fossils that banker templates have carried for years — which is exactly why the lint must catch them at the ship gate (both sessions ran `xl lint`; it passed).

## The rules (calibrated false-positive-averse)

New `defined-name-invalid` category:
1. **Fold-duplicate names, same scope** — NFKC (width) + ROOT lowercase (case) + small-kana→base-kana table. Scope-aware: the same folded name on different scopes is legal shadowing.
2. **Definitely-illegal names** — longer than 255 chars, whitespace, control characters.

**Deliberate non-goal:** emulating Excel's full name-character table. Calibration against the 25k surviving names shows Excel *accepts* `¤`, `・`, `･`, `–` while *rejecting* `†`, `€` — legacy Windows NLS classification, not Unicode categories. A category-based rule produces 4 false positives on this single corpus. The 6 garbage fossils therefore stay undetected in v1 (documented in code); the fold-duplicate rule alone already fails both incident files.

Also fixes #529: whitelists the suffix-less Microsoft externalLinkPath rel-type variants (`xlStartup`, `xlLibrary`, `xlAltStartup`) — previously 7 `wrong-rel-type` false positives on externalLink parts of a file Excel opens without complaint.

## Verification

- Incident file: **3 findings, exit 1** (g/ｇ, html/ＨＴＭＬ, ぁ/あ), and the 7 rel-type false positives gone; its Excel-repaired copy: **clean, exit 0**
- #525 incident file: 25 additional collision findings — every one matches a name Excel silently removed; its repaired copy: clean
- 7 new spec tests (collision, kana pair, scope-shadowing negative, 255-limit, whitespace, exact-dup degenerate, suffix-less variants) + 2 new SAX/DOM parity fixtures
- Full suite: `./mill __.test` → 1028/1028 SUCCESS

🤖 Generated with [Claude Code](https://claude.com/claude-code)