### PR TITLE
chore(release): Bump version to 0.19.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the XL project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.19.2] "Fixpoint" - 2026-08-06
+## [0.19.2] "Fixpoint" - 2026-08-08
 
 Wave 24: the 0.19.1 blind-regression round. Four new silent-wrong-number
 bugs were found in the field, and **three of them turned out to be one
@@ -13,6 +13,35 @@ root cause** — evaluation reading a stale or unevaluated cache instead of
 the value. This release fixes that root cause and the two independent
 bugs beside it. The governing principle throughout: **a missing value is
 always acceptable, a wrong one never is.**
+
+Late additions (2026-08-08, from two production Excel-repair incidents
+and a recalculation-latency incident): the evaluator performance stack
+(#521, #523, #524) and two new lint corruption classes (#527, #530).
+
+### Performance
+
+- **Recalculation is 7-37x faster than 0.19.1** across the stack
+  (#518/#521, #522/#523, #520/#524). Measured on JVM assembly:
+  9,900 x SUM($A$1:$A$5000): 47.9s -> **1.30s** (RSS 6.0GB -> 0.71GB);
+  200k-formula book: 95s -> **13.8s** (137.9s -> 10.8s at -Xmx512m);
+  50k book: 8.9s -> 3.1s. The pieces: linear-allocation Kahn core
+  (topological sort was 81% of recalc allocation), memoized range-edge
+  expansion (range deps no longer re-materialize per formula),
+  aggregate-fold memoization with single-flight (repeated SUM/AVERAGE
+  over one range fold it once per calculation generation), stack-safe
+  iterative Tarjan SCC engine, bounded-dependency extraction caching.
+- **SIGTERM terminates a mid-recalculation process** (#519/#521): a
+  finite `shutdownHookTimeout` (2s) replaces cats-effect's infinite
+  default — a TERM'd xl previously computed the entire remaining recalc
+  at full CPU and then discarded the result. The CPU-starvation warning
+  spam is disabled with it. Staged `-o`/`-i` output commits mean a
+  killed process cannot leave a torn destination (#524).
+- **`recalc --parallel N` / `recalculateParallel(n)`** (#520/#524):
+  wave-partitioned evaluation, equivalence-gated (bit-for-bit parity
+  with sequential, 7 pinned gates). Honest assessment: ~1.0x on
+  measured shapes today — the memoization above removed the redundant
+  work parallelism used to attack; ships as the correctness-proven
+  foundation that inherits every future serial-cost reduction.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ```scala 3 raw
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.19.1
+//> using dep com.tjclp::xl:0.19.2
 
 import com.tjclp.xl.{*, given}
 
@@ -55,13 +55,13 @@ import com.tjclp.xl.{*, given}
 
 ```scala 3 ignore
 // build.mill — single dependency for everything
-def ivyDeps = Agg(ivy"com.tjclp::xl:0.19.1")
+def ivyDeps = Agg(ivy"com.tjclp::xl:0.19.2")
 
 // Or individual modules for minimal footprint:
-// ivy"com.tjclp::xl-core:0.19.1"        — Pure domain model only
-// ivy"com.tjclp::xl-ooxml:0.19.1"       — Add OOXML read/write
-// ivy"com.tjclp::xl-cats-effect:0.19.1" — Add IO streaming
-// ivy"com.tjclp::xl-evaluator:0.19.1"   — Add formula evaluation
+// ivy"com.tjclp::xl-core:0.19.2"        — Pure domain model only
+// ivy"com.tjclp::xl-ooxml:0.19.2"       — Add OOXML read/write
+// ivy"com.tjclp::xl-cats-effect:0.19.2" — Add IO streaming
+// ivy"com.tjclp::xl-evaluator:0.19.2"   — Add formula evaluation
 ```
 
 ### Basic Usage

--- a/build.mill
+++ b/build.mill
@@ -14,7 +14,7 @@ val organization = "com.tjclp"
 /** Shared build configuration constants */
 object BuildConfig {
   /** Project version: CI sets PUBLISH_VERSION; local builds use this fallback */
-  val version: String = sys.env.getOrElse("PUBLISH_VERSION", "0.19.1")
+  val version: String = sys.env.getOrElse("PUBLISH_VERSION", "0.19.2")
 
   /** JVM options to silence Scala 3 LazyVals sun.misc.Unsafe deprecation warnings (JDK 21+) */
   val lazyValsJvmArgs: Seq[String] = Seq(

--- a/docs/QUICK-START.md
+++ b/docs/QUICK-START.md
@@ -12,19 +12,19 @@ import mill._, scalalib._
 
 object myproject extends ScalaModule {
   def scalaVersion = "3.8.3"
-  def ivyDeps = Agg(ivy"com.tjclp::xl:0.19.1")
+  def ivyDeps = Agg(ivy"com.tjclp::xl:0.19.2")
 }
 ```
 
 ### With sbt (build.sbt)
 ```scala
 scalaVersion := "3.8.3"
-libraryDependencies += "com.tjclp" %% "xl" % "0.19.1"
+libraryDependencies += "com.tjclp" %% "xl" % "0.19.2"
 ```
 
 ### With Scala CLI
 ```scala
-//> using dep com.tjclp::xl:0.19.1
+//> using dep com.tjclp::xl:0.19.2
 ```
 
 ### Individual Modules (Optional)
@@ -44,7 +44,7 @@ For scripts, skip the build setup entirely: a two-line `scala-cli` header and ON
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.19.1
+//> using dep com.tjclp::xl:0.19.2
 
 import com.tjclp.xl.scripting.{*, given}
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,6 +1,6 @@
 # XL Project Status
 
-**Last Updated**: 2026-08-06 (0.19.2)
+**Last Updated**: 2026-08-08 (0.19.2)
 
 ## Current State
 
@@ -8,7 +8,10 @@
 
 ### What Works (Production-Ready)
 
-**New in 0.19.2 "Fixpoint"** (2026-08-06) — recalculation & seeding integrity, wave 24:
+**New in 0.19.2 "Fixpoint"** (2026-08-08) — recalculation & seeding integrity (wave 24) + the perf stack + two lint corruption classes:
+- ✅ **Recalculation 7–37× faster** (#521, #523, #524) — linear Kahn core, memoized range-edge expansion, aggregate-fold memoization w/ single-flight, stack-safe Tarjan; 9,900×SUM(5000): 47.9s→1.30s, 200k book: 95s→13.8s; SIGTERM now kills a mid-recalc process in ~2s (#519) and `recalc --parallel N` ships equivalence-gated (#520)
+- ✅ **`external-ref-dangling` lint** (#525/#527) — dangling external-workbook ordinals (the cross-workbook sheet-transplant class; a field incident lost 935 formulas to Excel repair while lint read clean); #526 tracks the adoption/remap API
+- ✅ **`defined-name-invalid` lint** (#528/#530) — same-scope defined names colliding under Excel's case/width/kana-insensitive comparison (g/ｇ, html/ＨＴＭＬ — legacy fossils Excel removes, sometimes silently), 255-char limit, whitespace/control chars; suffix-less MS externalLinkPath rel types whitelisted (#529)
 - ✅ **Opt-in wave-parallel recalculation** (#520) — `Workbook.recalculateParallel(N)` / `xl recalc --parallel N` evaluates independent static waves concurrently, pins one clock generation, and folds results deterministically; dynamic references remain in the sequential evaluate-last bucket and iterative books retain their sequential SCC fixpoint
 - ✅ **One pass = the global fixpoint** (#492, #491) — iterative recalculation walks the SCC condensation in dependency-first order instead of splitting into preOrder / one flat Jacobi / postOrder, so no read can fall back to a stale cache and re-recalculating a correct multi-SCC circular book no longer corrupts it. `RecalcResult.cycles` / `.unconverged` / `.certified` report per-component verdicts
 - ✅ **Cycles warm-start from numeric caches** (#469) — zero-seeding no longer wipes valid caches of mutually-ISERROR-guarded pairs

--- a/docs/plan/roadmap.md
+++ b/docs/plan/roadmap.md
@@ -12,7 +12,7 @@
 
 **Current Status**: Production-ready with **115 formula functions** (incl. dynamic arrays SEQUENCE/SORT/UNIQUE/FILTER and OFFSET), **structural editing** (insert/delete rows & columns with formula rewriting), the **scripting prelude** (`com.tjclp.xl.scripting`), whole-workbook `recalculate`, named-range & hyperlink authoring, **typed charts + embedded pictures** (0.12.0), **conditional formatting** (0.12.1), SAX streaming (36% faster than POI), Excel tables, and full OOXML round-trip. 5,455 tests passing.
 
-**Current Version**: **0.19.2** "Fixpoint" (recalculation & seeding integrity, released 2026-08-06)
+**Current Version**: **0.19.2** "Fixpoint" (recalculation & seeding integrity + perf stack + lint corruption classes, released 2026-08-08)
 
 ---
 


### PR DESCRIPTION
Release prep for the 0.19.2 "Fixpoint" cut (2026-08-08): version fallback to 0.19.2, dep strings in README/QUICK-START, CHANGELOG gains the Performance section for the perf stack (#521/#523/#524) alongside the existing Wave-24 and lint entries (#527/#530), STATUS/roadmap refreshed.

After merge: annotated tag `v0.19.2` triggers the release workflow (native binaries × 5 platforms, Maven Central, CLI JAR, packaged skills, GitHub Release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)