### PR TITLE
chore(release): bump version to 0.19.3 "Namesake"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to the XL project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.19.3] "Namesake" - 2026-08-14
+
+Patch release: one performance fix (#535, GH-536), found live on a
+production lender model that could not complete a recalculation.
+
+### Performance
+
+- **Defined-name resolution is indexed** (#535/GH-536). Name lookup was a
+  linear scan of the workbook's name table, and dynamic-name
+  classification ran it for every sheet × name during graph construction
+  — O(sheets × names²) per recalculation before any formula evaluated.
+  Bank-authored templates carry six-figure name tables: a 96,384-name /
+  28,537-formula model did not finish `recalc` in 33 minutes, with 98.5%
+  of JFR execution samples inside the scan. `WorkbookMetadata` now
+  derives a lazy case-insensitive index — first-declared-wins,
+  per-code-point case folding, exactly the `equalsIgnoreCase` relation —
+  and the same book recalculates in 8.2s; its `iterate="1"` original
+  converges in 2 of 300 declared rounds in 8.4s; a 126,510-name sibling
+  that exhausts all 400 declared rounds completes in 27s. Resolution
+  semantics are unchanged and property-tested against the scan they
+  replaced, including supplementary-plane case pairs.
+
+Follow-ups filed: #537 (iterative-calculation costs — whole-walk
+aggregate-memo disable, per-round re-parsing, no stationarity exit),
+#538 (defined-name mutation matches case-sensitively while resolution is
+case-insensitive).
+
 ## [0.19.2] "Fixpoint" - 2026-08-08
 
 Wave 24: the 0.19.1 blind-regression round. Four new silent-wrong-number

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ```scala 3 raw
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.19.2
+//> using dep com.tjclp::xl:0.19.3
 
 import com.tjclp.xl.{*, given}
 
@@ -55,13 +55,13 @@ import com.tjclp.xl.{*, given}
 
 ```scala 3 ignore
 // build.mill — single dependency for everything
-def ivyDeps = Agg(ivy"com.tjclp::xl:0.19.2")
+def ivyDeps = Agg(ivy"com.tjclp::xl:0.19.3")
 
 // Or individual modules for minimal footprint:
-// ivy"com.tjclp::xl-core:0.19.2"        — Pure domain model only
-// ivy"com.tjclp::xl-ooxml:0.19.2"       — Add OOXML read/write
-// ivy"com.tjclp::xl-cats-effect:0.19.2" — Add IO streaming
-// ivy"com.tjclp::xl-evaluator:0.19.2"   — Add formula evaluation
+// ivy"com.tjclp::xl-core:0.19.3"        — Pure domain model only
+// ivy"com.tjclp::xl-ooxml:0.19.3"       — Add OOXML read/write
+// ivy"com.tjclp::xl-cats-effect:0.19.3" — Add IO streaming
+// ivy"com.tjclp::xl-evaluator:0.19.3"   — Add formula evaluation
 ```
 
 ### Basic Usage

--- a/build.mill
+++ b/build.mill
@@ -14,7 +14,7 @@ val organization = "com.tjclp"
 /** Shared build configuration constants */
 object BuildConfig {
   /** Project version: CI sets PUBLISH_VERSION; local builds use this fallback */
-  val version: String = sys.env.getOrElse("PUBLISH_VERSION", "0.19.2")
+  val version: String = sys.env.getOrElse("PUBLISH_VERSION", "0.19.3")
 
   /** JVM options to silence Scala 3 LazyVals sun.misc.Unsafe deprecation warnings (JDK 21+) */
   val lazyValsJvmArgs: Seq[String] = Seq(

--- a/docs/QUICK-START.md
+++ b/docs/QUICK-START.md
@@ -12,19 +12,19 @@ import mill._, scalalib._
 
 object myproject extends ScalaModule {
   def scalaVersion = "3.8.3"
-  def ivyDeps = Agg(ivy"com.tjclp::xl:0.19.2")
+  def ivyDeps = Agg(ivy"com.tjclp::xl:0.19.3")
 }
 ```
 
 ### With sbt (build.sbt)
 ```scala
 scalaVersion := "3.8.3"
-libraryDependencies += "com.tjclp" %% "xl" % "0.19.2"
+libraryDependencies += "com.tjclp" %% "xl" % "0.19.3"
 ```
 
 ### With Scala CLI
 ```scala
-//> using dep com.tjclp::xl:0.19.2
+//> using dep com.tjclp::xl:0.19.3
 ```
 
 ### Individual Modules (Optional)
@@ -44,7 +44,7 @@ For scripts, skip the build setup entirely: a two-line `scala-cli` header and ON
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.19.2
+//> using dep com.tjclp::xl:0.19.3
 
 import com.tjclp.xl.scripting.{*, given}
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,12 +1,15 @@
 # XL Project Status
 
-**Last Updated**: 2026-08-08 (0.19.2)
+**Last Updated**: 2026-08-14 (0.19.3)
 
 ## Current State
 
 > **For detailed phase completion status and roadmap, see [plan/roadmap.md](plan/roadmap.md)**
 
 ### What Works (Production-Ready)
+
+**New in 0.19.3 "Namesake"** (2026-08-14) — defined-name resolution indexed:
+- ✅ **Defined-name lookup is O(1)** (#535/GH-536) — name resolution was a linear scan of the name table and dynamic-name classification ran it per sheet × name (O(sheets × names²) per recalc); a production 96,384-name model went from >33 min (unfinished) to 8.2s, its `iterate="1"` original converges in 2/300 rounds in 8.4s, a 126,510-name sibling exhausting 400 rounds completes in 27s. Lazy per-metadata `DefinedNameIndex`, first-declared-wins, per-code-point case folding ≡ `equalsIgnoreCase`, property-tested against the scan it replaced. Follow-ups: #537 (iterative-path costs), #538 (mutation-API case sensitivity)
 
 **New in 0.19.2 "Fixpoint"** (2026-08-08) — recalculation & seeding integrity (wave 24) + the perf stack + two lint corruption classes:
 - ✅ **Recalculation 7–37× faster** (#521, #523, #524) — linear Kahn core, memoized range-edge expansion, aggregate-fold memoization w/ single-flight, stack-safe Tarjan; 9,900×SUM(5000): 47.9s→1.30s, 200k book: 95s→13.8s; SIGTERM now kills a mid-recalc process in ~2s (#519) and `recalc --parallel N` ships equivalence-gated (#520)

--- a/docs/plan/roadmap.md
+++ b/docs/plan/roadmap.md
@@ -12,7 +12,7 @@
 
 **Current Status**: Production-ready with **115 formula functions** (incl. dynamic arrays SEQUENCE/SORT/UNIQUE/FILTER and OFFSET), **structural editing** (insert/delete rows & columns with formula rewriting), the **scripting prelude** (`com.tjclp.xl.scripting`), whole-workbook `recalculate`, named-range & hyperlink authoring, **typed charts + embedded pictures** (0.12.0), **conditional formatting** (0.12.1), SAX streaming (36% faster than POI), Excel tables, and full OOXML round-trip. 5,455 tests passing.
 
-**Current Version**: **0.19.2** "Fixpoint" (recalculation & seeding integrity + perf stack + lint corruption classes, released 2026-08-08)
+**Current Version**: **0.19.3** "Namesake" (defined-name resolution indexed — O(sheets × names²) recalc scans removed, released 2026-08-14)
 
 ---
 
@@ -60,6 +60,10 @@ Phased: (a) verbatim chart/drawing preservation proven by the wave-2 fixture cor
 ### v0.12.1 "Clean Sweep" — wave 7 (Released 2026-06-11)
 
 Every remaining open issue closed in one wave. **Conditional formatting** ([#136](https://github.com/TJC-LP/xl/issues/136)) is the headline — typed cellIs/expression/colorScale/dataBar/top10/text rules + `dxf` differential formats, `sheet.conditionalFormat` authoring with auto-priority, structural-edit range shifting, unmodeled families preserved byte-faithfully — alongside twelve fidelity/writer fixes: openpyxl comment subdirectory dialect (#292), RichText SST keying (#303), exact surgical SST counts (#304), `[Content_Types]` preservation (#314), identity-keyed source mappings (#315), activeTab (#294), fitToPage tri-state (#284), `Cell.comment` deprecated→`Sheet.comments` (#295). Codec `put` paths 2.4x faster (#297).
+
+### v0.19.3 "Namesake" — defined-name index (Released 2026-08-14)
+
+One-fix patch ([#535](https://github.com/TJC-LP/xl/pull/535), [GH-536](https://github.com/TJC-LP/xl/issues/536)): defined-name resolution was a linear scan of the name table, and dynamic-name classification ran it for every sheet × name — O(sheets × names²) per recalculation. Found live on a bank-authored model with 96,384 defined names that could not finish a recalc (>33 min, killed; 98.5% of JFR samples in the scan); with the per-metadata lazy `DefinedNameIndex` it completes in 8.2s. Case folding is per code point, exactly the `equalsIgnoreCase` relation, property-tested against the scan it replaced. Follow-ups: [#537](https://github.com/TJC-LP/xl/issues/537) (iterative-calculation path costs), [#538](https://github.com/TJC-LP/xl/issues/538) (mutation-API case sensitivity).
 
 ### v0.19.2 "Fixpoint" — wave 24 (Released 2026-08-06)
 

--- a/docs/reference/scripting.md
+++ b/docs/reference/scripting.md
@@ -33,7 +33,7 @@ release bump is a mechanical substitution):
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.19.2
+//> using dep com.tjclp::xl:0.19.3
 import com.tjclp.xl.scripting.{*, given}
 
 val sheet = Sheet("Demo").put(ref"A1", "Hello").put(ref"B1", 42)
@@ -51,7 +51,7 @@ read and write is pure values.
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.19.2
+//> using dep com.tjclp::xl:0.19.3
 import com.tjclp.xl.scripting.{*, given}
 
 val wb = Excel.read("input.xlsx")
@@ -130,7 +130,7 @@ intended instead of surprising the chain:
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.19.2
+//> using dep com.tjclp::xl:0.19.3
 import com.tjclp.xl.scripting.{*, given}
 
 val region = Seq("North", "East").mkString(" ")                     // runtime name
@@ -196,7 +196,7 @@ throw — they are collected per cell.
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.19.2
+//> using dep com.tjclp::xl:0.19.3
 import com.tjclp.xl.scripting.{*, given}
 
 val title = CellStyle.default.bold.size(14.0).center
@@ -353,7 +353,7 @@ them explicitly:
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.19.2
+//> using dep com.tjclp::xl:0.19.3
 import com.tjclp.xl.scripting.{*, given}
 import com.tjclp.xl.sheets.{HeaderFooter, PageMargins, PageSetup, SheetView}
 
@@ -407,7 +407,7 @@ the whole workbook:
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.19.2
+//> using dep com.tjclp::xl:0.19.3
 import com.tjclp.xl.scripting.{*, given}
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global

--- a/examples/README.md
+++ b/examples/README.md
@@ -170,7 +170,7 @@ chmod +x examples/my_example.sc
 ./examples/my_example.sc
 ```
 
-The `project.scala` file centralizes dependencies (`com.tjclp::xl:0.19.2`) for all examples.
+The `project.scala` file centralizes dependencies (`com.tjclp::xl:0.19.3`) for all examples.
 
 ## Scripting Prelude & Skill
 

--- a/examples/project.scala
+++ b/examples/project.scala
@@ -2,4 +2,4 @@
 //> using repository ivy2Local
 
 // XL aggregate - includes all modules (core, ooxml, cats-effect, evaluator)
-//> using dep com.tjclp::xl:0.19.2
+//> using dep com.tjclp::xl:0.19.3

--- a/plugin/skills/xl-scripting/SKILL.md
+++ b/plugin/skills/xl-scripting/SKILL.md
@@ -38,7 +38,7 @@ The canonical header for every script (this is the single source of truth — re
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.19.2
+//> using dep com.tjclp::xl:0.19.3
 
 import com.tjclp.xl.scripting.{*, given}
 
@@ -104,7 +104,7 @@ wb.update("Sales", f).unsafe                       // throws structured XLExcept
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.19.2
+//> using dep com.tjclp::xl:0.19.3
 import com.tjclp.xl.scripting.{*, given}
 
 val wb = Excel.read("input.xlsx")
@@ -236,7 +236,7 @@ Native Excel `TABLE()` two-variable data tables (0.18.0) — the house sensitivi
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.19.2
+//> using dep com.tjclp::xl:0.19.3
 import com.tjclp.xl.scripting.{*, given}
 
 val model = Sheet("Sensitivity")
@@ -285,7 +285,7 @@ Or lean on totality so there is nothing to unwrap: literal refs, `upsert`, range
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.19.2
+//> using dep com.tjclp::xl:0.19.3
 import com.tjclp.xl.scripting.{*, given}
 import java.nio.file.{Files, Paths}
 import scala.jdk.CollectionConverters.*
@@ -307,7 +307,7 @@ println(s"merged ${inputs.size} files, ${merged.sheets.size} sheets")
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.19.2
+//> using dep com.tjclp::xl:0.19.3
 import com.tjclp.xl.scripting.{*, given}
 
 val data = List(("North", 125000.50), ("South", 98000.25), ("West", 143500.00))
@@ -335,7 +335,7 @@ println(if result.isClean then "✓ report written" else result.errors.map(_.ren
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.19.2
+//> using dep com.tjclp::xl:0.19.3
 import com.tjclp.xl.scripting.{*, given}
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global

--- a/plugin/skills/xl-scripting/reference/RECIPES.md
+++ b/plugin/skills/xl-scripting/reference/RECIPES.md
@@ -10,7 +10,7 @@ Apply a 5% price increase to column C of every workbook in a directory, in place
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.19.2
+//> using dep com.tjclp::xl:0.19.3
 import com.tjclp.xl.scripting.{*, given}
 import java.nio.file.{Files, Paths}
 import scala.jdk.CollectionConverters.*
@@ -42,7 +42,7 @@ Read rows into case classes; collect per-cell validation failures into a new Iss
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.19.2
+//> using dep com.tjclp::xl:0.19.3
 import com.tjclp.xl.scripting.{*, given}
 
 final case class Order(id: Int, customer: String, amount: BigDecimal)
@@ -76,7 +76,7 @@ Three-year projection with growth formulas; fail the script if any formula error
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.19.2
+//> using dep com.tjclp::xl:0.19.3
 import com.tjclp.xl.scripting.{*, given}
 
 val header = CellStyle.default.bold.size(12.0).center
@@ -111,7 +111,7 @@ Stack the data rows of every input file under one header.
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.19.2
+//> using dep com.tjclp::xl:0.19.3
 import com.tjclp.xl.scripting.{*, given}
 import java.nio.file.{Files, Paths}
 import scala.jdk.CollectionConverters.*
@@ -147,7 +147,7 @@ println(s"combined ${files.size} files, ${combined.cells.size} cells")
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.19.2
+//> using dep com.tjclp::xl:0.19.3
 import com.tjclp.xl.scripting.{*, given}
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
@@ -176,7 +176,7 @@ println("✓ filtered (constant memory)")
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.19.2
+//> using dep com.tjclp::xl:0.19.3
 import com.tjclp.xl.scripting.{*, given}
 
 val before = Excel.read("before.xlsx")
@@ -204,7 +204,7 @@ else
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.19.2
+//> using dep com.tjclp::xl:0.19.3
 import com.tjclp.xl.scripting.{*, given}
 import java.nio.file.{Files, Paths}
 import scala.jdk.CollectionConverters.*
@@ -232,7 +232,7 @@ cell ships a cached value for `data_only` readers, pandas, and Excel-before-reca
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.19.2
+//> using dep com.tjclp::xl:0.19.3
 import com.tjclp.xl.scripting.{*, given}
 
 val reps = List(("Alice", 120000.0), ("Bob", 98000.0), ("Carol", 143500.0))
@@ -267,7 +267,7 @@ frozen header, a list-dropdown data validation, and a provenance comment — no 
 
 ```scala
 //> using scala 3.8.3
-//> using dep com.tjclp::xl:0.19.2
+//> using dep com.tjclp::xl:0.19.3
 import com.tjclp.xl.scripting.{*, given}
 import com.tjclp.xl.sheets.SheetView // SheetView lives one import deeper than the prelude
 

--- a/xl-core/src/com/tjclp/xl/workbooks/WorkbookMetadata.scala
+++ b/xl-core/src/com/tjclp/xl/workbooks/WorkbookMetadata.scala
@@ -35,7 +35,7 @@ final case class WorkbookMetadata(
   modified: Option[java.time.LocalDateTime] = None,
   lastModifiedBy: Option[String] = None,
   application: Option[String] = Some("XL - Pure Scala 3.8 Excel Library"),
-  appVersion: Option[String] = Some("0.19.2"),
+  appVersion: Option[String] = Some("0.19.3"),
   theme: ThemePalette = ThemePalette.office,
   definedNames: Vector[DefinedName] = Vector.empty,
   sheetStates: Map[SheetName, Option[String]] = Map.empty,

--- a/xl/src/com/tjclp/xl/scripting.scala
+++ b/xl/src/com/tjclp/xl/scripting.scala
@@ -4,7 +4,7 @@ package com.tjclp.xl
  * Scripting prelude: everything a script needs in one import.
  *
  * {{{
- * //> using dep com.tjclp::xl:0.19.2
+ * //> using dep com.tjclp::xl:0.19.3
  * import com.tjclp.xl.scripting.{*, given}
  *
  * val wb = Excel.read("input.xlsx")


### PR DESCRIPTION
Release-prep for the 0.19.3 patch cut. Content: the defined-name index (#535, closes nothing itself — GH-536 already closed by the fix).

- CHANGELOG/STATUS/roadmap: 0.19.3 "Namesake" sections
- Version pins swept 0.19.2 → 0.19.3: README, QUICK-START, scripting docs, packaged xl-scripting skill (SKILL + RECIPES), examples, scripting.scala scaladoc, `WorkbookMetadata.appVersion`, `build.mill` `PUBLISH_VERSION` default

Tag `v0.19.3` follows the merge; release.yml publishes Maven Central + the 5-platform binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)